### PR TITLE
Fix custom MCP server documentation and sample configuration

### DIFF
--- a/docs/content/user-guide/samples/mcp-servers.mdx
+++ b/docs/content/user-guide/samples/mcp-servers.mdx
@@ -189,23 +189,22 @@ from mcp.server.fastmcp import FastMCP
 # Create an MCP server
 # Stateless server (no session persistence)
 mcp = FastMCP("MulDivMathServer", stateless_http=True, host="0.0.0.0")
- 
+
 # Add a multiply tool
 @mcp.tool()
 def multiply(a: int, b: int) -> int:
     """Multiply two numbers"""
     print(f"Received {a} * {b}")
     return a * b
- 
+
 # Add a divide tool
 @mcp.tool()
 def divide(a: float, b: float) -> float:
     """Divide two numbers"""
     print(f"Received {a} / {b}")
-    return a / b
- 
- 
- 
+    return a / b 
+
+
 if __name__ == "__main__":
     mcp.run(transport="streamable-http")
 ```

--- a/docs/content/user-guide/samples/mcp-servers.mdx
+++ b/docs/content/user-guide/samples/mcp-servers.mdx
@@ -185,7 +185,7 @@ RUN pip install 'mcp[cli]==1.9.2'
 
 ```python
 from mcp.server.fastmcp import FastMCP
- 
+
 # Create an MCP server
 # Stateless server (no session persistence)
 mcp = FastMCP("MulDivMathServer", stateless_http=True, host="0.0.0.0")

--- a/docs/content/user-guide/samples/mcp-servers.mdx
+++ b/docs/content/user-guide/samples/mcp-servers.mdx
@@ -185,27 +185,27 @@ RUN pip install 'mcp[cli]==1.9.2'
 
 ```python
 from mcp.server.fastmcp import FastMCP
-
+ 
 # Create an MCP server
 # Stateless server (no session persistence)
-mcp = FastMCP("MulDivMathServer", stateless_http=True)
-
+mcp = FastMCP("MulDivMathServer", stateless_http=True, host="0.0.0.0")
+ 
 # Add a multiply tool
 @mcp.tool()
 def multiply(a: int, b: int) -> int:
     """Multiply two numbers"""
     print(f"Received {a} * {b}")
     return a * b
-
+ 
 # Add a divide tool
 @mcp.tool()
 def divide(a: float, b: float) -> float:
     """Divide two numbers"""
     print(f"Received {a} / {b}")
     return a / b
-
-
-
+ 
+ 
+ 
 if __name__ == "__main__":
     mcp.run(transport="streamable-http")
 ```
@@ -233,13 +233,13 @@ metadata:
   name: simple-calculator-remote-http
 spec:
   address:
-    value: "http://localhost:8000/mcp"  # replace with full K8s service URL for deployment - "http://calc-service.default.svc.cluster.local" or "http://host.docker.internal:8000"
+    value: "http://localhost:8000/mcp"  # replace with full K8s service URL for deployment - "http://calc-service.default.svc.cluster.local" or "http://host.docker.internal:8000" or "http://host.minikube.internal:8000/mcp" if you use minikube
   timeout: "60s"
   transport: http
   description: "Remote server for performing calculations such as mul and div."
 ```
 
-- Please apply the above yaml
+- Please apply the above yaml (update to address value to http://host.minikube.internal:8000/mcp if you use minikube)
 - Shell verification
 ```sh
 k get mcpserver

--- a/samples/mcp/custom-mcp.yaml
+++ b/samples/mcp/custom-mcp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-calculator-remote-http
 spec:
   address:
-    value: "http://localhost:8000/mcp"  # replace with full K8s service URL for deployment - "http://sse-calc-service.default.svc.cluster.local"
+    value: "http://localhost:8000/mcp"  # replace with full K8s service URL for deployment - "http://sse-calc-service.default.svc.cluster.local" or "http://host.minikube.internal:8000/mcp" if you are using minikube
   timeout: "60s"
   transport: http
   description: "Remote server for performing calculations such as mul and div."
@@ -16,7 +16,7 @@ metadata:
   name: simple-calculator-remote-sse
 spec:
   address:
-    value: "http://localhost:8001/sse" # replace with full K8s service URL for deployment - "http://sse-calc-service.default.svc.cluster.local"
+    value: "http://localhost:8001/sse" # replace with full K8s service URL for deployment - "http://sse-calc-service.default.svc.cluster.local" or "http://host.minikube.internal:8000/sse" if you are using minikube
   timeout: "60s"
   transport: sse
   description: "Remote server for performing calculations such as add and sub."


### PR DESCRIPTION
PR Description:

**Summary**
Updated MCP server documentation and samples to fix connectivity issues in minikube environments.

**Changes**
Python script: Updated Streamable HTTP MCP server to bind to 0.0.0.0 
custom-mcp.yaml: Added http://host.minikube.internal:8000/mcp address option for minikube users

**Credit**
Thanks to @dwmkerr for the tips that resolved the MCPServer creation issues.