### PR TITLE
feat(dashboard): Define config as map in Helm chart values

### DIFF
--- a/services/ark-dashboard/chart/templates/deployment.yaml
+++ b/services/ark-dashboard/chart/templates/deployment.yaml
@@ -23,7 +23,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ default "default" .Values.serviceAccount.name }}
       {{- end }}
@@ -34,8 +33,20 @@ spec:
         imagePullPolicy: {{ .Values.app.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.targetPort }}
-        {{- if .Values.app.env }}
         env:
+          - name: NODE_ENV
+            value: {{ required "app.config.nodeEnv is required" .Values.app.config.nodeEnv | quote }}
+          - name: PORT
+            value: {{ required "app.config.port is required" .Values.app.config.port | quote }}
+          - name: HOSTNAME
+            value: {{ required "app.config.hostname is required" .Values.app.config.hostname | quote }}
+          - name: ARK_API_SERVICE_HOST
+            value: {{ required "app.config.arkApiService.host is required" .Values.app.config.arkApiService.host | quote }}
+          - name: ARK_API_SERVICE_PORT
+            value: {{ required "app.config.arkApiService.port is required" .Values.app.config.arkApiService.port | quote }}
+          - name: ARK_API_SERVICE_PROTOCOL
+            value: {{ required "app.config.arkApiService.protocol is required" .Values.app.config.arkApiService.protocol | quote }}
+          {{- if .Values.app.env }}
           {{- range .Values.app.env }}
           - name: {{ .name }}
             {{- if .value }}
@@ -45,7 +56,7 @@ spec:
               {{- toYaml .valueFrom | nindent 14 }}
             {{- end }}
           {{- end }}
-        {{- end }}
+          {{- end }}
         {{- if .Values.app.envFrom }}
         envFrom:
           {{- toYaml .Values.app.envFrom | nindent 10 }}

--- a/services/ark-dashboard/chart/values.yaml
+++ b/services/ark-dashboard/chart/values.yaml
@@ -12,21 +12,21 @@ app:
     repository: ark-dashboard
     tag: latest
     pullPolicy: IfNotPresent
+
+  # Well-known config variables, usually set as environment variables
+  config:
+    nodeEnv: "production"
+    port: "3000"
+    hostname: "0.0.0.0"
+    arkApiService:
+      host: "ark-api.default.svc.cluster.local"
+      port: "80"
+      protocol: "http"
   
-  # Environment variables
-  env:
-    - name: NODE_ENV
-      value: "production"
-    - name: PORT
-      value: "3000"
-    - name: HOSTNAME
-      value: "0.0.0.0"
-    - name: ARK_API_SERVICE_HOST
-      value: "ark-api.default.svc.cluster.local"
-    - name: ARK_API_SERVICE_PORT
-      value: "80"
-    - name: ARK_API_SERVICE_PROTOCOL
-      value: "http"
+  # Other environment variables
+  env: {}
+    # - name: EXAMPLE_KEY
+    #   value: "example value"
   
   # Optional: Import entire secrets/configmaps as env vars
   # envFrom:


### PR DESCRIPTION
This is needed to make the values easily override-able. For example, to set the host of ark-api (if running in a non-default namespace), you can now set `app.config.arkApiService.host`, rather than fragile array overrides like `.app.env[3].value`.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 