### PR TITLE
fix: set continuous listening for mcp go client

### DIFF
--- a/ark/internal/genai/mcp.go
+++ b/ark/internal/genai/mcp.go
@@ -49,6 +49,7 @@ func createHTTPClient(baseURL string, headers map[string]string) (*mcpclient.Cli
 
 	if len(headers) > 0 {
 		opts = append(opts, transport.WithHTTPHeaders(headers))
+		opts = append(opts, transport.WithContinuousListening())
 	}
 
 	mcpClient, err := mcpclient.NewStreamableHttpClient(baseURL, opts...)


### PR DESCRIPTION
#42

- this makes sure client keeps connection open and responds to continuous ping requests from server

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 