### PR TITLE
fix: quickstart fark and ark-cli installation

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -133,7 +133,7 @@ quickstart() {
     # Check ark controller status, will warn the user if not deployed.
     check_ark_controller
 
-    # Add this webhook health check here
+    # Webhook health check
     echo "testing webhook connectivity..."
     if ! kubectl get agent sample-agent >/dev/null 2>&1; then
         echo -e "${yellow}warning${nc}: webhook may not be ready, restarting controller..."

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -72,8 +72,8 @@ quickstart() {
     check_tool "docker" "brew install --cask docker"
     check_tool "helm" "brew install helm"
     check_tool "npm" "brew install node && npm install -g typescript && npm i -D @types/node"
-    check_tool "fark" "build_and_install_fark"
-    check_tool "ark" "build_and_install_ark_cli"
+    check_tool "fark" "make fark-build && make fark-install"
+    check_tool "ark" "make ark-cli-install"
     check_tool "java" "brew install openjdk"
     check_tool "java" "brew install openjdk" "java -version"
     check_optional_tool "k9s" "brew install k9s"
@@ -132,6 +132,14 @@ quickstart() {
 
     # Check ark controller status, will warn the user if not deployed.
     check_ark_controller
+
+    # Add this webhook health check here
+    echo "testing webhook connectivity..."
+    if ! kubectl get agent sample-agent >/dev/null 2>&1; then
+        echo -e "${yellow}warning${nc}: webhook may not be ready, restarting controller..."
+        kubectl delete pod -l app.kubernetes.io/name=ark-controller -n ark-system
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ark-controller -n ark-system --timeout=60s
+    fi
 
     # Check for default model (cluster is now running and kubectl should work)
     if kubectl get model default >/dev/null 2>&1; then

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.31",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.31",
+      "version": "0.1.33",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
1. Fix tool installation(fark and ark-cli) in quickstart script - replace function calls with make targets
2. Fix webhook race condition by adding health check and controller pod restart to ensure TLS certificates are loaded before webhook service starts.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 