### PR TITLE
fix: Trigger CI on draft → ready conversion (add ready_for_review to PR events)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["main"]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 # Release please will create pull requests, update the changelog, and cicd will


### PR DESCRIPTION
Add ready_for_review to pull_request.types in [cicd.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Reason: converting a Draft PR to "Ready for review" did not trigger CI because the workflow only listened for opened/synchronize/reopened. This ensures the pipeline (including build-and-test-services) runs when a draft is marked ready.
Impact: No change to existing triggers; only adds the conversion event. Safe, minimal CI config change.
Verification: Converting a draft PR to Ready for review should now queue the CI run.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 