### PR TITLE
feat(ark-api): Add singleNamespace option to Helm chart

### DIFF
--- a/services/ark-api/chart/templates/rbac.yaml
+++ b/services/ark-api/chart/templates/rbac.yaml
@@ -10,6 +10,29 @@ metadata:
     {{- end }}
 
 ---
+{{- if .Values.serviceAccount.rbac.singleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccount.name }}-helm-reader
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  # Permission to read secrets and events in the release namespace
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list"]
+  # Permission to read Gateway API resources in the release namespace
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "gateways"]
+    verbs: ["get", "list"]
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -39,6 +62,7 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get", "list"]
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,6 +81,22 @@ rules:
     verbs: ["get", "list", "create", "update", "patch", "delete"]
 
 ---
+{{- if .Values.serviceAccount.rbac.singleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccount.name }}-ark-resources
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  # Permission to access ark.mckinsey.com resources in the release namespace
+  - apiGroups: ["ark.mckinsey.com"]
+    resources: ["models", "agents", "queries", "teams", "tools", "workflows", "arktemplates", "mcpservers", "a2aservers", "memories", "evaluations", "evaluators"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -70,6 +110,7 @@ rules:
   - apiGroups: ["ark.mckinsey.com"]
     resources: ["models", "agents", "queries", "teams", "tools", "workflows", "arktemplates", "mcpservers", "a2aservers", "memories", "evaluations", "evaluators"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -91,6 +132,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+{{- if .Values.serviceAccount.rbac.singleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.name }}-helm-binding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}-helm-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -107,8 +167,28 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.serviceAccount.name }}-helm-reader
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 
 ---
+{{- if .Values.serviceAccount.rbac.singleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.name }}-ark-binding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}-ark-resources
+  apiGroup: rbac.authorization.k8s.io
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -125,4 +205,5 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.serviceAccount.name }}-ark-resources
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/services/ark-api/chart/values.yaml
+++ b/services/ark-api/chart/values.yaml
@@ -58,3 +58,5 @@ gateway:
 serviceAccount:
   name: ark-api-sa
   create: true
+  rbac:
+    singleNamespace: false


### PR DESCRIPTION
This switches to using plain namespaced Roles and RoleBindings, not creating anything at the cluster level. This is useful when the user only has access to a namespace and not wider cluster level permissions.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 