### PR TITLE
fix: add multi-platform fark binaries to releases and improve installation docs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -847,6 +847,49 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  release-fark:
+    needs: [check-release]
+    runs-on: ubuntu-24.04
+    if: ${{ needs.check-release.outputs.released && github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for goreleaser changelog
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --skip=publish
+          workdir: ./tools/fark
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ needs.check-release.outputs.tag }}
+
+      - name: Upload fark binaries to release
+        run: |
+          RELEASE_TAG="${{ needs.check-release.outputs.tag }}"
+          echo "Attaching fark binaries to release: $RELEASE_TAG"
+
+          # Upload all generated archives
+          find ./tools/fark/dist -name "*.tar.gz" -o -name "*.zip" | while read archive; do
+            echo "Uploading $(basename "$archive")"
+            gh release upload "$RELEASE_TAG" "$archive" --clobber
+          done
+
+          # Upload checksums file
+          if [ -f "./tools/fark/dist/checksums.txt" ]; then
+            gh release upload "$RELEASE_TAG" "./tools/fark/dist/checksums.txt" --clobber
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   run-deploy-workflow:
     needs: [check-release]
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 scratch.md
 .ark.env
 .env
-services/fark/fark
-services/ark/ark
+tools/fark/fark
 services/a2agw/a2agw
 .artifacts/
 local.mk

--- a/docs/content/developer-guide/cli-tools.mdx
+++ b/docs/content/developer-guide/cli-tools.mdx
@@ -27,8 +27,24 @@ Essential tool for managing Kubernetes clusters and ARK resources.
 
 ### Installation
 
+#### From GitHub Release (Recommended)
 ```bash
-# Build and install from repository root
+# Download latest release for your platform
+# Linux/macOS
+curl -L https://github.com/mckinsey/agents-at-scale-ark/releases/latest/download/fark_$(uname)_$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/').tar.gz | tar xz
+sudo mv fark /usr/local/bin/
+
+# Windows: Download fark_Windows_x86_64.zip from releases page
+
+# Verify installation
+fark --help
+```
+
+#### From Source
+```bash
+# Clone and build from repository
+git clone https://github.com/mckinsey/agents-at-scale-ark.git
+cd agents-at-scale-ark
 make fark-install
 
 # Verify installation

--- a/tools/fark/.goreleaser.yaml
+++ b/tools/fark/.goreleaser.yaml
@@ -71,6 +71,3 @@ changelog:
       order: 1
     - title: Others
       order: 999
-
-# Release section removed - handled by CI/CD workflow
-# The CI/CD workflow builds binaries and uploads them to the existing release

--- a/tools/fark/.goreleaser.yaml
+++ b/tools/fark/.goreleaser.yaml
@@ -35,7 +35,7 @@ archives:
     ids:
       - fark
     name_template: >-
-      fark-cli_
+      fark_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -44,9 +44,6 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    files:
-      - README.md
-      - LICENSE*
 
 checksum:
   name_template: 'checksums.txt'
@@ -75,35 +72,5 @@ changelog:
     - title: Others
       order: 999
 
-release:
-  github:
-    owner: McK-Internal
-    name: agents-at-scale
-  name_template: "Ark CLI {{.Tag}}"
-  header: |
-    ## Ark CLI Release {{.Tag}}
-    
-    This release contains the Ark CLI binary for multiple platforms.
-    
-    ### Installation
-    
-    Download the appropriate binary for your platform from the assets below.
-    
-    #### Linux/macOS
-    ```bash
-    # Download and install (replace URL with actual release URL)
-    curl -L -o fark https://github.com/McK-Internal/agents-at-scale/releases/download/{{.Tag}}/fark-cli_Linux_x86_64.tar.gz
-    tar -xzf fark-cli_Linux_x86_64.tar.gz
-    chmod +x fark
-    sudo mv fark /usr/local/bin/
-    ```
-    
-    #### Windows
-    Download the `fark-cli_Windows_x86_64.zip` file and extract the `fark.exe` binary.
-    
-  footer: |
-    ## Checksums
-    
-    All checksums are available in the `checksums.txt` file.
-    
-    **Full Changelog**: https://github.com/McK-Internal/agents-at-scale/compare/{{.PreviousTag}}...{{.Tag}}
+# Release section removed - handled by CI/CD workflow
+# The CI/CD workflow builds binaries and uploads them to the existing release

--- a/tools/fark/README.md
+++ b/tools/fark/README.md
@@ -2,10 +2,29 @@
 
 CLI tool and HTTP API for querying ARK agents, teams, and models.
 
-## Quickstart
+## Installation
+
+### From GitHub Release (Recommended)
+```bash
+# Download latest release for your platform
+# Linux/macOS (replace Darwin with Linux for Linux systems)
+curl -L https://github.com/mckinsey/agents-at-scale-ark/releases/latest/download/fark_$(uname)_$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/').tar.gz | tar xz
+sudo mv fark /usr/local/bin/
+
+# Windows: Download fark_Windows_x86_64.zip from releases page
+```
+
+### From Source
+```bash
+# Clone and build locally
+git clone https://github.com/mckinsey/agents-at-scale-ark.git
+cd agents-at-scale-ark
+make fark-install  # Builds and installs to ~/.local/bin
+```
+
+### Development
 ```bash
 make help          # Show available commands
-make fark-install  # Install CLI binary to /usr/local/bin
 make fark-dev      # Run in development mode
 ```
 


### PR DESCRIPTION
- Multi-platform fark binary releases for Linux/macOS/Windows
- Remove tracked fark binary from git and improve documentation

When a new release is created, fark binaries will automatically be built and attached for:
- Linux (amd64, arm64)
- macOS (amd64 Intel, arm64 Apple Silicon)  
- Windows (amd64)

Docs updated.