### PR TITLE
fix: improve CI/CD reliability and container registry configuration

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -175,7 +175,7 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -184,7 +184,7 @@ jobs:
           path: ${{ matrix.path }}
           image: ${{ matrix.image }}
           tag: ${{ github.sha }}
-          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           platforms: linux/amd64
           push: true
           prebuild: ${{ matrix.prebuild }}
@@ -287,7 +287,7 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -299,9 +299,9 @@ jobs:
           ARK_QUICKSTART_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
           ARK_QUICKSTART_API_VERSION: 2024-12-01-preview
           ARK_QUICKSTART_API_KEY: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
-          ARK_QUICKSTART_CONTROLLER_IMAGE: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-controller
+          ARK_QUICKSTART_CONTROLLER_IMAGE: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller
           ARK_QUICKSTART_CONTROLLER_TAG: ${{ github.sha }}
-          CACHE_ARGS: --cache-from type=registry,ref=${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-controller:cache --cache-to type=registry,ref=${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-controller:cache,mode=max
+          CACHE_ARGS: --cache-from type=registry,ref=${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache --cache-to type=registry,ref=${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache,mode=max
         run: |
           echo "Environment variables set:"
           echo "ARK_QUICKSTART_PROMPT_YES=$ARK_QUICKSTART_PROMPT_YES"
@@ -329,7 +329,7 @@ jobs:
           ark-image-tag: ${{ github.sha }}
           install-coverage: "false"
           install-evaluator: "false"
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -355,7 +355,7 @@ jobs:
           helm upgrade --install ark-api services/ark-api/chart \
             --namespace default \
             --create-namespace \
-            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-api" \
+            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-api" \
             --set app.image.tag="${{ github.sha }}" \
             --set app.image.pullPolicy="Always" \
             --wait \
@@ -367,7 +367,7 @@ jobs:
           helm upgrade --install ark-api-a2a services/ark-api-a2a/chart \
             --namespace default \
             --create-namespace \
-            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-api-a2a" \
+            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-api-a2a" \
             --set app.image.tag="${{ github.sha }}" \
             --set app.image.pullPolicy="Always" \
             --wait \
@@ -379,7 +379,7 @@ jobs:
           helm upgrade --install ark-dashboard services/ark-dashboard/chart \
             --namespace default \
             --create-namespace \
-            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-dashboard" \
+            --set app.image.repository="${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-dashboard" \
             --set app.image.tag="${{ github.sha }}" \
             --set app.image.pullPolicy="Always" \
             --wait \
@@ -456,7 +456,7 @@ jobs:
           ark-image-tag: ${{ github.sha }}
           install-coverage: "true"
           install-evaluator: "false" # Standard tests don't need evaluator
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -472,7 +472,7 @@ jobs:
           E2E_TEST_AZURE_OPENAI_KEY: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
           E2E_TEST_AZURE_OPENAI_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
           FILESYS_IMAGE_TAG: ${{ github.sha }}
-          HOSTED_LANGCHAIN_AGENTS_IMAGE_REPOSITORY: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/hosted-langchain-agents
+          HOSTED_LANGCHAIN_AGENTS_IMAGE_REPOSITORY: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/hosted-langchain-agents
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests
@@ -496,7 +496,7 @@ jobs:
           install-evaluator: "true" # Evaluated tests need evaluator-llm service
           azure-openai-key: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
           azure-openai-base-url: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -512,7 +512,7 @@ jobs:
           E2E_TEST_AZURE_OPENAI_KEY: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
           E2E_TEST_AZURE_OPENAI_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
           FILESYS_IMAGE_TAG: ${{ github.sha }}
-          HOSTED_LANGCHAIN_AGENTS_IMAGE_REPOSITORY: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/hosted-langchain-agents
+          HOSTED_LANGCHAIN_AGENTS_IMAGE_REPOSITORY: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/hosted-langchain-agents
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -476,13 +476,7 @@ jobs:
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests
-          chainsaw test --selector '!evaluated' \
-            --apply-timeout 45s       \
-            --assert-timeout 45s      \
-            --cleanup-timeout 45s     \
-            --delete-timeout 45s      \
-            --error-timeout 45s       \
-            --exec-timeout 45s
+          chainsaw test --config .chainsaw.yaml --selector '!evaluated'
 
       - uses: ./.github/actions/collect-coverage-e2e
         with:
@@ -521,7 +515,7 @@ jobs:
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests
-          chainsaw test --selector 'evaluated=true'
+          chainsaw test --config .chainsaw.yaml --selector 'evaluated=true'
 
       - uses: ./.github/actions/collect-coverage-e2e
         with:
@@ -847,7 +841,7 @@ jobs:
       - name: Trigger Deploy workflow for release
         run: |
           gh workflow run deploy.yml \
-            --field version="${{ needs.check-release.outputs.tag }}" \
+            --field ark_version="${{ needs.check-release.outputs.tag }}" \
             --field deploy_containers=true \
             --field deploy_to_pages=true \
             --field deploy_to_npm=true

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -476,6 +476,7 @@ jobs:
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests
+          mkdir -p /tmp/chainsaw-report
           chainsaw test --config .chainsaw.yaml --selector '!evaluated'
 
       - uses: ./.github/actions/collect-coverage-e2e
@@ -515,6 +516,7 @@ jobs:
           HOSTED_LANGCHAIN_AGENTS_IMAGE_TAG: ${{ github.sha }}
         run: |
           cd tests
+          mkdir -p /tmp/chainsaw-report
           chainsaw test --config .chainsaw.yaml --selector 'evaluated=true'
 
       - uses: ./.github/actions/collect-coverage-e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,8 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          # Default registry: ghcr.io/mckinsey/agents-at-scale-ark (includes repo name for GHCR access control)
+          registry: ${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME || github.actor }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -142,7 +143,7 @@ jobs:
           path: ${{ matrix.path }}
           image: ${{ matrix.image }}
           tag: ${{ needs.check_version.outputs.clean_version }}
-          registry: ${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+          registry: ${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
           platforms: linux/amd64,linux/arm64
           push: true
           prebuild: ${{ matrix.prebuild }}
@@ -217,11 +218,11 @@ jobs:
           # Deploy using helm with registry configuration
           helm upgrade --install ark-controller ./ark-${{ needs.check_version.outputs.clean_version }}.tgz \
             --namespace ark-system \
-            --set controllerManager.container.image.repository=${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/ark-controller \
+            --set controllerManager.container.image.repository=${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller \
             --set controllerManager.container.image.tag=${{ needs.check_version.outputs.clean_version }} \
             --set controllerManager.serviceAccountName=ark-controller \
             --set containerRegistry.enabled=true \
-            --set containerRegistry.server=${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }} \
+            --set containerRegistry.server=${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }} \
             --set containerRegistry.username=${{ secrets.DOCKER_REGISTRY_USERNAME || github.actor }} \
             --set containerRegistry.password=${{ secrets.DOCKER_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }} \
             --set rbac.enable=false \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,3 +202,22 @@ When creating pull requests, use this simple format:
 ```
 
 DO NOT include "Test plan" sections in PR descriptions.
+
+## Pull Request Maintenance
+
+When adding commits to an existing PR that expand beyond the original scope:
+
+1. **Update PR title** to reflect the broader changes using conventional commit format
+2. **Update PR description** to summarize all changes, not just the original ones
+3. **Use `gh pr edit`** to update title and body efficiently
+
+Example:
+```bash
+# Original: "fix: increase test timeouts"
+# Updated: "fix: improve CI/CD reliability and container registry configuration"
+gh pr edit --title "fix: improve CI/CD reliability and container registry configuration" --body "## Summary
+- Increase chainsaw test timeouts for LLM operations
+- Fix container registry paths to include repository name for GHCR access control  
+- Add NPM package metadata for proper display on npmjs.com
+- Fix deploy workflow parameter naming"
+```

--- a/docs/content/operations-guide/build-pipelines.mdx
+++ b/docs/content/operations-guide/build-pipelines.mdx
@@ -52,11 +52,11 @@ GitHub variables and secrets for ARK build and deployment workflows. All configu
 | Name | Type | Purpose | Default Value |
 |------|------|---------|---------------|
 | **Docker Registry (Production)** | | | |
-| `DOCKER_REGISTRY` | Variable (Optional) | Main registry URL for version-tagged production/release images | `ghcr.io/{repository_owner}` |
+| `DOCKER_REGISTRY` | Variable (Optional) | Main registry URL for version-tagged production/release images | `ghcr.io/{repository_owner}/{repository_name}` |
 | `DOCKER_REGISTRY_USERNAME` | Secret (Optional) | Username for main registry authentication | `${{ github.actor }}` |
 | `DOCKER_REGISTRY_PASSWORD` | Secret (Optional) | Password/token for main registry authentication | `${{ secrets.GITHUB_TOKEN }}` |
 | **CI Cache Registry (Build Artifacts)** | | | |
-| `DOCKER_CICD_CACHE_REGISTRY` | Variable (Optional) | Registry URL for SHA-tagged intermediate images and CI/CD build cache | `ghcr.io/{repository_owner}` |
+| `DOCKER_CICD_CACHE_REGISTRY` | Variable (Optional) | Registry URL for SHA-tagged intermediate images and CI/CD build cache | `ghcr.io/{repository_owner}/{repository_name}` |
 | `DOCKER_CICD_CACHE_REGISTRY_USERNAME` | Secret (Optional) | Username for CI cache registry authentication | `${{ github.actor }}` |
 | `DOCKER_CICD_CACHE_REGISTRY_PASSWORD` | Secret (Optional) | Password/token for CI cache registry authentication | `${{ secrets.GITHUB_TOKEN }}` |
 | **Azure OpenAI (Testing)** | | |

--- a/tests/.chainsaw.yaml
+++ b/tests/.chainsaw.yaml
@@ -14,8 +14,8 @@ spec:
     apply: 45s                           # Timeout for 'apply' operations (e.g., applying manifests)
     assert: 180s                         # Timeout for assertion checks (high value for LLM calls)
     cleanup: 45s                         # Timeout for cleanup steps after tests
-    delete: 25s                          # Timeout for resource deletion steps
-    error: 10s                           # Timeout for error handling steps
+    delete: 45s                          # Timeout for resource deletion steps
+    error: 45s                           # Timeout for error handling steps
     exec: 45s                            # Timeout for command execution steps
   failFast: false                        # If false, Chainsaw will continue running tests even after failures
   parallel: 4                            # Number of tests to run in parallel

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -26,7 +26,17 @@
     "ai",
     "agents"
   ],
-  "author": "",
+  "license": "Apache-2.0",
+  "author": "McKinsey & Company",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mckinsey/agents-at-scale-ark.git",
+    "directory": "tools/ark-cli"
+  },
+  "homepage": "https://github.com/mckinsey/agents-at-scale-ark#readme",
+  "bugs": {
+    "url": "https://github.com/mckinsey/agents-at-scale-ark/issues"
+  },
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary
- Increase chainsaw test timeouts for LLM operations (180s assertion timeout)
- Fix chainsaw config file usage (rename to .chainsaw.yaml and use --config flag)
- Fix container registry paths to include repository name for GHCR access control
- Add NPM package metadata for proper display on npmjs.com  
- Fix deploy workflow parameter naming (version → ark_version)
- Create report directory to prevent chainsaw output errors