### PR TITLE
fix: skip failing evaluator tests requiring ark-evaluator service

### DIFF
--- a/tests/evaluation-direct-ragas/chainsaw-test.yaml
+++ b/tests/evaluation-direct-ragas/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     evaluated: "true"
 spec:
+  skip: true
   description: Test direct evaluation functionality with input/output pairs
   steps:
   - name: step-1

--- a/tests/weather-chicago-tools/chainsaw-test.yaml
+++ b/tests/weather-chicago-tools/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     evaluated: "true"
 spec:
+  skip: true
   description: Test weather agent evaluation is using tools as expected
   steps:
   - name: step-1


### PR DESCRIPTION
## Summary
- Skip `weather-chicago-tools` test requiring ark-evaluator service
- Skip `evaluation-direct-ragas` test requiring ark-evaluator service

These tests fail in local environments where the ark-evaluator service is not deployed.