### PR TITLE
fix: correct evaluator tests requiring ark-evaluator service (revert)

### DIFF
--- a/tests/evaluation-direct-ragas/chainsaw-test.yaml
+++ b/tests/evaluation-direct-ragas/chainsaw-test.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     evaluated: "true"
 spec:
-  skip: true
   description: Test direct evaluation functionality with input/output pairs
   steps:
   - name: step-1

--- a/tests/weather-chicago-tools/chainsaw-test.yaml
+++ b/tests/weather-chicago-tools/chainsaw-test.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     evaluated: "true"
 spec:
-  skip: true
   description: Test weather agent evaluation is using tools as expected
   steps:
   - name: step-1


### PR DESCRIPTION
Reverts mckinsey/agents-at-scale-ark#230