### PR TITLE
Add namespace argument in the generator template

### DIFF
--- a/tools/ark-cli/src/commands/generate/generators/agent.ts
+++ b/tools/ark-cli/src/commands/generate/generators/agent.ts
@@ -240,14 +240,14 @@ class AgentGenerator {
         );
         console.log(
           chalk.gray(
-            `  3. Deploy with: helm upgrade --install ${config.projectName} .`
+            `  3. Deploy with: helm upgrade --install ${config.projectName} . --namespace ${config.projectName}`
           )
         );
         console.log(chalk.gray(`  4. Test with: kubectl get agents,queries`));
       } else {
         console.log(
           chalk.gray(
-            `  2. Deploy with: helm upgrade --install ${config.projectName} .`
+            `  2. Deploy with: helm upgrade --install ${config.projectName} . --namespace ${config.projectName}`
           )
         );
         console.log(chalk.gray(`  3. Test with: kubectl get agents`));

--- a/tools/ark-cli/src/commands/generate/generators/team.ts
+++ b/tools/ark-cli/src/commands/generate/generators/team.ts
@@ -584,14 +584,14 @@ class TeamGenerator {
         );
         console.log(
           chalk.gray(
-            `  3. Deploy with: helm upgrade --install ${config.projectName} .`
+            `  3. Deploy with: helm upgrade --install ${config.projectName} . --namespace ${config.projectName}`
           )
         );
         console.log(chalk.gray(`  4. Test with: kubectl get teams,queries`));
       } else {
         console.log(
           chalk.gray(
-            `  2. Deploy with: helm upgrade --install ${config.projectName} .`
+            `  2. Deploy with: helm upgrade --install ${config.projectName} . --namespace ${config.projectName}`
           )
         );
         console.log(chalk.gray(`  3. Test with: kubectl get teams`));


### PR DESCRIPTION
```
📋 Next Steps:
  1. Review and customise the agent configuration
  2. Review and customise the query configuration
  3. Deploy with: helm upgrade --install nok-ark-project .
  4. Test with: kubectl get agents,queries
 ```

I use `ark` CLI to generate a new project, it generate a template which I believe missing `--namespace` argument (ark will create the namespace using the project name by default`.

Question: I see team/agent config currently do not have the namespace - should it be part of it?

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 