### PR TITLE
feat: add queries get command with @latest support

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.39",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.39",
+      "version": "0.1.41",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -39,6 +39,7 @@
         "@types/debug": "^4.1.12",
         "@types/inquirer": "^9.0.7",
         "@types/jest": "^30.0.0",
+        "@types/marked-terminal": "^6.1.1",
         "@types/node": "^22.10.2",
         "@types/react": "^19.1.13",
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -2750,6 +2751,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2828,6 +2836,45 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/marked-terminal": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/marked-terminal/-/marked-terminal-6.1.1.tgz",
+      "integrity": "sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cardinal": "^2.1",
+        "@types/node": "*",
+        "chalk": "^5.3.0",
+        "marked": ">=6.0.0 <12"
+      }
+    },
+    "node_modules/@types/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@types/marked-terminal/node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -67,6 +67,7 @@
     "@types/debug": "^4.1.12",
     "@types/inquirer": "^9.0.7",
     "@types/jest": "^30.0.0",
+    "@types/marked-terminal": "^6.1.1",
     "@types/node": "^22.10.2",
     "@types/react": "^19.1.13",
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/tools/ark-cli/src/commands/completion/index.ts
+++ b/tools/ark-cli/src/commands/completion/index.ts
@@ -32,7 +32,7 @@ _ark_completion() {
   
   case \${COMP_CWORD} in
     1)
-      opts="agents chat cluster completion config dashboard docs generate install models query routes status targets teams tools uninstall help"
+      opts="agents chat cluster completion config dashboard docs generate install models queries query routes status targets teams tools uninstall help"
       COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
       return 0
       ;;
@@ -105,6 +105,11 @@ _ark_completion() {
           COMPREPLY=( $(compgen -W "\${targets}" -- \${cur}) )
           return 0
           ;;
+        queries)
+          opts="get"
+          COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
+          return 0
+          ;;
       esac
       ;;
   esac
@@ -146,6 +151,7 @@ _ark() {
         'generate[Generate ARK resources]' \\
         'install[Install ARK services]' \\
         'models[List available models]' \\
+        'queries[Manage query resources]' \\
         'query[Execute a single query]' \\
         'routes[List available routes]' \\
         'status[Check system status]' \\
@@ -223,6 +229,10 @@ _ark() {
             targets=('model/default' 'agent/sample-agent')
           fi
           _values 'available targets' \${targets[@]}
+          ;;
+        queries)
+          _values 'queries commands' \\
+            'get[Get a specific query]'
           ;;
       esac
       ;;

--- a/tools/ark-cli/src/commands/memory/index.spec.ts
+++ b/tools/ark-cli/src/commands/memory/index.spec.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, jest, beforeEach, afterEach, beforeAll } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+  beforeAll,
+} from '@jest/globals';
 
 // ESM-safe mocking: declare variables to hold dynamically imported modules
 let createMemoryCommand: any;
@@ -28,9 +36,11 @@ jest.unstable_mockModule('../../lib/arkApiProxy.js', () => ({
 
 beforeAll(async () => {
   // After mocks are registered, dynamically import modules
-  ({ ArkApiProxy } = await import('../../lib/arkApiProxy.js'));
-  ({ default: output } = await import('../../lib/output.js'));
-  ({ createMemoryCommand, deleteSession, deleteQuery, deleteAll } = await import('./index.js'));
+  ({ArkApiProxy} = await import('../../lib/arkApiProxy.js'));
+  ({default: output} = await import('../../lib/output.js'));
+  ({createMemoryCommand, deleteSession, deleteQuery, deleteAll} = await import(
+    './index.js'
+  ));
 });
 
 describe('Memory Command', () => {
@@ -48,7 +58,7 @@ describe('Memory Command', () => {
   describe('Command Structure', () => {
     it('should create memory command with correct structure', () => {
       const command = createMemoryCommand(mockConfig);
-      
+
       expect(command.name()).toBe('memory');
       expect(command.alias()).toBe('mem');
       expect(command.description()).toBe('Manage memory sessions and queries');
@@ -56,19 +66,24 @@ describe('Memory Command', () => {
 
     it('should have list subcommand', () => {
       const command = createMemoryCommand(mockConfig);
-      const subcommands = (command as any).commands.map((cmd: any) => cmd.name());
-      
+      const subcommands = (command as any).commands.map((cmd: any) =>
+        cmd.name()
+      );
+
       expect(subcommands).toContain('list');
     });
 
     it('should have delete subcommand with nested commands and flags', () => {
       const command = createMemoryCommand(mockConfig);
-      const deleteCommand = (command as any).commands.find((cmd: any) => cmd.name() === 'delete');
-      
+      const deleteCommand = (command as any).commands.find(
+        (cmd: any) => cmd.name() === 'delete'
+      );
+
       expect(deleteCommand).toBeDefined();
       expect(deleteCommand?.description()).toBe('Delete memory data');
-      
-      const deleteSubcommands = deleteCommand?.commands.map((cmd: any) => cmd.name()) || [];
+
+      const deleteSubcommands =
+        deleteCommand?.commands.map((cmd: any) => cmd.name()) || [];
       expect(deleteSubcommands).toContain('session');
       expect(deleteSubcommands).toContain('query');
       // --all flag is supported on the delete root instead of an 'all' subcommand
@@ -94,7 +109,9 @@ describe('Memory Command', () => {
     beforeEach(async () => {
       exitSpy = jest
         .spyOn(process as any, 'exit')
-        .mockImplementation((((..._args: unknown[]) => undefined) as unknown) as any);
+        .mockImplementation(
+          ((..._args: unknown[]) => undefined) as unknown as any
+        );
     });
 
     afterEach(() => {
@@ -103,44 +120,50 @@ describe('Memory Command', () => {
 
     it('deleteSession handles 500 error', async () => {
       const err = new Error('Internal Server Error');
-      const fakeClient = { deleteSession: (jest.fn() as any).mockRejectedValue(err) } as any;
+      const fakeClient = {
+        deleteSession: (jest.fn() as any).mockRejectedValue(err),
+      } as any;
       (ArkApiProxy as unknown as jest.Mock).mockImplementation(() => ({
         start: (jest.fn() as any).mockResolvedValue(fakeClient),
         stop: jest.fn(),
       }));
 
-      await deleteSession('sess-1', { output: 'text' }).catch(() => {});
+      await deleteSession('sess-1', {output: 'text'}).catch(() => {});
 
       expect(output.error).toHaveBeenCalled();
-      expect((process.exit as unknown as jest.Mock)).toHaveBeenCalledWith(1);
+      expect(process.exit as unknown as jest.Mock).toHaveBeenCalledWith(1);
     });
 
     it('deleteQuery handles network timeout', async () => {
       const err = new Error('Network timeout');
-      const fakeClient = { deleteQueryMessages: (jest.fn() as any).mockRejectedValue(err) } as any;
+      const fakeClient = {
+        deleteQueryMessages: (jest.fn() as any).mockRejectedValue(err),
+      } as any;
       (ArkApiProxy as unknown as jest.Mock).mockImplementation(() => ({
         start: (jest.fn() as any).mockResolvedValue(fakeClient),
         stop: jest.fn(),
       }));
 
-      await deleteQuery('sess-2', 'query-9', { output: 'text' }).catch(() => {});
+      await deleteQuery('sess-2', 'query-9', {output: 'text'}).catch(() => {});
 
       expect(output.error).toHaveBeenCalled();
-      expect((process.exit as unknown as jest.Mock)).toHaveBeenCalledWith(1);
+      expect(process.exit as unknown as jest.Mock).toHaveBeenCalledWith(1);
     });
 
     it('deleteAll handles no memory services reachable', async () => {
       const err = new Error('No memory services reachable');
-      const fakeClient = { deleteAllSessions: (jest.fn() as any).mockRejectedValue(err) } as any;
+      const fakeClient = {
+        deleteAllSessions: (jest.fn() as any).mockRejectedValue(err),
+      } as any;
       (ArkApiProxy as unknown as jest.Mock).mockImplementation(() => ({
         start: (jest.fn() as any).mockResolvedValue(fakeClient),
         stop: jest.fn(),
       }));
 
-      await deleteAll({ output: 'text' }).catch(() => {});
+      await deleteAll({output: 'text'}).catch(() => {});
 
       expect(output.error).toHaveBeenCalled();
-      expect((process.exit as unknown as jest.Mock)).toHaveBeenCalledWith(1);
+      expect(process.exit as unknown as jest.Mock).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/tools/ark-cli/src/commands/memory/index.ts
+++ b/tools/ark-cli/src/commands/memory/index.ts
@@ -1,13 +1,13 @@
-import { Command } from 'commander';
-import type { ArkConfig } from '../../lib/config.js';
+import {Command} from 'commander';
+import type {ArkConfig} from '../../lib/config.js';
 import output from '../../lib/output.js';
-import { ArkApiProxy } from '../../lib/arkApiProxy.js';
+import {ArkApiProxy} from '../../lib/arkApiProxy.js';
 
-export async function listSessions(options: { output?: string }) {
+export async function listSessions(options: {output?: string}) {
   try {
     const proxy = new ArkApiProxy();
     const arkApiClient = await proxy.start();
-    
+
     const sessions = await arkApiClient.getSessions();
 
     if (options.output === 'json') {
@@ -24,7 +24,7 @@ export async function listSessions(options: { output?: string }) {
     sessions.forEach((session: any) => {
       output.info(`  ${session.sessionId} (memory: ${session.memoryName})`);
     });
-    
+
     proxy.stop();
   } catch (error) {
     output.error('Failed to list sessions:', error);
@@ -32,20 +32,23 @@ export async function listSessions(options: { output?: string }) {
   }
 }
 
-export async function deleteSession(sessionId: string, options: { output?: string }) {
+export async function deleteSession(
+  sessionId: string,
+  options: {output?: string}
+) {
   try {
     const proxy = new ArkApiProxy();
     const arkApiClient = await proxy.start();
-    
+
     const response = await arkApiClient.deleteSession(sessionId);
-    
+
     if (options.output === 'json') {
       output.info(JSON.stringify(response, null, 2));
       return;
     }
 
     output.success(`Session ${sessionId} deleted successfully`);
-    
+
     proxy.stop();
   } catch (error) {
     output.error(`Failed to delete session ${sessionId}:`, error);
@@ -53,20 +56,26 @@ export async function deleteSession(sessionId: string, options: { output?: strin
   }
 }
 
-export async function deleteQuery(sessionId: string, queryId: string, options: { output?: string }) {
+export async function deleteQuery(
+  sessionId: string,
+  queryId: string,
+  options: {output?: string}
+) {
   try {
     const proxy = new ArkApiProxy();
     const arkApiClient = await proxy.start();
-    
+
     const response = await arkApiClient.deleteQueryMessages(sessionId, queryId);
-    
+
     if (options.output === 'json') {
       output.info(JSON.stringify(response, null, 2));
       return;
     }
 
-    output.success(`Query ${queryId} messages deleted successfully from session ${sessionId}`);
-    
+    output.success(
+      `Query ${queryId} messages deleted successfully from session ${sessionId}`
+    );
+
     proxy.stop();
   } catch (error) {
     output.error(`Failed to delete query ${queryId} messages:`, error);
@@ -74,20 +83,20 @@ export async function deleteQuery(sessionId: string, queryId: string, options: {
   }
 }
 
-export async function deleteAll(options: { output?: string }) {
+export async function deleteAll(options: {output?: string}) {
   try {
     const proxy = new ArkApiProxy();
     const arkApiClient = await proxy.start();
-    
+
     const response = await arkApiClient.deleteAllSessions();
-    
+
     if (options.output === 'json') {
       output.info(JSON.stringify(response, null, 2));
       return;
     }
 
     output.success('All sessions deleted successfully');
-    
+
     proxy.stop();
   } catch (error) {
     output.error('Failed to delete all sessions:', error);
@@ -98,9 +107,7 @@ export async function deleteAll(options: { output?: string }) {
 export function createMemoryCommand(_: ArkConfig): Command {
   const memoryCommand = new Command('memory');
 
-  memoryCommand
-    .description('Manage memory sessions and queries')
-    .alias('mem');
+  memoryCommand.description('Manage memory sessions and queries').alias('mem');
 
   // List sessions command
   memoryCommand

--- a/tools/ark-cli/src/commands/queries/index.ts
+++ b/tools/ark-cli/src/commands/queries/index.ts
@@ -1,0 +1,80 @@
+import {Command} from 'commander';
+import {marked} from 'marked';
+import TerminalRenderer from 'marked-terminal';
+import type {ArkConfig} from '../../lib/config.js';
+import output from '../../lib/output.js';
+import type {Query} from '../../lib/types.js';
+import {ExitCodes} from '../../lib/errors.js';
+import {getResource} from '../../lib/kubectl.js';
+
+function renderMarkdown(content: string): string {
+  if (process.stdout.isTTY) {
+    marked.setOptions({
+      // @ts-expect-error - TerminalRenderer types are incomplete
+      renderer: new TerminalRenderer({
+        showSectionPrefix: false,
+        reflowText: true,
+        // @ts-expect-error - preserveNewlines exists but not in types
+        preserveNewlines: true,
+      }),
+    });
+    return marked(content) as string;
+  }
+  return content;
+}
+
+async function getQuery(
+  name: string,
+  options: {output?: string; response?: boolean}
+) {
+  try {
+    const query = await getResource<Query>('queries', name);
+
+    if (options.response) {
+      if (query.status?.responses && query.status.responses.length > 0) {
+        const response = query.status.responses[0];
+        if (options.output === 'markdown') {
+          console.log(renderMarkdown(response.content || ''));
+        } else {
+          console.log(JSON.stringify(response, null, 2));
+        }
+      } else {
+        output.warning('No response available');
+      }
+    } else if (options.output === 'markdown') {
+      if (query.status?.responses && query.status.responses.length > 0) {
+        console.log(renderMarkdown(query.status.responses[0].content || ''));
+      } else {
+        output.warning('No response available');
+      }
+    } else {
+      console.log(JSON.stringify(query, null, 2));
+    }
+  } catch (error) {
+    output.error(
+      'fetching query:',
+      error instanceof Error ? error.message : error
+    );
+    process.exit(ExitCodes.CliError);
+  }
+}
+
+export function createQueriesCommand(_: ArkConfig): Command {
+  const queriesCommand = new Command('queries');
+
+  queriesCommand.description('Manage query resources');
+
+  const getCommand = new Command('get');
+  getCommand
+    .description('Get a specific query (@latest for most recent)')
+    .argument('<name>', 'Query name or @latest')
+    .option('-o, --output <format>', 'output format (json, markdown)', 'json')
+    .option('-r, --response', 'show only the response content', false)
+    .action(async (name: string, options) => {
+      await getQuery(name, options);
+    });
+
+  queriesCommand.addCommand(getCommand);
+
+  return queriesCommand;
+}

--- a/tools/ark-cli/src/components/ChatUI.tsx
+++ b/tools/ark-cli/src/components/ChatUI.tsx
@@ -92,10 +92,12 @@ const generateMessageId = (): string => {
 // Configure marked with terminal renderer for markdown output
 const configureMarkdown = () => {
   marked.setOptions({
+    // @ts-expect-error - TerminalRenderer types are incomplete
     renderer: new TerminalRenderer({
       showSectionPrefix: false,
       width: 80,
       reflowText: true,
+      // @ts-expect-error - preserveNewlines exists but not in types
       preserveNewlines: true,
     }),
   });

--- a/tools/ark-cli/src/index.tsx
+++ b/tools/ark-cli/src/index.tsx
@@ -21,6 +21,7 @@ import {createInstallCommand} from './commands/install/index.js';
 import {createMemoryCommand} from './commands/memory/index.js';
 import {createModelsCommand} from './commands/models/index.js';
 import {createQueryCommand} from './commands/query/index.js';
+import {createQueriesCommand} from './commands/queries/index.js';
 import {createUninstallCommand} from './commands/uninstall/index.js';
 import {createStatusCommand} from './commands/status/index.js';
 import {createConfigCommand} from './commands/config/index.js';
@@ -60,6 +61,7 @@ async function main() {
   program.addCommand(createMemoryCommand(config));
   program.addCommand(createModelsCommand(config));
   program.addCommand(createQueryCommand(config));
+  program.addCommand(createQueriesCommand(config));
   program.addCommand(createUninstallCommand(config));
   program.addCommand(createStatusCommand());
   program.addCommand(createConfigCommand(config));

--- a/tools/ark-cli/src/lib/arkApiClient.ts
+++ b/tools/ark-cli/src/lib/arkApiClient.ts
@@ -164,7 +164,7 @@ export class ArkApiClient {
   async deleteSession(sessionId: string): Promise<any> {
     try {
       const response = await fetch(`${this.baseUrl}/v1/sessions/${sessionId}`, {
-        method: 'DELETE'
+        method: 'DELETE',
       });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -179,9 +179,12 @@ export class ArkApiClient {
 
   async deleteQueryMessages(sessionId: string, queryId: string): Promise<any> {
     try {
-      const response = await fetch(`${this.baseUrl}/v1/sessions/${sessionId}/queries/${queryId}/messages`, {
-        method: 'DELETE'
-      });
+      const response = await fetch(
+        `${this.baseUrl}/v1/sessions/${sessionId}/queries/${queryId}/messages`,
+        {
+          method: 'DELETE',
+        }
+      );
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -196,7 +199,7 @@ export class ArkApiClient {
   async deleteAllSessions(): Promise<any> {
     try {
       const response = await fetch(`${this.baseUrl}/v1/sessions`, {
-        method: 'DELETE'
+        method: 'DELETE',
       });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/tools/ark-cli/src/lib/executeQuery.spec.ts
+++ b/tools/ark-cli/src/lib/executeQuery.spec.ts
@@ -83,7 +83,7 @@ describe('executeQuery', () => {
         if (args.includes('apply')) {
           return {stdout: '', stderr: '', exitCode: 0};
         }
-        if (args.includes('get') && args.includes('query')) {
+        if (args.includes('get') && args.includes('queries')) {
           return {
             stdout: JSON.stringify(mockQueryResponse),
             stderr: '',
@@ -116,7 +116,7 @@ describe('executeQuery', () => {
         if (args.includes('apply')) {
           return {stdout: '', stderr: '', exitCode: 0};
         }
-        if (args.includes('get') && args.includes('query')) {
+        if (args.includes('get') && args.includes('queries')) {
           return {
             stdout: JSON.stringify(mockQueryResponse),
             stderr: '',
@@ -155,7 +155,7 @@ describe('executeQuery', () => {
         if (args.includes('apply')) {
           return {stdout: '', stderr: '', exitCode: 0};
         }
-        if (args.includes('get') && args.includes('query')) {
+        if (args.includes('get') && args.includes('queries')) {
           return {
             stdout: JSON.stringify(mockQueryResponse),
             stderr: '',

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -9,6 +9,7 @@ import output from './output.js';
 import type {Query, QueryTarget} from './types.js';
 import {ExitCodes} from './errors.js';
 import {parseDuration} from './duration.js';
+import {getResource} from './kubectl.js';
 
 export interface QueryOptions {
   targetType: string; // 'model', 'agent', 'team'
@@ -97,13 +98,7 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
 
     // Fetch final query state
     try {
-      const {stdout} = await execa(
-        'kubectl',
-        ['get', 'query', queryName, '-o', 'json'],
-        {stdio: 'pipe'}
-      );
-
-      const query = JSON.parse(stdout) as Query;
+      const query = await getResource<Query>('queries', queryName);
       const phase = query.status?.phase;
 
       // Check if query completed successfully or with error

--- a/tools/ark-cli/src/lib/kubectl.spec.ts
+++ b/tools/ark-cli/src/lib/kubectl.spec.ts
@@ -1,0 +1,133 @@
+import {jest} from '@jest/globals';
+
+const mockExeca = jest.fn() as any;
+jest.unstable_mockModule('execa', () => ({
+  execa: mockExeca,
+}));
+
+const {getResource} = await import('./kubectl.js');
+
+interface TestResource {
+  metadata: {
+    name: string;
+    creationTimestamp: string;
+  };
+  spec?: {
+    value: string;
+  };
+}
+
+describe('kubectl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getResource', () => {
+    it('should get a specific resource by name', async () => {
+      const mockResource: TestResource = {
+        metadata: {
+          name: 'test-query',
+          creationTimestamp: '2024-01-01T00:00:00Z',
+        },
+        spec: {
+          value: 'test',
+        },
+      };
+
+      mockExeca.mockResolvedValue({
+        stdout: JSON.stringify(mockResource),
+      });
+
+      const result = await getResource<TestResource>('queries', 'test-query');
+
+      expect(result).toEqual(mockResource);
+      expect(mockExeca).toHaveBeenCalledWith(
+        'kubectl',
+        ['get', 'queries', 'test-query', '-o', 'json'],
+        {stdio: 'pipe'}
+      );
+    });
+
+    it('should get latest resource when name is @latest', async () => {
+      const mockResources: TestResource[] = [
+        {
+          metadata: {
+            name: 'query-1',
+            creationTimestamp: '2024-01-01T00:00:00Z',
+          },
+        },
+        {
+          metadata: {
+            name: 'query-2',
+            creationTimestamp: '2024-01-02T00:00:00Z',
+          },
+        },
+        {
+          metadata: {
+            name: 'query-3',
+            creationTimestamp: '2024-01-03T00:00:00Z',
+          },
+        },
+      ];
+
+      mockExeca.mockResolvedValue({
+        stdout: JSON.stringify({items: mockResources}),
+      });
+
+      const result = await getResource<TestResource>('queries', '@latest');
+
+      expect(result).toEqual(mockResources[2]);
+      expect(mockExeca).toHaveBeenCalledWith(
+        'kubectl',
+        [
+          'get',
+          'queries',
+          '--sort-by=.metadata.creationTimestamp',
+          '-o',
+          'json',
+        ],
+        {stdio: 'pipe'}
+      );
+    });
+
+    it('should throw error when @latest finds no resources', async () => {
+      mockExeca.mockResolvedValue({
+        stdout: JSON.stringify({items: []}),
+      });
+
+      await expect(
+        getResource<TestResource>('queries', '@latest')
+      ).rejects.toThrow('No queries found');
+    });
+
+    it('should handle kubectl errors', async () => {
+      mockExeca.mockRejectedValue(new Error('kubectl error'));
+
+      await expect(
+        getResource<TestResource>('queries', 'test-query')
+      ).rejects.toThrow('kubectl error');
+    });
+
+    it('should work with different resource types', async () => {
+      const mockAgent: TestResource = {
+        metadata: {
+          name: 'test-agent',
+          creationTimestamp: '2024-01-01T00:00:00Z',
+        },
+      };
+
+      mockExeca.mockResolvedValue({
+        stdout: JSON.stringify(mockAgent),
+      });
+
+      const result = await getResource<TestResource>('agents', 'test-agent');
+
+      expect(result).toEqual(mockAgent);
+      expect(mockExeca).toHaveBeenCalledWith(
+        'kubectl',
+        ['get', 'agents', 'test-agent', '-o', 'json'],
+        {stdio: 'pipe'}
+      );
+    });
+  });
+});

--- a/tools/ark-cli/src/lib/kubectl.ts
+++ b/tools/ark-cli/src/lib/kubectl.ts
@@ -1,0 +1,45 @@
+import {execa} from 'execa';
+import type {K8sListResource} from './types.js';
+
+interface K8sResource {
+  metadata: {
+    name: string;
+    creationTimestamp?: string;
+  };
+}
+
+export async function getResource<T extends K8sResource>(
+  resourceType: string,
+  name: string
+): Promise<T> {
+  if (name === '@latest') {
+    const result = await execa(
+      'kubectl',
+      [
+        'get',
+        resourceType,
+        '--sort-by=.metadata.creationTimestamp',
+        '-o',
+        'json',
+      ],
+      {stdio: 'pipe'}
+    );
+
+    const data = JSON.parse(result.stdout) as K8sListResource<T>;
+    const resources = data.items || [];
+
+    if (resources.length === 0) {
+      throw new Error(`No ${resourceType} found`);
+    }
+
+    return resources[resources.length - 1];
+  }
+
+  const result = await execa(
+    'kubectl',
+    ['get', resourceType, name, '-o', 'json'],
+    {stdio: 'pipe'}
+  );
+
+  return JSON.parse(result.stdout) as T;
+}

--- a/tools/ark-cli/src/lib/types.ts
+++ b/tools/ark-cli/src/lib/types.ts
@@ -67,6 +67,7 @@ export interface CommandVersionConfig {
 export interface K8sMetadata {
   name: string;
   namespace?: string;
+  creationTimestamp?: string;
 }
 
 export interface K8sCondition {


### PR DESCRIPTION

<img width="741" height="657" alt="image" src="https://github.com/user-attachments/assets/b3236578-852f-4031-9ede-f97ca6ee4c91" />


## Summary
- Adds `ark queries get <name>` command to retrieve query resources
- Supports `@latest` special name to get most recent query
- Output formats: json (default) and markdown with TTY-aware rendering
- `--response` flag to show only response content
- Creates generalized `getResource<T>()` function for kubectl operations
- Refactored `executeQuery` to use new function
- Fixed type errors from installing `@types/marked-terminal`