### PR TITLE
fix: raw message serialization golang structs

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -388,8 +388,7 @@ func (r *QueryReconciler) reconcileQueue(ctx context.Context, query arkv1alpha1.
 		if result.messages != nil {
 			rawJSON, err := serializeMessages(result.messages)
 			if err != nil {
-				logf.Log.Error(err, "Failed to serialize messages", "target", result.target)
-				rawJSON = "[]" // fallback to empty array
+				return nil, eventStream, fmt.Errorf("failed to serialize messages for target %v: %w", result.target, err)
 			}
 			allResponses = append(allResponses, arkv1alpha1.Response{
 				Target:  result.target,

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -386,15 +386,19 @@ func (r *QueryReconciler) reconcileQueue(ctx context.Context, query arkv1alpha1.
 		}
 		// Skip targets that were delegated to external execution engines (messages == nil)
 		if result.messages != nil {
-			rawBytes, _ := json.Marshal(result.messages) // full original message array
+			rawJSON, err := serializeMessages(result.messages)
+			if err != nil {
+				logf.Log.Error(err, "Failed to serialize messages", "target", result.target)
+				rawJSON = "[]" // fallback to empty array
+			}
 			allResponses = append(allResponses, arkv1alpha1.Response{
 				Target:  result.target,
 				Content: messageToText(result.messages[len(result.messages)-1]), // Get last message explicitly
-				Raw:     string(rawBytes),
+				Raw:     rawJSON,
 			})
 		}
 	}
-
+	
 	return allResponses, eventStream, nil
 }
 
@@ -415,6 +419,32 @@ func messageToText(message genai.Message) string {
 			"message", message)
 		return ""
 	}
+}
+
+// serializeMessages converts OpenAI union message types to their actual content for JSON serialization
+func serializeMessages(messages []genai.Message) (string, error) {
+	var actualMessages []interface{}
+	for _, msg := range messages {
+		switch {
+		case msg.OfAssistant != nil:
+			actualMessages = append(actualMessages, msg.OfAssistant)
+		case msg.OfUser != nil:
+			actualMessages = append(actualMessages, msg.OfUser)
+		case msg.OfSystem != nil:
+			actualMessages = append(actualMessages, msg.OfSystem)
+		case msg.OfTool != nil:
+			actualMessages = append(actualMessages, msg.OfTool)
+		case msg.OfFunction != nil:
+			actualMessages = append(actualMessages, msg.OfFunction)
+		default:
+			return "", fmt.Errorf("unknown message type encountered during serialization")
+		}
+	}
+	rawBytes, err := json.Marshal(actualMessages)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal messages: %w", err)
+	}
+	return string(rawBytes), nil
 }
 
 func (r *QueryReconciler) updateStatus(ctx context.Context, query *arkv1alpha1.Query, status string) error {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openai/openai-go"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/genai"
 )
 
 var _ = Describe("Query Controller", func() {
@@ -77,6 +79,34 @@ var _ = Describe("Query Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})
+
+var _ = Describe("Query Controller Message Serialization", func() {
+	Context("When serializing messages", func() {
+		It("should serialize all message types correctly", func() {
+			messages := []genai.Message{
+				genai.Message(openai.AssistantMessage("hello")),
+				genai.Message(openai.UserMessage("hi")),
+				genai.Message(openai.SystemMessage("sys")),
+				genai.Message(openai.ToolMessage("tool-content", "tool-1")),
+			}
+
+			jsonStr, err := serializeMessages(messages)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(jsonStr).To(ContainSubstring("assistant"))
+			Expect(jsonStr).To(ContainSubstring("user"))
+			Expect(jsonStr).To(ContainSubstring("system"))
+			Expect(jsonStr).To(ContainSubstring("tool"))
+		})
+
+		It("should return error for unknown message types", func() {
+			// Create a message with no known type
+			messages := []genai.Message{{}}
+			_, err := serializeMessages(messages)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown message type encountered during serialization"))
 		})
 	})
 })


### PR DESCRIPTION
## Fix OpenAI Message Serialization for Raw Field in Query Controller

**Problem:** The ARK Query controller was incorrectly serializing OpenAI union message types, causing Go struct metadata to leak into the Raw field instead of proper JSON content.

**Solution:** 
- Added `serializeMessages()` function to properly extract and serialize the actual message content from OpenAI's union types
- Implemented error handling for unknown message types

**Changes:**
- `query_controller.go`: New serialization logic with support for all OpenAI message types (Assistant, User, System, Tool, Function)
- `query_controller_test.go`: Complete test coverage for serialization scenarios

**Impact:** Query responses now contain properly formatted JSON in the Raw field instead of Go struct representations, enabling correct downstream processing of conversation history.

**Examples:**

Before:
```
[...]
Kind:         Query
[...]
  Phase:     done
  Responses:
    Content:  Why did the Berlin hipster burn his mouth? Because he drank his coffee before it was cool!
    Raw:      [{"OfAssistant":{"name":"first-agent","content":"Why did the Berlin hipster burn his mouth? Because he drank his coffee before it was cool!","role":"assistant"}}]
[...]
``` 
After
```
[...]
Kind:         Query
[...]
  Phase:     done
  Responses:
    Content:  Why did the scarecrow win an award?
Because he was outstanding in his field!
    Raw:  [{"content":"Why did the scarecrow win an award?\nBecause he was outstanding in his field!","role":"assistant"}]
[...]
```


## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 