### PR TITLE
feat: Use Anthropic Marketplace JSON in Marketplace Repo #438

### DIFF
--- a/docs/content/user-guide/ark-cli.mdx
+++ b/docs/content/user-guide/ark-cli.mdx
@@ -47,6 +47,26 @@ Then query any agent:
 
 That's it! The CLI maintains conversation context and lets you interact with any deployed ARK agents.
 
+## Marketplace
+
+The ARK CLI supports dynamic marketplace service enumeration from a `marketplace.json` file hosted in the marketplace repository.
+
+```bash
+# List available marketplace services
+ark marketplace list
+
+# Refresh the marketplace cache (bypasses 5-minute cache)
+ark marketplace list --refresh
+
+# Install a marketplace service
+ark install marketplace/<service-name>
+
+# Uninstall a marketplace service
+ark uninstall marketplace/<service-name>
+```
+
+The marketplace fetches services from `https://github.com/mckinsey/agents-at-scale-marketplace/raw/main/marketplace.json` using the Anthropic Marketplace JSON format. Results are cached for 5 minutes to reduce network requests. If the fetch fails, the CLI falls back to hardcoded services.
+
 ## Local Development
 
 ```bash

--- a/templates/marketplace/marketplace.json.example
+++ b/templates/marketplace/marketplace.json.example
@@ -1,0 +1,59 @@
+{
+  "version": "1.0.0",
+  "marketplace": "ARK Marketplace",
+  "items": [
+    {
+      "name": "phoenix",
+      "displayName": "Phoenix",
+      "description": "AI/ML observability and evaluation platform with OpenTelemetry integration",
+      "version": "0.1.5",
+      "author": "ARK Marketplace",
+      "homepage": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "repository": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "license": "Apache-2.0",
+      "tags": ["observability", "evaluation", "telemetry", "monitoring"],
+      "category": "observability",
+      "icon": "https://example.com/phoenix-icon.png",
+      "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/phoenix/",
+      "support": {
+        "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
+      },
+      "ark": {
+        "chartPath": "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/phoenix",
+        "namespace": "phoenix",
+        "helmReleaseName": "phoenix",
+        "installArgs": ["--create-namespace"],
+        "k8sServiceName": "phoenix",
+        "k8sServicePort": 6006,
+        "k8sDeploymentName": "phoenix"
+      }
+    },
+    {
+      "name": "langfuse",
+      "displayName": "Langfuse",
+      "description": "Open-source LLM observability and analytics platform with session tracking",
+      "version": "0.1.4",
+      "author": "ARK Marketplace",
+      "homepage": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "repository": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "license": "Apache-2.0",
+      "tags": ["observability", "analytics", "llm", "tracking"],
+      "category": "observability",
+      "icon": "https://example.com/langfuse-icon.png",
+      "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/langfuse/",
+      "support": {
+        "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
+      },
+      "ark": {
+        "chartPath": "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/langfuse",
+        "namespace": "telemetry",
+        "helmReleaseName": "langfuse",
+        "installArgs": ["--create-namespace"],
+        "k8sServiceName": "langfuse",
+        "k8sServicePort": 3000,
+        "k8sDeploymentName": "langfuse-web"
+      }
+    }
+  ]
+}
+

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -72,14 +72,14 @@ export async function installArk(
     // Check if it's a marketplace service
     if (isMarketplaceService(serviceName)) {
       const marketplaceServiceName = extractMarketplaceServiceName(serviceName);
-      const service = getMarketplaceService(marketplaceServiceName);
+      const service = await getMarketplaceService(marketplaceServiceName);
 
       if (!service) {
         output.error(
           `marketplace service '${marketplaceServiceName}' not found`
         );
         output.info('available marketplace services:');
-        const marketplaceServices = getAllMarketplaceServices();
+        const marketplaceServices = await getAllMarketplaceServices();
         for (const serviceName of Object.keys(marketplaceServices)) {
           output.info(`  marketplace/services/${serviceName}`);
         }

--- a/tools/ark-cli/src/commands/marketplace/index.spec.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.spec.ts
@@ -1,0 +1,119 @@
+import {jest} from '@jest/globals';
+import {Command} from 'commander';
+import type {ArkConfig} from '../../lib/config.js';
+import type {ServiceCollection} from '../../types/arkService.js';
+import type {AnthropicMarketplaceManifest} from '../../types/marketplace.js';
+
+const mockGetAllMarketplaceServices = jest.fn<
+  (forceRefresh?: boolean) => Promise<ServiceCollection>
+>();
+const mockFetchMarketplaceManifest = jest.fn<
+  (forceRefresh?: boolean) => Promise<AnthropicMarketplaceManifest | null>
+>();
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+jest.unstable_mockModule('../../marketplaceServices.js', () => ({
+  getAllMarketplaceServices: mockGetAllMarketplaceServices,
+}));
+
+jest.unstable_mockModule('../../lib/marketplaceFetcher.js', () => ({
+  fetchMarketplaceManifest: mockFetchMarketplaceManifest,
+}));
+
+const {createMarketplaceCommand} = await import('./index.js');
+
+describe('marketplace command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates marketplace command with correct structure', () => {
+    const command = createMarketplaceCommand({});
+
+    expect(command).toBeInstanceOf(Command);
+    expect(command.name()).toBe('marketplace');
+  });
+
+  it('lists services from manifest', async () => {
+    const mockServices = {
+      'test-service': {
+        name: 'test-service',
+        helmReleaseName: 'test-service',
+        description: 'Test service description',
+        enabled: true,
+        category: 'marketplace',
+        namespace: 'test-ns',
+      },
+    };
+
+    const mockManifest: AnthropicMarketplaceManifest = {
+      version: '1.0.0',
+      marketplace: 'ARK Marketplace',
+      items: [
+        {
+          name: 'test-service',
+          description: 'Test service',
+          ark: {
+            chartPath: 'oci://registry/test-service',
+            namespace: 'test',
+          },
+        },
+      ],
+    };
+
+    mockGetAllMarketplaceServices.mockResolvedValue(mockServices);
+    mockFetchMarketplaceManifest.mockResolvedValue(mockManifest);
+
+    const command = createMarketplaceCommand({} as ArkConfig);
+    await command.parseAsync(['node', 'test', 'list']);
+
+    expect(mockGetAllMarketplaceServices).toHaveBeenCalled();
+    expect(mockConsoleLog).toHaveBeenCalled();
+  });
+
+  it('shows fallback message when manifest unavailable', async () => {
+    const mockServices = {
+      phoenix: {
+        name: 'phoenix',
+        helmReleaseName: 'phoenix',
+        description: 'Phoenix service',
+        enabled: true,
+        category: 'marketplace',
+        namespace: 'phoenix',
+      },
+    };
+
+    mockGetAllMarketplaceServices.mockResolvedValue(mockServices);
+    mockFetchMarketplaceManifest.mockResolvedValue(null);
+
+    const command = createMarketplaceCommand({} as ArkConfig);
+    await command.parseAsync(['node', 'test', 'list']);
+
+    expect(mockConsoleLog).toHaveBeenCalled();
+    const logCalls = mockConsoleLog.mock.calls.map((c) => c[0]).join(' ');
+    expect(logCalls).toContain('fallback');
+  });
+
+  it('forces refresh when --refresh flag is used', async () => {
+    const mockServices = {
+      'refreshed-service': {
+        name: 'refreshed-service',
+        helmReleaseName: 'refreshed-service',
+        description: 'Refreshed',
+        enabled: true,
+        category: 'marketplace',
+        namespace: 'refreshed',
+      },
+    };
+
+    mockGetAllMarketplaceServices.mockResolvedValue(mockServices);
+    mockFetchMarketplaceManifest.mockResolvedValue(null);
+
+    const command = createMarketplaceCommand({} as ArkConfig);
+    await command.parseAsync(['node', 'test', 'list', '--refresh']);
+
+    expect(mockGetAllMarketplaceServices).toHaveBeenCalledWith(true);
+    expect(mockFetchMarketplaceManifest).toHaveBeenCalledWith(true);
+  });
+});
+

--- a/tools/ark-cli/src/commands/marketplace/index.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.ts
@@ -2,6 +2,7 @@ import {Command} from 'commander';
 import chalk from 'chalk';
 import type {ArkConfig} from '../../lib/config.js';
 import {getAllMarketplaceServices} from '../../marketplaceServices.js';
+import {fetchMarketplaceManifest} from '../../lib/marketplaceFetcher.js';
 
 function createMarketplaceCommand(_config: ArkConfig): Command {
   const marketplace = new Command('marketplace');
@@ -22,6 +23,7 @@ Registry: ${chalk.cyan('ghcr.io/mckinsey/agents-at-scale-marketplace/charts')}
       `
 ${chalk.cyan('Examples:')}
   ${chalk.yellow('ark marketplace list')}                        # List available services
+  ${chalk.yellow('ark marketplace list --refresh')}              # Refresh marketplace cache
   ${chalk.yellow('ark install marketplace/services/phoenix')}    # Install Phoenix
   ${chalk.yellow('ark uninstall marketplace/services/phoenix')}  # Uninstall Phoenix
   
@@ -36,10 +38,33 @@ ${chalk.cyan('Available Services:')}
   list
     .alias('ls')
     .description('List available marketplace services')
-    .action(() => {
-      const services = getAllMarketplaceServices();
+    .option('--refresh', 'Force refresh marketplace data from repository')
+    .action(async (options) => {
+      const forceRefresh = options.refresh === true;
+
+      if (forceRefresh) {
+        console.log(chalk.gray('Refreshing marketplace data...'));
+      }
+
+      const services = await getAllMarketplaceServices(forceRefresh);
+      const manifest = await fetchMarketplaceManifest(forceRefresh);
 
       console.log(chalk.blue('\n🏪 ARK Marketplace Services\n'));
+
+      if (manifest) {
+        console.log(
+          chalk.dim(
+            `Using marketplace.json (version: ${manifest.version})\n`
+          )
+        );
+      } else {
+        console.log(
+          chalk.dim(
+            'Using fallback services (marketplace.json unavailable)\n'
+          )
+        );
+      }
+
       console.log(
         chalk.gray(
           'Install with: ark install marketplace/services/<service-name>\n'
@@ -68,6 +93,13 @@ ${chalk.cyan('Available Services:')}
           'Registry: oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts'
         )
       );
+      if (manifest) {
+        console.log(
+          chalk.dim(
+            `Manifest: marketplace.json (${manifest.items?.length || 0} items)`
+          )
+        );
+      }
       console.log();
     });
 

--- a/tools/ark-cli/src/commands/uninstall/index.ts
+++ b/tools/ark-cli/src/commands/uninstall/index.ts
@@ -46,14 +46,14 @@ async function uninstallArk(
     // Check if it's a marketplace service
     if (isMarketplaceService(serviceName)) {
       const marketplaceServiceName = extractMarketplaceServiceName(serviceName);
-      const service = getMarketplaceService(marketplaceServiceName);
+      const service = await getMarketplaceService(marketplaceServiceName);
 
       if (!service) {
         output.error(
           `marketplace service '${marketplaceServiceName}' not found`
         );
         output.info('available marketplace services:');
-        const marketplaceServices = getAllMarketplaceServices();
+        const marketplaceServices = await getAllMarketplaceServices();
         for (const serviceName of Object.keys(marketplaceServices)) {
           output.info(`  marketplace/services/${serviceName}`);
         }

--- a/tools/ark-cli/src/lib/marketplaceFetcher.spec.ts
+++ b/tools/ark-cli/src/lib/marketplaceFetcher.spec.ts
@@ -1,0 +1,318 @@
+import {jest} from '@jest/globals';
+import type {AnthropicMarketplaceManifest} from '../types/marketplace.js';
+import type {AxiosResponse, AxiosRequestConfig} from 'axios';
+
+const mockAxiosGet = jest.fn<
+  (
+    url: string,
+    config?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<AnthropicMarketplaceManifest>>
+>();
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    get: mockAxiosGet,
+    isAxiosError: (error: unknown) => {
+      return (
+        typeof error === 'object' &&
+        error !== null &&
+        'isAxiosError' in error &&
+        error.isAxiosError === true
+      );
+    },
+  },
+}));
+
+const {
+  fetchMarketplaceManifest,
+  mapMarketplaceItemToArkService,
+  getMarketplaceServicesFromManifest,
+  clearMarketplaceCache,
+} = await import('./marketplaceFetcher.js');
+
+describe('marketplaceFetcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAxiosGet.mockClear();
+    clearMarketplaceCache();
+  });
+
+  describe('fetchMarketplaceManifest', () => {
+    it('fetches and returns manifest successfully', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [
+          {
+            name: 'test-service',
+            description: 'Test service',
+            ark: {
+              chartPath: 'oci://registry/test-service',
+              namespace: 'test',
+            },
+          },
+        ],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await fetchMarketplaceManifest();
+
+      expect(result).toEqual(mockManifest);
+      expect(mockAxiosGet).toHaveBeenCalledWith(
+        expect.stringContaining('marketplace.json'),
+        expect.objectContaining({
+          timeout: 10000,
+          headers: {Accept: 'application/json'},
+        })
+      );
+    });
+
+    it('returns null on network error', async () => {
+      const networkError = new Error('Network error');
+      (networkError as any).code = 'ENOTFOUND';
+      (networkError as any).isAxiosError = true;
+
+      mockAxiosGet.mockRejectedValue(networkError);
+
+      const result = await fetchMarketplaceManifest();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on connection refused', async () => {
+      const connectionError = Object.assign(new Error('Connection refused'), {
+        code: 'ECONNREFUSED',
+        isAxiosError: true,
+      });
+
+      mockAxiosGet.mockRejectedValue(connectionError);
+
+      const result = await fetchMarketplaceManifest();
+
+      expect(result).toBeNull();
+    });
+
+    it('caches manifest for subsequent calls', async () => {
+      clearMarketplaceCache();
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result1 = await fetchMarketplaceManifest();
+      const result2 = await fetchMarketplaceManifest();
+
+      expect(result1).toEqual(mockManifest);
+      expect(result2).toEqual(mockManifest);
+      expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('forces refresh when forceRefresh is true', async () => {
+      clearMarketplaceCache();
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      await fetchMarketplaceManifest();
+      await fetchMarketplaceManifest(true);
+
+      expect(mockAxiosGet).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('mapMarketplaceItemToArkService', () => {
+    it('maps marketplace item to ARK service correctly', () => {
+      const item = {
+        name: 'test-service',
+        description: 'Test description',
+        ark: {
+          chartPath: 'oci://registry/test',
+          namespace: 'test-ns',
+          helmReleaseName: 'test-release',
+          installArgs: ['--create-namespace'],
+          k8sServiceName: 'test-svc',
+          k8sServicePort: 8080,
+          k8sDeploymentName: 'test-deploy',
+        },
+      };
+
+      const result = mapMarketplaceItemToArkService(item);
+
+      expect(result).toEqual({
+        name: 'test-service',
+        helmReleaseName: 'test-release',
+        description: 'Test description',
+        enabled: true,
+        category: 'marketplace',
+        namespace: 'test-ns',
+        chartPath: 'oci://registry/test',
+        installArgs: ['--create-namespace'],
+        k8sServiceName: 'test-svc',
+        k8sServicePort: 8080,
+        k8sDeploymentName: 'test-deploy',
+      });
+    });
+
+    it('uses defaults when ark fields are missing', () => {
+      const item = {
+        name: 'simple-service',
+        description: 'Simple service',
+        ark: {},
+      };
+
+      const result = mapMarketplaceItemToArkService(item);
+
+      expect(result.name).toBe('simple-service');
+      expect(result.helmReleaseName).toBe('simple-service');
+      expect(result.namespace).toBe('simple-service');
+      expect(result.chartPath).toContain('simple-service');
+    });
+
+    it('sanitizes service name', () => {
+      const item = {
+        name: 'Test Service 123!',
+        description: 'Test',
+        ark: {},
+      };
+
+      const result = mapMarketplaceItemToArkService(item);
+
+      expect(result.name).toBe('test-service-123');
+    });
+  });
+
+  describe('getMarketplaceServicesFromManifest', () => {
+    it('converts manifest items to service collection', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [
+          {
+            name: 'service1',
+            description: 'Service 1',
+            ark: {
+              chartPath: 'oci://registry/service1',
+              namespace: 'ns1',
+            },
+          },
+          {
+            name: 'service2',
+            description: 'Service 2',
+            ark: {
+              chartPath: 'oci://registry/service2',
+              namespace: 'ns2',
+            },
+          },
+        ],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await getMarketplaceServicesFromManifest();
+
+      expect(result).not.toBeNull();
+      expect(result?.['service1']).toBeDefined();
+      expect(result?.['service2']).toBeDefined();
+      expect(result?.['service1']?.description).toBe('Service 1');
+      expect(result?.['service2']?.description).toBe('Service 2');
+    });
+
+    it('filters out items without ark field', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [
+          {
+            name: 'service1',
+            description: 'Service 1',
+            ark: {
+              chartPath: 'oci://registry/service1',
+            },
+          },
+          {
+            name: 'service2',
+            description: 'Service 2',
+          },
+        ],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await getMarketplaceServicesFromManifest();
+
+      expect(result).not.toBeNull();
+      expect(result?.['service1']).toBeDefined();
+      expect(result?.['service2']).toBeUndefined();
+    });
+
+    it('returns null when manifest fetch fails', async () => {
+      const networkError = new Error('Network error');
+      (networkError as any).code = 'ENOTFOUND';
+      (networkError as any).isAxiosError = true;
+
+      mockAxiosGet.mockRejectedValue(networkError);
+
+      const result = await getMarketplaceServicesFromManifest();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when manifest has no items', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await getMarketplaceServicesFromManifest();
+
+      expect(result).toBeNull();
+    });
+  });
+});
+

--- a/tools/ark-cli/src/lib/marketplaceFetcher.ts
+++ b/tools/ark-cli/src/lib/marketplaceFetcher.ts
@@ -1,0 +1,110 @@
+import axios from 'axios';
+import type {ArkService, ServiceCollection} from '../types/arkService.js';
+import type {
+  AnthropicMarketplaceManifest,
+  AnthropicMarketplaceItem,
+} from '../types/marketplace.js';
+
+const MARKETPLACE_REPO_URL =
+  'https://github.com/mckinsey/agents-at-scale-marketplace';
+const MARKETPLACE_JSON_URL = `${MARKETPLACE_REPO_URL}/raw/main/marketplace.json`;
+const MARKETPLACE_REGISTRY =
+  'oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts';
+
+let cachedManifest: AnthropicMarketplaceManifest | null = null;
+let cacheTimestamp: number | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function clearMarketplaceCache(): void {
+  cachedManifest = null;
+  cacheTimestamp = null;
+}
+
+export async function fetchMarketplaceManifest(
+  forceRefresh = false
+): Promise<AnthropicMarketplaceManifest | null> {
+  const now = Date.now();
+
+  if (
+    !forceRefresh &&
+    cachedManifest &&
+    cacheTimestamp &&
+    now - cacheTimestamp < CACHE_TTL_MS
+  ) {
+    return cachedManifest;
+  }
+
+  try {
+    const response = await axios.get<AnthropicMarketplaceManifest>(
+      MARKETPLACE_JSON_URL,
+      {
+        timeout: 10000,
+        headers: {
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    cachedManifest = response.data;
+    cacheTimestamp = now;
+    return cachedManifest;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+export function mapMarketplaceItemToArkService(
+  item: AnthropicMarketplaceItem,
+  registry: string = MARKETPLACE_REGISTRY
+): ArkService {
+  const serviceName = item.name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const chartPath =
+    item.ark?.chartPath || `${registry}/${serviceName}`;
+
+  return {
+    name: serviceName,
+    helmReleaseName: item.ark?.helmReleaseName || serviceName,
+    description: item.description,
+    enabled: true,
+    category: 'marketplace',
+    namespace: item.ark?.namespace || serviceName,
+    chartPath,
+    installArgs: item.ark?.installArgs || ['--create-namespace'],
+    k8sServiceName: item.ark?.k8sServiceName || serviceName,
+    k8sServicePort: item.ark?.k8sServicePort,
+    k8sPortForwardLocalPort: item.ark?.k8sPortForwardLocalPort,
+    k8sDeploymentName: item.ark?.k8sDeploymentName || serviceName,
+    k8sDevDeploymentName: item.ark?.k8sDevDeploymentName,
+  };
+}
+
+export async function getMarketplaceServicesFromManifest(
+  forceRefresh = false
+): Promise<ServiceCollection | null> {
+  const manifest = await fetchMarketplaceManifest(forceRefresh);
+  if (!manifest || !manifest.items) {
+    return null;
+  }
+
+  const services: ServiceCollection = {};
+  for (const item of manifest.items) {
+    if (item.ark) {
+      const serviceName = item.name
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/^-+|-+$/g, '');
+      services[serviceName] = mapMarketplaceItemToArkService(item);
+    }
+  }
+
+  return Object.keys(services).length > 0 ? services : null;
+}
+

--- a/tools/ark-cli/src/marketplaceServices.spec.ts
+++ b/tools/ark-cli/src/marketplaceServices.spec.ts
@@ -1,0 +1,183 @@
+import {jest} from '@jest/globals';
+import type {ServiceCollection} from './types/arkService.js';
+import type {AnthropicMarketplaceManifest} from './types/marketplace.js';
+
+const mockGetMarketplaceServicesFromManifest = jest.fn<
+  (forceRefresh?: boolean) => Promise<ServiceCollection | null>
+>();
+const mockFetchMarketplaceManifest = jest.fn<
+  (forceRefresh?: boolean) => Promise<AnthropicMarketplaceManifest | null>
+>();
+
+jest.unstable_mockModule('./lib/marketplaceFetcher.js', () => ({
+  getMarketplaceServicesFromManifest: mockGetMarketplaceServicesFromManifest,
+  fetchMarketplaceManifest: mockFetchMarketplaceManifest,
+}));
+
+const {
+  getAllMarketplaceServices,
+  getMarketplaceService,
+  getAllMarketplaceServicesSync,
+  getMarketplaceServiceSync,
+  fallbackMarketplaceServices,
+  clearMarketplaceServicesCache,
+} = await import('./marketplaceServices.js');
+
+describe('marketplaceServices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMarketplaceServicesFromManifest.mockClear();
+    clearMarketplaceServicesCache();
+  });
+
+  describe('getAllMarketplaceServices', () => {
+    it('returns manifest services when available', async () => {
+      const mockServices = {
+        'new-service': {
+          name: 'new-service',
+          helmReleaseName: 'new-service',
+          description: 'New service',
+          enabled: true,
+          category: 'marketplace',
+          namespace: 'new-ns',
+        },
+      };
+
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(mockServices);
+
+      const result = await getAllMarketplaceServices();
+
+      expect(result).toEqual(mockServices);
+      expect(mockGetMarketplaceServicesFromManifest).toHaveBeenCalledWith(
+        false
+      );
+    });
+
+    it('falls back to hardcoded services when manifest unavailable', async () => {
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(null);
+
+      const result = await getAllMarketplaceServices();
+
+      expect(result).toEqual(fallbackMarketplaceServices);
+      expect(result['phoenix']).toBeDefined();
+      expect(result['langfuse']).toBeDefined();
+    });
+
+    it('caches services between calls', async () => {
+      clearMarketplaceServicesCache();
+      const mockServices = {
+        'cached-service': {
+          name: 'cached-service',
+          helmReleaseName: 'cached-service',
+          description: 'Cached',
+          enabled: true,
+          category: 'marketplace',
+        },
+      };
+
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(mockServices);
+
+      const result1 = await getAllMarketplaceServices();
+      const result2 = await getAllMarketplaceServices();
+
+      expect(result1).toEqual(mockServices);
+      expect(result2).toEqual(mockServices);
+      expect(mockGetMarketplaceServicesFromManifest).toHaveBeenCalledTimes(1);
+    });
+
+    it('forces refresh when forceRefresh is true', async () => {
+      clearMarketplaceServicesCache();
+      const mockServices = {
+        'refreshed-service': {
+          name: 'refreshed-service',
+          helmReleaseName: 'refreshed-service',
+          description: 'Refreshed',
+          enabled: true,
+          category: 'marketplace',
+        },
+      };
+
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(mockServices);
+
+      await getAllMarketplaceServices();
+      await getAllMarketplaceServices(true);
+
+      expect(mockGetMarketplaceServicesFromManifest).toHaveBeenCalledTimes(2);
+      expect(mockGetMarketplaceServicesFromManifest).toHaveBeenLastCalledWith(
+        true
+      );
+    });
+  });
+
+  describe('getMarketplaceService', () => {
+    it('returns service by name from manifest', async () => {
+      const mockServices = {
+        'test-service': {
+          name: 'test-service',
+          helmReleaseName: 'test-service',
+          description: 'Test',
+          enabled: true,
+          category: 'marketplace',
+        },
+      };
+
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(mockServices);
+      await getAllMarketplaceServices(true);
+
+      const result = await getMarketplaceService('test-service');
+
+      expect(result).toEqual(mockServices['test-service']);
+    });
+
+    it('returns undefined for non-existent service', async () => {
+      const mockServices = {
+        'test-service': {
+          name: 'test-service',
+          helmReleaseName: 'test-service',
+          description: 'Test',
+          enabled: true,
+          category: 'marketplace',
+        },
+      };
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(mockServices);
+      await getAllMarketplaceServices(true);
+
+      const result = await getMarketplaceService('non-existent');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('falls back to hardcoded services', async () => {
+      mockGetMarketplaceServicesFromManifest.mockResolvedValue(null);
+      await getAllMarketplaceServices(true);
+
+      const result = await getMarketplaceService('phoenix');
+
+      expect(result).toEqual(fallbackMarketplaceServices['phoenix']);
+    });
+  });
+
+  describe('getAllMarketplaceServicesSync', () => {
+    it('returns fallback services immediately', () => {
+      const result = getAllMarketplaceServicesSync();
+
+      expect(result).toEqual(fallbackMarketplaceServices);
+      expect(mockGetMarketplaceServicesFromManifest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMarketplaceServiceSync', () => {
+    it('returns service from fallback services', () => {
+      const result = getMarketplaceServiceSync('phoenix');
+
+      expect(result).toEqual(fallbackMarketplaceServices['phoenix']);
+    });
+
+    it('returns undefined for non-existent service', () => {
+      const result = getMarketplaceServiceSync('non-existent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+});
+

--- a/tools/ark-cli/src/types/marketplace.ts
+++ b/tools/ark-cli/src/types/marketplace.ts
@@ -1,0 +1,37 @@
+export interface AnthropicMarketplaceItem {
+  name: string;
+  displayName?: string;
+  description: string;
+  version?: string;
+  author?: string;
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  tags?: string[];
+  category?: string;
+  icon?: string;
+  screenshots?: string[];
+  documentation?: string;
+  support?: {
+    email?: string;
+    url?: string;
+  };
+  metadata?: Record<string, unknown>;
+  ark?: {
+    chartPath?: string;
+    namespace?: string;
+    helmReleaseName?: string;
+    installArgs?: string[];
+    k8sServiceName?: string;
+    k8sServicePort?: number;
+    k8sPortForwardLocalPort?: number;
+    k8sDeploymentName?: string;
+    k8sDevDeploymentName?: string;
+  };
+}
+
+export interface AnthropicMarketplaceManifest {
+  version: string;
+  marketplace: string;
+  items: AnthropicMarketplaceItem[];
+}


### PR DESCRIPTION
This restores the changes from #445.

- Added Anthropic Marketplace JSON type definitions
- Implemented marketplace manifest fetcher with caching
- Updated marketplace services to fetch from JSON with fallback
- Added --refresh flag to marketplace list command
- Updated install/uninstall commands to use async marketplace service lookup
- Added comprehensive test coverage for all new functionality

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #438