### PR TITLE
docs: small typo in queries page

### DIFF
--- a/docs/content/user-guide/queries.mdx
+++ b/docs/content/user-guide/queries.mdx
@@ -5,7 +5,7 @@ description: Learn how to create and execute queries against agents and teams
 
 # Creating Queries
 
-Queries are how you interact with models, toosl, agents and teams in ARK. A query sends input to any target, or set of targets, and receives a response. You can create queries using `kubectl`, the `fark` CLI, the ARK APIs or our OpenAI-compatible endpoints.
+Queries are how you interact with models, tools, agents and teams in ARK. A query sends input to any target, or set of targets, and receives a response. You can create queries using `kubectl`, the `fark` CLI, the ARK APIs or our OpenAI-compatible endpoints.
 
 ## What is a Query?
 


### PR DESCRIPTION
Just a small fix while I was browsing the docs.

## Checklist

- [X] Follow the [contributor guide](./CONTRIBUTING.md)
- [X] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 