### PR TITLE
fix: enable service account token mounting for ark-mcp

### DIFF
--- a/services/ark-mcp/chart/templates/deployment.yaml
+++ b/services/ark-mcp/chart/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      automountServiceAccountToken: false
       containers:
         - name: {{ .Values.app.name }}
           image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Summary
Fix ark-mcp service failing to connect to Kubernetes API due to missing service account token mount.

## Problem
ark-mcp was getting the following error when trying to use ark-sdk:
```
Failed to load any Kubernetes config: Service token file does not exist.
```

The service account token at `/var/run/secrets/kubernetes.io/serviceaccount/` was not being mounted because the deployment had `automountServiceAccountToken: false`.

## Solution
Removed the explicit `automountServiceAccountToken: false` line from the deployment template, allowing it to default to `true` when a service account is specified. This follows the same pattern as ark-api, which also needs Kubernetes API access.
