### PR TITLE
feat: implement exit codes and remove auto-cleanup for queries

### DIFF
--- a/docs/content/developer-guide/ark-cli.mdx
+++ b/docs/content/developer-guide/ark-cli.mdx
@@ -90,6 +90,8 @@ Three main status codes are used:
 
 This helps scripts distinguish between usage errors and operational failures. Error details are printed by the CLI.
 
+Query operations return exit code `2` when execution fails, making error handling in scripts straightforward. This behavior aligns with Argo Workflows' `--wait` flag pattern (see [argoproj/argo-workflows#1008](https://github.com/argoproj/argo-workflows/issues/1008)).
+
 Example handling exit codes:
 
 ```bash

--- a/docs/content/developer-guide/ark-cli.mdx
+++ b/docs/content/developer-guide/ark-cli.mdx
@@ -80,17 +80,18 @@ Following kubectl/argo patterns. Essential parameters:
 
 ## Exit Code and Error Handling Conventions
 
-Three main status codes are used:
+Four main status codes are used:
 
 | Code | Meaning | When to Use |
 |------|---------|-------------|
 | `0` | Success | Command completed |
 | `1` | CLI Error | Invalid arguments, config issues |
-| `2` | Operation Error | Backend failure, timeout, resource error |
+| `2` | Operation Error | Backend failure, resource error |
+| `3` | Timeout | Operation exceeded time limit |
 
-This helps scripts distinguish between usage errors and operational failures. Error details are printed by the CLI.
+This helps scripts distinguish between usage errors, operational failures, and timeouts. Error details are printed by the CLI.
 
-Query operations return exit code `2` when execution fails, making error handling in scripts straightforward. This behavior aligns with Argo Workflows' `--wait` flag pattern (see [argoproj/argo-workflows#1008](https://github.com/argoproj/argo-workflows/issues/1008)).
+Query operations return exit code `2` when execution fails and `3` on timeout, making error handling in scripts straightforward. This behavior aligns with Argo Workflows' `--wait` flag pattern (see [argoproj/argo-workflows#1008](https://github.com/argoproj/argo-workflows/issues/1008)).
 
 Example handling exit codes:
 

--- a/tools/ark-cli/src/commands/query/index.ts
+++ b/tools/ark-cli/src/commands/query/index.ts
@@ -2,6 +2,7 @@ import {Command} from 'commander';
 import type {ArkConfig} from '../../lib/config.js';
 import output from '../../lib/output.js';
 import {executeQuery, parseTarget} from '../../lib/executeQuery.js';
+import {ExitCodes} from '../../lib/errors.js';
 
 export function createQueryCommand(_: ArkConfig): Command {
   const queryCommand = new Command('query');
@@ -11,13 +12,12 @@ export function createQueryCommand(_: ArkConfig): Command {
     .argument('<target>', 'Query target (e.g., model/default, agent/my-agent)')
     .argument('<message>', 'Message to send')
     .action(async (target: string, message: string) => {
-      // Parse and validate target format
       const parsed = parseTarget(target);
       if (!parsed) {
         output.error(
           'Invalid target format. Use: model/name or agent/name etc'
         );
-        process.exit(1);
+        process.exit(ExitCodes.CliError);
       }
 
       await executeQuery({

--- a/tools/ark-cli/src/lib/duration.spec.ts
+++ b/tools/ark-cli/src/lib/duration.spec.ts
@@ -1,0 +1,15 @@
+import {parseDuration} from './duration.js';
+
+describe('parseDuration', () => {
+  it('should parse durations correctly', () => {
+    expect(parseDuration('100ms')).toBe(100);
+    expect(parseDuration('30s')).toBe(30000);
+    expect(parseDuration('5m')).toBe(300000);
+    expect(parseDuration('1h')).toBe(3600000);
+  });
+
+  it('should throw on invalid format', () => {
+    expect(() => parseDuration('invalid')).toThrow('Invalid duration format');
+    expect(() => parseDuration('10')).toThrow('Invalid duration format');
+  });
+});

--- a/tools/ark-cli/src/lib/duration.ts
+++ b/tools/ark-cli/src/lib/duration.ts
@@ -1,0 +1,21 @@
+export function parseDuration(duration: string): number {
+  const match = duration.match(/^(\d+(?:\.\d+)?)(ms|s|m|h)$/);
+  if (!match) {
+    throw new Error(`Invalid duration format: ${duration}`);
+  }
+  const value = parseFloat(match[1]);
+  const unit = match[2];
+
+  switch (unit) {
+    case 'ms':
+      return value;
+    case 's':
+      return value * 1000;
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    default:
+      throw new Error(`Unknown duration unit: ${unit}`);
+  }
+}

--- a/tools/ark-cli/src/lib/errors.ts
+++ b/tools/ark-cli/src/lib/errors.ts
@@ -9,6 +9,7 @@ export const ExitCodes = {
   Success: 0,
   CliError: 1,
   OperationError: 2,
+  Timeout: 3,
 } as const;
 
 export enum ErrorCode {

--- a/tools/ark-cli/src/lib/errors.ts
+++ b/tools/ark-cli/src/lib/errors.ts
@@ -5,6 +5,12 @@
 import chalk from 'chalk';
 import fs from 'fs';
 
+export const ExitCodes = {
+  Success: 0,
+  CliError: 1,
+  OperationError: 2,
+} as const;
+
 export enum ErrorCode {
   INVALID_INPUT = 'INVALID_INPUT',
   FILE_NOT_FOUND = 'FILE_NOT_FOUND',

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -128,7 +128,7 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     if (!queryComplete) {
       spinner.fail('Query timed out');
       output.error('Query did not complete within 5 minutes');
-      process.exit(ExitCodes.OperationError);
+      process.exit(ExitCodes.Timeout);
     }
   } catch (error) {
     spinner.fail('Query failed');

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -7,11 +7,14 @@ import ora from 'ora';
 import output from './output.js';
 import type {Query, QueryTarget, K8sCondition} from './types.js';
 import {ExitCodes} from './errors.js';
+import {parseDuration} from './duration.js';
 
 export interface QueryOptions {
   targetType: string; // 'model', 'agent', 'team'
   targetName: string; // 'default', 'weather-agent', etc.
   message: string;
+  timeout?: string; // Query execution timeout (e.g., "30s", "5m", default "5m")
+  watchTimeout?: string; // CLI watch timeout (e.g., "6m", default timeout + 1 minute)
   verbose?: boolean;
 }
 
@@ -22,11 +25,16 @@ export interface QueryOptions {
 export async function executeQuery(options: QueryOptions): Promise<void> {
   const spinner = ora('Creating query...').start();
 
-  // Generate a unique query name
+  const queryTimeoutMs = options.timeout
+    ? parseDuration(options.timeout)
+    : parseDuration('5m');
+  const watchTimeoutMs = options.watchTimeout
+    ? parseDuration(options.watchTimeout)
+    : queryTimeoutMs + 60000;
+
   const timestamp = Date.now();
   const queryName = `cli-query-${timestamp}`;
 
-  // Create the Query resource
   const queryManifest: Partial<Query> = {
     apiVersion: 'ark.mckinsey.com/v1alpha1',
     kind: 'Query',
@@ -35,6 +43,7 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     },
     spec: {
       input: options.message,
+      ...(options.timeout && {timeout: options.timeout}),
       targets: [
         {
           type: options.targetType,
@@ -57,7 +66,7 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
 
     let queryComplete = false;
     let attempts = 0;
-    const maxAttempts = 300; // 5 minutes with 1 second intervals
+    const maxAttempts = Math.floor(watchTimeoutMs / 1000);
 
     while (!queryComplete && attempts < maxAttempts) {
       attempts++;
@@ -127,20 +136,15 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
 
     if (!queryComplete) {
       spinner.fail('Query timed out');
-      output.error('Query did not complete within 5 minutes');
+      output.error(
+        `Query did not complete within ${options.watchTimeout ?? `${Math.floor(watchTimeoutMs / 1000)}s`}`
+      );
       process.exit(ExitCodes.Timeout);
     }
   } catch (error) {
     spinner.fail('Query failed');
     output.error(error instanceof Error ? error.message : 'Unknown error');
     process.exit(ExitCodes.CliError);
-  } finally {
-    // Clean up the query resource
-    try {
-      await execa('kubectl', ['delete', 'query', queryName], {stdio: 'pipe'});
-    } catch {
-      // Ignore cleanup errors
-    }
   }
 }
 

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -6,6 +6,7 @@ import {execa} from 'execa';
 import ora from 'ora';
 import output from './output.js';
 import type {Query, QueryTarget, K8sCondition} from './types.js';
+import {ExitCodes} from './errors.js';
 
 export interface QueryOptions {
   targetType: string; // 'model', 'agent', 'team'
@@ -92,7 +93,6 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
           queryComplete = true;
           spinner.fail('Query failed');
 
-          // Try to get error message from conditions or status
           const errorCondition = query.status?.conditions?.find(
             (c: K8sCondition) => {
               return c.type === 'Complete' && c.status === 'False';
@@ -105,14 +105,15 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
           } else {
             output.error('Query failed with unknown error');
           }
+          process.exit(ExitCodes.OperationError);
         } else if (phase === 'canceled') {
           queryComplete = true;
           spinner.warn('Query canceled');
 
-          // Try to get cancellation reason if available
           if (query.status?.message) {
             output.warning(query.status.message);
           }
+          process.exit(ExitCodes.OperationError);
         }
       } catch {
         // Query might not exist yet, continue waiting
@@ -127,11 +128,12 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     if (!queryComplete) {
       spinner.fail('Query timed out');
       output.error('Query did not complete within 5 minutes');
+      process.exit(ExitCodes.OperationError);
     }
   } catch (error) {
     spinner.fail('Query failed');
     output.error(error instanceof Error ? error.message : 'Unknown error');
-    process.exit(1);
+    process.exit(ExitCodes.CliError);
   } finally {
     // Clean up the query resource
     try {


### PR DESCRIPTION
## Summary
- Add ExitCodes constants (Success: 0, CliError: 1, OperationError: 2, Timeout: 3)
- Remove auto-cleanup of CLI queries - queries now persist like Argo workflows
- Add timeout/watchTimeout params to QueryOptions using K8s duration format
- Create duration utility for parsing K8s durations (e.g., "30s", "5m", "1h")
- Exit with code 2 on query errors/cancellation, code 3 on watch timeout
- Update tests to use short timeouts (100ms/200ms) instead of 5 minutes
- Document exit code behavior in CLI developer guide

Aligns with Argo Workflows' --wait pattern for consistent script error handling.
References: https://github.com/argoproj/argo-workflows/issues/1008