### PR TITLE
fix: correct fark installation command in docs

### DIFF
--- a/docs/content/developer-guide/cli-tools.mdx
+++ b/docs/content/developer-guide/cli-tools.mdx
@@ -25,7 +25,7 @@ Interactive dashboard and system status monitoring tool.
 ```bash
 # Download latest release for your platform
 # Linux/macOS
-curl -L https://github.com/mckinsey/agents-at-scale-ark/releases/latest/download/fark_$(uname)_$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/').tar.gz | tar xz
+curl -L "https://github.com/mckinsey/agents-at-scale-ark/releases/latest/download/fark_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | tar xz
 sudo mv fark /usr/local/bin/
 
 # Windows: Download fark_Windows_x86_64.zip from releases page

--- a/tools/fark/README.md
+++ b/tools/fark/README.md
@@ -4,16 +4,6 @@ CLI tool and HTTP API for querying ARK agents, teams, and models.
 
 ## Installation
 
-### From GitHub Release (Recommended)
-```bash
-# Download latest release for your platform
-# Linux/macOS (replace Darwin with Linux for Linux systems)
-curl -L https://github.com/mckinsey/agents-at-scale-ark/releases/latest/download/fark_$(uname)_$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/').tar.gz | tar xz
-sudo mv fark /usr/local/bin/
-
-# Windows: Download fark_Windows_x86_64.zip from releases page
-```
-
 ### From Source
 ```bash
 # Clone and build locally


### PR DESCRIPTION
## Summary
- Added quotes to curl URL to prevent shell expansion issues
- Removed redundant sed pattern that replaced x86_64 with itself
- Removed duplicate installation instructions from tools/fark/README.md