### PR TITLE
feat: Added A2A server button in ARK dashboard

### DIFF
--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/a2a/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/a2a/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { A2AServersSection } from "@/components/sections/a2a-servers-section";
+import type { A2AServersSectionHandle } from "@/components/sections/a2a-servers-section";
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useRef } from "react";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -11,12 +12,13 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-// import { Button } from "@/components/ui/button";
-// import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 function A2AContent() {
   const searchParams = useSearchParams();
   const namespace = searchParams.get("namespace") || "default";
+  const a2aSectionRef = useRef<A2AServersSectionHandle>(null);
 
   return (
     <>
@@ -34,14 +36,15 @@ function A2AContent() {
           </BreadcrumbList>
         </Breadcrumb>
         <div className="ml-auto">
-          {/* <Button onClick={() => mcpSectionRef.current?.openAddEditor()}>
+          <Button onClick={() => a2aSectionRef.current?.openAddEditor()}>
             <Plus className="h-4 w-4 mr-2" />
             Add A2A Server
-          </Button> */}
+          </Button>
         </div>
       </header>
+
       <div className="flex flex-1 flex-col">
-        <A2AServersSection namespace={namespace} />
+        <A2AServersSection ref={a2aSectionRef} namespace={namespace} />
       </div>
     </>
   );

--- a/services/ark-dashboard/ark-dashboard/components/editors/a2a-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/a2a-editor.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/components/ui/use-toast";
+import type { A2AServerConfiguration } from "@/lib/services/a2a-servers";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  namespace: string;
+  onSave: (config: A2AServerConfiguration) => void;
+};
+
+export function A2AEditor({ open, onOpenChange, namespace, onSave }: Props) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [pollingInterval, setPollingInterval] = useState<number | "">("");
+
+  const isValid =
+    Boolean(name.trim() && baseUrl.trim()) &&
+    (pollingInterval === "" || !isNaN(Number(pollingInterval)));
+
+  const handleSave = () => {
+    if (!isValid) {
+      toast({
+        variant: "destructive",
+        title: "Please fill in required fields correctly"
+      });
+      return;
+    }
+
+    const config: A2AServerConfiguration = {
+      name,
+      namespace,
+      spec: {
+        description: description || undefined,
+        address: { value: baseUrl },
+        pollingInterval:
+          pollingInterval === "" ? undefined : Number(pollingInterval)
+      }
+    };
+
+    onSave(config);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create New A2A Server</DialogTitle>
+          <DialogDescription>
+            Fill in the information for the new A2A server.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {/* Name */}
+          <div className="grid gap-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., deep-research"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="grid gap-2">
+            <Label htmlFor="description">Description</Label>
+            <Input
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What this server does"
+            />
+          </div>
+
+          {/* URL */}
+          <div className="grid gap-2">
+            <Label htmlFor="base-url">URL</Label>
+            <Input
+              id="base-url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://agentspace-a2a.default.svc.cluster.local:2973/a2a/agent/..."
+            />
+          </div>
+
+          {/* Polling Interval */}
+          <div className="grid gap-2">
+            <Label htmlFor="polling-interval">
+              Polling Interval (seconds)
+            </Label>
+            <Input
+              id="polling-interval"
+              type="number"
+              value={pollingInterval}
+              onChange={(e) =>
+                setPollingInterval(e.target.value ? Number(e.target.value) : "")
+              }
+              placeholder="e.g., 60"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!isValid}>
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/sections/a2a-servers-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/a2a-servers-section.tsx
@@ -1,62 +1,90 @@
 "use client";
 
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, forwardRef, useImperativeHandle, useCallback } from "react";
 import { toast } from "@/components/ui/use-toast";
 import { A2AServersService, type A2AServer } from "@/lib/services";
 import { A2AServerCard } from "@/components/cards";
-import { A2AServerRow } from "@/components/rows/a2a-server-row";
 import { useDelayedLoading } from "@/lib/hooks";
 import { InfoDialog } from "@/components/dialogs/info-dialog";
-import { ToggleSwitch, type ToggleOption } from "@/components/ui/toggle-switch";
+import { A2AEditor } from "@/components/editors/a2a-editor";
+import type { A2AServerConfiguration } from "@/lib/services/a2a-servers";
 
 interface A2AServersSectionProps {
   namespace: string;
 }
 
-export const A2AServersSection: React.FC<A2AServersSectionProps> = ({
-  namespace
-}) => {
+export type A2AServersSectionHandle = {
+  openAddEditor: () => void;
+};
+
+export const A2AServersSection = forwardRef<
+  A2AServersSectionHandle,
+  A2AServersSectionProps
+>(function A2AServersSection({ namespace }, ref) {
   const [a2aServers, setA2AServers] = useState<A2AServer[]>([]);
   const [loading, setLoading] = useState(true);
   const showLoading = useDelayedLoading(loading);
   const [selectedServer, setSelectedServer] = useState<A2AServer | null>(null);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
-  const [showCompactView, setShowCompactView] = useState(false);
+  const [a2aEditorOpen, setA2aEditorOpen] = useState(false);
 
-  const viewOptions: ToggleOption[] = [
-    { id: "compact", label: "compact view", active: !showCompactView },
-    { id: "card", label: "card view", active: showCompactView }
-  ];
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAddEditor: () => setA2aEditorOpen(true)
+    }),
+    []
+  );
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await A2AServersService.getAll(namespace);
+      setA2AServers(data);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to load A2A servers:", error);
+      toast({
+        variant: "destructive",
+        title: "Failed to Load A2A Servers",
+        description:
+          error instanceof Error ? error.message : "An unexpected error occurred"
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [namespace]);
 
   useEffect(() => {
-    const loadData = async () => {
-      setLoading(true);
-      try {
-        const data = await A2AServersService.getAll(namespace);
-        setA2AServers(data);
-      } catch (error) {
-        console.error("Failed to load A2A servers:", error);
-        toast({
-          variant: "destructive",
-          title: "Failed to Load A2A Servers",
-          description:
-            error instanceof Error
-              ? error.message
-              : "An unexpected error occurred"
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadData();
-  }, [namespace]);
+    void loadData();
+  }, [loadData]);
 
   const handleInfo = (server: A2AServer) => {
     setSelectedServer(server);
     setInfoDialogOpen(true);
   };
+
+  const handleSave = async (config: A2AServerConfiguration) => {
+    try {
+      await A2AServersService.create(namespace, config);
+      toast({
+        variant: "success",
+        title: "A2A Server Created",
+        description: `Successfully created ${config.name}`
+      });
+      await loadData();
+      setA2aEditorOpen(false);
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Failed to Create A2A Server",
+        description:
+          error instanceof Error ? error.message : "An unexpected error occurred"
+      });
+    }
+  };
+
   if (showLoading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -67,38 +95,17 @@ export const A2AServersSection: React.FC<A2AServersSectionProps> = ({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-end px-6 py-3">
-        <ToggleSwitch
-          options={viewOptions}
-          onChange={(id) => setShowCompactView(id === "card")}
-        />
-      </div>
-
-      <main className="flex-1 overflow-auto px-6 py-0">
-        {showCompactView && (
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 pb-6">
-            {a2aServers.map((server) => (
-              <A2AServerCard
-                key={server.name || server.id}
-                a2aServer={server}
-                onInfo={handleInfo}
-                namespace={namespace}
-              />
-            ))}
-          </div>
-        )}
-
-        {!showCompactView && (
-          <div className="flex flex-col gap-3">
-            {a2aServers.map((server) => (
-              <A2AServerRow
-                key={server.name || server.id}
-                a2aServer={server}
-                onInfo={handleInfo}
-              />
-            ))}
-          </div>
-        )}
+      <main className="flex-1 overflow-auto p-6">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 pb-6">
+          {a2aServers.map((server) => (
+            <A2AServerCard
+              key={server.name || server.id}
+              a2aServer={server}
+              onInfo={handleInfo}
+              namespace={namespace}
+            />
+          ))}
+        </div>
       </main>
 
       {selectedServer && (
@@ -109,6 +116,13 @@ export const A2AServersSection: React.FC<A2AServersSectionProps> = ({
           data={selectedServer}
         />
       )}
+
+      <A2AEditor
+        open={a2aEditorOpen}
+        onOpenChange={setA2aEditorOpen}
+        namespace={namespace}
+        onSave={handleSave}
+      />
     </div>
   );
-};
+});

--- a/services/ark-dashboard/ark-dashboard/lib/services/a2a-servers.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/a2a-servers.ts
@@ -48,7 +48,6 @@ export interface A2AServerSpec {
   description?: string;
   headers?: Header[];
   pollingInterval?: number;
-  transport?: "http" | "sse";
   timeout?: string;
 }
 

--- a/services/ark-dashboard/ark-dashboard/lib/services/a2a-servers.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/a2a-servers.ts
@@ -47,7 +47,8 @@ export interface A2AServerSpec {
   };
   description?: string;
   headers?: Header[];
-  transport: "http" | "sse";
+  pollingInterval?: number;
+  transport?: "http" | "sse";
   timeout?: string;
 }
 


### PR DESCRIPTION
In this PR, we added an A2A Server button to the ARK dashboard, enabling users to create A2A servers manually through the dashboard without writing any code.
<img width="1785" height="574" alt="image" src="https://github.com/user-attachments/assets/63fe9d00-27a7-4a07-a31b-a90dbe11d47e" />
<img width="931" height="539" alt="image" src="https://github.com/user-attachments/assets/fb95a823-9a66-463c-af5d-06c250ede3aa" />


## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 