### PR TITLE
feat: update marketplace service paths to include 'services/' prefix

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -32,12 +32,12 @@ dependencies:
   # phoenix service for observability. phoenix has a hook to restart ark-controller to pick up its url
   # phoenix:
   #   git: https://github.com/mckinsey/agents-at-scale-marketplace
-  #   tag: phoenix-v0.1.3
+  #   tag: phoenix-v0.1.5
   #   subPath: services/phoenix
   # langfuse service for observability. langfuse has a hook to restart ark-controller to pick up its url
   # langfuse:
   #   git: https://github.com/mckinsey/agents-at-scale-marketplace
-  #   tag: langfuse-v0.1.2
+  #   tag: langfuse-v0.1.4
   #   subPath: services/langfuse
 
 # Vars - To disable, set environment variables before the devspace commands

--- a/tools/ark-cli/src/commands/completion/index.ts
+++ b/tools/ark-cli/src/commands/completion/index.ts
@@ -89,14 +89,14 @@ _ark_completion() {
           return 0
           ;;
         install)
-          # Suggest marketplace services with marketplace/ prefix
-          opts="marketplace/phoenix marketplace/langfuse"
+          # Suggest marketplace services with marketplace/services/ prefix
+          opts="marketplace/services/phoenix marketplace/services/langfuse"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
         uninstall)
-          # Suggest marketplace services with marketplace/ prefix
-          opts="marketplace/phoenix marketplace/langfuse"
+          # Suggest marketplace services with marketplace/services/ prefix
+          opts="marketplace/services/phoenix marketplace/services/langfuse"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
@@ -237,13 +237,13 @@ _ark() {
           ;;
         install)
           _values 'services to install' \\
-            'marketplace/phoenix[Phoenix observability platform]' \\
-            'marketplace/langfuse[Langfuse LLM analytics]'
+            'marketplace/services/phoenix[Phoenix observability platform]' \\
+            'marketplace/services/langfuse[Langfuse LLM analytics]'
           ;;
         uninstall)
           _values 'services to uninstall' \\
-            'marketplace/phoenix[Phoenix observability platform]' \\
-            'marketplace/langfuse[Langfuse LLM analytics]'
+            'marketplace/services/phoenix[Phoenix observability platform]' \\
+            'marketplace/services/langfuse[Langfuse LLM analytics]'
           ;;
         chat)
           # Get available targets dynamically

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -81,7 +81,7 @@ export async function installArk(
         output.info('available marketplace services:');
         const marketplaceServices = getAllMarketplaceServices();
         for (const serviceName of Object.keys(marketplaceServices)) {
-          output.info(`  marketplace/${serviceName}`);
+          output.info(`  marketplace/services/${serviceName}`);
         }
         process.exit(1);
       }

--- a/tools/ark-cli/src/commands/marketplace/index.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.ts
@@ -21,9 +21,9 @@ Registry: ${chalk.cyan('ghcr.io/mckinsey/agents-at-scale-marketplace/charts')}
       'after',
       `
 ${chalk.cyan('Examples:')}
-  ${chalk.yellow('ark marketplace list')}              # List available services
-  ${chalk.yellow('ark install marketplace/phoenix')}   # Install Phoenix
-  ${chalk.yellow('ark uninstall marketplace/phoenix')} # Uninstall Phoenix
+  ${chalk.yellow('ark marketplace list')}                        # List available services
+  ${chalk.yellow('ark install marketplace/services/phoenix')}    # Install Phoenix
+  ${chalk.yellow('ark uninstall marketplace/services/phoenix')}  # Uninstall Phoenix
   
 ${chalk.cyan('Available Services:')}
   • phoenix  - AI/ML observability and evaluation platform
@@ -41,12 +41,14 @@ ${chalk.cyan('Available Services:')}
 
       console.log(chalk.blue('\n🏪 ARK Marketplace Services\n'));
       console.log(
-        chalk.gray('Install with: ark install marketplace/<service-name>\n')
+        chalk.gray(
+          'Install with: ark install marketplace/services/<service-name>\n'
+        )
       );
 
       for (const [key, service] of Object.entries(services)) {
         const icon = '📦';
-        const serviceName = `marketplace/${key.padEnd(12)}`;
+        const serviceName = `marketplace/services/${key.padEnd(12)}`;
         const serviceDesc = service.description;
         console.log(
           `${icon} ${chalk.green(serviceName)} ${chalk.gray(serviceDesc)}`

--- a/tools/ark-cli/src/commands/uninstall/index.ts
+++ b/tools/ark-cli/src/commands/uninstall/index.ts
@@ -55,7 +55,7 @@ async function uninstallArk(
         output.info('available marketplace services:');
         const marketplaceServices = getAllMarketplaceServices();
         for (const serviceName of Object.keys(marketplaceServices)) {
-          output.info(`  marketplace/${serviceName}`);
+          output.info(`  marketplace/services/${serviceName}`);
         }
         process.exit(1);
       }

--- a/tools/ark-cli/src/marketplaceServices.ts
+++ b/tools/ark-cli/src/marketplaceServices.ts
@@ -35,7 +35,7 @@ export const marketplaceServices: ServiceCollection = {
       'Open-source LLM observability and analytics platform with session tracking',
     enabled: true,
     category: 'marketplace',
-    namespace: 'langfuse',
+    namespace: 'telemetry',
     chartPath: `${MARKETPLACE_REGISTRY}/langfuse`,
     installArgs: ['--create-namespace'],
     k8sServiceName: 'langfuse',
@@ -53,9 +53,10 @@ export function getAllMarketplaceServices(): ServiceCollection {
 }
 
 export function isMarketplaceService(name: string): boolean {
-  return name.startsWith('marketplace/');
+  return name.startsWith('marketplace/services/');
 }
 
 export function extractMarketplaceServiceName(path: string): string {
-  return path.replace(/^marketplace\//, '');
+  // Extract service name from marketplace/services/phoenix
+  return path.replace(/^marketplace\/services\//, '');
 }


### PR DESCRIPTION
Aligns CLI and DevSpace with marketplace repo's services directory structure.

**CLI path format updated:**
```bash
# Old ❌
ark install marketplace/phoenix

# New ✅
ark install marketplace/services/phoenix
```

### Changes
- Updated CLI to require `marketplace/services/` prefix
- Bumped marketplace service versions in devspace.yaml

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 