### PR TITLE
feat: support aws bedrock models on ark cli `ark create model` command

### DIFF
--- a/tools/ark-cli/src/commands/models/create.ts
+++ b/tools/ark-cli/src/commands/models/create.ts
@@ -8,6 +8,11 @@ export interface CreateModelOptions {
   baseUrl?: string;
   apiKey?: string;
   apiVersion?: string;
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  modelArn?: string;
   yes?: boolean;
 }
 
@@ -71,6 +76,7 @@ export async function createModel(
         choices: [
           {name: 'Azure OpenAI', value: 'azure'},
           {name: 'OpenAI', value: 'openai'},
+          {name: 'AWS Bedrock', value: 'bedrock'},
         ],
         default: 'azure',
       },
@@ -92,82 +98,160 @@ export async function createModel(
     model = answer.model;
   }
 
-  // Step 4: Get base URL
+  // Step 4: Get provider-specific configuration
   let baseUrl = options.baseUrl;
-  if (!baseUrl) {
-    const answer = await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'baseUrl',
-        message: 'base URL:',
-        validate: (input) => {
-          if (!input) return 'base URL is required';
-          try {
-            new URL(input);
-            return true;
-          } catch {
-            return 'please enter a valid URL';
-          }
-        },
-      },
-    ]);
-    baseUrl = answer.baseUrl;
-  }
-
-  // Validate and clean base URL
-  if (!baseUrl) {
-    output.error('base URL is required');
-    return false;
-  }
-  baseUrl = baseUrl.replace(/\/$/, '');
-
-  // Step 5: Get API version (Azure only)
-  let apiVersion = options.apiVersion || '';
-  if (modelType === 'azure' && !options.apiVersion) {
-    const answer = await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'apiVersion',
-        message: 'Azure API version:',
-        default: '2024-12-01-preview',
-      },
-    ]);
-    apiVersion = answer.apiVersion;
-  }
-
-  // Step 6: Get API key
   let apiKey = options.apiKey;
-  if (!apiKey) {
-    const answer = await inquirer.prompt([
-      {
-        type: 'password',
-        name: 'apiKey',
-        message: 'API key:',
-        mask: '*',
-        validate: (input) => {
-          if (!input) return 'API key is required';
-          return true;
+  let apiVersion = options.apiVersion || '';
+  let region = options.region;
+  let accessKeyId = options.accessKeyId;
+  let secretAccessKey = options.secretAccessKey;
+  let sessionToken = options.sessionToken;
+  let modelArn = options.modelArn;
+
+  if (modelType === 'bedrock') {
+    // AWS Bedrock configuration
+    if (!region) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'region',
+          message: 'AWS region:',
+          default: 'us-east-1',
         },
-      },
-    ]);
-    apiKey = answer.apiKey;
+      ]);
+      region = answer.region;
+    }
+
+    if (!accessKeyId) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'accessKeyId',
+          message: 'AWS access key ID:',
+          validate: (input) => {
+            if (!input) return 'access key ID is required';
+            return true;
+          },
+        },
+      ]);
+      accessKeyId = answer.accessKeyId;
+    }
+
+    if (!secretAccessKey) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'secretAccessKey',
+          message: 'AWS secret access key:',
+          mask: '*',
+          validate: (input) => {
+            if (!input) return 'secret access key is required';
+            return true;
+          },
+        },
+      ]);
+      secretAccessKey = answer.secretAccessKey;
+    }
+
+    if (!sessionToken) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'sessionToken',
+          message: 'AWS session token (optional, press enter to skip):',
+          mask: '*',
+        },
+      ]);
+      sessionToken = answer.sessionToken;
+    }
+
+    if (!modelArn) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'modelArn',
+          message: 'Model ARN (optional, press enter to skip):',
+        },
+      ]);
+      modelArn = answer.modelArn;
+    }
+  } else {
+    // OpenAI and Azure configuration
+    if (!baseUrl) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'baseUrl',
+          message: 'base URL:',
+          validate: (input) => {
+            if (!input) return 'base URL is required';
+            try {
+              new URL(input);
+              return true;
+            } catch {
+              return 'please enter a valid URL';
+            }
+          },
+        },
+      ]);
+      baseUrl = answer.baseUrl;
+    }
+
+    // Validate and clean base URL
+    if (!baseUrl) {
+      output.error('base URL is required');
+      return false;
+    }
+    baseUrl = baseUrl.replace(/\/$/, '');
+
+    if (modelType === 'azure' && !options.apiVersion) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'apiVersion',
+          message: 'Azure API version:',
+          default: '2024-12-01-preview',
+        },
+      ]);
+      apiVersion = answer.apiVersion;
+    }
+
+    if (!apiKey) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'apiKey',
+          message: 'API key:',
+          mask: '*',
+          validate: (input) => {
+            if (!input) return 'API key is required';
+            return true;
+          },
+        },
+      ]);
+      apiKey = answer.apiKey;
+    }
   }
 
-  // Step 6: Create the Kubernetes secret
-  const secretName = `${modelName}-model-api-key`;
+  // Step 5: Create the Kubernetes secret
+  const secretName = `${modelName}-model-secret`;
 
   try {
-    await execa(
-      'kubectl',
-      [
-        'create',
-        'secret',
-        'generic',
-        secretName,
-        `--from-literal=api-key=${apiKey}`,
-      ],
-      {stdio: 'pipe'}
-    );
+    const secretArgs = ['create', 'secret', 'generic', secretName];
+    
+    if (modelType === 'bedrock') {
+      // For Bedrock, store AWS credentials
+      secretArgs.push(`--from-literal=access-key-id=${accessKeyId}`);
+      secretArgs.push(`--from-literal=secret-access-key=${secretAccessKey}`);
+      if (sessionToken) {
+        secretArgs.push(`--from-literal=session-token=${sessionToken}`);
+      }
+    } else {
+      // For OpenAI and Azure, store API key
+      secretArgs.push(`--from-literal=api-key=${apiKey}`);
+    }
+
+    await execa('kubectl', secretArgs, {stdio: 'pipe'});
 
     output.success(`created secret ${secretName}`);
   } catch (error) {
@@ -176,7 +260,7 @@ export async function createModel(
     return false;
   }
 
-  // Step 7: Create the Model resource
+  // Step 6: Create the Model resource
   output.info(`creating model ${modelName}...`);
 
   const modelManifest = {
@@ -212,6 +296,47 @@ export async function createModel(
         value: apiVersion,
       },
     };
+  } else if (modelType === 'bedrock') {
+    const bedrockConfig: Record<string, unknown> = {
+      region: {
+        value: region,
+      },
+      accessKeyId: {
+        valueFrom: {
+          secretKeyRef: {
+            name: secretName,
+            key: 'access-key-id',
+          },
+        },
+      },
+      secretAccessKey: {
+        valueFrom: {
+          secretKeyRef: {
+            name: secretName,
+            key: 'secret-access-key',
+          },
+        },
+      },
+    };
+
+    if (sessionToken) {
+      bedrockConfig.sessionToken = {
+        valueFrom: {
+          secretKeyRef: {
+            name: secretName,
+            key: 'session-token',
+          },
+        },
+      };
+    }
+
+    if (modelArn) {
+      bedrockConfig.modelArn = {
+        value: modelArn,
+      };
+    }
+
+    modelManifest.spec.config.bedrock = bedrockConfig;
   } else {
     modelManifest.spec.config.openai = {
       apiKey: {

--- a/tools/ark-cli/src/commands/models/create.ts
+++ b/tools/ark-cli/src/commands/models/create.ts
@@ -1,6 +1,9 @@
 import {execa} from 'execa';
 import inquirer from 'inquirer';
 import output from '../../lib/output.js';
+import {ProviderConfigCollectorFactory} from './providers/factory.js';
+import {KubernetesSecretManager} from './kubernetes/secret-manager.js';
+import {KubernetesModelManifestBuilder} from './kubernetes/manifest-builder.js';
 
 export interface CreateModelOptions {
   type?: string;
@@ -98,162 +101,15 @@ export async function createModel(
     model = answer.model;
   }
 
-  // Step 4: Get provider-specific configuration
-  let baseUrl = options.baseUrl;
-  let apiKey = options.apiKey;
-  let apiVersion = options.apiVersion || '';
-  let region = options.region;
-  let accessKeyId = options.accessKeyId;
-  let secretAccessKey = options.secretAccessKey;
-  let sessionToken = options.sessionToken;
-  let modelArn = options.modelArn;
-
-  if (modelType === 'bedrock') {
-    // AWS Bedrock configuration
-    if (!region) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'region',
-          message: 'AWS region:',
-          default: 'us-east-1',
-        },
-      ]);
-      region = answer.region;
-    }
-
-    if (!accessKeyId) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'accessKeyId',
-          message: 'AWS access key ID:',
-          validate: (input) => {
-            if (!input) return 'access key ID is required';
-            return true;
-          },
-        },
-      ]);
-      accessKeyId = answer.accessKeyId;
-    }
-
-    if (!secretAccessKey) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'password',
-          name: 'secretAccessKey',
-          message: 'AWS secret access key:',
-          mask: '*',
-          validate: (input) => {
-            if (!input) return 'secret access key is required';
-            return true;
-          },
-        },
-      ]);
-      secretAccessKey = answer.secretAccessKey;
-    }
-
-    if (!sessionToken) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'password',
-          name: 'sessionToken',
-          message: 'AWS session token (optional, press enter to skip):',
-          mask: '*',
-        },
-      ]);
-      sessionToken = answer.sessionToken;
-    }
-
-    if (!modelArn) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'modelArn',
-          message: 'Model ARN (optional, press enter to skip):',
-        },
-      ]);
-      modelArn = answer.modelArn;
-    }
-  } else {
-    // OpenAI and Azure configuration
-    if (!baseUrl) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'baseUrl',
-          message: 'base URL:',
-          validate: (input) => {
-            if (!input) return 'base URL is required';
-            try {
-              new URL(input);
-              return true;
-            } catch {
-              return 'please enter a valid URL';
-            }
-          },
-        },
-      ]);
-      baseUrl = answer.baseUrl;
-    }
-
-    // Validate and clean base URL
-    if (!baseUrl) {
-      output.error('base URL is required');
-      return false;
-    }
-    baseUrl = baseUrl.replace(/\/$/, '');
-
-    if (modelType === 'azure' && !options.apiVersion) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'apiVersion',
-          message: 'Azure API version:',
-          default: '2024-12-01-preview',
-        },
-      ]);
-      apiVersion = answer.apiVersion;
-    }
-
-    if (!apiKey) {
-      const answer = await inquirer.prompt([
-        {
-          type: 'password',
-          name: 'apiKey',
-          message: 'API key:',
-          mask: '*',
-          validate: (input) => {
-            if (!input) return 'API key is required';
-            return true;
-          },
-        },
-      ]);
-      apiKey = answer.apiKey;
-    }
-  }
+  // Step 4: Collect provider-specific configuration
+  const collector = ProviderConfigCollectorFactory.create(modelType!);
+  const config = await collector.collectConfig({...options, model});
+  config.secretName = `${modelName!}-model-secret`;
 
   // Step 5: Create the Kubernetes secret
-  const secretName = `${modelName}-model-secret`;
-
   try {
-    const secretArgs = ['create', 'secret', 'generic', secretName];
-    
-    if (modelType === 'bedrock') {
-      // For Bedrock, store AWS credentials
-      secretArgs.push(`--from-literal=access-key-id=${accessKeyId}`);
-      secretArgs.push(`--from-literal=secret-access-key=${secretAccessKey}`);
-      if (sessionToken) {
-        secretArgs.push(`--from-literal=session-token=${sessionToken}`);
-      }
-    } else {
-      // For OpenAI and Azure, store API key
-      secretArgs.push(`--from-literal=api-key=${apiKey}`);
-    }
-
-    await execa('kubectl', secretArgs, {stdio: 'pipe'});
-
-    output.success(`created secret ${secretName}`);
+    const secretManager = new KubernetesSecretManager();
+    await secretManager.createSecret(config);
   } catch (error) {
     output.error('failed to create secret');
     console.error(error);
@@ -263,95 +119,8 @@ export async function createModel(
   // Step 6: Create the Model resource
   output.info(`creating model ${modelName}...`);
 
-  const modelManifest = {
-    apiVersion: 'ark.mckinsey.com/v1alpha1',
-    kind: 'Model',
-    metadata: {
-      name: modelName,
-    },
-    spec: {
-      type: modelType,
-      model: {
-        value: model,
-      },
-      config: {} as Record<string, unknown>,
-    },
-  };
-
-  // Add provider-specific config
-  if (modelType === 'azure') {
-    modelManifest.spec.config.azure = {
-      apiKey: {
-        valueFrom: {
-          secretKeyRef: {
-            name: secretName,
-            key: 'api-key',
-          },
-        },
-      },
-      baseUrl: {
-        value: baseUrl,
-      },
-      apiVersion: {
-        value: apiVersion,
-      },
-    };
-  } else if (modelType === 'bedrock') {
-    const bedrockConfig: Record<string, unknown> = {
-      region: {
-        value: region,
-      },
-      accessKeyId: {
-        valueFrom: {
-          secretKeyRef: {
-            name: secretName,
-            key: 'access-key-id',
-          },
-        },
-      },
-      secretAccessKey: {
-        valueFrom: {
-          secretKeyRef: {
-            name: secretName,
-            key: 'secret-access-key',
-          },
-        },
-      },
-    };
-
-    if (sessionToken) {
-      bedrockConfig.sessionToken = {
-        valueFrom: {
-          secretKeyRef: {
-            name: secretName,
-            key: 'session-token',
-          },
-        },
-      };
-    }
-
-    if (modelArn) {
-      bedrockConfig.modelArn = {
-        value: modelArn,
-      };
-    }
-
-    modelManifest.spec.config.bedrock = bedrockConfig;
-  } else {
-    modelManifest.spec.config.openai = {
-      apiKey: {
-        valueFrom: {
-          secretKeyRef: {
-            name: secretName,
-            key: 'api-key',
-          },
-        },
-      },
-      baseUrl: {
-        value: baseUrl,
-      },
-    };
-  }
+  const manifestBuilder = new KubernetesModelManifestBuilder(modelName!);
+  const modelManifest = manifestBuilder.build(config);
 
   try {
     // Apply the model manifest using kubectl

--- a/tools/ark-cli/src/commands/models/create.ts
+++ b/tools/ark-cli/src/commands/models/create.ts
@@ -1,41 +1,20 @@
 import {execa} from 'execa';
 import inquirer from 'inquirer';
 import output from '../../lib/output.js';
-import {ProviderConfigCollectorFactory} from './providers/index.js';
+import {BaseCollectorOptions, ProviderConfigCollectorFactory} from './providers/index.js';
 import {KubernetesSecretManager} from './kubernetes/secret-manager.js';
 import {KubernetesModelManifestBuilder} from './kubernetes/manifest-builder.js';
 
 /**
  * Common options for model creation.
  */
-export interface CommonModelOptions {
-  type?: string;
-  model?: string;
+export interface CreateModelOptions extends BaseCollectorOptions {
   yes?: boolean;
-}
-
-/**
- * CLI options bag - contains all possible provider-specific options.
- * This is intentionally loose to accommodate different provider requirements
- * from the CLI layer. Each collector extracts only what it needs.
- */
-export interface CreateModelCliOptions extends CommonModelOptions {
-  // OpenAI/Azure options
-  baseUrl?: string;
-  apiKey?: string;
-  // Azure-specific
-  apiVersion?: string;
-  // Bedrock-specific
-  region?: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
-  sessionToken?: string;
-  modelArn?: string;
 }
 
 export async function createModel(
   modelName?: string,
-  options: CreateModelCliOptions = {}
+  options: CreateModelOptions = {}
 ): Promise<boolean> {
   // Step 1: Get model name if not provided
   if (!modelName) {

--- a/tools/ark-cli/src/commands/models/create.ts
+++ b/tools/ark-cli/src/commands/models/create.ts
@@ -5,23 +5,37 @@ import {ProviderConfigCollectorFactory} from './providers/index.js';
 import {KubernetesSecretManager} from './kubernetes/secret-manager.js';
 import {KubernetesModelManifestBuilder} from './kubernetes/manifest-builder.js';
 
-export interface CreateModelOptions {
+/**
+ * Common options for model creation.
+ */
+export interface CommonModelOptions {
   type?: string;
   model?: string;
+  yes?: boolean;
+}
+
+/**
+ * CLI options bag - contains all possible provider-specific options.
+ * This is intentionally loose to accommodate different provider requirements
+ * from the CLI layer. Each collector extracts only what it needs.
+ */
+export interface CreateModelCliOptions extends CommonModelOptions {
+  // OpenAI/Azure options
   baseUrl?: string;
   apiKey?: string;
+  // Azure-specific
   apiVersion?: string;
+  // Bedrock-specific
   region?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
   sessionToken?: string;
   modelArn?: string;
-  yes?: boolean;
 }
 
 export async function createModel(
   modelName?: string,
-  options: CreateModelOptions = {}
+  options: CreateModelCliOptions = {}
 ): Promise<boolean> {
   // Step 1: Get model name if not provided
   if (!modelName) {

--- a/tools/ark-cli/src/commands/models/create.ts
+++ b/tools/ark-cli/src/commands/models/create.ts
@@ -1,7 +1,7 @@
 import {execa} from 'execa';
 import inquirer from 'inquirer';
 import output from '../../lib/output.js';
-import {ProviderConfigCollectorFactory} from './providers/factory.js';
+import {ProviderConfigCollectorFactory} from './providers/index.js';
 import {KubernetesSecretManager} from './kubernetes/secret-manager.js';
 import {KubernetesModelManifestBuilder} from './kubernetes/manifest-builder.js';
 

--- a/tools/ark-cli/src/commands/models/kubernetes/manifest-builder.ts
+++ b/tools/ark-cli/src/commands/models/kubernetes/manifest-builder.ts
@@ -1,0 +1,129 @@
+import {BedrockConfig, ProviderConfig} from '../providers/types.js';
+
+// Model manifest builder interface
+export interface ModelManifestBuilder {
+  build(config: ProviderConfig): Record<string, unknown>;
+}
+
+// Kubernetes model manifest builder
+export class KubernetesModelManifestBuilder implements ModelManifestBuilder {
+  constructor(private modelName: string) {}
+
+  build(config: ProviderConfig): Record<string, unknown> {
+    const manifest = {
+      apiVersion: 'ark.mckinsey.com/v1alpha1',
+      kind: 'Model',
+      metadata: {
+        name: this.modelName,
+      },
+      spec: {
+        type: config.type,
+        model: {
+          value: config.modelValue,
+        },
+        config: {} as Record<string, unknown>,
+      },
+    };
+
+    manifest.spec.config = this.buildProviderConfig(config);
+    return manifest;
+  }
+
+  private buildProviderConfig(
+    config: ProviderConfig
+  ): Record<string, unknown> {
+    if (config.type === 'azure') {
+      return {
+        azure: {
+          apiKey: {
+            valueFrom: {
+              secretKeyRef: {
+                name: config.secretName,
+                key: 'api-key',
+              },
+            },
+          },
+          baseUrl: {
+            value: config.baseUrl,
+          },
+          apiVersion: {
+            value: config.apiVersion,
+          },
+        },
+      };
+    }
+
+    if (config.type === 'bedrock') {
+      return this.buildBedrockConfig(config);
+    }
+
+    if (config.type === 'openai') {
+      return {
+        openai: {
+          apiKey: {
+            valueFrom: {
+              secretKeyRef: {
+                name: config.secretName,
+                key: 'api-key',
+              },
+            },
+          },
+          baseUrl: {
+            value: config.baseUrl,
+          },
+        },
+      };
+    }
+
+    throw new Error(
+      `Unknown provider type: ${(config as ProviderConfig).type}`
+    );
+  }
+
+  private buildBedrockConfig(config: BedrockConfig): Record<string, unknown> {
+    const bedrockConfig: Record<string, unknown> = {
+      bedrock: {
+        region: {
+          value: config.region,
+        },
+        accessKeyId: {
+          valueFrom: {
+            secretKeyRef: {
+              name: config.secretName,
+              key: 'access-key-id',
+            },
+          },
+        },
+        secretAccessKey: {
+          valueFrom: {
+            secretKeyRef: {
+              name: config.secretName,
+              key: 'secret-access-key',
+            },
+          },
+        },
+      },
+    };
+
+    const bedrock = bedrockConfig.bedrock as Record<string, unknown>;
+
+    if (config.sessionToken) {
+      bedrock.sessionToken = {
+        valueFrom: {
+          secretKeyRef: {
+            name: config.secretName,
+            key: 'session-token',
+          },
+        },
+      };
+    }
+
+    if (config.modelArn) {
+      bedrock.modelArn = {
+        value: config.modelArn,
+      };
+    }
+
+    return bedrockConfig;
+  }
+}

--- a/tools/ark-cli/src/commands/models/kubernetes/manifest-builder.ts
+++ b/tools/ark-cli/src/commands/models/kubernetes/manifest-builder.ts
@@ -1,4 +1,4 @@
-import {BedrockConfig, ProviderConfig} from '../providers/types.js';
+import {BedrockConfig, ProviderConfig} from '../providers/index.js';
 
 // Model manifest builder interface
 export interface ModelManifestBuilder {

--- a/tools/ark-cli/src/commands/models/kubernetes/secret-manager.ts
+++ b/tools/ark-cli/src/commands/models/kubernetes/secret-manager.ts
@@ -1,6 +1,6 @@
 import {execa} from 'execa';
 import output from '../../../lib/output.js';
-import {ProviderConfig} from '../providers/types.js';
+import {ProviderConfig} from '../providers/index.js';
 
 // Secret manager interface
 export interface SecretManager {

--- a/tools/ark-cli/src/commands/models/kubernetes/secret-manager.ts
+++ b/tools/ark-cli/src/commands/models/kubernetes/secret-manager.ts
@@ -1,0 +1,30 @@
+import {execa} from 'execa';
+import output from '../../../lib/output.js';
+import {ProviderConfig} from '../providers/types.js';
+
+// Secret manager interface
+export interface SecretManager {
+  createSecret(config: ProviderConfig): Promise<void>;
+}
+
+// Kubernetes secret manager implementation
+export class KubernetesSecretManager implements SecretManager {
+  async createSecret(config: ProviderConfig): Promise<void> {
+    const secretArgs = ['create', 'secret', 'generic', config.secretName];
+
+    if (config.type === 'bedrock') {
+      secretArgs.push(`--from-literal=access-key-id=${config.accessKeyId}`);
+      secretArgs.push(
+        `--from-literal=secret-access-key=${config.secretAccessKey}`
+      );
+      if (config.sessionToken) {
+        secretArgs.push(`--from-literal=session-token=${config.sessionToken}`);
+      }
+    } else {
+      secretArgs.push(`--from-literal=api-key=${config.apiKey}`);
+    }
+
+    await execa('kubectl', secretArgs, {stdio: 'pipe'});
+    output.success(`created secret ${config.secretName}`);
+  }
+}

--- a/tools/ark-cli/src/commands/models/providers/azure.spec.ts
+++ b/tools/ark-cli/src/commands/models/providers/azure.spec.ts
@@ -1,0 +1,291 @@
+import {jest} from '@jest/globals';
+
+const mockInquirer = {
+  prompt: jest.fn() as any,
+};
+jest.unstable_mockModule('inquirer', () => ({
+  default: mockInquirer,
+}));
+
+const {AzureConfigCollector} = await import('./azure.js');
+
+describe('AzureConfigCollector', () => {
+  let collector: InstanceType<typeof AzureConfigCollector>;
+
+  beforeEach(() => {
+    collector = new AzureConfigCollector();
+    jest.clearAllMocks();
+  });
+
+  describe('collectConfig', () => {
+    it('uses provided options without prompting', async () => {
+      const options = {
+        model: 'gpt-4o-mini',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiKey: 'azure-key-12345',
+        apiVersion: '2024-12-01-preview',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).not.toHaveBeenCalled();
+      expect(config).toEqual({
+        type: 'azure',
+        modelValue: 'gpt-4o-mini',
+        secretName: '',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiKey: 'azure-key-12345',
+        apiVersion: '2024-12-01-preview',
+      });
+    });
+
+    it('uses default apiVersion when not provided', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiVersion: '2024-12-01-preview',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'azure-key'});
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'apiVersion',
+          message: 'Azure API version:',
+          default: '2024-12-01-preview',
+        }),
+      ]);
+      expect(config.apiVersion).toBe('2024-12-01-preview');
+    });
+
+    it('prompts for missing baseUrl', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        baseUrl: 'https://contoso.openai.azure.com',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({apiVersion: '2024-10-01'});
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'azure-key'});
+
+      const options = {
+        model: 'gpt-4',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'baseUrl',
+          message: 'base URL:',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.baseUrl).toBe('https://contoso.openai.azure.com');
+    });
+
+    it('validates baseUrl is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({baseUrl: ''});
+
+      const options = {
+        model: 'gpt-4',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'base URL is required'
+      );
+    });
+
+    it('validates baseUrl is a valid URL', async () => {
+      const options = {
+        model: 'gpt-4',
+      };
+
+      // Get the validate function from the prompt call
+      mockInquirer.prompt.mockImplementationOnce(async (questions: any) => {
+        const validate = questions[0].validate;
+        
+        // Test invalid URL
+        expect(validate('not-a-url')).toBe('please enter a valid URL');
+        
+        // Test empty string
+        expect(validate('')).toBe('base URL is required');
+        
+        // Test valid URL
+        expect(validate('https://test.openai.azure.com')).toBe(true);
+        
+        return {baseUrl: 'https://test.openai.azure.com'};
+      });
+
+      mockInquirer.prompt.mockResolvedValueOnce({apiVersion: '2024-12-01-preview'});
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'azure-key'});
+
+      await collector.collectConfig(options);
+    });
+
+    it('removes trailing slash from baseUrl', async () => {
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com/',
+        apiKey: 'azure-key',
+        apiVersion: '2024-12-01-preview',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config.baseUrl).toBe('https://my-resource.openai.azure.com');
+    });
+
+    it('prompts for missing apiKey as password field', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiKey: 'azure-secret-key',
+      });
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiVersion: '2024-12-01-preview',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'password',
+          name: 'apiKey',
+          message: 'API key:',
+          mask: '*',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.apiKey).toBe('azure-secret-key');
+    });
+
+    it('validates apiKey is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: ''});
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiVersion: '2024-12-01-preview',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'API key is required'
+      );
+    });
+
+    it('tests apiKey validation function', async () => {
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiVersion: '2024-12-01-preview',
+      };
+
+      // Get the validate function from the prompt call
+      mockInquirer.prompt.mockImplementationOnce(async (questions: any) => {
+        const validate = questions[0].validate;
+        
+        // Test empty string
+        expect(validate('')).toBe('API key is required');
+        
+        // Test valid key
+        expect(validate('valid-azure-key')).toBe(true);
+        
+        return {apiKey: 'valid-azure-key'};
+      });
+
+      await collector.collectConfig(options);
+    });
+
+    it('collects full configuration through interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        baseUrl: 'https://eastus.openai.azure.com/',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiVersion: '2024-08-01-preview',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiKey: 'abc123def456',
+      });
+
+      const options = {
+        model: 'gpt-4o',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'azure',
+        modelValue: 'gpt-4o',
+        secretName: '',
+        baseUrl: 'https://eastus.openai.azure.com',
+        apiKey: 'abc123def456',
+        apiVersion: '2024-08-01-preview',
+      });
+    });
+
+    it('mixes CLI options and interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiKey: 'prompted-key',
+      });
+
+      const options = {
+        model: 'gpt-35-turbo',
+        baseUrl: 'https://westeurope.openai.azure.com',
+        apiVersion: '2024-06-01',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'azure',
+        modelValue: 'gpt-35-turbo',
+        secretName: '',
+        baseUrl: 'https://westeurope.openai.azure.com',
+        apiKey: 'prompted-key',
+        apiVersion: '2024-06-01',
+      });
+    });
+
+    it('accepts custom apiVersion', async () => {
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+        apiKey: 'azure-key',
+        apiVersion: '2023-05-15',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config.apiVersion).toBe('2023-05-15');
+    });
+
+    it('prompts for apiVersion when only baseUrl is provided', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiVersion: '2024-12-01-preview',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'azure-key'});
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://my-resource.openai.azure.com',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'apiVersion',
+          message: 'Azure API version:',
+          default: '2024-12-01-preview',
+        }),
+      ]);
+      expect(config.apiVersion).toBe('2024-12-01-preview');
+    });
+  });
+});

--- a/tools/ark-cli/src/commands/models/providers/azure.ts
+++ b/tools/ark-cli/src/commands/models/providers/azure.ts
@@ -1,8 +1,27 @@
 import inquirer from 'inquirer';
 import {CreateModelOptions} from '../create.js';
-import {AzureConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
 
-// Azure configuration collector
+/**
+ * Configuration for Azure OpenAI models.
+ */
+export interface AzureConfig extends BaseProviderConfig {
+  type: 'azure';
+  baseUrl: string;
+  apiKey: string;
+  apiVersion: string;
+}
+
+/**
+ * Configuration collector for Azure OpenAI models.
+ *
+ * Collects the necessary configuration to connect to Azure OpenAI Service:
+ * - baseUrl: The Azure OpenAI endpoint URL (e.g., https://<resource>.openai.azure.com)
+ * - apiVersion: The API version to use (defaults to 2024-12-01-preview)
+ * - apiKey: The authentication key for the Azure OpenAI resource
+ *
+ * Values can be provided via command-line options or will be prompted interactively.
+ */
 export class AzureConfigCollector implements ProviderConfigCollector {
   async collectConfig(options: CreateModelOptions): Promise<AzureConfig> {
     let baseUrl = options.baseUrl;

--- a/tools/ark-cli/src/commands/models/providers/azure.ts
+++ b/tools/ark-cli/src/commands/models/providers/azure.ts
@@ -1,5 +1,5 @@
 import inquirer from 'inquirer';
-import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, BaseCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for Azure OpenAI models.
@@ -14,7 +14,7 @@ export interface AzureConfig extends BaseProviderConfig {
 /**
  * Options specific to Azure collector.
  */
-export interface AzureCollectorOptions extends CommonCollectorOptions {
+export interface AzureCollectorOptions extends BaseCollectorOptions {
   baseUrl?: string;
   apiKey?: string;
   apiVersion?: string;
@@ -31,7 +31,7 @@ export interface AzureCollectorOptions extends CommonCollectorOptions {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class AzureConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CommonCollectorOptions): Promise<AzureConfig> {
+  async collectConfig(options: BaseCollectorOptions): Promise<AzureConfig> {
     const azureOptions = options as AzureCollectorOptions;
     
     let baseUrl = azureOptions.baseUrl;

--- a/tools/ark-cli/src/commands/models/providers/azure.ts
+++ b/tools/ark-cli/src/commands/models/providers/azure.ts
@@ -1,0 +1,77 @@
+import inquirer from 'inquirer';
+import {CreateModelOptions} from '../create.js';
+import {AzureConfig, ProviderConfigCollector} from './types.js';
+
+// Azure configuration collector
+export class AzureConfigCollector implements ProviderConfigCollector {
+  async collectConfig(options: CreateModelOptions): Promise<AzureConfig> {
+    let baseUrl = options.baseUrl;
+    if (!baseUrl) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'baseUrl',
+          message: 'base URL:',
+          validate: (input) => {
+            if (!input) return 'base URL is required';
+            try {
+              new URL(input);
+              return true;
+            } catch {
+              return 'please enter a valid URL';
+            }
+          },
+        },
+      ]);
+      baseUrl = answer.baseUrl;
+    }
+
+    if (!baseUrl) {
+      throw new Error('base URL is required');
+    }
+    baseUrl = baseUrl.replace(/\/$/, '');
+
+    let apiVersion = options.apiVersion || '';
+    if (!options.apiVersion) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'apiVersion',
+          message: 'Azure API version:',
+          default: '2024-12-01-preview',
+        },
+      ]);
+      apiVersion = answer.apiVersion;
+    }
+
+    let apiKey = options.apiKey;
+    if (!apiKey) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'apiKey',
+          message: 'API key:',
+          mask: '*',
+          validate: (input) => {
+            if (!input) return 'API key is required';
+            return true;
+          },
+        },
+      ]);
+      apiKey = answer.apiKey;
+    }
+
+    if (!apiKey) {
+      throw new Error('API key is required');
+    }
+
+    return {
+      type: 'azure',
+      modelValue: options.model!,
+      secretName: '',
+      baseUrl,
+      apiKey,
+      apiVersion,
+    };
+  }
+}

--- a/tools/ark-cli/src/commands/models/providers/azure.ts
+++ b/tools/ark-cli/src/commands/models/providers/azure.ts
@@ -1,6 +1,5 @@
 import inquirer from 'inquirer';
-import {CreateModelOptions} from '../create.js';
-import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for Azure OpenAI models.
@@ -10,6 +9,15 @@ export interface AzureConfig extends BaseProviderConfig {
   baseUrl: string;
   apiKey: string;
   apiVersion: string;
+}
+
+/**
+ * Options specific to Azure collector.
+ */
+export interface AzureCollectorOptions extends CommonCollectorOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  apiVersion?: string;
 }
 
 /**
@@ -23,8 +31,10 @@ export interface AzureConfig extends BaseProviderConfig {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class AzureConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CreateModelOptions): Promise<AzureConfig> {
-    let baseUrl = options.baseUrl;
+  async collectConfig(options: CommonCollectorOptions): Promise<AzureConfig> {
+    const azureOptions = options as AzureCollectorOptions;
+    
+    let baseUrl = azureOptions.baseUrl;
     if (!baseUrl) {
       const answer = await inquirer.prompt([
         {
@@ -50,8 +60,8 @@ export class AzureConfigCollector implements ProviderConfigCollector {
     }
     baseUrl = baseUrl.replace(/\/$/, '');
 
-    let apiVersion = options.apiVersion || '';
-    if (!options.apiVersion) {
+    let apiVersion = azureOptions.apiVersion || '';
+    if (!azureOptions.apiVersion) {
       const answer = await inquirer.prompt([
         {
           type: 'input',
@@ -63,7 +73,7 @@ export class AzureConfigCollector implements ProviderConfigCollector {
       apiVersion = answer.apiVersion;
     }
 
-    let apiKey = options.apiKey;
+    let apiKey = azureOptions.apiKey;
     if (!apiKey) {
       const answer = await inquirer.prompt([
         {

--- a/tools/ark-cli/src/commands/models/providers/bedrock.spec.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.spec.ts
@@ -1,0 +1,303 @@
+import {jest} from '@jest/globals';
+
+const mockInquirer = {
+  prompt: jest.fn() as any,
+};
+jest.unstable_mockModule('inquirer', () => ({
+  default: mockInquirer,
+}));
+
+const {BedrockConfigCollector} = await import('./bedrock.js');
+
+describe('BedrockConfigCollector', () => {
+  let collector: InstanceType<typeof BedrockConfigCollector>;
+
+  beforeEach(() => {
+    collector = new BedrockConfigCollector();
+    jest.clearAllMocks();
+  });
+
+  describe('collectConfig', () => {
+    it('uses provided options without prompting', async () => {
+      const options = {
+        model: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        sessionToken: 'session-token-123',
+        modelArn: 'arn:aws:bedrock:us-west-2:123456789012:model/test',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).not.toHaveBeenCalled();
+      expect(config).toEqual({
+        type: 'bedrock',
+        modelValue: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        secretName: '',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        sessionToken: 'session-token-123',
+        modelArn: 'arn:aws:bedrock:us-west-2:123456789012:model/test',
+      });
+    });
+
+    it('prompts for missing region with default', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({region: 'us-east-1'});
+      mockInquirer.prompt.mockResolvedValueOnce({accessKeyId: 'AKIATEST'});
+      mockInquirer.prompt.mockResolvedValueOnce({secretAccessKey: 'secret'});
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'region',
+          message: 'AWS region:',
+          default: 'us-east-1',
+        }),
+      ]);
+      expect(config.region).toBe('us-east-1');
+    });
+
+    it('throws error if region is missing after prompt', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({region: ''});
+
+      const options = {
+        model: 'test-model',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'region is required'
+      );
+    });
+
+    it('prompts for missing accessKeyId', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({secretAccessKey: 'secret'});
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'accessKeyId',
+          message: 'AWS access key ID:',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.accessKeyId).toBe('AKIAIOSFODNN7EXAMPLE');
+    });
+
+    it('validates accessKeyId is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({accessKeyId: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'access key ID is required'
+      );
+    });
+
+    it('prompts for missing secretAccessKey as password field', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'password',
+          name: 'secretAccessKey',
+          message: 'AWS secret access key:',
+          mask: '*',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.secretAccessKey).toBe(
+        'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      );
+    });
+
+    it('validates secretAccessKey is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({secretAccessKey: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'secret access key is required'
+      );
+    });
+
+    it('prompts for optional sessionToken', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        sessionToken: 'optional-token',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'password',
+          name: 'sessionToken',
+          message: 'AWS session token (optional, press enter to skip):',
+          mask: '*',
+        }),
+      ]);
+      expect(config.sessionToken).toBe('optional-token');
+    });
+
+    it('sets sessionToken to undefined when empty', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config.sessionToken).toBeUndefined();
+    });
+
+    it('prompts for optional modelArn', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({
+        modelArn: 'arn:aws:bedrock:us-west-2:123456789012:model/test',
+      });
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'modelArn',
+          message: 'Model ARN (optional, press enter to skip):',
+        }),
+      ]);
+      expect(config.modelArn).toBe(
+        'arn:aws:bedrock:us-west-2:123456789012:model/test'
+      );
+    });
+
+    it('sets modelArn to undefined when empty', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'us-west-2',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config.modelArn).toBeUndefined();
+    });
+
+    it('collects full configuration through interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({region: 'eu-west-1'});
+      mockInquirer.prompt.mockResolvedValueOnce({accessKeyId: 'AKIATEST'});
+      mockInquirer.prompt.mockResolvedValueOnce({secretAccessKey: 'secret123'});
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: 'token456'});
+      mockInquirer.prompt.mockResolvedValueOnce({
+        modelArn: 'arn:aws:bedrock:eu-west-1:123:model/claude',
+      });
+
+      const options = {
+        model: 'anthropic.claude-v2',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'bedrock',
+        modelValue: 'anthropic.claude-v2',
+        secretName: '',
+        region: 'eu-west-1',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret123',
+        sessionToken: 'token456',
+        modelArn: 'arn:aws:bedrock:eu-west-1:123:model/claude',
+      });
+    });
+
+    it('mixes CLI options and interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        accessKeyId: 'AKIAPROMPTED',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({sessionToken: ''});
+      mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
+
+      const options = {
+        model: 'test-model',
+        region: 'ap-south-1',
+        secretAccessKey: 'providedSecret',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'bedrock',
+        modelValue: 'test-model',
+        secretName: '',
+        region: 'ap-south-1',
+        accessKeyId: 'AKIAPROMPTED',
+        secretAccessKey: 'providedSecret',
+        sessionToken: undefined,
+        modelArn: undefined,
+      });
+    });
+  });
+});

--- a/tools/ark-cli/src/commands/models/providers/bedrock.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.ts
@@ -1,8 +1,31 @@
 import inquirer from 'inquirer';
 import {CreateModelOptions} from '../create.js';
-import {BedrockConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
 
-// Bedrock configuration collector
+/**
+ * Configuration for AWS Bedrock models.
+ */
+export interface BedrockConfig extends BaseProviderConfig {
+  type: 'bedrock';
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  modelArn?: string;
+}
+
+/**
+ * Configuration collector for AWS Bedrock models.
+ *
+ * Collects the necessary configuration to connect to AWS Bedrock:
+ * - region: The AWS region where Bedrock is deployed (e.g., us-east-1)
+ * - accessKeyId: AWS access key ID for authentication
+ * - secretAccessKey: AWS secret access key for authentication
+ * - sessionToken: (Optional) AWS session token for temporary credentials
+ * - modelArn: (Optional) Specific ARN for the model to use
+ *
+ * Values can be provided via command-line options or will be prompted interactively.
+ */
 export class BedrockConfigCollector implements ProviderConfigCollector {
   async collectConfig(options: CreateModelOptions): Promise<BedrockConfig> {
     let region = options.region;

--- a/tools/ark-cli/src/commands/models/providers/bedrock.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.ts
@@ -1,6 +1,5 @@
 import inquirer from 'inquirer';
-import {CreateModelOptions} from '../create.js';
-import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for AWS Bedrock models.
@@ -10,6 +9,17 @@ export interface BedrockConfig extends BaseProviderConfig {
   region: string;
   accessKeyId: string;
   secretAccessKey: string;
+  sessionToken?: string;
+  modelArn?: string;
+}
+
+/**
+ * Options specific to Bedrock collector.
+ */
+export interface BedrockCollectorOptions extends CommonCollectorOptions {
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
   sessionToken?: string;
   modelArn?: string;
 }
@@ -27,8 +37,10 @@ export interface BedrockConfig extends BaseProviderConfig {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class BedrockConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CreateModelOptions): Promise<BedrockConfig> {
-    let region = options.region;
+  async collectConfig(options: CommonCollectorOptions): Promise<BedrockConfig> {
+    const bedrockOptions = options as BedrockCollectorOptions;
+    
+    let region = bedrockOptions.region;
     if (!region) {
       const answer = await inquirer.prompt([
         {
@@ -45,7 +57,7 @@ export class BedrockConfigCollector implements ProviderConfigCollector {
       throw new Error('region is required');
     }
 
-    let accessKeyId = options.accessKeyId;
+    let accessKeyId = bedrockOptions.accessKeyId;
     if (!accessKeyId) {
       const answer = await inquirer.prompt([
         {
@@ -65,7 +77,7 @@ export class BedrockConfigCollector implements ProviderConfigCollector {
       throw new Error('access key ID is required');
     }
 
-    let secretAccessKey = options.secretAccessKey;
+    let secretAccessKey = bedrockOptions.secretAccessKey;
     if (!secretAccessKey) {
       const answer = await inquirer.prompt([
         {
@@ -86,7 +98,7 @@ export class BedrockConfigCollector implements ProviderConfigCollector {
       throw new Error('secret access key is required');
     }
 
-    let sessionToken = options.sessionToken;
+    let sessionToken = bedrockOptions.sessionToken;
     if (!sessionToken) {
       const answer = await inquirer.prompt([
         {
@@ -99,7 +111,7 @@ export class BedrockConfigCollector implements ProviderConfigCollector {
       sessionToken = answer.sessionToken;
     }
 
-    let modelArn = options.modelArn;
+    let modelArn = bedrockOptions.modelArn;
     if (!modelArn) {
       const answer = await inquirer.prompt([
         {

--- a/tools/ark-cli/src/commands/models/providers/bedrock.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.ts
@@ -1,0 +1,102 @@
+import inquirer from 'inquirer';
+import {CreateModelOptions} from '../create.js';
+import {BedrockConfig, ProviderConfigCollector} from './types.js';
+
+// Bedrock configuration collector
+export class BedrockConfigCollector implements ProviderConfigCollector {
+  async collectConfig(options: CreateModelOptions): Promise<BedrockConfig> {
+    let region = options.region;
+    if (!region) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'region',
+          message: 'AWS region:',
+          default: 'us-east-1',
+        },
+      ]);
+      region = answer.region;
+    }
+
+    if (!region) {
+      throw new Error('region is required');
+    }
+
+    let accessKeyId = options.accessKeyId;
+    if (!accessKeyId) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'accessKeyId',
+          message: 'AWS access key ID:',
+          validate: (input) => {
+            if (!input) return 'access key ID is required';
+            return true;
+          },
+        },
+      ]);
+      accessKeyId = answer.accessKeyId;
+    }
+
+    if (!accessKeyId) {
+      throw new Error('access key ID is required');
+    }
+
+    let secretAccessKey = options.secretAccessKey;
+    if (!secretAccessKey) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'secretAccessKey',
+          message: 'AWS secret access key:',
+          mask: '*',
+          validate: (input) => {
+            if (!input) return 'secret access key is required';
+            return true;
+          },
+        },
+      ]);
+      secretAccessKey = answer.secretAccessKey;
+    }
+
+    if (!secretAccessKey) {
+      throw new Error('secret access key is required');
+    }
+
+    let sessionToken = options.sessionToken;
+    if (!sessionToken) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'sessionToken',
+          message: 'AWS session token (optional, press enter to skip):',
+          mask: '*',
+        },
+      ]);
+      sessionToken = answer.sessionToken;
+    }
+
+    let modelArn = options.modelArn;
+    if (!modelArn) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'modelArn',
+          message: 'Model ARN (optional, press enter to skip):',
+        },
+      ]);
+      modelArn = answer.modelArn;
+    }
+
+    return {
+      type: 'bedrock',
+      modelValue: options.model!,
+      secretName: '',
+      region,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken: sessionToken || undefined,
+      modelArn: modelArn || undefined,
+    };
+  }
+}

--- a/tools/ark-cli/src/commands/models/providers/bedrock.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.ts
@@ -1,5 +1,5 @@
 import inquirer from 'inquirer';
-import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, BaseCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for AWS Bedrock models.
@@ -16,7 +16,7 @@ export interface BedrockConfig extends BaseProviderConfig {
 /**
  * Options specific to Bedrock collector.
  */
-export interface BedrockCollectorOptions extends CommonCollectorOptions {
+export interface BedrockCollectorOptions extends BaseCollectorOptions {
   region?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -37,7 +37,7 @@ export interface BedrockCollectorOptions extends CommonCollectorOptions {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class BedrockConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CommonCollectorOptions): Promise<BedrockConfig> {
+  async collectConfig(options: BaseCollectorOptions): Promise<BedrockConfig> {
     const bedrockOptions = options as BedrockCollectorOptions;
     
     let region = bedrockOptions.region;

--- a/tools/ark-cli/src/commands/models/providers/factory.ts
+++ b/tools/ark-cli/src/commands/models/providers/factory.ts
@@ -1,0 +1,20 @@
+import {ProviderConfigCollector} from './types.js';
+import {OpenAIConfigCollector} from './openai.js';
+import {AzureConfigCollector} from './azure.js';
+import {BedrockConfigCollector} from './bedrock.js';
+
+// Factory for creating provider configuration collectors
+export class ProviderConfigCollectorFactory {
+  static create(type: string): ProviderConfigCollector {
+    switch (type) {
+      case 'openai':
+        return new OpenAIConfigCollector();
+      case 'azure':
+        return new AzureConfigCollector();
+      case 'bedrock':
+        return new BedrockConfigCollector();
+      default:
+        throw new Error(`Unknown provider type: ${type}`);
+    }
+  }
+}

--- a/tools/ark-cli/src/commands/models/providers/factory.ts
+++ b/tools/ark-cli/src/commands/models/providers/factory.ts
@@ -3,8 +3,21 @@ import {OpenAIConfigCollector} from './openai.js';
 import {AzureConfigCollector} from './azure.js';
 import {BedrockConfigCollector} from './bedrock.js';
 
-// Factory for creating provider configuration collectors
+/**
+ * Factory for creating provider-specific configuration collectors.
+ *
+ * This factory uses the provider type to instantiate the appropriate collector
+ * that knows how to gather configuration for that specific provider.
+ * This pattern makes it easy to add new providers without modifying existing code.
+ */
 export class ProviderConfigCollectorFactory {
+  /**
+   * Creates a configuration collector for the specified provider type.
+   *
+   * @param type - The provider type ('openai', 'azure', or 'bedrock')
+   * @returns A collector instance for the specified provider
+   * @throws Error if the provider type is not recognized
+   */
   static create(type: string): ProviderConfigCollector {
     switch (type) {
       case 'openai':

--- a/tools/ark-cli/src/commands/models/providers/index.ts
+++ b/tools/ark-cli/src/commands/models/providers/index.ts
@@ -6,7 +6,7 @@
 
 export {
   BaseProviderConfig,
-  CommonCollectorOptions,
+  BaseCollectorOptions,
   ProviderConfigCollector,
 } from './types.js';
 export {

--- a/tools/ark-cli/src/commands/models/providers/index.ts
+++ b/tools/ark-cli/src/commands/models/providers/index.ts
@@ -4,10 +4,26 @@
  * This module exports all provider-specific configurations and their collectors.
  */
 
-export {BaseProviderConfig, ProviderConfigCollector} from './types.js';
-export {OpenAIConfig, OpenAIConfigCollector} from './openai.js';
-export {AzureConfig, AzureConfigCollector} from './azure.js';
-export {BedrockConfig, BedrockConfigCollector} from './bedrock.js';
+export {
+  BaseProviderConfig,
+  CommonCollectorOptions,
+  ProviderConfigCollector,
+} from './types.js';
+export {
+  OpenAIConfig,
+  OpenAICollectorOptions,
+  OpenAIConfigCollector,
+} from './openai.js';
+export {
+  AzureConfig,
+  AzureCollectorOptions,
+  AzureConfigCollector,
+} from './azure.js';
+export {
+  BedrockConfig,
+  BedrockCollectorOptions,
+  BedrockConfigCollector,
+} from './bedrock.js';
 export {ProviderConfigCollectorFactory} from './factory.js';
 
 import {OpenAIConfig} from './openai.js';

--- a/tools/ark-cli/src/commands/models/providers/index.ts
+++ b/tools/ark-cli/src/commands/models/providers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Provider configuration types and collectors.
+ *
+ * This module exports all provider-specific configurations and their collectors.
+ */
+
+export {BaseProviderConfig, ProviderConfigCollector} from './types.js';
+export {OpenAIConfig, OpenAIConfigCollector} from './openai.js';
+export {AzureConfig, AzureConfigCollector} from './azure.js';
+export {BedrockConfig, BedrockConfigCollector} from './bedrock.js';
+export {ProviderConfigCollectorFactory} from './factory.js';
+
+import {OpenAIConfig} from './openai.js';
+import {AzureConfig} from './azure.js';
+import {BedrockConfig} from './bedrock.js';
+
+/**
+ * Union type of all supported provider configurations.
+ */
+export type ProviderConfig = OpenAIConfig | AzureConfig | BedrockConfig;

--- a/tools/ark-cli/src/commands/models/providers/openai.spec.ts
+++ b/tools/ark-cli/src/commands/models/providers/openai.spec.ts
@@ -1,0 +1,233 @@
+import {jest} from '@jest/globals';
+
+const mockInquirer = {
+  prompt: jest.fn() as any,
+};
+jest.unstable_mockModule('inquirer', () => ({
+  default: mockInquirer,
+}));
+
+const {OpenAIConfigCollector} = await import('./openai.js');
+
+describe('OpenAIConfigCollector', () => {
+  let collector: InstanceType<typeof OpenAIConfigCollector>;
+
+  beforeEach(() => {
+    collector = new OpenAIConfigCollector();
+    jest.clearAllMocks();
+  });
+
+  describe('collectConfig', () => {
+    it('uses provided options without prompting', async () => {
+      const options = {
+        model: 'gpt-4o-mini',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test-key-12345',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).not.toHaveBeenCalled();
+      expect(config).toEqual({
+        type: 'openai',
+        modelValue: 'gpt-4o-mini',
+        secretName: '',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test-key-12345',
+      });
+    });
+
+    it('prompts for missing baseUrl', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        baseUrl: 'https://custom-openai.com',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'sk-custom-key'});
+
+      const options = {
+        model: 'gpt-4',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'input',
+          name: 'baseUrl',
+          message: 'base URL:',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.baseUrl).toBe('https://custom-openai.com');
+    });
+
+    it('validates baseUrl is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({baseUrl: ''});
+
+      const options = {
+        model: 'gpt-4',
+      };
+
+      // The validation happens in the prompt, but we test the final check
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'base URL is required'
+      );
+    });
+
+    it('validates baseUrl is a valid URL', async () => {
+      const options = {
+        model: 'gpt-4',
+      };
+
+      // Get the validate function from the prompt call
+      mockInquirer.prompt.mockImplementationOnce(async (questions: any) => {
+        const validate = questions[0].validate;
+        
+        // Test invalid URL
+        expect(validate('not-a-url')).toBe('please enter a valid URL');
+        
+        // Test empty string
+        expect(validate('')).toBe('base URL is required');
+        
+        // Test valid URL
+        expect(validate('https://api.openai.com')).toBe(true);
+        
+        return {baseUrl: 'https://api.openai.com'};
+      });
+
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'sk-key'});
+
+      await collector.collectConfig(options);
+    });
+
+    it('removes trailing slash from baseUrl', async () => {
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://api.openai.com/v1/',
+        apiKey: 'sk-test-key',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config.baseUrl).toBe('https://api.openai.com/v1');
+    });
+
+    it('prompts for missing apiKey as password field', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'sk-secret-key'});
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://api.openai.com/v1',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(mockInquirer.prompt).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'password',
+          name: 'apiKey',
+          message: 'API key:',
+          mask: '*',
+          validate: expect.any(Function),
+        }),
+      ]);
+      expect(config.apiKey).toBe('sk-secret-key');
+    });
+
+    it('validates apiKey is required', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: ''});
+
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://api.openai.com/v1',
+      };
+
+      await expect(collector.collectConfig(options)).rejects.toThrow(
+        'API key is required'
+      );
+    });
+
+    it('tests apiKey validation function', async () => {
+      const options = {
+        model: 'gpt-4',
+        baseUrl: 'https://api.openai.com/v1',
+      };
+
+      // Get the validate function from the prompt call
+      mockInquirer.prompt.mockImplementationOnce(async (questions: any) => {
+        const validate = questions[0].validate;
+        
+        // Test empty string
+        expect(validate('')).toBe('API key is required');
+        
+        // Test valid key
+        expect(validate('sk-valid-key')).toBe(true);
+        
+        return {apiKey: 'sk-valid-key'};
+      });
+
+      await collector.collectConfig(options);
+    });
+
+    it('collects full configuration through interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        baseUrl: 'https://api.openai.com/v1/',
+      });
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiKey: 'sk-proj-abc123',
+      });
+
+      const options = {
+        model: 'gpt-4o',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'openai',
+        modelValue: 'gpt-4o',
+        secretName: '',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-proj-abc123',
+      });
+    });
+
+    it('mixes CLI options and interactive prompts', async () => {
+      mockInquirer.prompt.mockResolvedValueOnce({
+        apiKey: 'sk-prompted-key',
+      });
+
+      const options = {
+        model: 'gpt-3.5-turbo',
+        baseUrl: 'https://custom-api.com/v1',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'openai',
+        modelValue: 'gpt-3.5-turbo',
+        secretName: '',
+        baseUrl: 'https://custom-api.com/v1',
+        apiKey: 'sk-prompted-key',
+      });
+    });
+
+    it('handles custom OpenAI-compatible endpoints', async () => {
+      const options = {
+        model: 'llama-3-8b',
+        baseUrl: 'https://localhost:8080/v1',
+        apiKey: 'local-key-123',
+      };
+
+      const config = await collector.collectConfig(options);
+
+      expect(config).toEqual({
+        type: 'openai',
+        modelValue: 'llama-3-8b',
+        secretName: '',
+        baseUrl: 'https://localhost:8080/v1',
+        apiKey: 'local-key-123',
+      });
+    });
+  });
+});

--- a/tools/ark-cli/src/commands/models/providers/openai.ts
+++ b/tools/ark-cli/src/commands/models/providers/openai.ts
@@ -1,6 +1,5 @@
 import inquirer from 'inquirer';
-import {CreateModelOptions} from '../create.js';
-import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for OpenAI models.
@@ -9,6 +8,14 @@ export interface OpenAIConfig extends BaseProviderConfig {
   type: 'openai';
   baseUrl: string;
   apiKey: string;
+}
+
+/**
+ * Options specific to OpenAI collector.
+ */
+export interface OpenAICollectorOptions extends CommonCollectorOptions {
+  baseUrl?: string;
+  apiKey?: string;
 }
 
 /**
@@ -21,8 +28,10 @@ export interface OpenAIConfig extends BaseProviderConfig {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class OpenAIConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CreateModelOptions): Promise<OpenAIConfig> {
-    let baseUrl = options.baseUrl;
+  async collectConfig(options: CommonCollectorOptions): Promise<OpenAIConfig> {
+    const openaiOptions = options as OpenAICollectorOptions;
+    
+    let baseUrl = openaiOptions.baseUrl;
     if (!baseUrl) {
       const answer = await inquirer.prompt([
         {
@@ -48,7 +57,7 @@ export class OpenAIConfigCollector implements ProviderConfigCollector {
     }
     baseUrl = baseUrl.replace(/\/$/, '');
 
-    let apiKey = options.apiKey;
+    let apiKey = openaiOptions.apiKey;
     if (!apiKey) {
       const answer = await inquirer.prompt([
         {

--- a/tools/ark-cli/src/commands/models/providers/openai.ts
+++ b/tools/ark-cli/src/commands/models/providers/openai.ts
@@ -1,0 +1,63 @@
+import inquirer from 'inquirer';
+import {CreateModelOptions} from '../create.js';
+import {OpenAIConfig, ProviderConfigCollector} from './types.js';
+
+// OpenAI configuration collector
+export class OpenAIConfigCollector implements ProviderConfigCollector {
+  async collectConfig(options: CreateModelOptions): Promise<OpenAIConfig> {
+    let baseUrl = options.baseUrl;
+    if (!baseUrl) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'baseUrl',
+          message: 'base URL:',
+          validate: (input) => {
+            if (!input) return 'base URL is required';
+            try {
+              new URL(input);
+              return true;
+            } catch {
+              return 'please enter a valid URL';
+            }
+          },
+        },
+      ]);
+      baseUrl = answer.baseUrl;
+    }
+
+    if (!baseUrl) {
+      throw new Error('base URL is required');
+    }
+    baseUrl = baseUrl.replace(/\/$/, '');
+
+    let apiKey = options.apiKey;
+    if (!apiKey) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'apiKey',
+          message: 'API key:',
+          mask: '*',
+          validate: (input) => {
+            if (!input) return 'API key is required';
+            return true;
+          },
+        },
+      ]);
+      apiKey = answer.apiKey;
+    }
+
+    if (!apiKey) {
+      throw new Error('API key is required');
+    }
+
+    return {
+      type: 'openai',
+      modelValue: options.model!,
+      secretName: '',
+      baseUrl,
+      apiKey,
+    };
+  }
+}

--- a/tools/ark-cli/src/commands/models/providers/openai.ts
+++ b/tools/ark-cli/src/commands/models/providers/openai.ts
@@ -1,5 +1,5 @@
 import inquirer from 'inquirer';
-import {BaseProviderConfig, CommonCollectorOptions, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, BaseCollectorOptions, ProviderConfigCollector} from './types.js';
 
 /**
  * Configuration for OpenAI models.
@@ -13,7 +13,7 @@ export interface OpenAIConfig extends BaseProviderConfig {
 /**
  * Options specific to OpenAI collector.
  */
-export interface OpenAICollectorOptions extends CommonCollectorOptions {
+export interface OpenAICollectorOptions extends BaseCollectorOptions {
   baseUrl?: string;
   apiKey?: string;
 }
@@ -28,7 +28,7 @@ export interface OpenAICollectorOptions extends CommonCollectorOptions {
  * Values can be provided via command-line options or will be prompted interactively.
  */
 export class OpenAIConfigCollector implements ProviderConfigCollector {
-  async collectConfig(options: CommonCollectorOptions): Promise<OpenAIConfig> {
+  async collectConfig(options: BaseCollectorOptions): Promise<OpenAIConfig> {
     const openaiOptions = options as OpenAICollectorOptions;
     
     let baseUrl = openaiOptions.baseUrl;

--- a/tools/ark-cli/src/commands/models/providers/openai.ts
+++ b/tools/ark-cli/src/commands/models/providers/openai.ts
@@ -1,8 +1,25 @@
 import inquirer from 'inquirer';
 import {CreateModelOptions} from '../create.js';
-import {OpenAIConfig, ProviderConfigCollector} from './types.js';
+import {BaseProviderConfig, ProviderConfigCollector} from './types.js';
 
-// OpenAI configuration collector
+/**
+ * Configuration for OpenAI models.
+ */
+export interface OpenAIConfig extends BaseProviderConfig {
+  type: 'openai';
+  baseUrl: string;
+  apiKey: string;
+}
+
+/**
+ * Configuration collector for OpenAI models.
+ *
+ * Collects the necessary configuration to connect to an OpenAI-compatible API:
+ * - baseUrl: The API endpoint URL (e.g., https://api.openai.com/v1)
+ * - apiKey: The authentication key for the API
+ *
+ * Values can be provided via command-line options or will be prompted interactively.
+ */
 export class OpenAIConfigCollector implements ProviderConfigCollector {
   async collectConfig(options: CreateModelOptions): Promise<OpenAIConfig> {
     let baseUrl = options.baseUrl;

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -1,0 +1,37 @@
+import {CreateModelOptions} from '../create.js';
+
+// Provider-specific configuration types
+export interface BaseProviderConfig {
+  type: string;
+  modelValue: string;
+  secretName: string;
+}
+
+export interface OpenAIConfig extends BaseProviderConfig {
+  type: 'openai';
+  baseUrl: string;
+  apiKey: string;
+}
+
+export interface AzureConfig extends BaseProviderConfig {
+  type: 'azure';
+  baseUrl: string;
+  apiKey: string;
+  apiVersion: string;
+}
+
+export interface BedrockConfig extends BaseProviderConfig {
+  type: 'bedrock';
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  modelArn?: string;
+}
+
+export type ProviderConfig = OpenAIConfig | AzureConfig | BedrockConfig;
+
+// Provider configuration collector interface
+export interface ProviderConfigCollector {
+  collectConfig(options: CreateModelOptions): Promise<ProviderConfig>;
+}

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -19,7 +19,7 @@ export interface BaseProviderConfig {
  */
 export interface BaseCollectorOptions {
   /**
-   * @field model Model name (e.g., 'gpt-4o-mini')
+   * Model name (e.g., 'gpt-4o-mini')
    */
   model?: string;
   

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -10,10 +10,24 @@ export interface BaseProviderConfig {
 }
 
 /**
- * Common options available to all collectors.
+ * Common options available to all providers collectors.
+ * 
+ * Can be extended with provider-specific options to grant more flexibility when configuring models on different providers.
+ * 
+ * @field model - Model name (e.g., 'gpt-4o-mini')
+ * @field type - Model provider type (e.g., 'azure', 'openai', 'bedrock')
  */
-export interface CommonCollectorOptions {
+export interface BaseCollectorOptions {
+  /**
+   * @field {model} Model name (e.g., 'gpt-4o-mini')
+   */
   model?: string;
+  
+  /**
+   * Model provider type (e.g., 'azure', 'openai', 'bedrock')
+   */
+  type?: string;
+
   [key: string]: unknown; // Allow provider-specific options to pass through
 }
 
@@ -38,5 +52,5 @@ export interface ProviderConfigCollector {
    * @returns A promise that resolves to a complete provider configuration with all required fields
    * @throws Error if a required field cannot be obtained or validation fails
    */
-  collectConfig(options: CommonCollectorOptions): Promise<ProviderConfig>;
+  collectConfig(options: BaseCollectorOptions): Promise<ProviderConfig>;
 }

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -19,7 +19,7 @@ export interface BaseProviderConfig {
  */
 export interface BaseCollectorOptions {
   /**
-   * @field {model} Model name (e.g., 'gpt-4o-mini')
+   * @field model Model name (e.g., 'gpt-4o-mini')
    */
   model?: string;
   

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -1,4 +1,3 @@
-import {CreateModelOptions} from '../create.js';
 import type {ProviderConfig} from './index.js';
 
 /**
@@ -8,6 +7,14 @@ export interface BaseProviderConfig {
   type: string;
   modelValue: string;
   secretName: string;
+}
+
+/**
+ * Common options available to all collectors.
+ */
+export interface CommonCollectorOptions {
+  model?: string;
+  [key: string]: unknown; // Allow provider-specific options to pass through
 }
 
 /**
@@ -26,9 +33,10 @@ export interface ProviderConfigCollector {
   /**
    * Collects provider-specific configuration by prompting for any missing values.
    *
-   * @param options - The command-line options that may contain some pre-filled values
+   * @param options - Options object that may contain pre-filled values.
+   *                  Each collector extracts only the fields it needs.
    * @returns A promise that resolves to a complete provider configuration with all required fields
    * @throws Error if a required field cannot be obtained or validation fails
    */
-  collectConfig(options: CreateModelOptions): Promise<ProviderConfig>;
+  collectConfig(options: CommonCollectorOptions): Promise<ProviderConfig>;
 }

--- a/tools/ark-cli/src/commands/models/providers/types.ts
+++ b/tools/ark-cli/src/commands/models/providers/types.ts
@@ -1,37 +1,34 @@
 import {CreateModelOptions} from '../create.js';
+import type {ProviderConfig} from './index.js';
 
-// Provider-specific configuration types
+/**
+ * Base configuration shared by all model providers.
+ */
 export interface BaseProviderConfig {
   type: string;
   modelValue: string;
   secretName: string;
 }
 
-export interface OpenAIConfig extends BaseProviderConfig {
-  type: 'openai';
-  baseUrl: string;
-  apiKey: string;
-}
-
-export interface AzureConfig extends BaseProviderConfig {
-  type: 'azure';
-  baseUrl: string;
-  apiKey: string;
-  apiVersion: string;
-}
-
-export interface BedrockConfig extends BaseProviderConfig {
-  type: 'bedrock';
-  region: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken?: string;
-  modelArn?: string;
-}
-
-export type ProviderConfig = OpenAIConfig | AzureConfig | BedrockConfig;
-
-// Provider configuration collector interface
+/**
+ * Provider configuration collector interface.
+ *
+ * A collector is responsible for gathering all the necessary configuration
+ * parameters for a specific model provider (OpenAI, Azure, Bedrock, etc.).
+ * It handles the interactive prompting of missing values and validation
+ * of user inputs, ensuring all required fields are collected before
+ * creating the model resource.
+ *
+ * The collector pattern allows each provider to define its own specific
+ * configuration requirements and prompts without affecting other providers.
+ */
 export interface ProviderConfigCollector {
+  /**
+   * Collects provider-specific configuration by prompting for any missing values.
+   *
+   * @param options - The command-line options that may contain some pre-filled values
+   * @returns A promise that resolves to a complete provider configuration with all required fields
+   * @throws Error if a required field cannot be obtained or validation fails
+   */
   collectConfig(options: CreateModelOptions): Promise<ProviderConfig>;
 }


### PR DESCRIPTION
Internal ticket: [ARKQB-362](https://mckinsey.atlassian.net/browse/ARKQB-362)

- `ark create model` command now supports AWS Bedrock models creation
- abstracted model-specific implementations using model-specific `ProviderConfig` and `ProviderConfigCollector` to collect provider-specific parameters from CLI
- added unit tests for new `collectors`
- ensured already existing unit tests are still passing

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 