### PR TITLE
feat: refactors dashboard layout to use unified page header

### DIFF
--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 package = true
 
 [tool.uv.sources]
-ark-sdk = { path = "../../../out/ark-sdk/py-sdk/dist/ark_sdk-0.1.36-py3-none-any.whl" }
+ark-sdk = { path = "out/ark_sdk-0.1.37-py3-none-any.whl" }
 
 [tool.coverage.run]
 data_file = "coverage/.coverage"

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/a2a/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/a2a/page.tsx
@@ -4,16 +4,13 @@ import { A2AServersSection } from "@/components/sections/a2a-servers-section";
 import type { A2AServersSectionHandle } from "@/components/sections/a2a-servers-section";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useRef } from "react";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb";
-import { Separator } from "@/components/ui/separator";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function A2AContent() {
   const searchParams = useSearchParams();
@@ -22,27 +19,12 @@ function A2AContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mr-2 data-[orientation=vertical]:h-4"
-        />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>A2A Servers</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => a2aSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add A2A Server
-          </Button>
-        </div>
-      </header>
-
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="A2A Servers" actions={
+        <Button onClick={() => a2aSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add A2A Server
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <A2AServersSection ref={a2aSectionRef} namespace={namespace} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/agents/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/agents/page.tsx
@@ -2,39 +2,25 @@
 
 import { AgentsSection } from "@/components/sections/agents-section"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function AgentsContent() {
   const agentsSectionRef = useRef<{ openAddEditor: () => void }>(null)
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Agents</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => agentsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Agent
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Agents" actions={
+        <Button onClick={() => agentsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Agent
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <AgentsSection ref={agentsSectionRef} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluation/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluation/[id]/page.tsx
@@ -2,16 +2,13 @@
 
 import { Suspense } from "react"
 import { useParams, useSearchParams } from "next/navigation"
-import { SidebarTrigger } from "@/components/ui/sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb"
 import { EvaluationDetailView } from "@/components/evaluation"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/evaluations', label: "Evaluations" }
+]
 
 function EvaluationDetailContent() {
   const params = useParams()
@@ -22,28 +19,7 @@ function EvaluationDetailContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/">
-                ARK Dashboard
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbLink href={`/evaluations`}>
-                Evaluations
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{evaluationId}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage={evaluationId} />
       <div className="flex flex-1 flex-col gap-4 p-4">
         <EvaluationDetailView evaluationId={evaluationId} namespace={namespace} enhanced={enhanced} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluations/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluations/page.tsx
@@ -3,17 +3,13 @@
 import { Suspense, useRef } from "react"
 import { useSearchParams } from "next/navigation"
 import { Plus } from "lucide-react"
-import { SidebarTrigger } from "@/components/ui/sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb"
 import { Button } from "@/components/ui/button"
 import { EvaluationsSection } from "@/components/sections"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function EvaluationsContent() {
   const searchParams = useSearchParams()
@@ -22,31 +18,15 @@ function EvaluationsContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/">
-                ARK Dashboard
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Evaluations</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => evaluationsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4" />
-            Add Evaluation
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Evaluations" actions={
+        <Button onClick={() => evaluationsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4" />
+          Add Evaluation
+        </Button>
+      } />
       <div className="flex flex-1 flex-col gap-4 p-4">
-        <EvaluationsSection 
-          ref={evaluationsSectionRef} 
+        <EvaluationsSection
+          ref={evaluationsSectionRef}
           initialQueryFilter={queryFilter}
         />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluators/[name]/edit/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluators/[name]/edit/page.tsx
@@ -1,15 +1,7 @@
 "use client";
 
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
 import { EvaluatorEditForm } from "@/components/forms/evaluator-edit-form";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { toast } from "@/components/ui/use-toast";
 import {
   evaluatorsService,
@@ -17,6 +9,11 @@ import {
 } from "@/lib/services";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/evaluators', label: "Evaluators" }
+]
 
 interface EvaluatorEditContentProps {
   namespace: string;
@@ -105,27 +102,7 @@ function EvaluatorEditContent({
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/">ARK Dashboard</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbLink href={`/evaluators`}>
-                Evaluators
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Edit {evaluator.name}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
-
+      <PageHeader breadcrumbs={breadcrumbs} currentPage={`Edit ${evaluator.name}`} />
       <div className="flex-1 overflow-hidden">
         <EvaluatorEditForm
           evaluator={evaluator}

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluators/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/evaluators/page.tsx
@@ -2,45 +2,25 @@
 
 import { Suspense, useRef } from "react"
 import { Plus } from "lucide-react"
-import { SidebarTrigger } from "@/components/ui/sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb"
 import { Button } from "@/components/ui/button"
 import { EvaluatorsSection } from "@/components/sections"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function EvaluatorsContent() {
   const evaluatorsSectionRef = useRef<{ openAddEditor: () => void }>(null)
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/">
-                ARK Dashboard
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Evaluators</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => evaluatorsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4" />
-            Add Evaluator
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Evaluators" actions={
+        <Button onClick={() => evaluatorsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4" />
+          Add Evaluator
+        </Button>
+      } />
       <div className="flex flex-1 flex-col gap-4 p-4">
         <EvaluatorsSection ref={evaluatorsSectionRef} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/event/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/event/[id]/page.tsx
@@ -1,17 +1,8 @@
 "use client";
 
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb";
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -23,6 +14,11 @@ import type { Event } from "@/lib/services/events";
 import { eventsService } from "@/lib/services/events";
 import { useParams, useRouter } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/events', label: "Events" }
+]
 
 // Reusable styles for table field headings
 const FIELD_HEADING_STYLES =
@@ -177,35 +173,7 @@ function EventDetailContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mr-2 data-[orientation=vertical]:h-4"
-        />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href={`/events`}>
-                Events
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{event.name}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => router.push(`/events`)}
-          >
-            Back to Events
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage={event.name} />
       <div className="flex h-full flex-col">
         {/* Event Details - Four Column Layout */}
         <div className="px-4 py-3 border-b bg-gray-50/30 dark:bg-gray-900/10">

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/events/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/events/page.tsx
@@ -1,12 +1,9 @@
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
 import { EventsSection } from "@/components/sections/events-section"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 type SearchParams = {
   page?: string
@@ -27,8 +24,8 @@ export default async function EventsPage({
   const filters = (await searchParams)
 
   const parsedFilters = {
-    page: filters.page ? parseInt(filters.page, 10): defaultPage,
-    limit: filters.limit ? parseInt(filters.limit, 10): defaultLimit,
+    page: filters.page ? parseInt(filters.page, 10) : defaultPage,
+    limit: filters.limit ? parseInt(filters.limit, 10) : defaultLimit,
     type: filters.type,
     kind: filters.kind,
     name: filters.name
@@ -36,19 +33,9 @@ export default async function EventsPage({
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Events</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Events" />
       <div className="flex flex-1 flex-col">
-        <EventsSection {...parsedFilters}/>
+        <EventsSection {...parsedFilters} />
       </div>
     </>
   )

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/mcp/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/mcp/page.tsx
@@ -3,16 +3,13 @@
 import { McpServersSection } from "@/components/sections/mcp-servers-section"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function McpContent() {
   const searchParams = useSearchParams()
@@ -21,23 +18,12 @@ function McpContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>MCP Servers</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => mcpSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add MCP Server
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="MCP Servers" actions={
+        <Button onClick={() => mcpSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add MCP Server
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <McpServersSection ref={mcpSectionRef} namespace={namespace} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/memory/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/memory/page.tsx
@@ -3,14 +3,11 @@
 import { MemorySection } from "@/components/sections/memory-section"
 import { useSearchParams } from "next/navigation"
 import { Suspense } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function MemoryContent() {
   const searchParams = useSearchParams()
@@ -23,17 +20,7 @@ function MemoryContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Memory</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Memory" />
       <div className="flex flex-1 flex-col">
         <MemorySection initialFilters={initialFilters} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/models/new/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/models/new/page.tsx
@@ -1,7 +1,5 @@
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
 import { ModelConfiguratorForm } from "@/components/forms/model-configuration-form";
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
-import { Separator } from "@/components/ui/separator";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 
 type SearchParams = {
   name?: string
@@ -11,34 +9,17 @@ type Props = {
   searchParams: Promise<SearchParams>
 }
 
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/models', label: "Models" }
+]
+
 export default async function CreateModelPage({ searchParams }: Props) {
   const params = (await searchParams)
 
   return (
     <div className="min-h-screen">
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/">
-                ARK Dashboard
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="/models">
-                Models
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator className="hidden md:block" />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Add New Model</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Add New Model" />
       <main className="container px-6 py-8">
         <ModelConfiguratorForm defaultName={params.name} />
       </main>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/models/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/models/page.tsx
@@ -3,17 +3,14 @@
 import { ModelsSection } from "@/components/sections/models-section"
 import { useSearchParams } from "next/navigation"
 import { Suspense } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
 import Link from "next/link"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function ModelsContent() {
   const searchParams = useSearchParams()
@@ -21,25 +18,14 @@ function ModelsContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Models</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Link href="/models/new">
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Model
-            </Button>
-          </Link>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Models" actions={
+        <Link href="/models/new">
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Model
+          </Button>
+        </Link>
+      } />
       <div className="flex flex-1 flex-col">
         <ModelsSection namespace={namespace} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/page.tsx
@@ -14,9 +14,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertTriangleIcon, ArrowRight } from "lucide-react";
 import Link from "next/link";
-import { SidebarTrigger } from "@/components/ui/sidebar";
-import { Separator } from "@/components/ui/separator";
-import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@/components/ui/breadcrumb";
+import { PageHeader } from "@/components/common/page-header";
 
 export default function HomePage() {
   const { data: models, isPending, error } = useGetAllModels();
@@ -44,17 +42,7 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>ARK Dashboard</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader currentPage="ARK Dashboard" />
       <main className="container p-6 py-8 space-y-8">
         <section>
           <h2 className="text-3xl font-bold text-balance mb-2">

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/queries/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/queries/page.tsx
@@ -2,38 +2,24 @@
 
 import { QueriesSection } from "@/components/sections/queries-section"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function QueriesContent() {
   const queriesSectionRef = useRef<{ openAddEditor: () => void }>(null)
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Queries</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => queriesSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Query
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Queries" actions={
+        <Button onClick={() => queriesSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Query
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <QueriesSection ref={queriesSectionRef} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
@@ -7,20 +7,10 @@ import { Copy } from "lucide-react"
 import { QueryTargetsField } from "@/components/query-fields/query-targets-field"
 import { QueryMemoryField } from "@/components/query-fields/query-memory-field"
 import { QueryEvaluationActions } from "@/components/query-actions"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
@@ -45,13 +35,18 @@ import { simplifyDuration } from "@/lib/utils/time";
 import { ARK_ANNOTATIONS } from "@/lib/constants/annotations";
 import JsonDisplay from "@/components/JsonDisplay"
 import { ErrorResponseContent } from '@/components/ErrorResponseContent';
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
 
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/queries', label: "Queries" }
+]
 
 // Component for rendering response content
-function ResponseContent({ content, viewMode, rawJson }: { content: string, viewMode: 'content'| 'text' | 'markdown' | 'raw', rawJson?: unknown }) {
-  
+function ResponseContent({ content, viewMode, rawJson }: { content: string, viewMode: 'content' | 'text' | 'markdown' | 'raw', rawJson?: unknown }) {
+
   const markdownContent = useMarkdownProcessor(content);
-  
+
   if (viewMode === 'raw') {
     const getJsonDisplay = () => {
       if (rawJson && typeof rawJson === 'object' && (rawJson as { raw?: string }).raw) {
@@ -60,7 +55,7 @@ function ResponseContent({ content, viewMode, rawJson }: { content: string, view
           // Create a more readable structure
           const readableJson = {
             content: (rawJson as { content?: string }).content || "No content",
-            target: (rawJson as { target?: { name?: string; type?: string } }).target || "No target", 
+            target: (rawJson as { target?: { name?: string; type?: string } }).target || "No target",
             raw: parsed
           };
           return readableJson;
@@ -73,14 +68,14 @@ function ResponseContent({ content, viewMode, rawJson }: { content: string, view
 
     return (
       <div className="text-sm">
-        <JsonDisplay 
-          value={getJsonDisplay()} 
+        <JsonDisplay
+          value={getJsonDisplay()}
           className="bg-black text-white p-4 rounded text-sm font-mono whitespace-pre-wrap break-words"
         />
       </div>
     )
   }
-  
+
 
   if (viewMode === "content") {
     return <div className="text-sm">{markdownContent}</div>;
@@ -93,7 +88,7 @@ function ResponseContent({ content, viewMode, rawJson }: { content: string, view
       </pre>
     )
   }
-  
+
   return (
     <pre className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono bg-gray-50 dark:bg-gray-900/50 p-3">
       {content || "No content"}
@@ -161,9 +156,9 @@ function QueryDurationField({ mode, value, onChange, label, placeholder, inputRe
           </TooltipProvider>
         </td>
         <td className="px-3 py-2">
-          <Input 
+          <Input
             ref={inputRef}
-            value={value || ''} 
+            value={value || ''}
             onChange={(e) => onChange?.(e.target.value)}
             placeholder={placeholder}
             className="text-xs"
@@ -212,9 +207,9 @@ function QueryNameField({ mode, value, onChange, label, placeholder, inputRef, t
           </TooltipProvider>
         </td>
         <td className="px-3 py-2">
-          <Input 
+          <Input
             ref={inputRef}
-            value={value || ''} 
+            value={value || ''}
             onChange={(e) => onChange?.(e.target.value)}
             placeholder={placeholder || "Enter query name"}
             className="text-xs"
@@ -257,7 +252,7 @@ interface QueryStreamingFieldProps {
 
 function QueryStreamingField({ mode, value, onChange, label, tooltip, metadata }: QueryStreamingFieldProps) {
   // For view mode, check if streaming annotation exists
-  const isStreamingEnabled = mode === 'view' 
+  const isStreamingEnabled = mode === 'view'
     ? metadata?.annotations?.[ARK_ANNOTATIONS.STREAMING_ENABLED] === "true"
     : value
 
@@ -304,9 +299,9 @@ function QueryDetailContent() {
   const [query, setQuery] = useState<TypedQueryDetailResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [evaluationCount, setEvaluationCount] = useState(0)
-  const [availableTargets, setAvailableTargets] = useState<Array<{name: string, type: 'agent' | 'model' | 'team' | 'tool'}>>([])
+  const [availableTargets, setAvailableTargets] = useState<Array<{ name: string, type: 'agent' | 'model' | 'team' | 'tool' }>>([])
   const [targetsLoading, setTargetsLoading] = useState(false)
-  const [availableMemories, setAvailableMemories] = useState<Array<{name: string}>>([])
+  const [availableMemories, setAvailableMemories] = useState<Array<{ name: string }>>([])
   const [memoriesLoading, setMemoriesLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [responseViewMode, setResponseViewMode] = useState<'content' | 'raw'>('content')
@@ -318,7 +313,7 @@ function QueryDetailContent() {
   // Copy schema to clipboard
   const copySchemaToClipboard = async () => {
     if (!toolSchema?.spec?.inputSchema) return
-    
+
     const schemaText = getSchemaExample(toolSchema.spec.inputSchema) || '{}'
     try {
       await navigator.clipboard.writeText(schemaText)
@@ -328,7 +323,7 @@ function QueryDetailContent() {
       })
     } catch {
       toast({
-        variant: "destructive", 
+        variant: "destructive",
         title: "Copy failed",
         description: "Could not copy to clipboard"
       })
@@ -339,8 +334,8 @@ function QueryDetailContent() {
   const getSchemaExample = (schema: Record<string, unknown>): string | null => {
     // Look for explicit examples
     if (schema.example) {
-      return typeof schema.example === 'string' 
-        ? schema.example 
+      return typeof schema.example === 'string'
+        ? schema.example
         : JSON.stringify(schema.example, null, 2)
     }
 
@@ -383,7 +378,7 @@ function QueryDetailContent() {
 
   const handleSaveQuery = async () => {
     if (!query) return
-    
+
     // Validate required fields
     if (!query.targets || query.targets.length === 0) {
       toast({
@@ -394,7 +389,7 @@ function QueryDetailContent() {
       // TODO: Focus targets field
       return
     }
-    
+
     setSaving(true)
     try {
       // Auto-generate name if empty
@@ -406,7 +401,7 @@ function QueryDetailContent() {
         const randomSuffix = (randomValue % 900000) + 100000;
         queryName = `ark-${dateStr}-${randomSuffix}`
       }
-      
+
       // Prepare the query data for the API
       const queryData = {
         name: queryName,
@@ -425,12 +420,12 @@ function QueryDetailContent() {
       }
 
       const savedQuery = await queriesService.create(queryData)
-      
+
       toast({
         title: "Query Executed",
         description: `Query "${savedQuery.name}" has been created and is now executing.`
       })
-      
+
       // Navigate to the created query
       router.push(`/query/${savedQuery.name}`)
     } catch (error) {
@@ -546,7 +541,7 @@ function QueryDetailContent() {
   // Fetch tool schema when exactly one tool is selected
   useEffect(() => {
     const selectedTools = query?.targets?.filter(t => t.type === 'tool') || []
-    
+
     if (selectedTools.length === 1) {
       const toolName = selectedTools[0].name
       toolsService.getDetail(toolName)
@@ -580,23 +575,8 @@ function QueryDetailContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href={`/queries`}>
-                Queries
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{isNew ? 'New Query' : query.name}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto flex gap-2">
+      <PageHeader breadcrumbs={breadcrumbs} currentPage={isNew ? 'New Query' : query.name} actions={
+        <>
           {!isNew && (
             <QueryEvaluationActions
               queryName={queryId}
@@ -604,15 +584,15 @@ function QueryDetailContent() {
           )}
           {isNew && (
             <>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 size="sm"
                 onClick={() => router.push(`/query/new`)}
               >
                 New Query
               </Button>
-              <Button 
-                variant="default" 
+              <Button
+                variant="default"
                 size="sm"
                 onClick={handleSaveQuery}
                 disabled={saving}
@@ -622,349 +602,345 @@ function QueryDetailContent() {
             </>
           )}
           {!isNew && (
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={() => router.push(`/query/new`)}
             >
               New Query
             </Button>
           )}
-        </div>
-      </header>
+        </>
+      } />
       <div className="flex h-full flex-col">
 
-      {/* Query Details - Three Column Layout */}
-      <div className="px-4 py-3 border-b bg-gray-50/30 dark:bg-gray-900/10">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
-          
-          {/* Query Column */}
-          <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <div className="flex items-center justify-between">
-                <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Query</h3>
-                <a href={`/events?kind=Query&name=${query.name}`} className="text-xs text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">
-                  View Events
-                </a>
-              </div>
-            </div>
-            <table className="w-full table-fixed">
-              <tbody>
-                <QueryNameField 
-                  mode={mode}
-                  value={query.name}
-                  onChange={(name) => setQuery(prev => prev ? { ...prev, name } : null)}
-                  label="Name"
-                  placeholder="Default: Auto-generated"
-                  inputRef={nameFieldRef}
-                />
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className="px-3 py-2 text-xs font-medium text-gray-400 dark:text-gray-600 bg-gray-50 dark:bg-gray-900/50 w-1/3 text-left">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger className="cursor-help text-left" tabIndex={-1}>
-                          Svc. Account
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Kubernetes ServiceAccount used for RBAC permissions during query execution</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-400 dark:text-gray-600">
-                    {query.serviceAccount || "—"}
-                  </td>
-                </tr>
-                <QueryTargetsField 
-                  mode={mode}
-                  value={query.targets || []}
-                  onChange={(targets) => setQuery(prev => prev ? { ...prev, targets } : null)}
-                  label="Targets"
-                  availableTargets={availableTargets}
-                  loading={targetsLoading}
-                />
-                <QueryNameField 
-                  mode={mode}
-                  value={query.sessionId}
-                  onChange={(sessionId) => setQuery(prev => prev ? { ...prev, sessionId } : null)}
-                  label="Session ID"
-                  placeholder="Default: Auto-generated"
-                  tooltip="Identifier for grouping related queries, used for conversation memory"
-                />
-              </tbody>
-            </table>
-          </div>
+        {/* Query Details - Three Column Layout */}
+        <div className="px-4 py-3 border-b bg-gray-50/30 dark:bg-gray-900/10">
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
 
-          {/* Configuration Column */}
-          <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Configuration</h3>
-            </div>
-            <table className="w-full">
-              <tbody>
-                <QueryDurationField 
-                  mode={mode}
-                  value={query.timeout}
-                  onChange={(timeout) => setQuery(prev => prev ? { ...prev, timeout } : null)}
-                  label="Timeout"
-                  placeholder="Default: 5m"
-                  tooltip="How long the query can execute for before it is stopped"
-                />
-                <QueryDurationField 
-                  mode={mode}
-                  value={query.ttl}
-                  onChange={(ttl) => setQuery(prev => prev ? { ...prev, ttl } : null)}
-                  label="TTL"
-                  placeholder="Default: 720h"
-                  tooltip="How long the query will remain in the system before it is deleted"
-                />
-                <QueryMemoryField 
-                  mode={mode}
-                  value={query.memory}
-                  onChange={(memory) => setQuery(prev => prev ? { ...prev, memory } : null)}
-                  label="Memory"
-                  availableMemories={availableMemories}
-                  loading={memoriesLoading}
-                />
-                <QueryStreamingField 
-                  mode={mode}
-                  value={streaming}
-                  onChange={setStreaming}
-                  label="Streaming"
-                  metadata={query.metadata}
-                />
-                <tr>
-                  <td className={FIELD_HEADING_STYLES}>
-                    Parameters
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.parameters?.length ? `${query.parameters.length} param(s)` : "—"}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          {/* Advanced Settings Column */}
-          <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Advanced Settings</h3>
-            </div>
-            <table className="w-full">
-              <tbody>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Selector
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.selector ? "Configured" : "—"}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          {/* Status & Results Column */}
-          <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Status & Results</h3>
-            </div>
-            <table className="w-full">
-              <tbody>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Phase
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {isNew ? "—" : query.status?.phase}
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Cancel
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.cancel ? "Requested" : "No"}
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Responses
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.status?.responses?.length || 0}
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Token Usage
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {query.status?.tokenUsage ? `${query.status.tokenUsage.promptTokens || 0} / ${query.status.tokenUsage.completionTokens || 0}` : "—"}
-                  </td>
-                </tr>
-                <tr>
-                  <td className={FIELD_HEADING_STYLES}>
-                    Evaluations
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {evaluationCount}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-        </div>
-      </div>
-
-      {/* Input and Responses Section */}
-      <div className="flex-1 flex flex-col min-h-0">
-        <ScrollArea className="flex-1 p-3">
-          <div className="space-y-3">
-            
-            {/* Input Table */}
+            {/* Query Column */}
             <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-              {/* Header */}
-              {mode === 'new' && toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? (
-                <div className="grid grid-cols-2 gap-0 bg-gray-100 dark:bg-gray-800 border-b">
-                  <div className="px-3 py-2 border-r border-gray-200 dark:border-gray-700">
+              <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Query</h3>
+                  <a href={`/events?kind=Query&name=${query.name}`} className="text-xs text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">
+                    View Events
+                  </a>
+                </div>
+              </div>
+              <table className="w-full table-fixed">
+                <tbody>
+                  <QueryNameField
+                    mode={mode}
+                    value={query.name}
+                    onChange={(name) => setQuery(prev => prev ? { ...prev, name } : null)}
+                    label="Name"
+                    placeholder="Default: Auto-generated"
+                    inputRef={nameFieldRef}
+                  />
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className="px-3 py-2 text-xs font-medium text-gray-400 dark:text-gray-600 bg-gray-50 dark:bg-gray-900/50 w-1/3 text-left">
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-help text-left" tabIndex={-1}>
+                            Svc. Account
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Kubernetes ServiceAccount used for RBAC permissions during query execution</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-400 dark:text-gray-600">
+                      {query.serviceAccount || "—"}
+                    </td>
+                  </tr>
+                  <QueryTargetsField
+                    mode={mode}
+                    value={query.targets || []}
+                    onChange={(targets) => setQuery(prev => prev ? { ...prev, targets } : null)}
+                    label="Targets"
+                    availableTargets={availableTargets}
+                    loading={targetsLoading}
+                  />
+                  <QueryNameField
+                    mode={mode}
+                    value={query.sessionId}
+                    onChange={(sessionId) => setQuery(prev => prev ? { ...prev, sessionId } : null)}
+                    label="Session ID"
+                    placeholder="Default: Auto-generated"
+                    tooltip="Identifier for grouping related queries, used for conversation memory"
+                  />
+                </tbody>
+              </table>
+            </div>
+
+            {/* Configuration Column */}
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+              <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+                <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Configuration</h3>
+              </div>
+              <table className="w-full">
+                <tbody>
+                  <QueryDurationField
+                    mode={mode}
+                    value={query.timeout}
+                    onChange={(timeout) => setQuery(prev => prev ? { ...prev, timeout } : null)}
+                    label="Timeout"
+                    placeholder="Default: 5m"
+                    tooltip="How long the query can execute for before it is stopped"
+                  />
+                  <QueryDurationField
+                    mode={mode}
+                    value={query.ttl}
+                    onChange={(ttl) => setQuery(prev => prev ? { ...prev, ttl } : null)}
+                    label="TTL"
+                    placeholder="Default: 720h"
+                    tooltip="How long the query will remain in the system before it is deleted"
+                  />
+                  <QueryMemoryField
+                    mode={mode}
+                    value={query.memory}
+                    onChange={(memory) => setQuery(prev => prev ? { ...prev, memory } : null)}
+                    label="Memory"
+                    availableMemories={availableMemories}
+                    loading={memoriesLoading}
+                  />
+                  <QueryStreamingField
+                    mode={mode}
+                    value={streaming}
+                    onChange={setStreaming}
+                    label="Streaming"
+                    metadata={query.metadata}
+                  />
+                  <tr>
+                    <td className={FIELD_HEADING_STYLES}>
+                      Parameters
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {query.parameters?.length ? `${query.parameters.length} param(s)` : "—"}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* Advanced Settings Column */}
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+              <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+                <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Advanced Settings</h3>
+              </div>
+              <table className="w-full">
+                <tbody>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className={FIELD_HEADING_STYLES}>
+                      Selector
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {query.selector ? "Configured" : "—"}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* Status & Results Column */}
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+              <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+                <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Status & Results</h3>
+              </div>
+              <table className="w-full">
+                <tbody>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className={FIELD_HEADING_STYLES}>
+                      Phase
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {isNew ? "—" : query.status?.phase}
+                    </td>
+                  </tr>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className={FIELD_HEADING_STYLES}>
+                      Cancel
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {query.cancel ? "Requested" : "No"}
+                    </td>
+                  </tr>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className={FIELD_HEADING_STYLES}>
+                      Responses
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {query.status?.responses?.length || 0}
+                    </td>
+                  </tr>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className={FIELD_HEADING_STYLES}>
+                      Token Usage
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {query.status?.tokenUsage ? `${query.status.tokenUsage.promptTokens || 0} / ${query.status.tokenUsage.completionTokens || 0}` : "—"}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className={FIELD_HEADING_STYLES}>
+                      Evaluations
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                      {evaluationCount}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Input and Responses Section */}
+        <div className="flex-1 flex flex-col min-h-0">
+          <ScrollArea className="flex-1 p-3">
+            <div className="space-y-3">
+
+              {/* Input Table */}
+              <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+                {/* Header */}
+                {mode === 'new' && toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? (
+                  <div className="grid grid-cols-2 gap-0 bg-gray-100 dark:bg-gray-800 border-b">
+                    <div className="px-3 py-2 border-r border-gray-200 dark:border-gray-700">
+                      <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Input</h3>
+                    </div>
+                    <div className="px-3 py-2 flex items-center gap-2">
+                      <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Input Schema</h3>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={copySchemaToClipboard}
+                        className="h-auto p-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                      >
+                        <Copy className="h-2 w-2" />
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
                     <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Input</h3>
                   </div>
-                  <div className="px-3 py-2 flex items-center gap-2">
-                    <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Input Schema</h3>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={copySchemaToClipboard}
-                      className="h-auto p-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                    >
-                      <Copy className="h-2 w-2" />
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
-                  <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Input</h3>
-                </div>
-              )}
+                )}
 
-              {/* Content */}
-              {mode === 'new' ? (
-                <div className={toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? 'grid grid-cols-2 gap-0' : 'p-3'}>
-                  {/* Input Section */}
-                  <div className={toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? 'p-3 border-r border-gray-200 dark:border-gray-700' : ''}>
-                    <Textarea
-                      value={typeof query.input === 'string' ? query.input || '' : ''}
-                      onChange={(e) => setQuery(prev => prev ? { ...prev, input: e.target.value } : null)}
-                      placeholder="Enter your query input..."
-                      className="min-h-[200px] text-sm font-mono resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
-                    />
-                  </div>
-                  
-                  {/* Tool Schema Example - only show for single tool selection */}
-                  {toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 && (
-                    <div className="p-3">
+                {/* Content */}
+                {mode === 'new' ? (
+                  <div className={toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? 'grid grid-cols-2 gap-0' : 'p-3'}>
+                    {/* Input Section */}
+                    <div className={toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 ? 'p-3 border-r border-gray-200 dark:border-gray-700' : ''}>
                       <Textarea
-                        value={toolSchema.spec?.inputSchema ? getSchemaExample(toolSchema.spec.inputSchema) || '{}' : '{}'}
-                        readOnly
+                        value={typeof query.input === 'string' ? query.input || '' : ''}
+                        onChange={(e) => setQuery(prev => prev ? { ...prev, input: e.target.value } : null)}
+                        placeholder="Enter your query input..."
                         className="min-h-[200px] text-sm font-mono resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
                       />
                     </div>
-                  )}
+
+                    {/* Tool Schema Example - only show for single tool selection */}
+                    {toolSchema && query.targets?.filter(t => t.type === 'tool').length === 1 && (
+                      <div className="p-3">
+                        <Textarea
+                          value={toolSchema.spec?.inputSchema ? getSchemaExample(toolSchema.spec.inputSchema) || '{}' : '{}'}
+                          readOnly
+                          className="min-h-[200px] text-sm font-mono resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+                        />
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <pre className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono bg-gray-50 dark:bg-gray-900/50 p-3">
+                    {typeof query.input === 'string' ? query.input : Array.isArray(query.input) ? JSON.stringify(query.input, null, 2) : ''}
+                  </pre>
+                )}
+              </div>
+
+              {/* Conditional Response or Error Section */}
+              {query.status?.responses && query.status.responses.length > 0 ? (
+                /* Response Section - show when there are responses */
+                <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+                  <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
+                    <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Response</h3>
+                    <div className="flex items-center gap-1 text-xs overflow-x-auto whitespace-nowrap flex-shrink-0">
+                      <button
+                        className={`px-2 py-1 rounded ${responseViewMode === 'content'
+                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'text-gray-500 dark:text-gray-400'
+                          }`}
+                        onClick={() => setResponseViewMode('content')}
+                      >
+                        Content
+                      </button>
+                      <button
+                        className={`px-2 py-1 rounded ${responseViewMode === 'raw'
+                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'text-gray-500 dark:text-gray-400'
+                          }`}
+                        onClick={() => setResponseViewMode('raw')}
+                      >
+                        Raw
+                      </button>
+                    </div>
+                  </div>
+                  <div className="p-3">
+                    {query.status?.responses?.map((response, index) => (
+                      <div key={index} className="mb-4 last:mb-0">
+                        <ResponseContent
+                          content={response.content || "No content"}
+                          viewMode={responseViewMode}
+                          rawJson={response}
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              ) : (
-                <pre className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono bg-gray-50 dark:bg-gray-900/50 p-3">
-                  {typeof query.input === 'string' ? query.input : Array.isArray(query.input) ? JSON.stringify(query.input, null, 2) : ''}
-                </pre>
+              ) : !isNew && (query.status?.phase === 'failed' || query.status?.phase === 'error') ? (
+                <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+                  <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
+                    <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Error</h3>
+                    <div className="flex items-center gap-1 text-xs overflow-x-auto whitespace-nowrap flex-shrink-0">
+                      <button
+                        className={`px-2 py-1 rounded ${errorViewMode === 'events'
+                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'text-gray-500 dark:text-gray-400'
+                          }`}
+                        onClick={() => setErrorViewMode('events')}
+                      >
+                        Events
+                      </button>
+                      <button
+                        className={`px-2 py-1 rounded ${errorViewMode === 'details'
+                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'text-gray-500 dark:text-gray-400'
+                          }`}
+                        onClick={() => setErrorViewMode('details')}
+                      >
+                        Details
+                      </button>
+                    </div>
+                  </div>
+                  <div className="p-3">
+                    <ErrorResponseContent
+                      query={query}
+                      viewMode={errorViewMode}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {!isNew && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
+                  Note: Events expire after a certain amount of time and may no longer be available for viewing.
+                </div>
               )}
             </div>
-
-                        {/* Conditional Response or Error Section */}
-            {query.status?.responses && query.status.responses.length > 0 ? (
-              /* Response Section - show when there are responses */
-              <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-                <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
-                  <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Response</h3>
-                  <div className="flex items-center gap-1 text-xs overflow-x-auto whitespace-nowrap flex-shrink-0">
-                    <button 
-                      className={`px-2 py-1 rounded ${
-                        responseViewMode === 'content' 
-                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300' 
-                          : 'text-gray-500 dark:text-gray-400'
-                      }`}
-                      onClick={() => setResponseViewMode('content')}
-                    >
-                      Content
-                    </button>
-                    <button 
-                      className={`px-2 py-1 rounded ${
-                        responseViewMode === 'raw' 
-                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300' 
-                          : 'text-gray-500 dark:text-gray-400'
-                      }`}
-                      onClick={() => setResponseViewMode('raw')}
-                    >
-                      Raw
-                    </button>
-                  </div>
-                </div>
-                <div className="p-3">
-                  {query.status?.responses?.map((response, index) => (
-                    <div key={index} className="mb-4 last:mb-0">
-                      <ResponseContent 
-                        content={response.content || "No content"} 
-                        viewMode={responseViewMode} 
-                        rawJson={response} 
-                      />
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : !isNew && (query.status?.phase === 'failed' || query.status?.phase === 'error') ? (
-              <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-                <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b flex items-center justify-between">
-                  <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Error</h3>
-                  <div className="flex items-center gap-1 text-xs overflow-x-auto whitespace-nowrap flex-shrink-0">
-                    <button 
-                      className={`px-2 py-1 rounded ${
-                        errorViewMode === 'events' 
-                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300' 
-                          : 'text-gray-500 dark:text-gray-400'
-                      }`}
-                      onClick={() => setErrorViewMode('events')}
-                    >
-                      Events
-                    </button>
-                    <button 
-                      className={`px-2 py-1 rounded ${
-                        errorViewMode === 'details' 
-                          ? 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300' 
-                          : 'text-gray-500 dark:text-gray-400'
-                      }`}
-                      onClick={() => setErrorViewMode('details')}
-                    >
-                      Details
-                    </button>
-                  </div>
-                </div>
-                <div className="p-3">
-                  <ErrorResponseContent
-                    query={query}
-                    viewMode={errorViewMode}
-                  />
-                </div>
-              </div>
-            ) : null}
-            
-            {!isNew && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
-              Note: Events expire after a certain amount of time and may no longer be available for viewing.
-            </div>
-            )}
-          </div>
-        </ScrollArea>
-      </div>
+          </ScrollArea>
+        </div>
       </div>
     </>
   )

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/secrets/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/secrets/page.tsx
@@ -3,16 +3,13 @@
 import { SecretsSection } from "@/components/sections/secrets-section"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function SecretsContent() {
   const searchParams = useSearchParams()
@@ -21,23 +18,12 @@ function SecretsContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Secrets</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => secretsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Secret
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Secrets" actions={
+        <Button onClick={() => secretsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Secret
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <SecretsSection ref={secretsSectionRef} namespace={namespace} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/services/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/services/page.tsx
@@ -22,16 +22,14 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from "@/components/ui/tooltip"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
+
 import { ExternalLink } from "lucide-react"
 import { arkServicesService, type ArkService } from "@/lib/services"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 // Column definitions
 const columns: ColumnDef<ArkService>[] = [
@@ -84,7 +82,7 @@ const columns: ColumnDef<ArkService>[] = [
       const service = row.original
       const chartVersion = service.chart_version
       const appVersion = service.app_version
-      
+
       return (
         <div className="text-sm">
           {appVersion && (
@@ -113,7 +111,7 @@ const columns: ColumnDef<ArkService>[] = [
     cell: ({ row }) => {
       const updated = row.original.updated
       if (!updated) return <div className="text-muted-foreground text-sm">-</div>
-      
+
       try {
         const date = new Date(updated)
         const now = new Date()
@@ -121,7 +119,7 @@ const columns: ColumnDef<ArkService>[] = [
         const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
         const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
         const diffMinutes = Math.floor(diffMs / (1000 * 60))
-        
+
         let timeAgo
         if (diffDays > 0) {
           timeAgo = `${diffDays}d ago`
@@ -132,7 +130,7 @@ const columns: ColumnDef<ArkService>[] = [
         } else {
           timeAgo = "Just now"
         }
-        
+
         return (
           <div className="text-sm">
             <div>{timeAgo}</div>
@@ -154,7 +152,7 @@ const columns: ColumnDef<ArkService>[] = [
       if (!routes || routes.length === 0) {
         return <div className="text-muted-foreground text-sm">No routes</div>
       }
-      
+
       return (
         <div className="space-y-1">
           {routes.map((route, index) => (
@@ -202,9 +200,9 @@ function DataTable<TData, TValue>({
                     {header.isPlaceholder
                       ? null
                       : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
                   </TableHead>
                 )
               })}
@@ -263,17 +261,7 @@ function ServicesContent() {
   if (loading) {
     return (
       <>
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-          <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbPage>ARK Services</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-        </header>
+        <PageHeader breadcrumbs={breadcrumbs} currentPage="ARK Services" />
         <div className="flex flex-1 flex-col">
           <main className="flex-1 overflow-auto p-4">
             <div className="flex items-center justify-center h-32">
@@ -288,17 +276,7 @@ function ServicesContent() {
   if (error) {
     return (
       <>
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-          <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbPage>ARK Services</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-        </header>
+        <PageHeader breadcrumbs={breadcrumbs} currentPage="ARK Services" />
         <div className="flex flex-1 flex-col">
           <main className="flex-1 overflow-auto p-4">
             <div className="text-red-600 bg-red-50 border border-red-200 rounded-md p-4">
@@ -313,17 +291,7 @@ function ServicesContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>ARK Services</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="ARK Services" />
       <div className="flex flex-1 flex-col">
         <main className="flex-1 overflow-auto p-4">
           <DataTable columns={columns} data={services} />

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/teams/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/teams/page.tsx
@@ -2,39 +2,25 @@
 
 import { TeamsSection } from "@/components/sections/teams-section"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function TeamsContent() {
   const teamsSectionRef = useRef<{ openAddEditor: () => void }>(null)
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Teams</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => teamsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Team
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Teams" actions={
+        <Button onClick={() => teamsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Team
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <TeamsSection ref={teamsSectionRef} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/tool/[name]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/tool/[name]/page.tsx
@@ -1,20 +1,15 @@
 "use client"
 
 import { useParams } from "next/navigation";
-import { useState , useEffect} from "react";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbLink,
-  BreadcrumbPage,
-  BreadcrumbSeparator
-} from "@/components/ui/breadcrumb"
+import { useState, useEffect } from "react";
 import { toolsService } from "@/lib/services";
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { ToolDetail } from "@/lib/services/tools";
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header";
 
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" },
+  { href: '/tools', label: "Tools" }
+]
 
 const FIELD_HEADING_STYLES = "px-3 py-2 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 w-1/3 text-left"
 
@@ -50,87 +45,71 @@ export default function ToolDetailsPage() {
 
   return (
     <>
-         <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-            <BreadcrumbLink href={`/tools`}>
-                Tools
-            </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{toolName}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage={toolName} />
       {/* Tool Details Content */}
       <div className="m-4">
-      <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Tool description</h3>
-            </div>
-            <table className="w-full">
-              <tbody>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Name
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                  {toolName}
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Description
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                    {tool?.description ?? null}
-                  </td>
-                </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Tool type
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
-                  {tool?.spec?.type ?? null}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+          <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+            <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Tool description</h3>
           </div>
-
-          <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden mt-5">
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
-              <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Annotations and metadata</h3>
-            </div>
-            <table className="w-full">
-              <tbody>
+          <table className="w-full">
+            <tbody>
               <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Status
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                <td className={FIELD_HEADING_STYLES}>
+                  Name
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                  {toolName}
+                </td>
+              </tr>
+              <tr className="border-b border-gray-100 dark:border-gray-800">
+                <td className={FIELD_HEADING_STYLES}>
+                  Description
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                  {tool?.description ?? null}
+                </td>
+              </tr>
+              <tr className="border-b border-gray-100 dark:border-gray-800">
+                <td className={FIELD_HEADING_STYLES}>
+                  Tool type
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                  {tool?.spec?.type ?? null}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden mt-5">
+          <div className="px-3 py-2 bg-gray-100 dark:bg-gray-800 border-b">
+            <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">Annotations and metadata</h3>
+          </div>
+          <table className="w-full">
+            <tbody>
+              <tr className="border-b border-gray-100 dark:border-gray-800">
+                <td className={FIELD_HEADING_STYLES}>
+                  Status
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
                   {JSON.stringify(tool?.status?.state)}
                 </td>
               </tr>
-                <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <td className={FIELD_HEADING_STYLES}>
-                    Input schema
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+              <tr className="border-b border-gray-100 dark:border-gray-800">
+                <td className={FIELD_HEADING_STYLES}>
+                  Input schema
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
                   <pre className="whitespace-pre-wrap">
                     {JSON.stringify(tool?.spec?.inputSchema, null, 2)}
                   </pre>
                 </td>
               </tr>
-              </tbody>
-            </table>
-          </div>
-          </div>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </>
   );
 }

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/tools/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/tools/page.tsx
@@ -3,16 +3,13 @@
 import { ToolsSection } from "@/components/sections/tools-section"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useRef } from "react"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage
-} from "@/components/ui/breadcrumb"
-import { Separator } from "@/components/ui/separator"
-import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
+import { BreadcrumbElement, PageHeader } from "@/components/common/page-header"
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: "ARK Dashboard" }
+]
 
 function ToolsContent() {
   const searchParams = useSearchParams()
@@ -21,23 +18,12 @@ function ToolsContent() {
 
   return (
     <>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Tools</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="ml-auto">
-          <Button onClick={() => toolsSectionRef.current?.openAddEditor()}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Tool
-          </Button>
-        </div>
-      </header>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Tools" actions={
+        <Button onClick={() => toolsSectionRef.current?.openAddEditor()}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Tool
+        </Button>
+      } />
       <div className="flex flex-1 flex-col">
         <ToolsSection ref={toolsSectionRef} namespace={namespace} />
       </div>

--- a/services/ark-dashboard/ark-dashboard/components/common/page-header.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/common/page-header.tsx
@@ -1,0 +1,157 @@
+import { ComponentProps, Fragment, ReactNode } from "react"
+import { SidebarTrigger } from "@/components/ui/sidebar"
+import { Separator } from "@/components/ui/separator"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbEllipsis,
+  BreadcrumbSeparator
+} from "@/components/ui/breadcrumb"
+
+import Link from "next/link"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
+import { Button } from "../ui/button"
+import { Info } from "lucide-react"
+
+export type BreadcrumbElement = {
+  label: string;
+  href: ComponentProps<typeof Link>["href"];
+}
+
+type BreadcrumbsDropdownProps = {
+  elements: BreadcrumbElement[]
+}
+
+function BreadcrumbsDropdown({ elements }: BreadcrumbsDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-1">
+        <BreadcrumbEllipsis className="size-4" />
+        <span className="sr-only">Toggle menu</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {elements.map((e) => (
+          <Link href={e.href} key={e.label}>
+            <DropdownMenuItem >{e.label}</DropdownMenuItem>
+          </Link>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+type BreadcrumbsLinksProps = {
+  elements?: BreadcrumbElement[]
+}
+
+function BreadcrumbsLinks({ elements }: BreadcrumbsLinksProps) {
+  return (
+    <>
+      {elements?.map((link) => (
+        <Fragment key={link.label}>
+          <BreadcrumbItem >
+            <BreadcrumbLink asChild>
+              <Link href={link.href}>{link.label}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+        </Fragment>
+      ))
+      }
+    </>
+  )
+}
+
+function HeaderTooltip() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link href="https://mckinsey.github.io/agents-at-scale-ark/">
+          <Button variant="ghost">
+            <Info className="h-4 w-4" />
+          </Button>
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>Help</span>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+type PageHeaderProps = {
+  breadcrumbs?: BreadcrumbElement[]
+  currentPage: string
+  actions?: ReactNode
+}
+
+export function PageHeader({ breadcrumbs, currentPage, actions }: PageHeaderProps) {
+  const firstCrumb = (breadcrumbs?.length || 0) > 2 ? breadcrumbs?.[0] : undefined;
+  const crumbsInDropdown = (breadcrumbs?.length || 0) > 2 ? breadcrumbs?.slice(1, -1) : undefined;
+  const visibleCrumbs = (breadcrumbs?.length || 0) > 2 ? breadcrumbs?.slice(-1) : breadcrumbs;
+
+  return (
+    <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+      <SidebarTrigger className="-ml-1" />
+      <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+      {/* Mobile */}
+      <Breadcrumb className="block md:hidden">
+        <BreadcrumbList>
+          {breadcrumbs?.length ? (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbsDropdown elements={breadcrumbs} />
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          ) : null}
+          <BreadcrumbItem>
+            <BreadcrumbPage>{currentPage}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      {/* Desktop */}
+      <Breadcrumb className="hidden md:block">
+        <BreadcrumbList>
+          {firstCrumb && (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href={firstCrumb.href}>
+                    {firstCrumb.label}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          )}
+          {crumbsInDropdown ? (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbsDropdown elements={crumbsInDropdown} />
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          ) : null}
+          <BreadcrumbsLinks elements={visibleCrumbs} />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{currentPage}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <div className="ml-auto space-x-2 flex items-center">
+        {actions && (actions)}
+        <HeaderTooltip />
+      </div>
+    </header>
+  )
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/tooltip.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/tooltip.tsx
@@ -52,6 +52,7 @@ function TooltipContent({
         {...props}
       >
         {children}
+        {/* TODO: The tooltip arrow does not have a border, the content does => looks weird */}
         <TooltipPrimitive.Arrow className="bg-white fill-white z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
Streamlines header and breadcrumb rendering across dashboard pages by introducing a reusable page header component.
Replaces scattered UI elements with a consistent structure, improving maintainability and user experience.
Adds help button to the header.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues [ARKQB-388](https://mckinsey.atlassian.net/browse/ARKQB-388)

### Single element
<img width="1920" height="591" alt="Screenshot 2025-10-10 at 13 33 48" src="https://github.com/user-attachments/assets/4c4311f6-119e-460b-991e-410bb734f983" />

### Up to 3 elements
<img width="1920" height="591" alt="Screenshot 2025-10-10 at 13 32 23" src="https://github.com/user-attachments/assets/721ee193-ede0-49c8-852d-d078839743fb" />
<img width="1920" height="591" alt="Screenshot 2025-10-10 at 13 32 59" src="https://github.com/user-attachments/assets/1d656c3f-5a75-4305-bea2-dad237331569" />

### More than 3 elements
<img width="1920" height="591" alt="Screenshot 2025-10-10 at 13 33 27" src="https://github.com/user-attachments/assets/495845b5-add0-4d5c-999f-9ec8bfbfa337" />
<img width="1920" height="591" alt="Screenshot 2025-10-10 at 13 33 34" src="https://github.com/user-attachments/assets/2164d154-73b9-417b-9834-acf950ab314d" />

### Mobile

<img width="516" height="591" alt="Screenshot 2025-10-10 at 13 35 04" src="https://github.com/user-attachments/assets/1e47e2b1-2ece-4868-9eaf-f5c77b8bf47a" />
<img width="516" height="591" alt="Screenshot 2025-10-10 at 13 35 21" src="https://github.com/user-attachments/assets/db6ed618-b811-4f2f-bc43-82b597baa1e5" />


