### PR TITLE
docs: license link in contributing.md fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,4 +85,4 @@ Libraries and SDKs currently exist for:
 
 ## Guidelines for contributing developers
 
-Note that any contributions you make will be under the Agents At Scale [license](./LICENSE.md).
+Note that any contributions you make will be under the Agents At Scale [license](./LICENSE).


### PR DESCRIPTION
## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #88 