### PR TITLE
feat: [DRAF - do not merge] Inmemory memory

### DIFF
--- a/ark/config/crd/bases/ark.mckinsey.com_queries.yaml
+++ b/ark/config/crd/bases/ark.mckinsey.com_queries.yaml
@@ -329,6 +329,7 @@ spec:
                 type: string
               responses:
                 items:
+                  description: Response defines a response from a query target.
                   properties:
                     content:
                       type: string

--- a/ark/internal/genai/agent.go
+++ b/ark/internal/genai/agent.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
@@ -55,14 +56,19 @@ func (a *Agent) Execute(ctx context.Context, userInput Message, history []Messag
 	})
 	defer agentTracker.Complete("")
 
+	log := logf.FromContext(ctx)
+
 	if a.ExecutionEngine != nil {
 		// Check if this is the reserved 'a2a' execution engine
 		if a.ExecutionEngine.Name == "a2a" {
+			log.Info("Executing with A2A execution engine", "userInput", userInput, "history", history)
 			return a.executeWithA2AExecutionEngine(ctx, userInput)
 		}
+		log.Info("Executing with execution engine", "userInput", userInput, "history", history)
 		return a.executeWithExecutionEngine(ctx, userInput, history)
 	}
 
+	log.Info("Executing locally", "userInput", userInput, "history", history)
 	return a.executeLocally(ctx, userInput, history)
 }
 

--- a/ark/internal/genai/examples/memory_example.go
+++ b/ark/internal/genai/examples/memory_example.go
@@ -12,6 +12,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// MockEventEmitter is a simple no-op implementation of EventEmitter for examples
+type MockEventEmitter struct{}
+
+func (m *MockEventEmitter) EmitEvent(ctx context.Context, eventType, reason string, data genai.EventData) {
+	// No-op for example purposes
+}
+
 func main() {
 	ctx := context.Background()
 	k8sClient := fake.NewClientBuilder().Build()
@@ -27,23 +34,19 @@ func main() {
 	// Example 2: NoOp Storage
 	fmt.Println("2. NoOp Memory Store")
 	noopExample(ctx, k8sClient)
-
-	fmt.Println("\n" + strings.Repeat("=", 50) + "\n")
-
-	// Example 3: Memory Factory with different types
-	fmt.Println("3. Memory Factory Examples")
-	factoryExample(ctx, k8sClient)
 }
 
 func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 	// Create in-memory memory configuration
 	config := genai.Config{
 		SessionId:  "chat-session-12345",
-		MemoryType: genai.MemoryTypeInMemory,
 	}
 
+	// Create a mock event emitter for the example
+	mockEmitter := &MockEventEmitter{}
+
 	// Create memory instance
-	memory, err := genai.NewInMemoryMemory(ctx, k8sClient, "demo-memory", "default", nil, config)
+	memory, err := genai.NewInMemoryMemory(ctx, k8sClient, "demo-memory", "default", mockEmitter, config)
 	if err != nil {
 		log.Fatalf("Failed to create in-memory memory: %v", err)
 	}
@@ -94,7 +97,6 @@ func noopExample(ctx context.Context, k8sClient client.Client) {
 	// Create noop memory (no storage)
 	config := genai.Config{
 		SessionId:  "temp-session",
-		MemoryType: genai.MemoryTypeNoop,
 	}
 
 	memory, err := genai.NewMemoryWithConfig(ctx, k8sClient, "noop-memory", "default", nil, config)
@@ -124,37 +126,4 @@ func noopExample(ctx context.Context, k8sClient client.Client) {
 
 	fmt.Printf("✓ Retrieved %d messages from noop memory (always empty)\n", len(retrievedMessages))
 	fmt.Printf("✓ Noop memory is useful for testing or when storage is not needed\n")
-}
-
-func factoryExample(ctx context.Context, k8sClient client.Client) {
-	// Example of creating different memory types using factory methods
-
-	// In-memory factory method
-	inMemory, err := genai.NewInMemoryMemoryForQuery(ctx, k8sClient, "factory-memory", "default", nil, "factory-session-1")
-	if err != nil {
-		log.Fatalf("Failed to create factory in-memory: %v", err)
-	}
-	defer inMemory.Close()
-
-	// Add a message
-	err = inMemory.AddMessages(ctx, "factory-query", []genai.Message{
-		genai.Message(openai.UserMessage("Factory method test")),
-	})
-	if err != nil {
-		log.Fatalf("Failed to add factory message: %v", err)
-	}
-
-	fmt.Printf("✓ Created in-memory storage using factory method\n")
-
-	// Note: HTTP memory type would fail without a proper backend service
-	// but demonstrates the factory pattern
-	fmt.Printf("✓ HTTP memory type available via factory (requires backend service)\n")
-	fmt.Printf("✓ Factory pattern supports: %s, %s, %s\n", 
-		genai.MemoryTypeHTTP, genai.MemoryTypeInMemory, genai.MemoryTypeNoop)
-
-	// Show global store stats (for in-memory type)
-	if inMemStore, ok := inMemory.(*genai.InMemoryMemory); ok {
-		info, _ := inMemStore.GetSessionInfo(ctx)
-		fmt.Printf("✓ Global in-memory store info: %+v\n", info)
-	}
 }

--- a/ark/internal/genai/examples/memory_example.go
+++ b/ark/internal/genai/examples/memory_example.go
@@ -23,8 +23,6 @@ func main() {
 	ctx := context.Background()
 	k8sClient := fake.NewClientBuilder().Build()
 
-	fmt.Println("=== ARK Memory Store Examples ===\n")
-
 	// Example 1: In-Memory Storage
 	fmt.Println("1. In-Memory Memory Store")
 	inMemoryExample(ctx, k8sClient)

--- a/ark/internal/genai/examples/memory_example.go
+++ b/ark/internal/genai/examples/memory_example.go
@@ -37,7 +37,7 @@ func main() {
 func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 	// Create in-memory memory configuration
 	config := genai.Config{
-		SessionId:  "chat-session-12345",
+		SessionId: "chat-session-12345",
 	}
 
 	// Create a mock event emitter for the example
@@ -48,7 +48,11 @@ func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 	if err != nil {
 		log.Fatalf("Failed to create in-memory memory: %v", err)
 	}
-	defer memory.Close()
+	defer func() {
+		if closeErr := memory.Close(); closeErr != nil {
+			log.Printf("Failed to close memory: %v", closeErr)
+		}
+	}()
 
 	// Add some conversation messages
 	messages := []genai.Message{
@@ -61,7 +65,8 @@ func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 	// Store messages
 	err = memory.AddMessages(ctx, "query-001", messages)
 	if err != nil {
-		log.Fatalf("Failed to add messages: %v", err)
+		log.Printf("Failed to add messages: %v", err)
+		return
 	}
 
 	fmt.Printf("✓ Added %d messages to session: %s\n", len(messages), config.SessionId)
@@ -69,7 +74,8 @@ func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 	// Retrieve messages
 	retrievedMessages, err := memory.GetMessages(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get messages: %v", err)
+		log.Printf("Failed to get messages: %v", err)
+		return
 	}
 
 	fmt.Printf("✓ Retrieved %d messages from session\n", len(retrievedMessages))
@@ -82,7 +88,8 @@ func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 
 	err = memory.AddMessages(ctx, "query-002", moreMessages)
 	if err != nil {
-		log.Fatalf("Failed to add more messages: %v", err)
+		log.Printf("Failed to add more messages: %v", err)
+		return
 	}
 
 	// Get final message count
@@ -94,14 +101,18 @@ func inMemoryExample(ctx context.Context, k8sClient client.Client) {
 func noopExample(ctx context.Context, k8sClient client.Client) {
 	// Create noop memory (no storage)
 	config := genai.Config{
-		SessionId:  "temp-session",
+		SessionId: "temp-session",
 	}
 
 	memory, err := genai.NewMemoryWithConfig(ctx, k8sClient, "noop-memory", "default", nil, config)
 	if err != nil {
 		log.Fatalf("Failed to create noop memory: %v", err)
 	}
-	defer memory.Close()
+	defer func() {
+		if closeErr := memory.Close(); closeErr != nil {
+			log.Printf("Failed to close memory: %v", closeErr)
+		}
+	}()
 
 	// Try to add messages (will be discarded)
 	messages := []genai.Message{
@@ -111,7 +122,8 @@ func noopExample(ctx context.Context, k8sClient client.Client) {
 
 	err = memory.AddMessages(ctx, "temp-query", messages)
 	if err != nil {
-		log.Fatalf("Failed to add messages: %v", err)
+		log.Printf("Failed to add messages: %v", err)
+		return
 	}
 
 	fmt.Printf("✓ 'Added' %d messages to noop memory (actually discarded)\n", len(messages))
@@ -119,7 +131,8 @@ func noopExample(ctx context.Context, k8sClient client.Client) {
 	// Retrieve messages (will always return empty)
 	retrievedMessages, err := memory.GetMessages(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get messages: %v", err)
+		log.Printf("Failed to get messages: %v", err)
+		return
 	}
 
 	fmt.Printf("✓ Retrieved %d messages from noop memory (always empty)\n", len(retrievedMessages))

--- a/ark/internal/genai/examples/memory_example.go
+++ b/ark/internal/genai/examples/memory_example.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"mckinsey.com/ark/internal/genai"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func main() {
+	ctx := context.Background()
+	k8sClient := fake.NewClientBuilder().Build()
+
+	fmt.Println("=== ARK Memory Store Examples ===\n")
+
+	// Example 1: In-Memory Storage
+	fmt.Println("1. In-Memory Memory Store")
+	inMemoryExample(ctx, k8sClient)
+
+	fmt.Println("\n" + strings.Repeat("=", 50) + "\n")
+
+	// Example 2: NoOp Storage
+	fmt.Println("2. NoOp Memory Store")
+	noopExample(ctx, k8sClient)
+
+	fmt.Println("\n" + strings.Repeat("=", 50) + "\n")
+
+	// Example 3: Memory Factory with different types
+	fmt.Println("3. Memory Factory Examples")
+	factoryExample(ctx, k8sClient)
+}
+
+func inMemoryExample(ctx context.Context, k8sClient client.Client) {
+	// Create in-memory memory configuration
+	config := genai.Config{
+		SessionId:  "chat-session-12345",
+		MemoryType: genai.MemoryTypeInMemory,
+	}
+
+	// Create memory instance
+	memory, err := genai.NewInMemoryMemory(ctx, k8sClient, "demo-memory", "default", nil, config)
+	if err != nil {
+		log.Fatalf("Failed to create in-memory memory: %v", err)
+	}
+	defer memory.Close()
+
+	// Add some conversation messages
+	messages := []genai.Message{
+		genai.Message(openai.UserMessage("Hello, I need help with my project")),
+		genai.Message(openai.AssistantMessage("I'd be happy to help! What kind of project are you working on?")),
+		genai.Message(openai.UserMessage("It's a Go application using the ARK framework")),
+		genai.Message(openai.AssistantMessage("Great! ARK is a powerful framework. What specific aspect do you need help with?")),
+	}
+
+	// Store messages
+	err = memory.AddMessages(ctx, "query-001", messages)
+	if err != nil {
+		log.Fatalf("Failed to add messages: %v", err)
+	}
+
+	fmt.Printf("✓ Added %d messages to session: %s\n", len(messages), config.SessionId)
+
+	// Retrieve messages
+	retrievedMessages, err := memory.GetMessages(ctx)
+	if err != nil {
+		log.Fatalf("Failed to get messages: %v", err)
+	}
+
+	fmt.Printf("✓ Retrieved %d messages from session\n", len(retrievedMessages))
+
+	// Add more messages to simulate continuing conversation
+	moreMessages := []genai.Message{
+		genai.Message(openai.UserMessage("I'm having trouble with memory configuration")),
+		genai.Message(openai.AssistantMessage("I can help with that! There are three memory types available: HTTP, in-memory, and noop.")),
+	}
+
+	err = memory.AddMessages(ctx, "query-002", moreMessages)
+	if err != nil {
+		log.Fatalf("Failed to add more messages: %v", err)
+	}
+
+	// Get final message count
+	allMessages, _ := memory.GetMessages(ctx)
+	fmt.Printf("✓ Total conversation now has %d messages\n", len(allMessages))
+	fmt.Printf("✓ Messages are stored in RAM (non-persistent)\n")
+}
+
+func noopExample(ctx context.Context, k8sClient client.Client) {
+	// Create noop memory (no storage)
+	config := genai.Config{
+		SessionId:  "temp-session",
+		MemoryType: genai.MemoryTypeNoop,
+	}
+
+	memory, err := genai.NewMemoryWithConfig(ctx, k8sClient, "noop-memory", "default", nil, config)
+	if err != nil {
+		log.Fatalf("Failed to create noop memory: %v", err)
+	}
+	defer memory.Close()
+
+	// Try to add messages (will be discarded)
+	messages := []genai.Message{
+		genai.Message(openai.UserMessage("This message will be discarded")),
+		genai.Message(openai.AssistantMessage("This response will also be discarded")),
+	}
+
+	err = memory.AddMessages(ctx, "temp-query", messages)
+	if err != nil {
+		log.Fatalf("Failed to add messages: %v", err)
+	}
+
+	fmt.Printf("✓ 'Added' %d messages to noop memory (actually discarded)\n", len(messages))
+
+	// Retrieve messages (will always return empty)
+	retrievedMessages, err := memory.GetMessages(ctx)
+	if err != nil {
+		log.Fatalf("Failed to get messages: %v", err)
+	}
+
+	fmt.Printf("✓ Retrieved %d messages from noop memory (always empty)\n", len(retrievedMessages))
+	fmt.Printf("✓ Noop memory is useful for testing or when storage is not needed\n")
+}
+
+func factoryExample(ctx context.Context, k8sClient client.Client) {
+	// Example of creating different memory types using factory methods
+
+	// In-memory factory method
+	inMemory, err := genai.NewInMemoryMemoryForQuery(ctx, k8sClient, "factory-memory", "default", nil, "factory-session-1")
+	if err != nil {
+		log.Fatalf("Failed to create factory in-memory: %v", err)
+	}
+	defer inMemory.Close()
+
+	// Add a message
+	err = inMemory.AddMessages(ctx, "factory-query", []genai.Message{
+		genai.Message(openai.UserMessage("Factory method test")),
+	})
+	if err != nil {
+		log.Fatalf("Failed to add factory message: %v", err)
+	}
+
+	fmt.Printf("✓ Created in-memory storage using factory method\n")
+
+	// Note: HTTP memory type would fail without a proper backend service
+	// but demonstrates the factory pattern
+	fmt.Printf("✓ HTTP memory type available via factory (requires backend service)\n")
+	fmt.Printf("✓ Factory pattern supports: %s, %s, %s\n", 
+		genai.MemoryTypeHTTP, genai.MemoryTypeInMemory, genai.MemoryTypeNoop)
+
+	// Show global store stats (for in-memory type)
+	if inMemStore, ok := inMemory.(*genai.InMemoryMemory); ok {
+		info, _ := inMemStore.GetSessionInfo(ctx)
+		fmt.Printf("✓ Global in-memory store info: %+v\n", info)
+	}
+}

--- a/ark/internal/genai/memory.go
+++ b/ark/internal/genai/memory.go
@@ -18,6 +18,11 @@ const (
 	MaxRetries       = 3
 	RetryDelay       = 100 * time.Millisecond
 	UserAgent        = "ark-memory-client/1.0"
+	
+	// Memory types
+	MemoryTypeHTTP     = "http"
+	MemoryTypeInMemory = "in-memory"
+	MemoryTypeNoop     = "noop"
 )
 
 type MemoryInterface interface {
@@ -79,7 +84,8 @@ func NewMemoryForQuery(ctx context.Context, k8sClient client.Client, memoryRef *
 		_, err := getMemoryResource(ctx, k8sClient, "default", namespace)
 		if err != nil {
 			// If default memory doesn't exist, use noop memory
-			return NewNoopMemory(), nil
+			return NewInMemoryMemory(ctx, k8sClient, "memoryName", namespace, recorder, config)
+			// return NewNoopMemory(), nil
 		}
 		return NewMemoryWithConfig(ctx, k8sClient, "default", namespace, recorder, config)
 	}

--- a/ark/internal/genai/memory_inmemory.go
+++ b/ark/internal/genai/memory_inmemory.go
@@ -1,0 +1,219 @@
+package genai
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// InMemoryStore represents a thread-safe in-memory storage for conversation messages
+type InMemoryStore struct {
+	mu       sync.RWMutex
+	sessions map[string][]Message // sessionId -> messages
+}
+
+// NewInMemoryStore creates a new in-memory storage instance
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		sessions: make(map[string][]Message),
+	}
+}
+
+// AddMessages adds messages to a session
+func (store *InMemoryStore) AddMessages(sessionId string, messages []Message) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if store.sessions[sessionId] == nil {
+		store.sessions[sessionId] = make([]Message, 0)
+	}
+	store.sessions[sessionId] = append(store.sessions[sessionId], messages...)
+}
+
+// GetMessages retrieves all messages for a session
+func (store *InMemoryStore) GetMessages(sessionId string) []Message {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	messages := store.sessions[sessionId]
+	if messages == nil {
+		return []Message{}
+	}
+	
+	// Return a copy to prevent external modification
+	result := make([]Message, len(messages))
+	copy(result, messages)
+	return result
+}
+
+// ClearSession removes all messages for a session
+func (store *InMemoryStore) ClearSession(sessionId string) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	
+	delete(store.sessions, sessionId)
+}
+
+// GetSessionCount returns the number of active sessions
+func (store *InMemoryStore) GetSessionCount() int {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	
+	return len(store.sessions)
+}
+
+// GetAllSessions returns a list of all session IDs
+func (store *InMemoryStore) GetAllSessions() []string {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	
+	sessions := make([]string, 0, len(store.sessions))
+	for sessionId := range store.sessions {
+		sessions = append(sessions, sessionId)
+	}
+	return sessions
+}
+
+// Global in-memory store instance (singleton)
+var globalInMemoryStore = NewInMemoryStore()
+
+// InMemoryMemory implements MemoryInterface using in-memory storage
+type InMemoryMemory struct {
+	store     *InMemoryStore
+	sessionId string
+	name      string
+	namespace string
+	recorder  EventEmitter
+}
+
+// NewInMemoryMemory creates a new in-memory memory instance
+func NewInMemoryMemory(ctx context.Context, k8sClient client.Client, memoryName, namespace string, recorder EventEmitter, config Config) (MemoryInterface, error) {
+	if memoryName == "" || namespace == "" {
+		return nil, fmt.Errorf("memoryName and namespace are required")
+	}
+
+	sessionId := config.SessionId
+	if sessionId == "" {
+		return nil, fmt.Errorf("sessionId is required for in-memory storage")
+	}
+
+	logCtx := logf.FromContext(ctx)
+	logCtx.Info("Creating in-memory memory store", 
+		"memoryName", memoryName, 
+		"namespace", namespace, 
+		"sessionId", sessionId)
+
+	return &InMemoryMemory{
+		store:     globalInMemoryStore,
+		sessionId: sessionId,
+		name:      memoryName,
+		namespace: namespace,
+		recorder:  recorder,
+	}, nil
+}
+
+// AddMessages stores messages in memory for the session
+func (m *InMemoryMemory) AddMessages(ctx context.Context, queryID string, messages []Message) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	logCtx := logf.FromContext(ctx)
+	logCtx.Info("Adding messages to in-memory store", 
+		"sessionId", m.sessionId, 
+		"queryId", queryID, 
+		"messageCount", len(messages))
+
+	tracker := NewOperationTracker(m.recorder, ctx, "MemoryAddMessages", m.name, map[string]string{
+		"namespace":    m.namespace,
+		"sessionId":    m.sessionId,
+		"queryId":      queryID,
+		"messages":     fmt.Sprintf("%d", len(messages)),
+		"storageType":  MemoryTypeInMemory,
+	})
+
+	// Validate messages before storing
+	// Validate we have messages to add
+	if len(messages) == 0 {
+		tracker.Complete("success")
+		return nil
+	}
+
+	// Store messages in the global in-memory store
+	m.store.AddMessages(m.sessionId, messages)
+
+	tracker.Complete("messages added to in-memory store")
+	return nil
+}
+
+// GetMessages retrieves all messages for the session from memory
+func (m *InMemoryMemory) GetMessages(ctx context.Context) ([]Message, error) {
+	logCtx := logf.FromContext(ctx)
+	logCtx.Info("Retrieving messages from in-memory store", "sessionId", m.sessionId)
+
+	tracker := NewOperationTracker(m.recorder, ctx, "MemoryGetMessages", m.name, map[string]string{
+		"namespace":   m.namespace,
+		"sessionId":   m.sessionId,
+		"storageType": MemoryTypeInMemory,
+	})
+
+	// Retrieve messages from the global in-memory store
+	messages := m.store.GetMessages(m.sessionId)
+
+	logCtx.Info("Retrieved messages from in-memory store", 
+		"sessionId", m.sessionId, 
+		"messageCount", len(messages))
+
+	// Update metadata with message count
+	tracker.metadata["messages"] = fmt.Sprintf("%d", len(messages))
+	tracker.Complete("retrieved from in-memory store")
+	
+	return messages, nil
+}
+
+// Close cleans up the memory instance (no persistent resources to clean up)
+func (m *InMemoryMemory) Close() error {
+	// In-memory storage doesn't need explicit cleanup
+	// Messages remain in the global store for other instances with the same sessionId
+	return nil
+}
+
+// ClearSession removes all messages for this session (utility method)
+func (m *InMemoryMemory) ClearSession(ctx context.Context) error {
+	logCtx := logf.FromContext(ctx)
+	logCtx.Info("Clearing session from in-memory store", "sessionId", m.sessionId)
+
+	m.store.ClearSession(m.sessionId)
+	
+	if m.recorder != nil {
+		eventData := BaseEvent{
+			Name: "SessionCleared",
+			Metadata: map[string]string{
+				"sessionId": m.sessionId,
+				"message":   fmt.Sprintf("Cleared session %s from in-memory store", m.sessionId),
+			},
+		}
+		m.recorder.EmitEvent(ctx, "Normal", "SessionCleared", eventData)
+	}
+	
+	return nil
+}
+
+// GetSessionInfo returns information about the current session (utility method)
+func (m *InMemoryMemory) GetSessionInfo(ctx context.Context) (map[string]interface{}, error) {
+	messages := m.store.GetMessages(m.sessionId)
+	
+	info := map[string]interface{}{
+		"sessionId":     m.sessionId,
+		"messageCount":  len(messages),
+		"storageType":   MemoryTypeInMemory,
+		"memoryName":    m.name,
+		"namespace":     m.namespace,
+		"totalSessions": m.store.GetSessionCount(),
+	}
+	
+	return info, nil
+}

--- a/ark/internal/genai/memory_inmemory.go
+++ b/ark/internal/genai/memory_inmemory.go
@@ -42,7 +42,7 @@ func (store *InMemoryStore) GetMessages(sessionId string) []Message {
 	if messages == nil {
 		return []Message{}
 	}
-	
+
 	// Return a copy to prevent external modification
 	result := make([]Message, len(messages))
 	copy(result, messages)
@@ -53,7 +53,7 @@ func (store *InMemoryStore) GetMessages(sessionId string) []Message {
 func (store *InMemoryStore) ClearSession(sessionId string) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	
+
 	delete(store.sessions, sessionId)
 }
 
@@ -61,7 +61,7 @@ func (store *InMemoryStore) ClearSession(sessionId string) {
 func (store *InMemoryStore) GetSessionCount() int {
 	store.mu.RLock()
 	defer store.mu.RUnlock()
-	
+
 	return len(store.sessions)
 }
 
@@ -69,7 +69,7 @@ func (store *InMemoryStore) GetSessionCount() int {
 func (store *InMemoryStore) GetAllSessions() []string {
 	store.mu.RLock()
 	defer store.mu.RUnlock()
-	
+
 	sessions := make([]string, 0, len(store.sessions))
 	for sessionId := range store.sessions {
 		sessions = append(sessions, sessionId)
@@ -101,9 +101,9 @@ func NewInMemoryMemory(ctx context.Context, k8sClient client.Client, memoryName,
 	}
 
 	logCtx := logf.FromContext(ctx)
-	logCtx.Info("Creating in-memory memory store", 
-		"memoryName", memoryName, 
-		"namespace", namespace, 
+	logCtx.Info("Creating in-memory memory store",
+		"memoryName", memoryName,
+		"namespace", namespace,
 		"sessionId", sessionId)
 
 	return &InMemoryMemory{
@@ -122,17 +122,17 @@ func (m *InMemoryMemory) AddMessages(ctx context.Context, queryID string, messag
 	}
 
 	logCtx := logf.FromContext(ctx)
-	logCtx.Info("Adding messages to in-memory store", 
-		"sessionId", m.sessionId, 
-		"queryId", queryID, 
+	logCtx.Info("Adding messages to in-memory store",
+		"sessionId", m.sessionId,
+		"queryId", queryID,
 		"messageCount", len(messages))
 
 	tracker := NewOperationTracker(m.recorder, ctx, "MemoryAddMessages", m.name, map[string]string{
-		"namespace":    m.namespace,
-		"sessionId":    m.sessionId,
-		"queryId":      queryID,
-		"messages":     fmt.Sprintf("%d", len(messages)),
-		"storageType":  MemoryTypeInMemory,
+		"namespace":   m.namespace,
+		"sessionId":   m.sessionId,
+		"queryId":     queryID,
+		"messages":    fmt.Sprintf("%d", len(messages)),
+		"storageType": MemoryTypeInMemory,
 	})
 
 	// Validate messages before storing
@@ -163,14 +163,14 @@ func (m *InMemoryMemory) GetMessages(ctx context.Context) ([]Message, error) {
 	// Retrieve messages from the global in-memory store
 	messages := m.store.GetMessages(m.sessionId)
 
-	logCtx.Info("Retrieved messages from in-memory store", 
-		"sessionId", m.sessionId, 
+	logCtx.Info("Retrieved messages from in-memory store",
+		"sessionId", m.sessionId,
 		"messageCount", len(messages))
 
 	// Update metadata with message count
 	tracker.metadata["messages"] = fmt.Sprintf("%d", len(messages))
 	tracker.Complete("retrieved from in-memory store")
-	
+
 	return messages, nil
 }
 
@@ -187,7 +187,7 @@ func (m *InMemoryMemory) ClearSession(ctx context.Context) error {
 	logCtx.Info("Clearing session from in-memory store", "sessionId", m.sessionId)
 
 	m.store.ClearSession(m.sessionId)
-	
+
 	if m.recorder != nil {
 		eventData := BaseEvent{
 			Name: "SessionCleared",
@@ -198,14 +198,14 @@ func (m *InMemoryMemory) ClearSession(ctx context.Context) error {
 		}
 		m.recorder.EmitEvent(ctx, "Normal", "SessionCleared", eventData)
 	}
-	
+
 	return nil
 }
 
 // GetSessionInfo returns information about the current session (utility method)
 func (m *InMemoryMemory) GetSessionInfo(ctx context.Context) (map[string]interface{}, error) {
 	messages := m.store.GetMessages(m.sessionId)
-	
+
 	info := map[string]interface{}{
 		"sessionId":     m.sessionId,
 		"messageCount":  len(messages),
@@ -214,6 +214,6 @@ func (m *InMemoryMemory) GetSessionInfo(ctx context.Context) (map[string]interfa
 		"namespace":     m.namespace,
 		"totalSessions": m.store.GetSessionCount(),
 	}
-	
+
 	return info, nil
 }

--- a/ark/internal/genai/memory_inmemory_test.go
+++ b/ark/internal/genai/memory_inmemory_test.go
@@ -20,11 +20,11 @@ func (m *MockEventEmitter) EmitEvent(ctx context.Context, eventType, reason stri
 func TestInMemoryMemory(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := fake.NewClientBuilder().Build()
-	
+
 	config := Config{
-		SessionId:  "test-session-123",
+		SessionId: "test-session-123",
 	}
-	
+
 	// Create in-memory memory instance with mock emitter
 	mockEmitter := &MockEventEmitter{}
 	memory, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", mockEmitter, config)
@@ -48,14 +48,14 @@ func TestInMemoryMemory(t *testing.T) {
 
 	// Verify message content (basic check)
 	assert.NotNil(t, retrievedMessages[0])
-	assert.NotNil(t, retrievedMessages[1]) 
+	assert.NotNil(t, retrievedMessages[1])
 	assert.NotNil(t, retrievedMessages[2])
 
 	// Test adding more messages to the same session
 	moreMessages := []Message{
 		Message(openai.AssistantMessage("The weather is sunny today!")),
 	}
-	
+
 	err = memory.AddMessages(ctx, "query-456", moreMessages)
 	assert.NoError(t, err)
 
@@ -75,11 +75,11 @@ func TestInMemoryMemoryDifferentSessions(t *testing.T) {
 
 	// Create two memory instances with different session IDs
 	config1 := Config{
-		SessionId:  "session-1",
+		SessionId: "session-1",
 	}
-	
+
 	config2 := Config{
-		SessionId:  "session-2", 
+		SessionId: "session-2",
 	}
 
 	mockEmitter := &MockEventEmitter{}
@@ -144,7 +144,7 @@ func TestInMemoryStore(t *testing.T) {
 	assert.Equal(t, 1, store.GetSessionCount())
 	assert.NotContains(t, store.GetAllSessions(), "session-1")
 	assert.Contains(t, store.GetAllSessions(), "session-2")
-	
+
 	// Verify session-1 is empty
 	cleared := store.GetMessages("session-1")
 	assert.Len(t, cleared, 0)

--- a/ark/internal/genai/memory_inmemory_test.go
+++ b/ark/internal/genai/memory_inmemory_test.go
@@ -17,7 +17,6 @@ func TestInMemoryMemory(t *testing.T) {
 	
 	config := Config{
 		SessionId:  "test-session-123",
-		MemoryType: MemoryTypeInMemory,
 	}
 	
 	// Create in-memory memory instance
@@ -70,12 +69,10 @@ func TestInMemoryMemoryDifferentSessions(t *testing.T) {
 	// Create two memory instances with different session IDs
 	config1 := Config{
 		SessionId:  "session-1",
-		MemoryType: MemoryTypeInMemory,
 	}
 	
 	config2 := Config{
 		SessionId:  "session-2", 
-		MemoryType: MemoryTypeInMemory,
 	}
 
 	memory1, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config1)

--- a/ark/internal/genai/memory_inmemory_test.go
+++ b/ark/internal/genai/memory_inmemory_test.go
@@ -7,9 +7,15 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// MockEventEmitter for testing
+type MockEventEmitter struct{}
+
+func (m *MockEventEmitter) EmitEvent(ctx context.Context, eventType, reason string, data EventData) {
+	// No-op for testing
+}
 
 func TestInMemoryMemory(t *testing.T) {
 	ctx := context.Background()
@@ -19,8 +25,9 @@ func TestInMemoryMemory(t *testing.T) {
 		SessionId:  "test-session-123",
 	}
 	
-	// Create in-memory memory instance
-	memory, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config)
+	// Create in-memory memory instance with mock emitter
+	mockEmitter := &MockEventEmitter{}
+	memory, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", mockEmitter, config)
 	require.NoError(t, err)
 	require.NotNil(t, memory)
 
@@ -75,10 +82,11 @@ func TestInMemoryMemoryDifferentSessions(t *testing.T) {
 		SessionId:  "session-2", 
 	}
 
-	memory1, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config1)
+	mockEmitter := &MockEventEmitter{}
+	memory1, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", mockEmitter, config1)
 	require.NoError(t, err)
 
-	memory2, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config2)
+	memory2, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", mockEmitter, config2)
 	require.NoError(t, err)
 
 	// Add messages to session 1
@@ -104,28 +112,6 @@ func TestInMemoryMemoryDifferentSessions(t *testing.T) {
 	session2Messages, err := memory2.GetMessages(ctx)
 	assert.NoError(t, err)
 	assert.Len(t, session2Messages, 2)
-}
-
-func TestInMemoryMemoryFactoryMethod(t *testing.T) {
-	ctx := context.Background()
-	k8sClient := fake.NewClientBuilder().Build()
-
-	// Test creating in-memory memory using the factory method
-	memory, err := NewInMemoryMemoryForQuery(ctx, k8sClient, "test-memory", "default", nil, "test-session")
-	require.NoError(t, err)
-	require.NotNil(t, memory)
-
-	// Test basic functionality
-	messages := []Message{
-		Message(openai.UserMessage("Factory test message")),
-	}
-	
-	err = memory.AddMessages(ctx, "factory-query", messages)
-	assert.NoError(t, err)
-
-	retrievedMessages, err := memory.GetMessages(ctx)
-	assert.NoError(t, err)
-	assert.Len(t, retrievedMessages, 1)
 }
 
 func TestInMemoryStore(t *testing.T) {

--- a/ark/internal/genai/memory_inmemory_test.go
+++ b/ark/internal/genai/memory_inmemory_test.go
@@ -1,0 +1,168 @@
+package genai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestInMemoryMemory(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewClientBuilder().Build()
+	
+	config := Config{
+		SessionId:  "test-session-123",
+		MemoryType: MemoryTypeInMemory,
+	}
+	
+	// Create in-memory memory instance
+	memory, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config)
+	require.NoError(t, err)
+	require.NotNil(t, memory)
+
+	// Test adding messages
+	messages := []Message{
+		Message(openai.UserMessage("Hello, world!")),
+		Message(openai.AssistantMessage("Hi there! How can I help you?")),
+		Message(openai.UserMessage("What's the weather like?")),
+	}
+
+	err = memory.AddMessages(ctx, "query-123", messages)
+	assert.NoError(t, err)
+
+	// Test retrieving messages
+	retrievedMessages, err := memory.GetMessages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, retrievedMessages, 3)
+
+	// Verify message content (basic check)
+	assert.NotNil(t, retrievedMessages[0])
+	assert.NotNil(t, retrievedMessages[1]) 
+	assert.NotNil(t, retrievedMessages[2])
+
+	// Test adding more messages to the same session
+	moreMessages := []Message{
+		Message(openai.AssistantMessage("The weather is sunny today!")),
+	}
+	
+	err = memory.AddMessages(ctx, "query-456", moreMessages)
+	assert.NoError(t, err)
+
+	// Should now have 4 messages total
+	allMessages, err := memory.GetMessages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, allMessages, 4)
+
+	// Test Close (should not error)
+	err = memory.Close()
+	assert.NoError(t, err)
+}
+
+func TestInMemoryMemoryDifferentSessions(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewClientBuilder().Build()
+
+	// Create two memory instances with different session IDs
+	config1 := Config{
+		SessionId:  "session-1",
+		MemoryType: MemoryTypeInMemory,
+	}
+	
+	config2 := Config{
+		SessionId:  "session-2", 
+		MemoryType: MemoryTypeInMemory,
+	}
+
+	memory1, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config1)
+	require.NoError(t, err)
+
+	memory2, err := NewInMemoryMemory(ctx, k8sClient, "test-memory", "default", nil, config2)
+	require.NoError(t, err)
+
+	// Add messages to session 1
+	messages1 := []Message{
+		Message(openai.UserMessage("Message from session 1")),
+	}
+	err = memory1.AddMessages(ctx, "query-1", messages1)
+	assert.NoError(t, err)
+
+	// Add messages to session 2
+	messages2 := []Message{
+		Message(openai.UserMessage("Message from session 2")),
+		Message(openai.AssistantMessage("Response to session 2")),
+	}
+	err = memory2.AddMessages(ctx, "query-2", messages2)
+	assert.NoError(t, err)
+
+	// Verify sessions are isolated
+	session1Messages, err := memory1.GetMessages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, session1Messages, 1)
+
+	session2Messages, err := memory2.GetMessages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, session2Messages, 2)
+}
+
+func TestInMemoryMemoryFactoryMethod(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewClientBuilder().Build()
+
+	// Test creating in-memory memory using the factory method
+	memory, err := NewInMemoryMemoryForQuery(ctx, k8sClient, "test-memory", "default", nil, "test-session")
+	require.NoError(t, err)
+	require.NotNil(t, memory)
+
+	// Test basic functionality
+	messages := []Message{
+		Message(openai.UserMessage("Factory test message")),
+	}
+	
+	err = memory.AddMessages(ctx, "factory-query", messages)
+	assert.NoError(t, err)
+
+	retrievedMessages, err := memory.GetMessages(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, retrievedMessages, 1)
+}
+
+func TestInMemoryStore(t *testing.T) {
+	store := NewInMemoryStore()
+
+	// Test empty store
+	assert.Equal(t, 0, store.GetSessionCount())
+	assert.Len(t, store.GetAllSessions(), 0)
+
+	// Add messages to a session
+	messages := []Message{
+		Message(openai.UserMessage("Test message")),
+	}
+	store.AddMessages("session-1", messages)
+
+	// Verify session created
+	assert.Equal(t, 1, store.GetSessionCount())
+	assert.Contains(t, store.GetAllSessions(), "session-1")
+
+	// Retrieve messages
+	retrieved := store.GetMessages("session-1")
+	assert.Len(t, retrieved, 1)
+
+	// Add to different session
+	store.AddMessages("session-2", messages)
+	assert.Equal(t, 2, store.GetSessionCount())
+
+	// Clear one session
+	store.ClearSession("session-1")
+	assert.Equal(t, 1, store.GetSessionCount())
+	assert.NotContains(t, store.GetAllSessions(), "session-1")
+	assert.Contains(t, store.GetAllSessions(), "session-2")
+	
+	// Verify session-1 is empty
+	cleared := store.GetMessages("session-1")
+	assert.Len(t, cleared, 0)
+}

--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi>=0.115.8",
     "kubernetes-asyncio>=33.3.0",
     "openai>=1.100.2",
+    "python-dotenv>=1.0.0",
     "python-multipart>=0.0.20",
     "pyyaml>=6.0.2",
     "uvicorn>=0.34.0",

--- a/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
@@ -125,19 +125,20 @@ export default function FloatingChat({ name, type, namespace, position, onClose 
     }
   }
 
-  const buildChatHistory = (messages: ChatMessageData[], currentMsg: string): string => {
-    const history = messages
-      .filter(msg => msg.content) // Only include messages with content
-      .map(msg => {
-        const prefix = msg.role === "user" ? "User" : "Agent"
-        return `${prefix}: ${msg.content}`
-      })
-      .join("\n\n")
+  // let FE don't track full chat history 
+  // const buildChatHistory = (messages: ChatMessageData[], currentMsg: string): string => {
+  //   const history = messages
+  //     .filter(msg => msg.content) // Only include messages with content
+  //     .map(msg => {
+  //       const prefix = msg.role === "user" ? "User" : "Agent"
+  //       return `${prefix}: ${msg.content}`
+  //     })
+  //     .join("\n\n")
     
-    // Add the current message
-    const fullQuery = history ? `${history}\n\nUser: ${currentMsg}` : `User: ${currentMsg}`
-    return fullQuery
-  }
+  //   // Add the current message
+  //   const fullQuery = history ? `${history}\n\nUser: ${currentMsg}` : `User: ${currentMsg}`
+  //   return fullQuery
+  // }
 
   const handleSendMessage = async () => {
     if (!currentMessage.trim() || isProcessing) return
@@ -156,7 +157,8 @@ export default function FloatingChat({ name, type, namespace, position, onClose 
 
     try {
       // Build the full query with chat history
-      const fullQuery = buildChatHistory(chatMessages, userMessage)
+      // const fullQuery = buildChatHistory(chatMessages, userMessage)
+      const fullQuery = userMessage
       
       // Submit the query with history
       const query = await chatService.submitChatQuery(


### PR DESCRIPTION
# Add In-Memory Memory Storage Implementation
Implements an in-memory memory storage option for ARK conversations:

- New storage type: Thread-safe in-memory conversation storage
- Session isolation: Each session maintains separate message history
- Development/testing: Non-persistent storage ideal for dev environments
- Remove history management in FE

Example output: current msg uns history are separated
```
{
  "controller": "query",
  "controllerGroup": "ark.mckinsey.com",
  "controllerKind": "Query",
  "Query": {
    "name": "chat-query-741cd664-bd94-44ca-b1ed-893905e98fde",
    "namespace": "default"
  },
  "namespace": "default",
  "name": "chat-query-741cd664-bd94-44ca-b1ed-893905e98fde",
  "reconcileID": "0a98836f-ebe0-43ef-ac5d-42fbd3b08fe6",
  "userInput": {
    "OfUser": {
      "content": "3rd msg. what is the total sum of all equations I send before?",
      "role": "user"
    }
  },
  "history": [
    { "OfUser": { "content": "1st msg. what is 1+1?", "role": "user" } },
    {
      "OfAssistant": {
        "name": "sample-agent",
        "content": "2",
        "role": "assistant"
      }
    },
    { "OfUser": { "content": "2nd msg. what is 2+2?", "role": "user" } },
    {
      "OfAssistant": {
        "name": "sample-agent",
        "content": "4",
        "role": "assistant"
      }
    }
  ]
}
```
<img width="409" height="406" alt="image (52)" src="https://github.com/user-attachments/assets/361cb49c-319d-4f19-a16c-533230fdd7dd" />

