### PR TITLE
chore: add root codeowners to all specific patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 * @dwmkerr @cm94242 @Nab-0 @CeliaPrieto @david-gombos
 
 # Significant changes to K8S CRDs.
-/ark/config/crd/ @dwmkerr @cm94242
-/ark/api/ @dwmkerr @cm94242
+/ark/config/crd/ @dwmkerr @cm94242 @Nab-0 @CeliaPrieto @david-gombos
+/ark/api/ @dwmkerr @cm94242 @Nab-0 @CeliaPrieto @david-gombos
 
 # UI - led by @av3n93rz. TLs/PM fallback.
-/services/ark-dashboard/ @av3n93rz @dwmkerr @cm94242 @Nab-0
+/services/ark-dashboard/ @av3n93rz @dwmkerr @cm94242 @Nab-0 @CeliaPrieto @david-gombos


### PR DESCRIPTION
Add @david-gombos and @CeliaPrieto to specific CODEOWNERS patterns for dashboard, CRD, and API directories to ensure root codeowners can approve all PRs

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 