### PR TITLE
fix: stop Queries flipping between `canceled` and `running` phases

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -120,7 +120,7 @@ func (r *QueryReconciler) handleQueryExecution(ctx context.Context, req ctrl.Req
 	}
 
 	switch obj.Status.Phase {
-	case statusDone, statusError:
+	case statusDone, statusError, statusCanceled:
 		return ctrl.Result{
 			RequeueAfter: time.Until(expiry),
 		}, nil


### PR DESCRIPTION
This handles a missing case where a Query has `spec.cancel: true` and is in `status.phase: canceled`, causing canceled queries to flip-flop between `canceled` and `running` phases.

In this state, Queries did not hit either the `if cancel && !canceled` conditional and any cases in the switch, so it fell through to the default case where it would be set back to `running` phase and be requeued. On the next reconcile (a moment later), it would again be set to `canceled` and requeued.

Now, no action is taken by the reconciler, and the Query is quietly requeued until its TTL when it can be deleted.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 