### PR TITLE
fix: enable external PRs to use fork's container registry

### DIFF
--- a/.github/actions/setup-container-cache-registry/action.yml
+++ b/.github/actions/setup-container-cache-registry/action.yml
@@ -1,0 +1,79 @@
+name: 'Setup Container Cache Registry'
+description: 'Determines which container registry to use for caching images across CI/CD pipeline stages'
+
+inputs:
+  docker-cicd-cache-registry:
+    description: 'Override registry URL from repository variables'
+    required: false
+
+outputs:
+  ci-cache-registry:
+    description: 'Container registry URL to use for this workflow run'
+    value: ${{ steps.set-registry.outputs.ci-cache-registry }}
+  is-fork-pr:
+    description: 'Whether this is a PR from a forked repository'
+    value: ${{ steps.set-registry.outputs.is-fork-pr }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: set-registry
+      name: Determine Container Registry
+      shell: bash
+      run: |
+        # Container Registry Resolution
+        #
+        # This step determines which container registry to use for caching images,
+        # based on the PR source.
+        # 
+        # This is critical for supporting external contributors who cannot push to
+        # the main repository's GitHub Container Registry (ghcr.io).
+        # 1. External PR (from fork): Uses fork's registry (e.g., ghcr.io/username/repository-name)
+        # 2. Internal PR (branch in main repo): Uses organization registry (e.g., ghcr.io/mckinsey/agents-at-scale-ark)
+        # 3. Manual override: Respects DOCKER_CICD_CACHE_REGISTRY if set in repo variables
+        
+        # Show the current source repo.
+        echo "Event: ${{ github.event_name }}"
+        echo "Repository: ${{ github.repository }}"
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "PR Head Repo: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "PR Base Repo: ${{ github.event.pull_request.base.repo.full_name }}"
+          echo "PR Author: ${{ github.event.pull_request.user.login }}"
+        fi
+        
+        # Check if this is a PR from a fork
+        if [[ "${{ github.event_name }}" == "pull_request" ]] && \
+           [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          # EXTERNAL PR: Use the fork's registry
+          # The fork owner's GITHUB_TOKEN has write access to their own namespace
+          # Example: ghcr.io/forked-owner/forked-repo-name
+          REGISTRY="ghcr.io/${{ github.event.pull_request.head.repo.full_name }}"
+          IS_FORK_PR="true"
+          echo "External PR detected - using fork's registry: $REGISTRY"
+        else
+          # INTERNAL PR or PUSH: Use the organization's registry
+          # Default format: ghcr.io/organization/repository
+          REGISTRY="${{ inputs.docker-cicd-cache-registry || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}"
+          IS_FORK_PR="false"
+          echo "Internal event - using org registry: $REGISTRY"
+        fi
+        
+        # Output for use in other jobs
+        echo "ci-cache-registry=$REGISTRY" >> $GITHUB_OUTPUT
+        echo "is-fork-pr=$IS_FORK_PR" >> $GITHUB_OUTPUT
+        
+        # Brief summary for workflow run visibility
+        echo "### Container Registry Configuration" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| **Registry** | \`$REGISTRY\` |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Is Fork PR** | $IS_FORK_PR |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Event Type** | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| **Actor** | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+        
+        # Validation
+        if [[ -z "$REGISTRY" ]]; then
+          echo "ERROR: Registry could not be determined"
+          exit 1
+        fi

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -32,6 +32,19 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Setup job to determine container cache registry
+  setup-container-cache-registry:
+    runs-on: ubuntu-24.04
+    outputs:
+      ci-cache-registry: ${{ steps.setup-registry.outputs.ci-cache-registry }}
+      is-fork-pr: ${{ steps.setup-registry.outputs.is-fork-pr }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: setup-registry
+        uses: ./.github/actions/setup-container-cache-registry
+        with:
+          docker-cicd-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY }}
+
   # Security scan with JFrog Xray
   jfrog-xray-scan:
     runs-on: ubuntu-24.04
@@ -132,7 +145,7 @@ jobs:
           artifact-suffix: ark-api-a2a-unit
 
   build-containers:
-    needs: [build-libs]
+    needs: [setup-container-cache-registry, build-libs]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -177,7 +190,7 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
+          registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
           username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -186,7 +199,7 @@ jobs:
           path: ${{ matrix.path }}
           image: ${{ matrix.image }}
           tag: ${{ github.sha }}
-          registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
+          registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
           platforms: linux/amd64
           push: true
           prebuild: ${{ matrix.prebuild }}
@@ -211,7 +224,7 @@ jobs:
           retention-days: 30
 
   e2e-quickstart:
-    needs: [build-containers]
+    needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -321,7 +334,7 @@ jobs:
           fark agent sample-agent "confirm you have read this message"
 
   e2e-smoke-test:
-    needs: [build-containers]
+    needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -331,7 +344,7 @@ jobs:
           ark-image-tag: ${{ github.sha }}
           install-coverage: "false"
           install-evaluator: "false"
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
+          ci-cache-registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -448,7 +461,7 @@ jobs:
 
 
   e2e-tests-standard:
-    needs: [build-containers]
+    needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -458,7 +471,7 @@ jobs:
           ark-image-tag: ${{ github.sha }}
           install-coverage: "true"
           install-evaluator: "false" # Standard tests don't need evaluator
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
+          ci-cache-registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
@@ -486,7 +499,7 @@ jobs:
           artifact-name: coverage-reports-standard
 
   e2e-tests-evaluated:
-    needs: [build-containers]
+    needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -498,7 +511,7 @@ jobs:
           install-evaluator: "true" # Evaluated tests need ark-evaluator service
           azure-openai-key: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
           azure-openai-base-url: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
-          ci-cache-registry: ${{ vars.DOCKER_CICD_CACHE_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}
+          ci-cache-registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 

--- a/docs/content/operations-guide/build-pipelines.mdx
+++ b/docs/content/operations-guide/build-pipelines.mdx
@@ -11,6 +11,8 @@ description: Required secrets and environment variables for ARK CI/CD pipelines
 
 The CI/CD pipeline builds and tests all ARK components, services, and documentation on every push. It includes library builds, single-platform container builds (AMD64) for testing, E2E testing, and release preparation.
 
+The pipeline begins with a `setup-container-cache-registry` job that determines the container registry used to cache images across CI/CD pipeline stages - fork PRs use their own GitHub Container Registry namespace (e.g., `ghcr.io/username/agents-at-scale-ark`) while internal PRs use the organization's registry.
+
 ![CI/CD Pipeline](./images/cicd-pipeline.png)
 
 ### Deploy


### PR DESCRIPTION
## Summary
- Fix CI/CD pipeline failures for external contributors by dynamically selecting container registry
- Fork PRs use their own GHCR namespace while internal PRs use organization registry
- Add setup-pipeline job that determines the cache registry for all pipeline stages