### PR TITLE
fix: Enable mock LLM for CI/CD e2e-quickstart

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -375,7 +375,7 @@ jobs:
           metrics-enabled: false
           traefik-enabled: false
           k3s-channel: latest
-          mock-llm-enabled: false
+          mock-llm-enabled: true
 
       - name: Install fark, ark CLI and configure kubectl
         run: |
@@ -401,11 +401,10 @@ jobs:
       - name: Run quickstart
         env:
           ARK_QUICKSTART_PROMPT_YES: 1
-          ARK_QUICKSTART_MODEL_TYPE: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL && 'azure' || 'openai' }}
-          ARK_QUICKSTART_MODEL_VERSION: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL && 'gpt-4.1-mini' || 'gpt-4' }}
-          ARK_QUICKSTART_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL != '' &&  secrets.CICD_AZURE_OPENAI_BASE_URL || 'http://mock-llm.default.svc.cluster.local/v1' }}
-          ARK_QUICKSTART_API_VERSION: 2024-12-01-preview
-          ARK_QUICKSTART_API_KEY: ${{ secrets.CICD_AZURE_OPENAI_KEY != '' && secrets.CICD_AZURE_OPENAI_KEY || 'xxxxxxxxxxx' }}
+          ARK_QUICKSTART_MODEL_TYPE: 'openai'
+          ARK_QUICKSTART_MODEL_VERSION: 'gpt-5'
+          ARK_QUICKSTART_BASE_URL: 'http://mock-llm.default.svc.cluster.local/v1'
+          ARK_QUICKSTART_API_KEY: 'xxxxxxxxxxx'
           ARK_QUICKSTART_CONTROLLER_IMAGE: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller
           ARK_QUICKSTART_CONTROLLER_TAG: ${{ github.sha }}
           CACHE_ARGS: --cache-from type=registry,ref=${{ needs.setup-container-cache-registry.outputs.ci-cache-registry || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache --cache-to type=registry,ref=${{ needs.setup-container-cache-registry.outputs.ci-cache-registry|| format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache,mode=max
@@ -415,11 +414,11 @@ jobs:
           echo "ARK_QUICKSTART_MODEL_TYPE=$ARK_QUICKSTART_MODEL_TYPE"
           echo "ARK_QUICKSTART_MODEL_VERSION=$ARK_QUICKSTART_MODEL_VERSION"
           echo "ARK_QUICKSTART_BASE_URL=$ARK_QUICKSTART_BASE_URL"
-          echo "ARK_QUICKSTART_API_VERSION=$ARK_QUICKSTART_API_VERSION"
           echo "ARK_QUICKSTART_API_KEY=***"
           make quickstart-force
       - name: Test end-to-end query
         run: |
+          kubectl describe agent sample-agent
           # Test the soon-to-be-deprecated query script (still used in quickstart).
           ./scripts/query.sh agent/sample-agent "confirm you have read this message"
           # Test fark.

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -404,7 +404,7 @@ jobs:
           ARK_QUICKSTART_MODEL_TYPE: 'openai'
           ARK_QUICKSTART_MODEL_VERSION: 'gpt-5'
           ARK_QUICKSTART_BASE_URL: 'http://mock-llm.default.svc.cluster.local/v1'
-          ARK_QUICKSTART_API_KEY: 'xxxxxxxxxxx'
+          ARK_QUICKSTART_API_KEY: 'mock-api-key'
           ARK_QUICKSTART_CONTROLLER_IMAGE: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller
           ARK_QUICKSTART_CONTROLLER_TAG: ${{ github.sha }}
           CACHE_ARGS: --cache-from type=registry,ref=${{ needs.setup-container-cache-registry.outputs.ci-cache-registry || format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache --cache-to type=registry,ref=${{ needs.setup-container-cache-registry.outputs.ci-cache-registry|| format('ghcr.io/{0}/{1}', github.repository_owner, github.event.repository.name) }}/ark-controller:cache,mode=max


### PR DESCRIPTION
**Description:**
Replaces conditional Azure OpenAI configuration with hardcoded mock LLM setup for consistent CI testing. This removes dependency on CI secrets for LLM configuration, ensuring tests run reliably without external API dependencies.

This change will unblock community contributions that currently fail at the CI/CD e2e-quickstart step due to missing Azure OpenAI secrets, such as:
- PR #466: https://github.com/mckinsey/agents-at-scale-ark/pull/466
- Failed run: https://github.com/mckinsey/agents-at-scale-ark/actions/runs/19534400967/job/56043786666

**Impact:** CI tests no longer require Azure OpenAI secrets, making them accessible to external contributors and more reliable for the entire development workflow.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 