### PR TITLE
fix: add BaseURL support for Bedrock models

### DIFF
--- a/ark/api/v1alpha1/model_types.go
+++ b/ark/api/v1alpha1/model_types.go
@@ -43,6 +43,8 @@ type BedrockModelConfig struct {
 	// +kubebuilder:validation:Optional
 	Region *ValueSource `json:"region,omitempty"`
 	// +kubebuilder:validation:Optional
+	BaseURL *ValueSource `json:"baseUrl,omitempty"`
+	// +kubebuilder:validation:Optional
 	AccessKeyID *ValueSource `json:"accessKeyId,omitempty"`
 	// +kubebuilder:validation:Optional
 	SecretAccessKey *ValueSource `json:"secretAccessKey,omitempty"`

--- a/ark/config/crd/bases/ark.mckinsey.com_models.yaml
+++ b/ark/config/crd/bases/ark.mckinsey.com_models.yaml
@@ -466,6 +466,86 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      baseUrl:
+                        description: ValueSource represents a source for a configuration
+                          value
+                        properties:
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key from a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceRef:
+                                properties:
+                                  name:
+                                    description: Name of the service
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the service. Defaults
+                                      to the namespace as the resource.
+                                    type: string
+                                  path:
+                                    description: Optional path to append to the service
+                                      address. For models might be 'v1', for gemini
+                                      might be 'v1beta/openai', for mcp servers might
+                                      be 'mcp'.
+                                    type: string
+                                  port:
+                                    description: Port name to use. If not specified,
+                                      uses the service's only port or first port.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                        type: object
                       maxTokens:
                         maximum: 100000
                         minimum: 1

--- a/ark/internal/genai/model_bedrock.go
+++ b/ark/internal/genai/model_bedrock.go
@@ -14,6 +14,7 @@ func loadBedrockConfig(ctx context.Context, resolver *common.ValueSourceResolver
 	}
 
 	region := resolveOptionalValue(ctx, resolver, config.Region, namespace)
+	baseURL := resolveOptionalValue(ctx, resolver, config.BaseURL, namespace)
 	accessKeyID := resolveOptionalValue(ctx, resolver, config.AccessKeyID, namespace)
 	secretAccessKey := resolveOptionalValue(ctx, resolver, config.SecretAccessKey, namespace)
 	sessionToken := resolveOptionalValue(ctx, resolver, config.SessionToken, namespace)
@@ -45,7 +46,7 @@ func loadBedrockConfig(ctx context.Context, resolver *common.ValueSourceResolver
 		properties["temperature"] = *config.Temperature
 	}
 
-	bedrockModel := NewBedrockModel(modelName, region, accessKeyID, secretAccessKey, sessionToken, modelArn, properties)
+	bedrockModel := NewBedrockModel(modelName, region, baseURL, accessKeyID, secretAccessKey, sessionToken, modelArn, properties)
 	model.Provider = bedrockModel
 	model.Properties = properties
 

--- a/ark/internal/genai/provider_bedrock.go
+++ b/ark/internal/genai/provider_bedrock.go
@@ -17,6 +17,7 @@ import (
 type BedrockModel struct {
 	Model           string
 	Region          string
+	BaseURL         string
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
@@ -64,10 +65,11 @@ type bedrockContent struct {
 	Input map[string]interface{} `json:"input,omitempty"`
 }
 
-func NewBedrockModel(model, region, accessKeyID, secretAccessKey, sessionToken, modelArn string, properties map[string]string) *BedrockModel {
+func NewBedrockModel(model, region, baseURL, accessKeyID, secretAccessKey, sessionToken, modelArn string, properties map[string]string) *BedrockModel {
 	return &BedrockModel{
 		Model:           model,
 		Region:          region,
+		BaseURL:         baseURL,
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
 		SessionToken:    sessionToken,
@@ -93,6 +95,11 @@ func (bm *BedrockModel) initClient(ctx context.Context) error {
 
 	if err != nil {
 		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	// If BaseURL is provided, use it as custom endpoint
+	if bm.BaseURL != "" {
+		cfg.BaseEndpoint = aws.String(bm.BaseURL)
 	}
 
 	bm.client = bedrockruntime.NewFromConfig(cfg)
@@ -315,6 +322,9 @@ func (bm *BedrockModel) BuildConfig() map[string]any {
 
 	if bm.Region != "" {
 		cfg["region"] = bm.Region
+	}
+	if bm.BaseURL != "" {
+		cfg["baseUrl"] = bm.BaseURL
 	}
 	if bm.AccessKeyID != "" {
 		cfg["accessKeyId"] = bm.AccessKeyID


### PR DESCRIPTION
## Summary
- Add BaseURL field to BedrockModelConfig for AI Gateway support
- Update Bedrock provider to use custom endpoint when BaseURL provided
- Fix ChatCompletion method signatures to match interface
- Generate CRD with new baseUrl field

This allows Bedrock models to use custom endpoints like AI Gateway for monitoring, access control, and rate limiting.

Example usage:
```yaml
apiVersion: ark.mckinsey.com/v1alpha1
kind: Model
metadata:
  name: claude-haiku
spec:
  type: bedrock
  model:
    value: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
  config:
    bedrock:
      baseUrl:
        value: "https://aws-bedrock.prod.ai-gateway.quantumblack.com/your-project-id"
```

Fixes: ARKQB-252

<img width="819" height="550" alt="image" src="https://github.com/user-attachments/assets/c8e1fe9a-8b1f-4a19-b54f-563bbb45d027" />
