### PR TITLE
fix: fixed SSE support for golang mcp client

### DIFF
--- a/ark/go.mod
+++ b/ark/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.10
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.39.0
-	github.com/google/jsonschema-go v0.2.3
+	github.com/google/jsonschema-go v0.3.0
 	github.com/itchyny/gojq v0.12.17
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
@@ -29,7 +29,6 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0 // indirect
 )
 
 require (
@@ -96,7 +95,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.4 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/modelcontextprotocol/go-sdk v0.3.1
+	github.com/modelcontextprotocol/go-sdk v1.0.0
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -114,7 +113,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/ark/go.sum
+++ b/ark/go.sum
@@ -114,8 +114,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.2.3 h1:dkP3B96OtZKKFvdrUSaDkL+YDx8Uw9uC4Y+eukpCnmM=
-github.com/google/jsonschema-go v0.2.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -156,8 +156,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/modelcontextprotocol/go-sdk v0.3.1 h1:0z04yIPlSwTluuelCBaL+wUag4YeflIU2Fr4Icb7M+o=
-github.com/modelcontextprotocol/go-sdk v0.3.1/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
+github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKRyQSJgw8q8V74=
+github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -236,8 +236,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 h1:lwI4D
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0/go.mod h1:Kz/oCE7z5wuyhPxsXDuaPteSWqjSBD5YaSdbxZYGbGk=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 h1:aTL7F04bJHUlztTsNGJ2l+6he8c+y/b//eR0jjjemT4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0/go.mod h1:kldtb7jDTeol0l3ewcmd8SDvx3EmIE7lyvqbasU3QC4=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0 h1:kJxSDN4SgWWTjG/hPp3O7LCGLcHXFlvS2/FFOrwL+SE=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0/go.mod h1:mgIOzS7iZeKJdeB8/NYHrJ48fdGc71Llo5bJ1J4DWUE=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
 go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
 go.opentelemetry.io/otel/sdk v1.38.0 h1:l48sr5YbNf2hpCUj/FoGhW9yDkl+Ma+LrVl8qaM5b+E=

--- a/ark/internal/genai/mcp.go
+++ b/ark/internal/genai/mcp.go
@@ -74,8 +74,15 @@ func performBackoff(ctx context.Context, attempt int, baseURL string) error {
 
 func createTransport(baseURL string, headers map[string]string, timeout time.Duration, transportType string) mcp.Transport {
 	// Create HTTP client with headers
-	httpClient := &http.Client{
-		Timeout: timeout,
+	var httpClient *http.Client
+	if transportType == "sse" {
+		httpClient = &http.Client{
+			// No timeout for SSE: connections are long-lived
+		}
+	} else {
+		httpClient = &http.Client{
+			Timeout: timeout,
+		}
 	}
 
 	// If we have headers, wrap the transport
@@ -124,11 +131,14 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
-func attemptMCPConnection(ctx, connectCtx context.Context, mcpClient *mcp.Client, baseURL string, headers map[string]string, httpTimeout time.Duration, transportType string) (*mcp.ClientSession, error) {
+func attemptMCPConnection(ctx context.Context, mcpClient *mcp.Client, baseURL string, headers map[string]string, httpTimeout time.Duration, transportType string) (*mcp.ClientSession, error) {
 	log := logf.FromContext(ctx)
 
 	transport := createTransport(baseURL, headers, httpTimeout, transportType)
-	session, err := mcpClient.Connect(connectCtx, transport, nil)
+
+	// For SSE, the context passed here controls the connection lifetime
+	// It should be the caller's context, not a temporary one
+	session, err := mcpClient.Connect(ctx, transport, nil)
 	if err != nil {
 		if isRetryableError(err) {
 			log.V(1).Info("retryable error connecting MCP client", "error", err)
@@ -148,19 +158,24 @@ func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[s
 		return nil, err
 	}
 
-	connectCtx, cancel := context.WithTimeout(context.Background(), connectTimeout)
-	defer cancel()
+	// Create a context with timeout ONLY for the retry loop
+	// The caller's context (ctx) is used for the actual connection and should control its lifetime
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), connectTimeout)
+	defer retryCancel()
 
 	var lastErr error
 	var session *mcp.ClientSession
 	for attempt := range maxRetries {
 		if attempt > 0 {
-			if err := performBackoff(connectCtx, attempt, baseURL); err != nil {
+			if err := performBackoff(retryCtx, attempt, baseURL); err != nil {
 				return nil, err
 			}
 		}
 
-		session, err = attemptMCPConnection(ctx, connectCtx, mcpClient, baseURL, headers, httpTimeout, transportType)
+		// Use the caller's context for the connection
+		// For SSE: This context controls the connection lifetime - when ctx is canceled, connection closes
+		// For HTTP: This context is used per-request
+		session, err = attemptMCPConnection(ctx, mcpClient, baseURL, headers, httpTimeout, transportType)
 		if err == nil {
 			log.Info("MCP client connected successfully", "server", baseURL, "attempts", attempt+1)
 			return &MCPClient{

--- a/ark/internal/genai/mcp.go
+++ b/ark/internal/genai/mcp.go
@@ -49,11 +49,6 @@ func NewMCPClient(ctx context.Context, baseURL string, headers map[string]string
 	return mcpClient, nil
 }
 
-func createSSEClient() (*mcp.Client, error) {
-	// Create HTTP client which is backwards compatible with SSE transport
-	return createHTTPClient()
-}
-
 func createHTTPClient() (*mcp.Client, error) {
 	impl := &mcp.Implementation{
 		Name:    arkv1alpha1.GroupVersion.Group,
@@ -62,17 +57,6 @@ func createHTTPClient() (*mcp.Client, error) {
 
 	mcpClient := mcp.NewClient(impl, nil)
 	return mcpClient, nil
-}
-
-func createMCPClientByTransport(transportType string) (*mcp.Client, error) {
-	switch transportType {
-	case "sse":
-		return createSSEClient()
-	case "http":
-		return createHTTPClient()
-	default:
-		return nil, fmt.Errorf("unsupported transport type: %s", transportType)
-	}
 }
 
 func performBackoff(ctx context.Context, attempt int, baseURL string) error {
@@ -88,7 +72,7 @@ func performBackoff(ctx context.Context, attempt int, baseURL string) error {
 	}
 }
 
-func createTransport(baseURL string, headers map[string]string, timeout time.Duration) mcp.Transport {
+func createTransport(baseURL string, headers map[string]string, timeout time.Duration, transportType string) mcp.Transport {
 	// Create HTTP client with headers
 	httpClient := &http.Client{
 		Timeout: timeout,
@@ -102,14 +86,26 @@ func createTransport(baseURL string, headers map[string]string, timeout time.Dur
 		}
 	}
 
-	u, _ := url.Parse(baseURL)
-	u.Path = path.Join(u.Path, "mcp")
-	fullURL := u.String()
-
-	return &mcp.StreamableClientTransport{
-		Endpoint:   fullURL,
-		HTTPClient: httpClient,
-		MaxRetries: 5,
+	switch transportType {
+	case "sse":
+		u, _ := url.Parse(baseURL)
+		u.Path = path.Join(u.Path, "sse")
+		fullURL := u.String()
+		return &mcp.SSEClientTransport{
+			Endpoint:   fullURL,
+			HTTPClient: httpClient,
+		}
+	case "http":
+		u, _ := url.Parse(baseURL)
+		u.Path = path.Join(u.Path, "mcp")
+		fullURL := u.String()
+		return &mcp.StreamableClientTransport{
+			Endpoint:   fullURL,
+			HTTPClient: httpClient,
+			MaxRetries: 5,
+		}
+	default:
+		panic("unsupported transport type: " + transportType)
 	}
 }
 
@@ -128,10 +124,10 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
-func attemptMCPConnection(ctx, connectCtx context.Context, mcpClient *mcp.Client, baseURL string, headers map[string]string, httpTimeout time.Duration) (*mcp.ClientSession, error) {
+func attemptMCPConnection(ctx, connectCtx context.Context, mcpClient *mcp.Client, baseURL string, headers map[string]string, httpTimeout time.Duration, transportType string) (*mcp.ClientSession, error) {
 	log := logf.FromContext(ctx)
 
-	transport := createTransport(baseURL, headers, httpTimeout)
+	transport := createTransport(baseURL, headers, httpTimeout, transportType)
 	session, err := mcpClient.Connect(connectCtx, transport, nil)
 	if err != nil {
 		if isRetryableError(err) {
@@ -147,7 +143,7 @@ func attemptMCPConnection(ctx, connectCtx context.Context, mcpClient *mcp.Client
 func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[string]string, transportType string, httpTimeout time.Duration, maxRetries int, connectTimeout time.Duration) (*MCPClient, error) {
 	log := logf.FromContext(ctx)
 
-	mcpClient, err := createMCPClientByTransport(transportType)
+	mcpClient, err := createHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +160,7 @@ func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[s
 			}
 		}
 
-		session, err = attemptMCPConnection(ctx, connectCtx, mcpClient, baseURL, headers, httpTimeout)
+		session, err = attemptMCPConnection(ctx, connectCtx, mcpClient, baseURL, headers, httpTimeout, transportType)
 		if err == nil {
 			log.Info("MCP client connected successfully", "server", baseURL, "attempts", attempt+1)
 			return &MCPClient{

--- a/ark/internal/genai/mcp.go
+++ b/ark/internal/genai/mcp.go
@@ -32,8 +32,12 @@ type MCPClient struct {
 	client  *mcp.ClientSession
 }
 
+var (
+	connectMaxReties = 5
+)
+
 func NewMCPClient(ctx context.Context, baseURL string, headers map[string]string, transportType string, timeout time.Duration, mcpSetting MCPSettings) (*MCPClient, error) {
-	mcpClient, err := createMCPClientWithRetry(ctx, baseURL, headers, transportType, timeout, 5, 120*time.Second)
+	mcpClient, err := createMCPClientWithRetry(ctx, baseURL, headers, transportType, timeout, connectMaxReties)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +154,7 @@ func attemptMCPConnection(ctx context.Context, mcpClient *mcp.Client, baseURL st
 	return session, nil
 }
 
-func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[string]string, transportType string, httpTimeout time.Duration, maxRetries int, connectTimeout time.Duration) (*MCPClient, error) {
+func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[string]string, transportType string, httpTimeout time.Duration, maxRetries int) (*MCPClient, error) {
 	log := logf.FromContext(ctx)
 
 	mcpClient, err := createHTTPClient()
@@ -160,7 +164,7 @@ func createMCPClientWithRetry(ctx context.Context, baseURL string, headers map[s
 
 	// Create a context with timeout ONLY for the retry loop
 	// The caller's context (ctx) is used for the actual connection and should control its lifetime
-	retryCtx, retryCancel := context.WithTimeout(context.Background(), connectTimeout)
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer retryCancel()
 
 	var lastErr error

--- a/ark/internal/genai/mcp_test.go
+++ b/ark/internal/genai/mcp_test.go
@@ -63,7 +63,19 @@ func TestNewMCPClient(t *testing.T) {
 
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			// Store server and client for cleanup
 			mcpServerMock := mcpServerMock{}.New(t, tc.mcpServer.connectionOptions)
+			var mcpClient *MCPClient
+
+			t.Cleanup(func() {
+				// Release connections when test completes
+				if mcpClient != nil && mcpClient.client != nil {
+					_ = mcpClient.client.Close()
+				}
+
+				// And shut down server
+				_ = mcpServerMock.Shutdown(t.Context())
+			})
 
 			// Start server in a goroutine since ListenAndServe blocks
 			go func() {
@@ -73,20 +85,7 @@ func TestNewMCPClient(t *testing.T) {
 					t.Errorf("Failed to start MCP server mock: %v", err)
 				}
 			}()
-
-			// Clean up server when test completes
-			t.Cleanup(func() {
-				fmt.Println("Shutting down MCP server mock...")
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_ = mcpServerMock.Shutdown(ctx)
-
-				// Ensure server has time to shut down
-				time.Sleep(300 * time.Millisecond)
-			})
-
-			// Give the server time to start
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 
 			ctx := t.Context()
 			client, err := NewMCPClient(
@@ -103,6 +102,9 @@ func TestNewMCPClient(t *testing.T) {
 			if client == nil {
 				t.Fatal("Expected a valid MCP client, got nil")
 			}
+
+			// Store client for cleanup
+			mcpClient = client
 
 			tools, err := client.ListTools(ctx)
 			require.NoError(t, err)
@@ -134,7 +136,7 @@ func (m *mcpServerMock) ListenAndServe(t *testing.T) error {
 	var handler http.Handler
 	switch m.opts.transport {
 	case "sse":
-		handler = mcp.NewSSEHandler(m.getServerFn())
+		handler = mcp.NewSSEHandler(m.getServerFn(), nil)
 	case "http":
 		handler = mcp.NewStreamableHTTPHandler(m.getServerFn(), nil)
 	default:
@@ -157,14 +159,7 @@ func (m *mcpServerMock) Shutdown(ctx context.Context) error {
 
 func (m *mcpServerMock) getServerFn() func(request *http.Request) *mcp.Server {
 	return func(request *http.Request) *mcp.Server {
-		fmt.Printf("incoming request: %+v\n", request)
-		url := request.URL.Path
-		switch url {
-		case "/mcp", "/sse":
-			return m.server
-		default:
-			panic("endpoint not implemented")
-		}
+		return m.server
 	}
 }
 

--- a/ark/internal/genai/mcp_test.go
+++ b/ark/internal/genai/mcp_test.go
@@ -1,0 +1,181 @@
+package genai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+type mcpConnectionOps struct {
+	host      string
+	port      string
+	transport string
+}
+type testOptions struct {
+	mcpServer struct {
+		connectionOptions mcpConnectionOps
+	}
+	mcpClient struct {
+		connectionOptions mcpConnectionOps
+	}
+}
+
+func TestNewMCPClient(t *testing.T) {
+	testCases := map[string]testOptions{
+		"Creates MCPClient over HTTP transport": {
+			mcpServer: struct{ connectionOptions mcpConnectionOps }{
+				connectionOptions: mcpConnectionOps{
+					host:      "localhost",
+					port:      "8888",
+					transport: "http",
+				},
+			},
+			mcpClient: struct{ connectionOptions mcpConnectionOps }{
+				connectionOptions: mcpConnectionOps{
+					host:      "localhost",
+					port:      "8888",
+					transport: "http",
+				},
+			},
+		},
+		"Creates MCPClient over SSE transport": {
+			mcpServer: struct{ connectionOptions mcpConnectionOps }{
+				connectionOptions: mcpConnectionOps{
+					host:      "localhost",
+					port:      "8888",
+					transport: "sse",
+				},
+			},
+			mcpClient: struct{ connectionOptions mcpConnectionOps }{
+				connectionOptions: mcpConnectionOps{
+					host:      "localhost",
+					port:      "8888",
+					transport: "sse",
+				},
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			mcpServerMock := mcpServerMock{}.New(t, tc.mcpServer.connectionOptions)
+
+			// Start server in a goroutine since ListenAndServe blocks
+			go func() {
+				fmt.Println("Starting MCP server mock...")
+				err := mcpServerMock.ListenAndServe(t)
+				if err != nil && err != http.ErrServerClosed {
+					t.Errorf("Failed to start MCP server mock: %v", err)
+				}
+			}()
+
+			// Clean up server when test completes
+			t.Cleanup(func() {
+				fmt.Println("Shutting down MCP server mock...")
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = mcpServerMock.Shutdown(ctx)
+
+				// Ensure server has time to shut down
+				time.Sleep(300 * time.Millisecond)
+			})
+
+			// Give the server time to start
+			time.Sleep(300 * time.Millisecond)
+
+			ctx := t.Context()
+			client, err := NewMCPClient(
+				ctx,
+				fmt.Sprintf("http://%s:%s", tc.mcpClient.connectionOptions.host, tc.mcpClient.connectionOptions.port),
+				nil,
+				tc.mcpClient.connectionOptions.transport,
+				30*time.Second,
+				MCPSettings{},
+			)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if client == nil {
+				t.Fatal("Expected a valid MCP client, got nil")
+			}
+
+			tools, err := client.ListTools(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "greet", tools[0].Name)
+		})
+	}
+}
+
+type mcpServerMock struct {
+	server     *mcp.Server
+	httpServer *http.Server
+	opts       mcpConnectionOps
+}
+
+func (m mcpServerMock) New(t *testing.T, opts mcpConnectionOps) *mcpServerMock {
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "greeter", Version: "v0.0.1"}, nil)
+
+	mcp.AddTool(mcpServer, &mcp.Tool{Name: "greet", Description: "say hi"}, m.sayHi)
+
+	return &mcpServerMock{
+		server: mcpServer,
+		opts:   opts,
+	}
+}
+
+func (m *mcpServerMock) ListenAndServe(t *testing.T) error {
+	t.Helper()
+
+	var handler http.Handler
+	switch m.opts.transport {
+	case "sse":
+		handler = mcp.NewSSEHandler(m.getServerFn())
+	case "http":
+		handler = mcp.NewStreamableHTTPHandler(m.getServerFn(), nil)
+	default:
+		panic("unsupported transport")
+	}
+
+	m.httpServer = &http.Server{
+		Addr:    fmt.Sprintf("%s:%s", m.opts.host, m.opts.port),
+		Handler: handler,
+	}
+	return m.httpServer.ListenAndServe()
+}
+
+func (m *mcpServerMock) Shutdown(ctx context.Context) error {
+	if m.httpServer != nil {
+		return m.httpServer.Shutdown(ctx)
+	}
+	return nil
+}
+
+func (m *mcpServerMock) getServerFn() func(request *http.Request) *mcp.Server {
+	return func(request *http.Request) *mcp.Server {
+		fmt.Printf("incoming request: %+v\n", request)
+		url := request.URL.Path
+		switch url {
+		case "/mcp", "/sse":
+			return m.server
+		default:
+			panic("endpoint not implemented")
+		}
+	}
+}
+
+type sayHiParams struct {
+	Name string `json:"name"`
+}
+
+func (m *mcpServerMock) sayHi(ctx context.Context, req *mcp.CallToolRequest, args sayHiParams) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi " + args.Name},
+		},
+	}, nil, nil
+}


### PR DESCRIPTION
This PR:

- fixes SSE transport support for golang mcp client (issue introduced likely from #165 while switching to github.com/modelcontextprotocol/go-sdk/mcp pkg)
- fixes a timeout issue making the connection close too early (this is not suitable for SSE as this communication requires long lived connections)
- fixed a timeout issue making mcp calls retried after 120s (hardcoded) ignoring the mcpserver timeout setting added in #334 
- updates modelcontextprotocol/go-sdk dependency to 1.0.0

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 