### PR TITLE
fix: add unit test to ci/cd and fix failing tests

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -168,8 +168,8 @@ jobs:
           args: "--version"
 
       - run: make -j24 build-all
-      
-      - run: make -j24 test-all
+
+      - run: make -j24 services-test-all
       
       - uses: ./.github/actions/collect-coverage
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -169,6 +169,8 @@ jobs:
 
       - run: make -j24 build-all
       
+      - run: make -j24 test-all
+      
       - uses: ./.github/actions/collect-coverage
         with:
           source-path: services/ark-api/ark-api/coverage/

--- a/services/ark-cluster-memory/ark-cluster-memory/test/server.test.ts
+++ b/services/ark-cluster-memory/ark-cluster-memory/test/server.test.ts
@@ -2,6 +2,12 @@ import request from 'supertest';
 import app from '../src/server.js';
 
 describe('ARK Cluster Memory API', () => {
+  afterEach(async () => {
+      const getResponse = await request(app).delete('/messages');
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body.message).toEqual("Memory purged");
+   });
+
   describe('Health Check', () => {
     test('GET /health should return OK', async () => {
       const response = await request(app).get('/health');

--- a/services/ark-evaluator/tests/test_metric_unified_endpoints.py
+++ b/services/ark-evaluator/tests/test_metric_unified_endpoints.py
@@ -130,8 +130,13 @@ class TestUnifiedEndpoints:
         assert call_args.queryRef.name == "test-query"
         assert call_args.queryRef.namespace == "default"
     
-    def test_evaluate_batch_endpoint_not_implemented(self, client):
+    def test_evaluate_batch_endpoint_not_implemented(self, client, mock_evaluator):
         """Test /evaluate endpoint with batch type returns not implemented"""
+
+        # Mock the evaluator response
+        mock_response = Mock()
+        mock_evaluator.evaluate_query_ref = AsyncMock(return_value=mock_response)
+
         request_data = {
             "type": "batch",
             "config": {


### PR DESCRIPTION
**CI/CD Workflow:** 
Adds a `make -j24 services-test-all` step to the GitHub Actions workflow for more comprehensive service testing.

**Test Isolation:** 
Adds memory purge after each test in ark-cluster-memory API tests to ensure a clean state between tests. 

**Batch Endpoint Test:** 
Updates the batch endpoint test in ark-evaluator to use a mock evaluator, improving test isolation and reliability. Otherwise the test tries to read cube config.
