### PR TITLE
fix: missing QueryClientProvider issue, queries tab ui glitch

### DIFF
--- a/docs/content/reference/contributors.mdx
+++ b/docs/content/reference/contributors.mdx
@@ -2,9 +2,7 @@
 
 This project follows the [All Contributors](https://github.com/all-contributors/all-contributors) specification to recognize contributions of all kinds.
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-<iframe src={useBaseUrl('contributors.html')} style={{width: '100%', height: '300px', border: 0}} title="Contributors" />
+<iframe src="/contributors.html" style={{width: '100%', height: '300px', border: 0}} title="Contributors" />
 
 ## How to Add Contributors
 

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/layout.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/layout.tsx
@@ -1,12 +1,8 @@
 "use client"
 
-import ChatManager from "@/components/chat-manager";
-import { ChatProvider } from "@/lib/chat-context";
-import { Toaster } from "@/components/ui/toaster";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
 import { useAutoSignout } from "@/hooks/useAutoSignout";
 import { useRefreshAccessToken } from "@/hooks/useRefreshAccessToken";
+import { Providers } from "./providers";
 
 export default function DashboardLayout({
   children
@@ -16,14 +12,5 @@ export default function DashboardLayout({
   useAutoSignout()
   useRefreshAccessToken()
 
-  return (
-    <ChatProvider>
-      <SidebarProvider>
-        <AppSidebar />
-        <SidebarInset>{children}</SidebarInset>
-      </SidebarProvider>
-      <ChatManager />
-      <Toaster />
-    </ChatProvider>
-  );
+  return (<Providers>{children}</Providers>);
 }

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/providers.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/providers.tsx
@@ -2,11 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
-import { AppSidebar } from "../components/app-sidebar";
-import ChatManager from "../components/chat-manager";
-import { SidebarInset, SidebarProvider } from "../components/ui/sidebar";
-import { Toaster } from "../components/ui/toaster";
-import { ChatProvider } from "../lib/chat-context";
+import { AppSidebar } from "@/components/app-sidebar";
+import ChatManager from "@/components/chat-manager";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { Toaster } from "@/components/ui/toaster";
+import { ChatProvider } from "@/lib/chat-context";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   // Prevents QueryClient from being recreated on each render


### PR DESCRIPTION
Fixes:
- the missing QueryClientProvider issue in the ark-dashboard
- the queries tab having 2 versions overlapping each other on the ark-dashboard

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 

<img width="1920" height="1007" alt="Screenshot 2025-09-12 at 17 17 53" src="https://github.com/user-attachments/assets/3a71d8b0-71d5-4929-a847-2840b513d3bf" />

