### PR TITLE
fix: devspace httproutes missing

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -72,6 +72,8 @@ deployments:
             requests:
               memory: "256Mi"
               cpu: "200m"
+        httpRoute:
+          enabled: true
 
   ark-dashboard:
     namespace: default
@@ -91,6 +93,8 @@ deployments:
             requests:
               memory: "256Mi"
               cpu: "200m"
+        httpRoute:
+          enabled: true
 
   ark-controller:
     namespace: ark-system


### PR DESCRIPTION
- running `devspace dev` properly sets up routes for local testing

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 