### PR TITLE
fix: configure artifact repository when minio enabled, also show post-install notes

### DIFF
--- a/services/argo-workflows/chart/templates/NOTES.txt
+++ b/services/argo-workflows/chart/templates/NOTES.txt
@@ -1,0 +1,36 @@
+Argo Workflows has been deployed!
+
+Wait for services to be ready:
+  kubectl wait --for=condition=Available -n {{ .Release.Namespace }} deployment/argo-workflows-server --timeout=5m
+{{- if .Values.minio.enabled }}
+  kubectl wait --for=condition=Ready -n {{ .Release.Namespace }} tenant/myminio --timeout=5m
+{{- end }}
+
+Argo Workflows Dashboard:
+{{- if .Values.httpRoute.argo.enabled }}
+  Access via HTTPRoute:
+{{- range .Values.httpRoute.argo.hostnames }}
+    http://{{ . }}
+{{- end }}
+{{- end }}
+  Port Forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/argo-workflows-server 2746:2746
+    Then access: http://localhost:2746
+
+{{- if .Values.minio.enabled }}
+
+Minio Dashboard:
+{{- if .Values.httpRoute.minio.enabled }}
+  Access via HTTPRoute:
+{{- range .Values.httpRoute.minio.hostnames }}
+    https://{{ . }}
+{{- end }}
+{{- end }}
+  Port Forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/myminio-console 9443:9443
+    Then access: https://localhost:9443
+
+  Credentials:
+    Username: {{ .Values.minio.tenant.configSecret.accessKey }}
+    Password: {{ .Values.minio.tenant.configSecret.secretKey }}
+{{- end }}

--- a/services/argo-workflows/chart/values.yaml
+++ b/services/argo-workflows/chart/values.yaml
@@ -54,6 +54,15 @@ argo-workflows:
         memory: "256Mi"
         cpu: "200m"
 
+  # Workflow defaults - applied to all workflows
+  workflowDefaults:
+    spec:
+      # Reference the artifact repository ConfigMap when Minio is enabled
+      # This is populated by the artifact-repository.yaml template
+      artifactRepositoryRef:
+        configMap: artifact-repositories
+        key: default
+
 # Additional role bindings. For development, we are generally installing argo
 # into an existing tenant namespace (such as 'default'). So we can bind the
 # argo workflow to the tenant service account.

--- a/services/argo-workflows/chart/values.yaml
+++ b/services/argo-workflows/chart/values.yaml
@@ -20,6 +20,15 @@ argo-workflows:
         memory: "512Mi"
         cpu: "500m"
 
+    # Workflow defaults - applied to all workflows
+    workflowDefaults:
+      spec:
+        # Reference the artifact repository ConfigMap when Minio is enabled
+        # This is populated by the artifact-repository.yaml template
+        artifactRepositoryRef:
+          configMap: artifact-repositories
+          key: default
+
   # Server configuration
   server:
     # Development mode, disable auth.
@@ -53,15 +62,6 @@ argo-workflows:
       limits:
         memory: "256Mi"
         cpu: "200m"
-
-  # Workflow defaults - applied to all workflows
-  workflowDefaults:
-    spec:
-      # Reference the artifact repository ConfigMap when Minio is enabled
-      # This is populated by the artifact-repository.yaml template
-      artifactRepositoryRef:
-        configMap: artifact-repositories
-        key: default
 
 # Additional role bindings. For development, we are generally installing argo
 # into an existing tenant namespace (such as 'default'). So we can bind the


### PR DESCRIPTION
When `minio.enabled=true`, the chart creates the `artifact-repositories` ConfigMap but doesn't configure the workflow controller to use it. This causes:

```
Error: failed to resolve artifact repository: failed to find any artifact repository for artifact repository ref "artifact-repositories#default-artifact-repository"
```

This PR adds `workflowDefaults.spec.artifactRepositoryRef` pointing to the ConfigMap created by the chart.

This PR also improves the chart `NOTES.txt` to have useful post-install instructions:

<img width="848" height="497" alt="image" src="https://github.com/user-attachments/assets/f40ac78e-80c9-4f1e-b93d-975c08e15ee3" />
