### PR TITLE
fix: New query display bug fix

### DIFF
--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
@@ -781,7 +781,7 @@ function QueryDetailContent() {
                     Phase
                   </td>
                   <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {isNew ? "—" : (query.status?.phase || "draft")}
+                    {isNew ? "—" : query.status?.phase}
                   </td>
                 </tr>
                 <tr className="border-b border-gray-100 dark:border-gray-800">
@@ -963,7 +963,7 @@ function QueryDetailContent() {
               </div>
             ) : null}
             
-            {!isNew && (query.status?.phase === 'failed' || query.status?.phase === 'error') && (
+            {!isNew && (
             <div className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
               Note: Events expire after a certain amount of time and may no longer be available for viewing.
             </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
@@ -781,7 +781,7 @@ function QueryDetailContent() {
                     Phase
                   </td>
                   <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.status?.phase || "pending"}
+                    {isNew ? "—" : (query.status?.phase || "draft")}
                   </td>
                 </tr>
                 <tr className="border-b border-gray-100 dark:border-gray-800">
@@ -926,8 +926,7 @@ function QueryDetailContent() {
                   ))}
                 </div>
               </div>
-            ) : (
-              /* Error Section - show when there's an error or no responses */
+            ) : !isNew && (query.status?.phase === 'failed' || query.status?.phase === 'error') ? (
               <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
                 <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
                   <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Error</h3>
@@ -962,11 +961,13 @@ function QueryDetailContent() {
                   />
                 </div>
               </div>
-            )}
+            ) : null}
             
+            {!isNew && (query.status?.phase === 'failed' || query.status?.phase === 'error') && (
             <div className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
               Note: Events expire after a certain amount of time and may no longer be available for viewing.
             </div>
+            )}
           </div>
         </ScrollArea>
       </div>

--- a/services/ark-dashboard/ark-dashboard/components/ErrorResponseContent.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ErrorResponseContent.tsx
@@ -106,22 +106,32 @@ export function ErrorResponseContent({ query, viewMode, namespace }: ErrorRespon
       };
     }
 
-    // Fallback to generic error
-    return {
-      type: 'Unknown Error',
-      message: 'Query failed - no specific error details available',
-      details: {
-        phase: query.status?.phase,
-        responses: query.status?.responses?.length || 0,
-        timestamp: query.creationTimestamp
-      }
-    };
+    // Only show error if query is actually failed/error
+    if (query.status?.phase === 'failed' || query.status?.phase === 'error') {
+      return {
+        type: 'Unknown Error',
+        message: 'Query failed - no specific error details available',
+        details: {
+          phase: query.status?.phase,
+          responses: query.status?.responses?.length || 0,
+          timestamp: query.creationTimestamp
+        }
+      };
+    }
+    
+    // For running queries, return null to not show error
+    return null;
   };
 
   const errorDetails = getErrorDetails();
 
   if (loading) {
     return <div className="text-center text-muted-foreground py-4 text-sm">Loading error details...</div>;
+  }
+
+  // If no error details (e.g., for running queries), don't show anything
+  if (!errorDetails) {
+    return null;
   }
 
   if (viewMode === 'details') {

--- a/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
@@ -43,7 +43,9 @@ export const QueriesSection = forwardRef<{ openAddEditor: () => void }, QueriesS
   }));
 
   const getStatus = (query: QueryResponse) => {
-    return (query.status as { phase?: string })?.phase || "pending";
+    const phase = (query.status as { phase?: string })?.phase;
+    if (!phase) return "draft";
+    return phase;
   };
 
   const {

--- a/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
@@ -43,9 +43,7 @@ export const QueriesSection = forwardRef<{ openAddEditor: () => void }, QueriesS
   }));
 
   const getStatus = (query: QueryResponse) => {
-    const phase = (query.status as { phase?: string })?.phase;
-    if (!phase) return "draft";
-    return phase;
+    return (query.status as { phase?: string })?.phase || "—";
   };
 
   const {


### PR DESCRIPTION
1. The ErrorResponseContent component was showing "Query failed - no specific error details available" for all queries that didn't have error events, including running queries.
 - Added phase/status check condition
 - Returned null for running queries
2. New query page incorrectly showed error panel and "pending" status
  - Error panel now completely hidden and will display only when there is an error
  - Phase field shows "-" instead of "pending" for new queries

<img width="1740" height="963" alt="image" src="https://github.com/user-attachments/assets/e446420c-e5be-4a76-88db-1e3462ba6a3c" />


## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 