### PR TITLE
fix: remove setup.py to prevent imp module error in Python 3.12+

### DIFF
--- a/lib/ark-sdk/install.sh
+++ b/lib/ark-sdk/install.sh
@@ -62,5 +62,8 @@ uv run python generate_ark_clients.py -t "$OPENAPI_FILE" \
 uv sync
 
 pushd "$PY_SDK_DIR" >/dev/null
+
+rm -f setup.py setup.cfg
+
 uv run python -m build .
 popd >/dev/null


### PR DESCRIPTION
The OpenAPI Generator creates both setup.py and pyproject.toml.
When both exist, some build tools may invoke setuptools instead of hatchling, causing installation failures with`ModuleNotFoundError: No module named 'imp'` on Python 3.12+ where the imp module was removed. Removing setup.py/setup.cfg ensures the build uses only hatchling as specified in pyproject.toml.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 