### PR TITLE
fix: `devspace dev` dashboard console errors

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -165,6 +165,9 @@ dev:
   ark-dashboard:
     imageSelector: ark-dashboard
     devImage: node:24-alpine
+    env:
+      - name: NODE_ENV
+        value: development
     command:
       [
         "sh",


### PR DESCRIPTION
## Description

When launching `devspace dev`, dashboard is failing to handle auth session API request calls and logging some errors:

<img width="939" height="813" alt="session" src="https://github.com/user-attachments/assets/9f1876cf-df27-4f57-8752-eaef7971fd40" />

Adding the correct NODE_ENV variable fixes it. 

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 