### PR TITLE
fix: CI/CD workflow issues

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -811,6 +811,7 @@ jobs:
           - ark-dashboard
           - ark-mcp
           - localhost-gateway
+          - ark-tenant
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           REGISTRY="${{ vars.DOCKER_REGISTRY || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}"
           IMAGE="${{ matrix.image }}"
-          VERSION="${{ needs.check_version.outputs.clean_version }}"
+          VERSION="${{ needs.resolve_version.outputs.clean_version }}"
           
           echo "Tagging and pushing $REGISTRY/$IMAGE:$VERSION as 'latest'"
           docker buildx imagetools create \

--- a/services/ark-dashboard/chart/values.yaml
+++ b/services/ark-dashboard/chart/values.yaml
@@ -19,7 +19,7 @@ app:
     port: "3000"
     hostname: "0.0.0.0"
     arkApiService:
-      host: "ark-api.default.svc.cluster.local"
+      host: "ark-api"
       port: "80"
       protocol: "http"
   


### PR DESCRIPTION
## Summary
- Add ark-tenant to release-charts matrix so it gets uploaded to GitHub releases
- Fix typo in deploy.yml where VERSION was empty due to wrong job reference (needs.check_version -> needs.resolve_version)
- Simplify ark-api service reference from FQDN to just service name since ark-dashboard always runs in the same namespace