### PR TITLE
fix(ark-cli): properly show query error

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -506,7 +506,14 @@ func (r *QueryReconciler) updateStatusWithDuration(ctx context.Context, query *a
 	case statusDone:
 		r.setConditionCompleted(query, metav1.ConditionTrue, "QuerySucceeded", "Query completed successfully")
 	case statusError:
-		r.setConditionCompleted(query, metav1.ConditionTrue, "QueryErrored", "Query completed with error")
+		errorMsg := "Query completed with error"
+		for _, response := range query.Status.Responses {
+			if response.Phase == statusError && response.Content != "" {
+				errorMsg = response.Content
+				break
+			}
+		}
+		r.setConditionCompleted(query, metav1.ConditionTrue, "QueryErrored", errorMsg)
 	case statusCanceled:
 		r.setConditionCompleted(query, metav1.ConditionTrue, "QueryCanceled", "Query canceled")
 	}

--- a/ark/internal/genai/a2a.go
+++ b/ark/internal/genai/a2a.go
@@ -130,9 +130,17 @@ func executeA2AAgentMessage(ctx context.Context, a2aClient *a2aclient.A2AClient,
 		protocol.NewTextPart(input),
 	})
 
+	blocking := true
 	params := protocol.SendMessageParams{
 		RPCID:   protocol.GenerateRPCID(),
 		Message: message,
+		// Blocking: true causes the A2A server to wait for task completion before responding.
+		// When false, the server returns immediately with a Task in "submitted" state, requiring
+		// the client to poll for updates. Ark currently only supports blocking mode, expecting
+		// Tasks to be in terminal state ("completed" or "failed") when returned.
+		Configuration: &protocol.SendMessageConfiguration{
+			Blocking: &blocking,
+		},
 	}
 
 	result, err := a2aClient.SendMessage(ctx, params)

--- a/ark/internal/genai/a2a_types.go
+++ b/ark/internal/genai/a2a_types.go
@@ -11,14 +11,14 @@ const ExecutionEngineA2A = "a2a"
 
 // A2A Task states from the A2A protocol
 const (
-	TaskStateSubmitted    = "submitted"
-	TaskStateWorking      = "working"
+	TaskStateSubmitted     = "submitted"
+	TaskStateWorking       = "working"
 	TaskStateInputRequired = "input-required"
-	TaskStateCompleted    = "completed"
-	TaskStateCanceled     = "canceled"
-	TaskStateFailed       = "failed"
-	TaskStateRejected     = "rejected"
-	TaskStateAuthRequired = "auth-required"
+	TaskStateCompleted     = "completed"
+	TaskStateCanceled      = "canceled"
+	TaskStateFailed        = "failed"
+	TaskStateRejected      = "rejected"
+	TaskStateAuthRequired  = "auth-required"
 )
 
 // Use the official A2A library types

--- a/tools/ark-cli/src/commands/query/index.spec.ts
+++ b/tools/ark-cli/src/commands/query/index.spec.ts
@@ -20,6 +20,10 @@ const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
   throw new Error('process.exit called');
 }) as any);
 
+const mockConsoleError = jest
+  .spyOn(console, 'error')
+  .mockImplementation(() => {});
+
 const {createQueryCommand} = await import('./index.js');
 
 describe('createQueryCommand', () => {
@@ -68,8 +72,8 @@ describe('createQueryCommand', () => {
 
     expect(mockParseTarget).toHaveBeenCalledWith('invalid-target');
     expect(mockExecuteQuery).not.toHaveBeenCalled();
-    expect(mockOutput.error).toHaveBeenCalledWith(
-      'Invalid target format. Use: model/name or agent/name etc'
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid target format')
     );
     expect(mockExit).toHaveBeenCalledWith(1);
   });

--- a/tools/ark-cli/src/commands/query/index.ts
+++ b/tools/ark-cli/src/commands/query/index.ts
@@ -1,6 +1,6 @@
 import {Command} from 'commander';
+import chalk from 'chalk';
 import type {ArkConfig} from '../../lib/config.js';
-import output from '../../lib/output.js';
 import {executeQuery, parseTarget} from '../../lib/executeQuery.js';
 import {ExitCodes} from '../../lib/errors.js';
 
@@ -14,8 +14,8 @@ export function createQueryCommand(_: ArkConfig): Command {
     .action(async (target: string, message: string) => {
       const parsed = parseTarget(target);
       if (!parsed) {
-        output.error(
-          'Invalid target format. Use: model/name or agent/name etc'
+        console.error(
+          chalk.red('Invalid target format. Use: model/name or agent/name etc')
         );
         process.exit(ExitCodes.CliError);
       }

--- a/tools/ark-cli/src/lib/arkApiClient.ts
+++ b/tools/ark-cli/src/lib/arkApiClient.ts
@@ -53,6 +53,7 @@ export class ArkApiClient {
       baseURL: `${arkApiUrl}/openai/v1`,
       apiKey: 'dummy', // ark-api doesn't require an API key
       dangerouslyAllowBrowser: false,
+      maxRetries: 0, // Disable automatic retries for query errors
     });
   }
 

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -6,7 +6,7 @@ import {execa} from 'execa';
 import ora from 'ora';
 import chalk from 'chalk';
 import output from './output.js';
-import type {Query, QueryTarget, K8sCondition} from './types.js';
+import type {Query, QueryTarget} from './types.js';
 import {ExitCodes} from './errors.js';
 import {parseDuration} from './duration.js';
 
@@ -104,7 +104,9 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
           spinner.stop();
 
           const response = query.status?.responses?.[0];
-          console.error(chalk.red(response?.content || 'Query failed with unknown error'));
+          console.error(
+            chalk.red(response?.content || 'Query failed with unknown error')
+          );
           process.exit(ExitCodes.OperationError);
         } else if (phase === 'canceled') {
           queryComplete = true;
@@ -126,7 +128,7 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     }
 
     if (!queryComplete) {
-      spinner.fail();
+      spinner.stop();
       console.error(
         chalk.red(
           `Query did not complete within ${options.watchTimeout ?? `${Math.floor(watchTimeoutMs / 1000)}s`}`
@@ -136,7 +138,9 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     }
   } catch (error) {
     spinner.stop();
-    console.error(chalk.red(error instanceof Error ? error.message : 'Unknown error'));
+    console.error(
+      chalk.red(error instanceof Error ? error.message : 'Unknown error')
+    );
     process.exit(ExitCodes.CliError);
   }
 }

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -4,6 +4,7 @@
 
 import {execa} from 'execa';
 import ora from 'ora';
+import chalk from 'chalk';
 import output from './output.js';
 import type {Query, QueryTarget, K8sCondition} from './types.js';
 import {ExitCodes} from './errors.js';
@@ -89,31 +90,21 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
         // Check if query is complete based on phase
         if (phase === 'done') {
           queryComplete = true;
-          spinner.succeed('Query completed');
+          spinner.stop();
 
           // Extract and display the response from responses array
           if (query.status?.responses && query.status.responses.length > 0) {
             const response = query.status.responses[0];
-            console.log('\n' + (response.content || response));
+            console.log(response.content || response);
           } else {
             output.warning('No response received');
           }
         } else if (phase === 'error') {
           queryComplete = true;
-          spinner.fail('Query failed');
+          spinner.stop();
 
-          const errorCondition = query.status?.conditions?.find(
-            (c: K8sCondition) => {
-              return c.type === 'Complete' && c.status === 'False';
-            }
-          );
-          if (errorCondition?.message) {
-            output.error(errorCondition.message);
-          } else if (query.status?.error) {
-            output.error(query.status.error);
-          } else {
-            output.error('Query failed with unknown error');
-          }
+          const response = query.status?.responses?.[0];
+          console.error(chalk.red(response?.content || 'Query failed with unknown error'));
           process.exit(ExitCodes.OperationError);
         } else if (phase === 'canceled') {
           queryComplete = true;
@@ -135,15 +126,17 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     }
 
     if (!queryComplete) {
-      spinner.fail('Query timed out');
-      output.error(
-        `Query did not complete within ${options.watchTimeout ?? `${Math.floor(watchTimeoutMs / 1000)}s`}`
+      spinner.fail();
+      console.error(
+        chalk.red(
+          `Query did not complete within ${options.watchTimeout ?? `${Math.floor(watchTimeoutMs / 1000)}s`}`
+        )
       );
       process.exit(ExitCodes.Timeout);
     }
   } catch (error) {
-    spinner.fail('Query failed');
-    output.error(error instanceof Error ? error.message : 'Unknown error');
+    spinner.stop();
+    console.error(chalk.red(error instanceof Error ? error.message : 'Unknown error'));
     process.exit(ExitCodes.CliError);
   }
 }


### PR DESCRIPTION
fix(ark-controller): show query error message in conditions.Message

fix(ark-cli): do not show superfluous error/success content, just the query output

Issue one - success and error notes are not required and make it hard to script output. just show the response or error. Original:

<img width="692" height="231" alt="image" src="https://github.com/user-attachments/assets/0034e4c7-ea8a-43d9-a403-41ae07d0e766" />

Fixed:

<img width="838" height="332" alt="image" src="https://github.com/user-attachments/assets/db88920e-f273-41ea-a4c1-2e109f5a4c09" />

Issue 2: The cli was checking the condition message, that's wrong and has been fixed, but the condition message should actually be the error anyway. incorrect:

<img width="844" height="483" alt="image" src="https://github.com/user-attachments/assets/c3e48f56-7e71-4c39-b49e-076a06f1e8be" />

Correct:

<img width="842" height="419" alt="image" src="https://github.com/user-attachments/assets/bb6fc60c-0678-4ea8-8b23-c4a170079e5c" />

Issue 3: was showing 'No response received' or something for errors, this was incorrect and how the error object is shown, a follow on error is that for streaming we don't get any error back at all. However, the non streaming error message is correct.

<img width="832" height="206" alt="image" src="https://github.com/user-attachments/assets/e10d65ac-bc5d-414c-836c-4fbdccd31fe0" />
