### PR TITLE
feat: added cli command `ark queries delete`

### DIFF
--- a/tools/ark-cli/src/commands/queries/delete.spec.ts
+++ b/tools/ark-cli/src/commands/queries/delete.spec.ts
@@ -1,0 +1,111 @@
+import {jest} from '@jest/globals';
+
+const mockExeca = jest.fn() as any;
+jest.unstable_mockModule('execa', () => ({
+  execa: mockExeca,
+}));
+
+const {createQueriesCommand} = await import('./index.js');
+const {deleteQuery} = await import('./delete.js');
+import output from '../../lib/output.js';
+
+describe('queries delete command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.log = jest.fn();
+    jest.spyOn(output, 'warning').mockImplementation(() => {});
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  it('should delete a query by name', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: '',
+    });
+
+    const command = createQueriesCommand({});
+    await command.parseAsync(['node', 'test', 'delete', 'query-1']);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'kubectl',
+      ['delete', 'queries', 'query-1'],
+      {stdio: 'pipe'}
+    );
+    expect(output.warning).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('should delete all queries with --all flag', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: '',
+    });
+
+    const command = createQueriesCommand({});
+    await command.parseAsync(['node', 'test', 'delete', '--all']);
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'kubectl',
+      ['delete', 'queries', '--all'],
+      {stdio: 'pipe'}
+    );
+    expect(output.warning).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteQuery function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  it('should error when neither name nor all flag is provided', async () => {
+    await deleteQuery(undefined, {});
+
+    expect(output.error).toHaveBeenCalledWith(
+      'Either provide a query name or use --all flag'
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle deletion errors gracefully', async () => {
+    mockExeca.mockRejectedValue(new Error('query not found'));
+
+    await deleteQuery('nonexistent-query', {});
+
+    expect(output.error).toHaveBeenCalledWith(
+      'deleting query:',
+      'query not found'
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('should call deleteResource with query name', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: '',
+    });
+
+    await deleteQuery('my-query', {});
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'kubectl',
+      ['delete', 'queries', 'my-query'],
+      {stdio: 'pipe'}
+    );
+  });
+
+  it('should delete all queries when all option is true', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: '',
+    });
+
+    await deleteQuery(undefined, {all: true});
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'kubectl',
+      ['delete', 'queries', '--all'],
+      {stdio: 'pipe'}
+    );
+  });
+});

--- a/tools/ark-cli/src/commands/queries/delete.ts
+++ b/tools/ark-cli/src/commands/queries/delete.ts
@@ -1,0 +1,29 @@
+import output from '../../lib/output.js';
+import {ExitCodes} from '../../lib/errors.js';
+import {deleteResource} from '../../lib/kubectl.js';
+
+interface DeleteQueryOptions {
+  all?: boolean;
+}
+
+export async function deleteQuery(
+  name: string | undefined,
+  options: DeleteQueryOptions
+): Promise<void> {
+  try {
+    if (options.all) {
+      await deleteResource('queries', undefined, {all: true});
+    } else if (name) {
+      await deleteResource('queries', name);
+    } else {
+      output.error('Either provide a query name or use --all flag');
+      process.exit(ExitCodes.CliError);
+    }
+  } catch (error) {
+    output.error(
+      'deleting query:',
+      error instanceof Error ? error.message : error
+    );
+    process.exit(ExitCodes.CliError);
+  }
+}

--- a/tools/ark-cli/src/commands/queries/index.ts
+++ b/tools/ark-cli/src/commands/queries/index.ts
@@ -6,6 +6,7 @@ import output from '../../lib/output.js';
 import type {Query} from '../../lib/types.js';
 import {ExitCodes} from '../../lib/errors.js';
 import {getResource} from '../../lib/kubectl.js';
+import {deleteQuery} from './delete.js';
 
 function renderMarkdown(content: string): string {
   if (process.stdout.isTTY) {
@@ -75,6 +76,17 @@ export function createQueriesCommand(_: ArkConfig): Command {
     });
 
   queriesCommand.addCommand(getCommand);
+
+  const deleteCommand = new Command('delete');
+  deleteCommand
+    .description('Delete a query')
+    .argument('[name]', 'Query name')
+    .option('--all', 'delete all queries', false)
+    .action(async (name: string | undefined, options) => {
+      await deleteQuery(name, options);
+    });
+
+  queriesCommand.addCommand(deleteCommand);
 
   return queriesCommand;
 }

--- a/tools/ark-cli/src/lib/kubectl.spec.ts
+++ b/tools/ark-cli/src/lib/kubectl.spec.ts
@@ -5,7 +5,10 @@ jest.unstable_mockModule('execa', () => ({
   execa: mockExeca,
 }));
 
-const {getResource} = await import('./kubectl.js');
+const {
+  getResource,
+  deleteResource,
+} = await import('./kubectl.js');
 
 interface TestResource {
   metadata: {
@@ -126,6 +129,36 @@ describe('kubectl', () => {
       expect(mockExeca).toHaveBeenCalledWith(
         'kubectl',
         ['get', 'agents', 'test-agent', '-o', 'json'],
+        {stdio: 'pipe'}
+      );
+    });
+  });
+
+  describe('deleteResource', () => {
+    it('should delete a resource by name', async () => {
+      mockExeca.mockResolvedValue({
+        stdout: '',
+      });
+
+      await deleteResource('queries', 'test-query');
+
+      expect(mockExeca).toHaveBeenCalledWith(
+        'kubectl',
+        ['delete', 'queries', 'test-query'],
+        {stdio: 'pipe'}
+      );
+    });
+
+    it('should delete all resources of a type when all option is true', async () => {
+      mockExeca.mockResolvedValue({
+        stdout: '',
+      });
+
+      await deleteResource('queries', undefined, {all: true});
+
+      expect(mockExeca).toHaveBeenCalledWith(
+        'kubectl',
+        ['delete', 'queries', '--all'],
         {stdio: 'pipe'}
       );
     });

--- a/tools/ark-cli/src/lib/kubectl.ts
+++ b/tools/ark-cli/src/lib/kubectl.ts
@@ -43,3 +43,21 @@ export async function getResource<T extends K8sResource>(
 
   return JSON.parse(result.stdout) as T;
 }
+
+export async function deleteResource(
+  resourceType: string,
+  name?: string,
+  options?: {
+    all?: boolean;
+  }
+): Promise<void> {
+  const args: string[] = ['delete', resourceType];
+
+  if (options?.all) {
+    args.push('--all');
+  } else if (name) {
+    args.push(name);
+  }
+
+  await execa('kubectl', args, {stdio: 'pipe'});
+}


### PR DESCRIPTION
This PR adds `ark queries delete` command. [Internal ticket here](https://mckinsey.atlassian.net/browse/ARKQB-374)
This command supports:
- delete by name
- delete all via `--all` flag

Delete by name:
<img width="738" height="468" alt="image" src="https://github.com/user-attachments/assets/32f47dcf-678c-4d20-8651-ec256eddade6" />


Delete all:
<img width="738" height="468" alt="image" src="https://github.com/user-attachments/assets/b80110dd-78f1-4592-8f72-fa4808907cd9" />


## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 