### PR TITLE
fix: sync dist CRDs with latest changes

### DIFF
--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_agents.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_agents.yaml
@@ -278,4 +278,4 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}
+{{- end -}}

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_evaluations.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_evaluations.yaml
@@ -150,7 +150,8 @@ spec:
                                       queryParameterRef:
                                         properties:
                                           name:
-                                            description: Name of the parameter from the Query resource
+                                            description: Name of the parameter from
+                                              the Query resource
                                             minLength: 1
                                             type: string
                                         required:
@@ -378,7 +379,8 @@ spec:
                                     queryParameterRef:
                                       properties:
                                         name:
-                                          description: Name of the parameter from the Query resource
+                                          description: Name of the parameter from
+                                            the Query resource
                                           minLength: 1
                                           type: string
                                       required:
@@ -486,7 +488,8 @@ spec:
                                 queryParameterRef:
                                   properties:
                                     name:
-                                      description: Name of the parameter from the Query resource
+                                      description: Name of the parameter from the
+                                        Query resource
                                       minLength: 1
                                       type: string
                                   required:
@@ -606,7 +609,8 @@ spec:
                             queryParameterRef:
                               properties:
                                 name:
-                                  description: Name of the parameter from the Query resource
+                                  description: Name of the parameter from the Query
+                                    resource
                                   minLength: 1
                                   type: string
                               required:

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_evaluators.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_evaluators.yaml
@@ -89,6 +89,15 @@ spec:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
+                      queryParameterRef:
+                        properties:
+                          name:
+                            description: Name of the parameter from the Query resource
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
                       secretKeyRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_mcpservers.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_mcpservers.yaml
@@ -90,6 +90,15 @@ spec:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
+                      queryParameterRef:
+                        properties:
+                          name:
+                            description: Name of the parameter from the Query resource
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
                       secretKeyRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_memories.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_memories.yaml
@@ -88,6 +88,15 @@ spec:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
+                      queryParameterRef:
+                        properties:
+                          name:
+                            description: Name of the parameter from the Query resource
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
                       secretKeyRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_models.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_models.yaml
@@ -93,6 +93,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -173,6 +183,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -253,6 +273,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -334,6 +364,16 @@ spec:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                queryParameterRef:
+                                  properties:
+                                    name:
+                                      description: Name of the parameter from the
+                                        Query resource
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 secretKeyRef:
                                   description: SecretKeySelector selects a key of
                                     a Secret.
@@ -423,6 +463,106 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              secretKeyRef:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceRef:
+                                properties:
+                                  name:
+                                    description: Name of the service
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the service. Defaults
+                                      to the namespace as the resource.
+                                    type: string
+                                  path:
+                                    description: Optional path to append to the service
+                                      address. For models might be 'v1', for gemini
+                                      might be 'v1beta/openai', for mcp servers might
+                                      be 'mcp'.
+                                    type: string
+                                  port:
+                                    description: Port name to use. If not specified,
+                                      uses the service's only port or first port.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                        type: object
+                      baseUrl:
+                        description: ValueSource represents a source for a configuration
+                          value
+                        properties:
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key from a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -507,6 +647,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -588,6 +738,16 @@ spec:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                queryParameterRef:
+                                  properties:
+                                    name:
+                                      description: Name of the parameter from the
+                                        Query resource
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 secretKeyRef:
                                   description: SecretKeySelector selects a key of
                                     a Secret.
@@ -669,6 +829,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -749,6 +919,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -829,6 +1009,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -916,6 +1106,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -996,6 +1196,16 @@ spec:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              queryParameterRef:
+                                properties:
+                                  name:
+                                    description: Name of the parameter from the Query
+                                      resource
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
                               secretKeyRef:
                                 description: SecretKeySelector selects a key of a
                                   Secret.
@@ -1077,6 +1287,16 @@ spec:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                queryParameterRef:
+                                  properties:
+                                    name:
+                                      description: Name of the parameter from the
+                                        Query resource
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 secretKeyRef:
                                   description: SecretKeySelector selects a key of
                                     a Secret.
@@ -1162,6 +1382,15 @@ spec:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
+                      queryParameterRef:
+                        properties:
+                          name:
+                            description: Name of the parameter from the Query resource
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
                       secretKeyRef:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_queries.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_queries.yaml
@@ -27,9 +27,6 @@ spec:
     - jsonPath: .status.duration
       name: Duration
       type: string
-    - jsonPath: .status.evaluations.length
-      name: Evaluations
-      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -59,67 +56,6 @@ spec:
               cancel:
                 description: When true, indicates intent to cancel the query
                 type: boolean
-              evaluatorSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              evaluators:
-                items:
-                  properties:
-                    name:
-                      minLength: 1
-                      type: string
-                    namespace:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
               input:
                 minLength: 1
                 type: string
@@ -317,21 +253,6 @@ spec:
             properties:
               duration:
                 type: string
-              evaluations:
-                items:
-                  properties:
-                    evaluatorName:
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    passed:
-                      type: boolean
-                    score:
-                      type: string
-                  type: object
-                type: array
               phase:
                 default: pending
                 enum:
@@ -343,6 +264,7 @@ spec:
                 type: string
               responses:
                 items:
+                  description: Response defines a response from a query target.
                   properties:
                     content:
                       type: string

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_tools.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_tools.yaml
@@ -146,7 +146,8 @@ spec:
                             queryParameterRef:
                               properties:
                                 name:
-                                  description: Name of the parameter from the Query resource
+                                  description: Name of the parameter from the Query
+                                    resource
                                   minLength: 1
                                   type: string
                               required:

--- a/ark/dist/chart/templates/rbac/ark_controller_role.yaml
+++ b/ark/dist/chart/templates/rbac/ark_controller_role.yaml
@@ -26,14 +26,12 @@ rules:
   - list
   - patch
   - watch
-{{- if .Values.rbac.impersonation.enabled }}
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   verbs:
   - impersonate
-{{- end }}
 - apiGroups:
   - ark.mckinsey.com
   resources:


### PR DESCRIPTION
## Summary
- Sync dist Helm chart CRDs with raw CRDs from config/crd/bases
- Add missing baseUrl field for Bedrock models (from PR #124)
- Add missing queryParameterRef support across all ValueSource fields (from PR #140)