### PR TITLE
feat(charts): add http gateway and ingress opt-in support

### DIFF
--- a/services/ark-api-a2a/build.mk
+++ b/services/ark-api-a2a/build.mk
@@ -78,6 +78,7 @@ $(ARK_API_A2A_STAMP_INSTALL): $(ARK_API_A2A_STAMP_BUILD) $$(ARK_API_STAMP_INSTAL
 		--create-namespace \
 		--set app.image.repository=$(ARK_API_A2A_IMAGE) \
 		--set app.image.tag=$(ARK_API_A2A_TAG) \
+		--set httpRoute.enabled=true \
 		--wait \
 		--timeout=5m
 	@echo "ark-api-a2a installed successfully!"

--- a/services/ark-api-a2a/chart/templates/httproute.yaml
+++ b/services/ark-api-a2a/chart/templates/httproute.yaml
@@ -1,25 +1,42 @@
+{{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ark-api-a2a
   namespace: {{ .Values.namespace }}
-  annotations:
-    description: "HTTPRoute for ARK API A2A gateway service"
+  labels:
+    app: ark-api-a2a
     {{- with .Values.global.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-    - name: {{ .Values.gateway.name }}
-      namespace: {{ .Values.gateway.namespace }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-    - "ark-api-a2a.127.0.0.1.nip.io"
-    - "ark-api-a2a.default.127.0.0.1.nip.io"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    # Default rule: route all traffic to the service
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {{ .Values.service.name }}
-          port: {{ .Values.service.port }}
+        - name: {{ $.Values.service.name }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/services/ark-api-a2a/chart/templates/ingress.yaml
+++ b/services/ark-api-a2a/chart/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ark-api-a2a
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: ark-api-a2a
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/ark-api-a2a/chart/values.yaml
+++ b/services/ark-api-a2a/chart/values.yaml
@@ -12,12 +12,41 @@ global:
   annotations:
     ark.mckinsey.com/service: ark-api-a2a
 
-# Gateway configuration for HTTPRoute
-gateway:
-  # Namespace where localhost-gateway is installed
-  namespace: ark-system
-  # Gateway name to reference
-  name: localhost-gateway
+# Ingress configuration (legacy routing method)
+# Disabled by default. Use this for traditional Kubernetes Ingress routing.
+# For newer deployments, consider using HTTPRoute (below) with Gateway API instead.
+ingress:
+  enabled: false
+  className: ""  # e.g., "nginx", "traefik", "kong"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: ark-api-a2a.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: ark-api-a2a-tls
+  #    hosts:
+  #      - ark-api-a2a.example.local
+
+# HTTPRoute configuration (Gateway API - modern routing method)
+# Disabled by default. This is the preferred routing method for Kubernetes 1.23+
+# with Gateway API CRDs installed. Example values below show localhost development setup.
+httpRoute:
+  enabled: false
+  annotations: {}
+    # Custom annotations can be added here
+  # Gateway references
+  parentRefs:
+    - name: localhost-gateway
+      namespace: ark-system
+  # Hostnames this route matches
+  hostnames:
+    - "ark-api-a2a.127.0.0.1.nip.io"
+    - "ark-api-a2a.default.127.0.0.1.nip.io"
 
 # Service configuration for HTTPRoute
 service:

--- a/services/ark-api/build.mk
+++ b/services/ark-api/build.mk
@@ -88,6 +88,7 @@ $(ARK_API_STAMP_INSTALL): $(ARK_API_STAMP_BUILD) $$(LOCALHOST_GATEWAY_STAMP_INST
 		--create-namespace \
 		--set app.image.repository=$(ARK_API_IMAGE) \
 		--set app.image.tag=$(ARK_API_TAG) \
+		--set httpRoute.enabled=true \
 		--wait \
 		--timeout=5m
 	@echo "ark-api installed successfully"

--- a/services/ark-api/chart/templates/httproute.yaml
+++ b/services/ark-api/chart/templates/httproute.yaml
@@ -1,51 +1,42 @@
-# HTTPRoute for service name access
+{{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ark-api
+  name: {{ .Values.app.name }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    description: "Routes ark-api service traffic"
+  labels:
+    app: {{ .Values.app.name }}
     {{- with .Values.global.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
-spec:
-  parentRefs:
-  - name: {{ .Values.gateway.name }}
-    namespace: {{ .Values.gateway.namespace }}
-  hostnames:
-  - "ark-api.127.0.0.1.nip.io"
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: {{ .Values.service.name }}
-      port: {{ .Values.service.port }}
----
-# HTTPRoute for explicit namespace access
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ark-api-default
-  namespace: {{ .Release.Namespace }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
   annotations:
-    description: "Routes ark-api with explicit namespace"
-    {{- with .Values.global.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-  - name: {{ .Values.gateway.name }}
-    namespace: {{ .Values.gateway.namespace }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-  - "ark-api.default.127.0.0.1.nip.io"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: {{ .Values.service.name }}
-      port: {{ .Values.service.port }}
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    # Default rule: route all traffic to the service
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $.Values.service.name }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/services/ark-api/chart/templates/ingress.yaml
+++ b/services/ark-api/chart/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.app.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.app.name }}
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/ark-api/chart/values.yaml
+++ b/services/ark-api/chart/values.yaml
@@ -47,12 +47,41 @@ service:
   port: 80
   targetPort: 8000
 
-# Gateway configuration for HTTPRoute
-gateway:
-  # Namespace where localhost-gateway is installed
-  namespace: ark-system
-  # Gateway name to reference
-  name: localhost-gateway
+# Ingress configuration (legacy routing method)
+# Disabled by default. Use this for traditional Kubernetes Ingress routing.
+# For newer deployments, consider using HTTPRoute (below) with Gateway API instead.
+ingress:
+  enabled: false
+  className: ""  # e.g., "nginx", "traefik", "kong"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: ark-api.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: ark-api-tls
+  #    hosts:
+  #      - ark-api.example.local
+
+# HTTPRoute configuration (Gateway API - modern routing method)
+# Disabled by default. This is the preferred routing method for Kubernetes 1.23+
+# with Gateway API CRDs installed. Example values below show localhost development setup.
+httpRoute:
+  enabled: false
+  annotations: {}
+    # Custom annotations can be added here
+  # Gateway references
+  parentRefs:
+    - name: localhost-gateway
+      namespace: ark-system
+  # Hostnames this route matches
+  hostnames:
+    - "ark-api.127.0.0.1.nip.io"
+    - "ark-api.default.127.0.0.1.nip.io"
 
 # Service account configuration
 serviceAccount:

--- a/services/ark-dashboard/build.mk
+++ b/services/ark-dashboard/build.mk
@@ -71,6 +71,7 @@ $(ARK_DASHBOARD_STAMP_INSTALL): $(ARK_DASHBOARD_STAMP_BUILD) $$(ARK_API_STAMP_IN
 		--create-namespace \
 		--set app.image.repository=$(DASHBOARD_IMAGE) \
 		--set app.image.tag=$(DASHBOARD_TAG) \
+		--set httpRoute.enabled=true \
 		--wait \
 		--timeout=5m
 	@echo "ark-dashboard installed successfully"

--- a/services/ark-dashboard/chart/templates/httproute.yaml
+++ b/services/ark-dashboard/chart/templates/httproute.yaml
@@ -1,27 +1,42 @@
-{{- range .Values.routes }}
----
+{{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ .name }}
-  namespace: {{ $.Release.Namespace }}
-  annotations:
-    description: {{ .description | quote }}
-    {{- with $.Values.global.annotations }}
-    {{- toYaml . | nindent 4 }}
+  name: {{ .Values.app.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.app.name }}
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-  - name: {{ $.Values.gateway.name }}
-    namespace: {{ $.Values.gateway.namespace }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-  - {{ .hostname | quote }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: {{ $.Values.service.name }}
-      port: {{ $.Values.service.port }}
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    # Default rule: route all traffic to the service
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $.Values.service.name }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/services/ark-dashboard/chart/templates/ingress.yaml
+++ b/services/ark-dashboard/chart/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.app.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.app.name }}
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/ark-dashboard/chart/values.yaml
+++ b/services/ark-dashboard/chart/values.yaml
@@ -78,21 +78,49 @@ service:
   port: 3000
   targetPort: 3000
 
-# Gateway configuration for HTTPRoute
-gateway:
-  # Namespace where localhost-gateway is installed
-  namespace: ark-system
-  # Gateway name to reference
-  name: localhost-gateway
+# Ingress configuration (legacy routing method)
+# Disabled by default. Use this for traditional Kubernetes Ingress routing.
+# For newer deployments, consider using HTTPRoute (below) with Gateway API instead.
+ingress:
+  enabled: false
+  className: ""  # e.g., "nginx", "traefik", "kong"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: dashboard.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: dashboard-tls
+  #    hosts:
+  #      - dashboard.example.local
 
-# HTTPRoute configuration
-routes:
-- name: dashboard-root
-  hostname: "127.0.0.1.nip.io"
-  description: "Routes root domain traffic to dashboard"
-- name: dashboard
-  hostname: "dashboard.127.0.0.1.nip.io"
-  description: "Routes dashboard service traffic"
-- name: dashboard-default
-  hostname: "dashboard.default.127.0.0.1.nip.io"
-  description: "Routes dashboard with explicit namespace"
+# HTTPRoute configuration (Gateway API - modern routing method)
+# Disabled by default. This is the preferred routing method for Kubernetes 1.23+
+# with Gateway API CRDs installed. Example values below show localhost development setup.
+httpRoute:
+  enabled: false
+  annotations: {}
+    # Custom annotations can be added here
+  # Gateway references
+  parentRefs:
+    - name: localhost-gateway
+      namespace: ark-system
+      # sectionName: http  # optional, for specific listener
+  # Hostnames this route matches
+  hostnames:
+    - "127.0.0.1.nip.io"
+    - "dashboard.127.0.0.1.nip.io"
+    - "dashboard.default.127.0.0.1.nip.io"
+  # Routing rules (if not specified, defaults to routing all paths to the service)
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /
+  #     backendRefs:
+  #       - name: ark-dashboard
+  #         port: 3000

--- a/services/ark-mcp/build.mk
+++ b/services/ark-mcp/build.mk
@@ -63,7 +63,7 @@ $(ARK_MCP_STAMP_INSTALL): $(ARK_MCP_STAMP_BUILD)
 	cp $(ARK_SDK_WHL) $(ARK_MCP_SERVICE_DIR)/ark-mcp/out/
 	./scripts/build-and-push.sh -i $(ARK_MCP_IMAGE) -t $(ARK_MCP_TAG) -f $(ARK_MCP_SERVICE_DIR)/Dockerfile -c $(ARK_MCP_SERVICE_DIR)
 	@rm -rf $(ARK_MCP_SERVICE_DIR)/ark-mcp/out
-	cd $(ARK_MCP_SERVICE_DIR) && helm upgrade --install ark-mcp ./chart -n $(ARK_MCP_NAMESPACE) --create-namespace --set app.image.repository=$(ARK_MCP_IMAGE) --set app.image.tag=$(ARK_MCP_TAG)
+	cd $(ARK_MCP_SERVICE_DIR) && helm upgrade --install ark-mcp ./chart -n $(ARK_MCP_NAMESPACE) --create-namespace --set app.image.repository=$(ARK_MCP_IMAGE) --set app.image.tag=$(ARK_MCP_TAG) --set httpRoute.enabled=true
 	@touch $@
 
 # Dev target dependencies - prepare local environment  

--- a/services/ark-mcp/chart/templates/httproute.yaml
+++ b/services/ark-mcp/chart/templates/httproute.yaml
@@ -1,27 +1,42 @@
-{{- if .Values.gateway.enabled | default true }}
-# HTTPRoute for explicit namespace access
+{{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ .Values.service.name }}-{{ .Release.Namespace }}
+  name: {{ .Values.app.name }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    description: "Routes ark-mcp with explicit namespace"
+  labels:
+    app: {{ .Values.app.name }}
     {{- with .Values.global.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-  - name: {{ .Values.gateway.name }}
-    namespace: {{ .Values.gateway.namespace }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-  - "ark-mcp.{{ .Release.Namespace }}.127.0.0.1.nip.io"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: {{ .Values.service.name }}
-      port: {{ .Values.service.port }}
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    # Default rule: route all traffic to the service
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $.Values.service.name }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/services/ark-mcp/chart/templates/ingress.yaml
+++ b/services/ark-mcp/chart/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.app.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.app.name }}
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/ark-mcp/chart/values.yaml
+++ b/services/ark-mcp/chart/values.yaml
@@ -30,14 +30,40 @@ service:
   port: 80
   targetPort: 2627
 
-# Gateway configuration for HTTPRoute
-gateway:
-  # Enable/disable HTTPRoute creation
-  enabled: true
-  # Namespace where localhost-gateway is installed
-  namespace: ark-system
-  # Gateway name to reference
-  name: localhost-gateway
+# Ingress configuration (legacy routing method)
+# Disabled by default. Use this for traditional Kubernetes Ingress routing.
+# For newer deployments, consider using HTTPRoute (below) with Gateway API instead.
+ingress:
+  enabled: false
+  className: ""  # e.g., "nginx", "traefik", "kong"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: ark-mcp.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: ark-mcp-tls
+  #    hosts:
+  #      - ark-mcp.example.local
+
+# HTTPRoute configuration (Gateway API - modern routing method)
+# Disabled by default. This is the preferred routing method for Kubernetes 1.23+
+# with Gateway API CRDs installed. Example values below show localhost development setup.
+httpRoute:
+  enabled: false
+  annotations: {}
+    # Custom annotations can be added here
+  # Gateway references
+  parentRefs:
+    - name: localhost-gateway
+      namespace: ark-system
+  # Hostnames this route matches
+  hostnames:
+    - "ark-mcp.default.127.0.0.1.nip.io"
 
 # Service account configuration
 serviceAccount:

--- a/services/langfuse/build.mk
+++ b/services/langfuse/build.mk
@@ -46,7 +46,8 @@ $(LANGFUSE_STAMP_INSTALL): | $(OUT)
 	cd $(LANGFUSE_SERVICE_DIR)/chart && helm dependency update
 	helm upgrade --install $(LANGFUSE_HELM_RELEASE) $(LANGFUSE_SERVICE_DIR)/chart -n $(LANGFUSE_NAMESPACE) --create-namespace \
 		--set demo.project.publicKey=$(LANGFUSE_PUBLIC_KEY) \
-		--set demo.project.secretKey=$(LANGFUSE_SECRET_KEY)
+		--set demo.project.secretKey=$(LANGFUSE_SECRET_KEY) \
+		--set httpRoute.enabled=true
 	$(MAKE) $(LANGFUSE_SERVICE_NAME)-deploy-otel-headers
 	@touch $@
 

--- a/services/langfuse/chart/templates/httproute.yaml
+++ b/services/langfuse/chart/templates/httproute.yaml
@@ -1,25 +1,42 @@
-# HTTPRoute for explicit namespace access
+{{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: langfuse-telemetry
   namespace: {{ .Values.namespace }}
-  annotations:
-    description: "Routes langfuse with explicit namespace"
+  labels:
+    app: langfuse
     {{- with .Values.global.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-  - name: {{ .Values.gateway.name }}
-    namespace: {{ .Values.gateway.namespace }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-  - "langfuse.{{ .Values.namespace }}.127.0.0.1.nip.io"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: {{ .Values.service.name }}
-      port: {{ .Values.service.port }}
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    # Default rule: route all traffic to the service
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $.Values.service.name }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/services/langfuse/chart/templates/ingress.yaml
+++ b/services/langfuse/chart/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: langfuse-telemetry
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: langfuse
+    {{- with .Values.global.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/services/langfuse/chart/values.yaml
+++ b/services/langfuse/chart/values.yaml
@@ -5,12 +5,40 @@ global:
   annotations:
     ark.mckinsey.com/service: langfuse
 
-# Gateway configuration for HTTPRoute
-gateway:
-  # Namespace where localhost-gateway is installed
-  namespace: ark-system
-  # Gateway name to reference
-  name: localhost-gateway
+# Ingress configuration (legacy routing method)
+# Disabled by default. Use this for traditional Kubernetes Ingress routing.
+# For newer deployments, consider using HTTPRoute (below) with Gateway API instead.
+ingress:
+  enabled: false
+  className: ""  # e.g., "nginx", "traefik", "kong"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: langfuse.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: langfuse-tls
+  #    hosts:
+  #      - langfuse.example.local
+
+# HTTPRoute configuration (Gateway API - modern routing method)
+# Disabled by default. This is the preferred routing method for Kubernetes 1.23+
+# with Gateway API CRDs installed. Example values below show localhost development setup.
+httpRoute:
+  enabled: false
+  annotations: {}
+    # Custom annotations can be added here
+  # Gateway references
+  parentRefs:
+    - name: localhost-gateway
+      namespace: ark-system
+  # Hostnames this route matches
+  hostnames:
+    - "langfuse.telemetry.127.0.0.1.nip.io"
 
 # Service configuration for HTTPRoute
 service:


### PR DESCRIPTION
- Add standard Helm Ingress configuration to all service charts  
- Migrate from custom gateway pattern to standard httpRoute/ingress patterns
- Both routing methods disabled by default, cluster admins or operators opt-in

## Changes

### Chart Updates
- Added standard `ingress:` block configuration (disabled by default)
- Migrated custom `gateway:` block to standard `httpRoute:` pattern
- Created single HTTPRoute with multiple hostnames (replacing multiple HTTPRoute resources)
- Added comprehensive documentation and examples in values.yaml

### Services Updated
- **ark-dashboard**: 3 hostnames (root, dashboard, dashboard.default)
- **langfuse**: 1 hostname (langfuse.telemetry)
- **ark-mcp**: 1 hostname (ark-mcp.default)
- **ark-api**: 2 hostnames (ark-api, ark-api.default)
- **ark-api-a2a**: 2 hostnames (ark-api-a2a, ark-api-a2a.default)

### Makefile Updates
- Updated all service makefiles to use `--set httpRoute.enabled=true`
- Maintains backward compatibility while adopting standard patterns