### PR TITLE
docs: clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 
 ## Quickstart
 
-Ensure you have [Node.js](https://nodejs.org/en/download) and [Helm](https://helm.sh/docs/intro/install/) installed. Then run the following commands to install Ark:
+You will need a Kubernetes cluster to install Ark into. You can use [Minikube](https://minikube.sigs.k8s.io/docs/start), [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/), [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) or similar to run a local cluster. 
+
+Ensure you have [Node.js](https://nodejs.org/en/download) and [Helm](https://helm.sh/docs/intro/install/) installed, as well as [kubectl](https://kubernetes.io/docs/reference/kubectl/) if not already installed as part of your Kubernetes setup. Then run the following commands to install Ark:
 
 ```bash
 # Install the 'ark' CLI:
@@ -39,13 +41,11 @@ ark models create default
 ark dashboard
 ```
 
-In most cases the default installation options will be sufficient. This will install the Ark dependencies, the controller, the APIs and the dashboard. You can optionally setup a `default` model that will be the default used by agents. You will need a Kubernetes cluster to install Ark into, you can use [Minikube](https://minikube.sigs.k8s.io/docs/start), [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/), [Docker Desktop](https://docs.docker.com/desktop/kubernetes/) or similar to run a local cluster. The `install` command will warn if any required dependencies are missing.
+In most cases the default installation options will be sufficient. This will install the Ark dependencies, the controller, the APIs and the dashboard. You can optionally setup a `default` model that will be the default used by agents. The `install` command will warn if any required dependencies are missing.
 
 User guides, developer guides, operations guides and API reference documentation is all available at:
 
 https://mckinsey.github.io/agents-at-scale-ark/
-
-The [Quickstart](https://mckinsey.github.io/agents-at-scale-ark/quickstart/) guide will walk you through the process of configuring a model, creating an agent and running basic queries.
 
 To troubleshoot an installation, run `ark status`.
 


### PR DESCRIPTION
A small tweak to the readme to reduce confusion when installing from a new laptop. Puts the section about having Kubernetes and kubectl installed before the ark install command, which will fail if these requirements aren't met.

Removes link to the quickstart page which doesn't contain the information that the readme says it does, and which is mostly redundant with this readme. There doesn't seem to be an obvious page that does contain this information and it seems best to just use the link to the guide in the previous line.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 