### PR TITLE
fix: arkqb 361 configurable mcp timeout

### DIFF
--- a/ark/api/v1alpha1/mcpserver_types.go
+++ b/ark/api/v1alpha1/mcpserver_types.go
@@ -11,6 +11,9 @@ type MCPServerSpec struct {
 	Address ValueSource `json:"address"`
 	// +kubebuilder:validation:Optional
 	Headers []Header `json:"headers,omitempty"`
+	// Timeout specifies the maximum duration for MCP tool calls to this server.
+	// Use this to support long-running operations (e.g., "5m", "10m", "30m").
+	// Defaults to "30s" if not specified.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="30s"
 	Timeout string `json:"timeout,omitempty"`

--- a/mcp/filesys/chart/templates/mcpserver.yaml
+++ b/mcp/filesys/chart/templates/mcpserver.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   description: "MCP Filesystem Server providing file operations"
   transport: sse
+  {{- if .Values.mcpServer.timeout }}
+  timeout: {{ .Values.mcpServer.timeout | quote }}
+  {{- end }}
   address:
     valueFrom:
       serviceRef:

--- a/mcp/filesys/chart/values.yaml
+++ b/mcp/filesys/chart/values.yaml
@@ -73,3 +73,6 @@ config:
 serviceAccount:
   name: mcp-filesys-sa
   create: true
+
+mcpServer:
+  # timeout: "30s"  # Uncomment and adjust for long-running file operations (e.g., "5m", "10m")

--- a/templates/mcp-server/README.md
+++ b/templates/mcp-server/README.md
@@ -62,6 +62,7 @@ kubectl get queries
 | `image.repository` | string | `"{{ .Values.mcpServerName }}"` | Image repository   |
 | `image.tag`        | string | `"latest"`                      | Image tag          |
 | `service.port`     | int    | `8080`                          | Service port       |
+| `mcpServer.timeout` | string | `"30s"`                        | Timeout for MCP tool calls (e.g., "5m", "10m") |
 
 {{- if .Values.requiresAuth }}
 | `auth.token` | string | `""` | Authentication token |

--- a/templates/mcp-server/chart/templates/mcpserver.yaml
+++ b/templates/mcp-server/chart/templates/mcpserver.yaml
@@ -15,6 +15,9 @@ spec:
         path: {{ .Values.mcpServer.path }}
         {{- end }}
   transport: sse
+  {{- if .Values.mcpServer.timeout }}
+  timeout: {{ .Values.mcpServer.timeout | quote }}
+  {{- end }}
   {{- if .Values.mcpServer.description }}
   description: {{ .Values.mcpServer.description | quote }}
   {{- end }}

--- a/templates/mcp-server/chart/values.yaml
+++ b/templates/mcp-server/chart/values.yaml
@@ -82,3 +82,4 @@ mcpServer:
   name: ""
   description: "{{ .Values.description }}"
   path: "/mcp"
+  # timeout: "30s"  # Uncomment and adjust for long-running operations (e.g., "5m", "10m")


### PR DESCRIPTION
## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues
https://mckinsey.atlassian.net/browse/ARKQB-361

The already existing mcpServer.Spec.Timeout field, which is used for the timeout (and was already present in the CRD) is now passed to the HTTP client. 
(It defaults to 30 seconds to ensure backward compatibility)
