### PR TITLE
fix: add webhook initialization delay in quickstart

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -133,13 +133,8 @@ quickstart() {
     # Check ark controller status, will warn the user if not deployed.
     check_ark_controller
 
-    # Webhook health check
-    echo "testing webhook connectivity..."
-    if ! kubectl get agent sample-agent >/dev/null 2>&1; then
-        echo -e "${yellow}warning${nc}: webhook may not be ready, restarting controller..."
-        kubectl delete pod -l app.kubernetes.io/name=ark-controller -n ark-system
-        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ark-controller -n ark-system --timeout=60s
-    fi
+    # Wait for webhook to be ready
+    sleep 5
 
     # Check for default model (cluster is now running and kubectl should work)
     if kubectl get model default >/dev/null 2>&1; then
@@ -516,6 +511,8 @@ check_ark_controller() {
             # Wait for controller to be ready before webhook validation can work
             kubectl wait --for=condition=available deployment/${ARK_CONTROLLER_NAME} -n ark-system --timeout=300s
             echo -e "${green}✔${nc} ark controller deployed"
+            # Wait for webhook server to fully initialize
+            sleep 10
         else
             echo -e "${yellow}warning${nc}: skipping ark controller deployment"
         fi

--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 package = true
 
 [tool.uv.sources]
-ark-sdk = { path = "../../../out/ark-sdk/py-sdk/dist/ark_sdk-0.1.34-py3-none-any.whl" }
+ark-sdk = { path = "../../../out/ark-sdk/py-sdk/dist/ark_sdk-0.1.35-py3-none-any.whl" }
 
 [tool.coverage.run]
 data_file = "coverage/.coverage"

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -119,26 +119,13 @@ export interface paths {
         };
         /**
          * List Secrets
-         * @description List all Kubernetes secrets in a namespace.
-         *
-         *     Args:
-         *         namespace: The namespace to list secrets from
-         *
-         *     Returns:
-         *         SecretListResponse: List of all secrets in the namespace
+         * @description List all secrets in namespace using ark-sdk.
          */
         get: operations["list_secrets_v1_namespaces__namespace__secrets_get"];
         put?: never;
         /**
          * Create Secret
-         * @description Create a new Kubernetes secret.
-         *
-         *     Args:
-         *         namespace: The namespace to create the secret in
-         *         body: The secret creation request
-         *
-         *     Returns:
-         *         SecretDetailResponse: The created secret details
+         * @description Create a new secret using ark-sdk.
          */
         post: operations["create_secret_v1_namespaces__namespace__secrets_post"];
         delete?: never;
@@ -156,37 +143,18 @@ export interface paths {
         };
         /**
          * Get Secret
-         * @description Get a specific Kubernetes secret by name.
-         *
-         *     Args:
-         *         namespace: The namespace to get the secret from
-         *         secret_name: The name of the secret
-         *
-         *     Returns:
-         *         SecretDetailResponse: The secret details with total data length
+         * @description Get a specific secret using ark-sdk.
          */
         get: operations["get_secret_v1_namespaces__namespace__secrets__secret_name__get"];
         /**
          * Update Secret
-         * @description Update a Kubernetes secret by name.
-         *
-         *     Args:
-         *         namespace: The namespace containing the secret
-         *         secret_name: The name of the secret
-         *         body: The secret update request
-         *
-         *     Returns:
-         *         SecretDetailResponse: The updated secret details
+         * @description Update a secret using ark-sdk.
          */
         put: operations["update_secret_v1_namespaces__namespace__secrets__secret_name__put"];
         post?: never;
         /**
          * Delete Secret
-         * @description Delete a Kubernetes secret by name.
-         *
-         *     Args:
-         *         namespace: The namespace containing the secret
-         *         secret_name: The name of the secret
+         * @description Delete a secret using ark-sdk.
          */
         delete: operations["delete_secret_v1_namespaces__namespace__secrets__secret_name__delete"];
         options?: never;
@@ -2256,6 +2224,8 @@ export interface components {
             message: {
                 [key: string]: unknown;
             };
+            /** Sequence */
+            sequence?: number | null;
         };
         /**
          * MemoryResponse
@@ -3514,11 +3484,13 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            204: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": unknown;
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Summary
- Add simple delays to allow webhook server to fully initialize
- Remove unnecessary controller restart that was counterproductive

## Problem
Webhook connection refused errors during quickstart when creating default model.

## Solution  
1. Wait 10 seconds after initial controller deployment for webhook to initialize
2. Wait 5 seconds before creating model resources
3. Remove the flawed webhook "test" that was restarting the controller unnecessarily

This minimal fix addresses the race condition without adding complexity.