### PR TITLE
fix: increase chainsaw test assertion timeouts for LLM operations

### DIFF
--- a/tests/a2aserver/chainsaw-test.yaml
+++ b/tests/a2aserver/chainsaw-test.yaml
@@ -7,7 +7,6 @@ spec:
   description: Tests LangChain weather agent A2A integration with templated queries
   timeouts:
     apply: 60s
-    assert: 180s
     cleanup: 60s
   steps:
     - name: setup-credentials-and-resources

--- a/tests/agent-structured-output/chainsaw-test.yaml
+++ b/tests/agent-structured-output/chainsaw-test.yaml
@@ -6,7 +6,6 @@ spec:
   description: Test agent structured output with JSON schema
   timeouts:
     apply: 30s
-    assert: 120s
     cleanup: 30s
   steps:
   - name: deploy-resources

--- a/tests/chainsaw.yml
+++ b/tests/chainsaw.yml
@@ -12,7 +12,7 @@ spec:
   reportName: /tmp/chainsaw-report/chainsaw-report.json  # Path where the test report will be saved
   timeouts:
     apply: 45s                           # Timeout for 'apply' operations (e.g., applying manifests)
-    assert: 20s                          # Timeout for assertion checks
+    assert: 180s                         # Timeout for assertion checks (high value for LLM calls)
     cleanup: 45s                         # Timeout for cleanup steps after tests
     delete: 25s                          # Timeout for resource deletion steps
     error: 10s                           # Timeout for error handling steps

--- a/tests/mcp-filesys/chainsaw-test.yaml
+++ b/tests/mcp-filesys/chainsaw-test.yaml
@@ -7,7 +7,7 @@ spec:
   # Re-enable when issue: https://mckinsey.atlassian.net/browse/AAS-2485 is resolved.
   skip: true
   timeouts:
-    exec: 300s
+    exec: 300s  # Extended timeout for Helm operations and service deployment
   description: Test MCP Filesystem Server deployment and ARK integration using Helm chart
   steps:
   - name: deploy-mcp-server-with-helm

--- a/tests/team-selector/chainsaw-test.yaml
+++ b/tests/team-selector/chainsaw-test.yaml
@@ -6,8 +6,6 @@ spec:
   description: Test selector team strategy with AI-driven participant selection
   # Selector strategy requires multiple AI model calls for participant selection
   # and can take longer than default timeouts, especially with maxTurns: 6
-  timeouts:
-    assert: 120s  # Allow 2 minutes for team coordination with multiple AI calls
   steps:
   - name: step-1
     try:


### PR DESCRIPTION
## Summary
- Increase global assertion timeout from 20s to 180s to handle LLM call latency
- Remove redundant custom assert timeouts from individual tests  
- Add clear comments explaining timeout values
- Ensures model-token-usage and other LLM tests complete successfully