### PR TITLE
fix(auth): auth mode open does not lead to signout

### DIFF
--- a/services/ark-dashboard/ark-dashboard/.env.example
+++ b/services/ark-dashboard/ark-dashboard/.env.example
@@ -25,5 +25,9 @@ SESSION_MAX_AGE=
 #Defaults to 10mins
 #E.G. 300000 (5 minutes) means tokens will be refreshed every 5 minutes
 NEXT_PUBLIC_TOKEN_REFRESH_INTERVAL_MS=
+#Inactivity Timeout in milliseconds
+#Defaults to 30mins
+#E.G. 300000 (5 minutes) means the user will be signed out automatically after 30 mins of inactivity
+NEXT_PUBLIC_FALLBACK_INACTIVITY_TIMEOUT=
 #The authentication mode. If you set it to "open", the application will not require you to sign in.
 AUTH_MODE=sso

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import middleware from '@/middleware';
 import type { NextRequestWithAuth } from '@/auth';
@@ -24,6 +24,13 @@ vi.mock('@/auth', () => ({
 describe('middleware default export', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Set required environment variables
+    process.env.BASE_URL = 'https://example.com';
+  });
+
+  afterEach(() => {
+    // Clean up environment variables
+    delete process.env.BASE_URL;
   });
 
   const createMockRequest = (pathname: string): NextRequestWithAuth => {
@@ -52,7 +59,7 @@ describe('middleware default export', () => {
       await (middleware as any)(request);
 
       expect(NextResponse.redirect).toHaveBeenCalledWith(
-        new URL('/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com%2Fdashboard', 'https://example.com')
+        new URL('/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com', 'https://example.com')
       );
     });
 

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/layout.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/layout.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { useAutoSignout } from "@/hooks/useAutoSignout";
-import { useRefreshAccessToken } from "@/hooks/useRefreshAccessToken";
 import { Providers } from "./providers";
 
 export default function DashboardLayout({
@@ -9,8 +7,5 @@ export default function DashboardLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  useAutoSignout()
-  useRefreshAccessToken()
-
   return (<Providers>{children}</Providers>);
 }

--- a/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
@@ -10,7 +10,10 @@ export async function GET(request: NextRequest) {
     cookieName: COOKIE_SESSION_TOKEN
   })
 
-  const baseURL = process.env.BASE_URL || request.nextUrl.origin;
+  const protocol = request.headers.get('x-forwarded-proto') || 'https'
+  const host = request.headers.get('host') || request.nextUrl.origin;
+
+  const baseURL = process.env.BASE_URL || `${protocol}://${host}`
   const redirectURL = `${baseURL}/signout`;
   if (!token?.id_token) {
     return NextResponse.redirect(new URL("/signout", baseURL)); // no session, just go home

--- a/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
@@ -10,10 +10,7 @@ export async function GET(request: NextRequest) {
     cookieName: COOKIE_SESSION_TOKEN
   })
 
-  const protocol = request.headers.get('x-forwarded-proto') || 'https'
-  const host = request.headers.get('host') || request.nextUrl.origin;
-
-  const baseURL = process.env.BASE_URL || `${protocol}://${host}`
+  const baseURL = process.env.BASE_URL
   const redirectURL = `${baseURL}/signout`;
   if (!token?.id_token) {
     return NextResponse.redirect(new URL("/signout", baseURL)); // no session, just go home

--- a/services/ark-dashboard/ark-dashboard/app/layout.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/layout.tsx
@@ -2,9 +2,8 @@ import type { Metadata } from "next";
 
 import "./globals.css";
 import localFont from "next/font/local";
-import { auth } from "@/auth";
-import { SessionProvider } from "next-auth/react";
 import { Toaster } from "@/components/ui/toaster";
+import { SSOModeProvider, OpenModeProvider } from "@/providers/AuthProviders";
 
 const geistSans = localFont({
   src: [
@@ -52,17 +51,18 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await auth()
+  const isSSOEnabled = process.env.AUTH_MODE === 'sso'
+  const AuthProvider = isSSOEnabled ? SSOModeProvider : OpenModeProvider
 
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <SessionProvider session={session}>
+        <AuthProvider>
           {children}
           <Toaster />
-        </SessionProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
@@ -35,10 +35,12 @@ import { NamespaceEditor } from "@/components/editors"
 import { UserDetails } from "./user"
 import { signout } from "@/lib/auth/signout"
 import { useNamespace } from "@/providers/NamespaceProvider"
+import { useUser } from "@/providers/UserProvider"
 
 export function AppSidebar() {
   const router = useRouter()
   const pathname = usePathname()
+  const { user } = useUser()
 
   const {
     availableNamespaces,
@@ -52,6 +54,7 @@ export function AppSidebar() {
   const [loading, setLoading] = useState(true)
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null)
   const [namespaceEditorOpen, setNamespaceEditorOpen] = useState(false)
+
   const isPlaceholderSection = (key: string): boolean => {
     const placeholderKeys: string[] = []
     return placeholderKeys.includes(key)
@@ -279,32 +282,34 @@ export function AppSidebar() {
             </p>
             <p>Kubernetes {systemInfo.kubernetes_version}</p>
           </div>)}
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <SidebarMenuButton className="h-12">
-                    <UserDetails/>
-                    <ChevronsUpDownIcon className="ml-auto"/>
-                  </SidebarMenuButton>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="right"
-                  align="end"
-                  className="w-[--radix-popper-anchor-width]"
-                >
-                  <DropdownMenuLabel>
-                    <UserDetails/>
-                  </DropdownMenuLabel>
-                  <DropdownMenuSeparator/>
-                  <DropdownMenuItem onClick={signout}>
-                    <LogOut/>
-                    <span>Sign out</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </SidebarMenuItem>
-          </SidebarMenu>
+          {user && (
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <SidebarMenuButton className="h-12">
+                      <UserDetails user={user}/>
+                      <ChevronsUpDownIcon className="ml-auto"/>
+                    </SidebarMenuButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    side="right"
+                    align="end"
+                    className="w-[--radix-popper-anchor-width]"
+                  >
+                    <DropdownMenuLabel>
+                      <UserDetails user={user}/>
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator/>
+                    <DropdownMenuItem onClick={signout}>
+                      <LogOut/>
+                      <span>Sign out</span>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          )}
         </SidebarFooter>
       </Sidebar>
       

--- a/services/ark-dashboard/ark-dashboard/components/auth/AuthUtilsWrapper.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/auth/AuthUtilsWrapper.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { useAutoSignout } from "@/hooks/useAutoSignout";
+import { useRefreshAccessToken } from "@/hooks/useRefreshAccessToken";
+
+export function AuthUtilsWrapper() {
+  useAutoSignout()
+  useRefreshAccessToken()
+
+  return null;
+}

--- a/services/ark-dashboard/ark-dashboard/components/auth/index.ts
+++ b/services/ark-dashboard/ark-dashboard/components/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './AuthUtilsWrapper'

--- a/services/ark-dashboard/ark-dashboard/components/user/user-details.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/user/user-details.tsx
@@ -1,36 +1,34 @@
-'use client'
+"use client";
+import { User } from "@/lib/types/user";
 /* eslint-disable @next/next/no-img-element */
-import { useSession } from "next-auth/react";
 
-export function UserDetails() {
-  const { data: session } = useSession();
+type Props = {
+  user: User;
+};
 
+export function UserDetails({ user }: Props) {
   return (
-    <>
-      {session?.user ? (
-        <div className="flex gap-2">
-          <span className="relative flex size-8 shrink-0 overflow-hidden h-8 w-8 rounded-lg select-none">
-            {session?.user.image ? (
-              <img
-                src={session?.user.image}
-                alt={session?.user.name || "Avatar"}
-                className="aspect-square select-none"
-              />
-            ) : (
-              <div className="aspect-square flex items-center justify-center bg-foreground text-background">
-                {session?.user.name
-                  ?.split(" ")
-                  .slice(0, 2)
-                  .map((i) => i[0])}
-              </div>
-            )}
-          </span>
-          <div className="grid flex-1 text-left text-sm leading-tight">
-            <span className="truncate font-medium">{session?.user.name}</span>
-            <span className="truncate text-xs">{session?.user.email}</span>
+    <div className="flex gap-2">
+      <span className="relative flex size-8 shrink-0 overflow-hidden h-8 w-8 rounded-lg select-none">
+        {user.image ? (
+          <img
+            src={user.image}
+            alt={user.name || "Avatar"}
+            className="aspect-square select-none"
+          />
+        ) : (
+          <div className="aspect-square flex items-center justify-center bg-foreground text-background">
+            {user.name
+              ?.split(" ")
+              .slice(0, 2)
+              .map((i) => i[0])}
           </div>
-        </div>
-      ) : null}
-    </>
+        )}
+      </span>
+      <div className="grid flex-1 text-left text-sm leading-tight">
+        <span className="truncate font-medium">{user.name}</span>
+        <span className="truncate text-xs">{user.email}</span>
+      </div>
+    </div>
   );
 }

--- a/services/ark-dashboard/ark-dashboard/lib/types/user.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/types/user.ts
@@ -1,0 +1,6 @@
+export type User ={
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+};

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -63,10 +63,13 @@ export default auth(async (req: NextRequestWithAuth) => {
   if (!req.auth) {
     //If the user is trying to access a page other than the signin page, set it as the callback url.
     if(req.nextUrl.pathname !== SIGNIN_PATH) {
+      const baseURL = process.env.BASE_URL
+
       const newUrl = new URL(
-        `${SIGNIN_PATH}?callbackUrl=${encodeURIComponent(req.url)}`,
-        req.nextUrl.origin
+        `${SIGNIN_PATH}?callbackUrl=${encodeURIComponent(baseURL!)}`,
+        baseURL
       )
+
       return NextResponse.redirect(newUrl)
     }
     return NextResponse.next()

--- a/services/ark-dashboard/ark-dashboard/providers/AuthProviders.tsx
+++ b/services/ark-dashboard/ark-dashboard/providers/AuthProviders.tsx
@@ -1,0 +1,26 @@
+import { PropsWithChildren } from "react";
+import { SessionProvider } from "next-auth/react";
+import { UserProvider } from "./UserProvider";
+import { AuthUtilsWrapper } from "@/components/auth";
+import { auth } from "@/auth";
+
+export async function SSOModeProvider({ children }: PropsWithChildren) {
+  const session = await auth()
+
+  return (
+    <SessionProvider session={session}>
+      <AuthUtilsWrapper />
+      <UserProvider user={session?.user}>
+        {children}
+      </UserProvider>
+    </SessionProvider>
+  )
+}
+
+export function OpenModeProvider({ children }: PropsWithChildren) {
+  return (
+    <UserProvider>
+      {children}
+    </UserProvider>
+  )
+}

--- a/services/ark-dashboard/ark-dashboard/providers/UserProvider.tsx
+++ b/services/ark-dashboard/ark-dashboard/providers/UserProvider.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { User } from '@/lib/types/user';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
+
+type Props = {
+  user?: User | null;
+}
+
+interface UserContext {
+  user?: User | null
+}
+
+const UserContext = createContext<UserContext | undefined>(
+  undefined
+);
+
+function UserProvider({ children, user }: PropsWithChildren<Props>) {
+  return (
+    <UserContext.Provider value={{ user }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+function useUser() {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+
+  return context;
+};
+
+export { UserProvider, useUser };

--- a/services/ark-dashboard/chart/values.yaml
+++ b/services/ark-dashboard/chart/values.yaml
@@ -46,6 +46,8 @@ app:
       value: ""
     - name: NEXT_PUBLIC_TOKEN_REFRESH_INTERVAL_MS
       value: "600000" #10 mins
+    - name: NEXT_PUBLIC_FALLBACK_INACTIVITY_TIMEOUT
+      value: "1800000" #30 mins
     - name: AUTH_MODE
       value: "open"
   


### PR DESCRIPTION
Replaces direct session usage with a unified user context and provider, separates authentication utility hooks, and introduces mode-specific auth providers to simplify and clarify authentication logic. Improves component structure and prepares for easier future extensibility.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 