### PR TITLE
docs: improve troubleshooting guide and streamline quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,11 @@ Libraries and SDKs currently exist for:
 - Python
 - Node.JS
 
+## Contributing to docs
+You can help us improve the [documentation](https://mckinsey.github.io/agents-at-scale-ark/) online. A contribution to the docs is often the easiest way to get started contributing to the project.
+
+In order to preview the docs locally, you can run `make docs` in the root of the project. This will run the documentation site with live-reload, and you can then view the docs at `http://localhost:3000`.
+
 ## Guidelines for contributing developers
 
 Note that any contributions you make will be under the Agents At Scale [license](./LICENSE).

--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -4,7 +4,23 @@ title: Getting Started
 
 # Quickstart
 
-Ensure you have [Node.js](https://nodejs.org/en/download) and [Helm](https://helm.sh/docs/intro/install/) installed. Then run the following commands to install Ark:
+Ensure you have [Node.js](https://nodejs.org/en/download) and [Orbstack](https://orbstack.dev/) installed. 
+
+The easiest way to ensure you have everything needed is to use [Homebrew](https://brew.sh/):
+
+```bash
+brew install node
+brew install kubectl
+brew install orbstack
+```
+
+Verify that your context is set to Orbstack by using:
+
+```bash
+kubectl config get-contexts
+```
+
+Then run the following commands to install Ark:
 
 ```bash
 # Install the 'ark' CLI:

--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -4,23 +4,7 @@ title: Getting Started
 
 # Quickstart
 
-Ensure you have [Node.js](https://nodejs.org/en/download) and [Orbstack](https://orbstack.dev/) installed. 
-
-The easiest way to ensure you have everything needed is to use [Homebrew](https://brew.sh/):
-
-```bash
-brew install node
-brew install kubectl
-brew install orbstack
-```
-
-Verify that your context is set to Orbstack by using:
-
-```bash
-kubectl config get-contexts
-```
-
-Then run the following commands to install Ark:
+Ensure you have [Node.js](https://nodejs.org/en/download) and [Helm](https://helm.sh/docs/intro/install/) installed. Then run the following commands to install Ark:
 
 ```bash
 # Install the 'ark' CLI:
@@ -46,6 +30,6 @@ Detailed instructions on how to install specific componets, configure RBAC, setu
 
 You can also install the [Fark](../developer-guide/cli-tools.mdx) (Fast Agentic Runtime Kit) CLI tool to manage agents, run queries and more.
 
-## Windows Installation
+## Troubleshooting
 
-To run Ark on Windows, you can run Kubernetes in [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/), [Minikube](https://minikube.sigs.k8s.io/docs/start/) or other Kubernetes cluster providers. In most cases you will have to enable [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install). Additional instructions and troubleshooting guides are in the [Installing Ark on Windows](../reference/troubleshooting#installing-ark-on-windows) section of the [Troubleshooting](../reference/troubleshooting) guide.
+If you encounter any issues during installation, see the [Troubleshooting](../reference/troubleshooting) guide.

--- a/docs/content/reference/troubleshooting.mdx
+++ b/docs/content/reference/troubleshooting.mdx
@@ -2,7 +2,35 @@
 
 Troubleshooting guide for challenges when installing or using Ark.
 
-## Installing Ark on Windows
+## Ark Installation
+
+This section covers common issues and solutions when installing Ark on various platforms.
+
+### Prerequisites
+
+Before installing Ark, ensure you have:
+- [Node.js](https://nodejs.org/en/download) (v18 or later)
+- A Kubernetes cluster (e.g.,  [Docker Desktop](https://docs.docker.com/desktop/), [Minikube](https://minikube.sigs.k8s.io/docs/start/), [Kind](https://kind.sigs.k8s.io/), or [Orbstack](https://orbstack.dev/)).
+- kubectl and Helm
+
+The easiest way to install dependencies on macOS:
+
+```bash
+brew install node kubectl helm
+
+# Install a cluster such as:
+# brew install minikube
+# brew install kind
+# brew install orbstack
+```
+
+Verify your cluster context:
+
+```bash
+kubectl config get-contexts
+```
+
+### Installing Ark on Windows
 
 Ark requires a Kubernetes cluster to run. There are a number of potential issues that can arise from permissions, organizational policies and so on, particularly around running Hypervisors (which is needed to run services like Docker and local Kubernetes clusters).
 


### PR DESCRIPTION
## Summary
- Move installation prerequisites to troubleshooting guide  
- Add 'Ark Installation' section with common issues
- Keep quickstart lean and focused on core steps
- Windows installation now as subsection under Ark Installation

Based on PR #216 from @maxschulz-COL

Closes #216