### PR TITLE
chore: adds code owner for ark-dashboard service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 
 /ark/config/crd/ @dwmkerr @Roman-Galeev @cm94242
 /ark/api/ @dwmkerr @Roman-Galeev @cm94242
+/services/ark-dashboard/ @av3n93rz


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 