### PR TITLE
feat: chat streaming can be enabled under feature flag

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/experimental-features.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/experimental-features.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   A2A_TASKS_FEATURE_KEY,
+  CHAT_STREAMING_FEATURE_KEY,
   isA2ATasksEnabledAtom,
   storedIsA2ATasksEnabledAtom,
+  storedIsChatStreamingEnabledAtom,
 } from '@/atoms/experimental-features';
 
 describe('A2A Tasks Feature Flag Atoms', () => {
@@ -60,6 +62,26 @@ describe('A2A Tasks Feature Flag Atoms', () => {
       expect(() => {
         // @ts-expect-error derived atoms are read-only
         store.set(isA2ATasksEnabledAtom, true);
+      }).toThrow();
+    });
+  });
+
+  describe('experimental-chat-streaming', () => {
+    it('should default to false', () => {
+      expect(CHAT_STREAMING_FEATURE_KEY).toBe('experimental-chat-streaming');
+      expect(store.get(storedIsChatStreamingEnabledAtom)).toBe(false);
+    });
+
+    it('should return true when storedIsChatStreamingEnabledAtom is true', () => {
+      store.set(storedIsChatStreamingEnabledAtom, true);
+      const value = store.get(storedIsChatStreamingEnabledAtom);
+      expect(value).toBe(true);
+    });
+
+    it('should be read-only (derived atom)', () => {
+      expect(() => {
+        // @ts-expect-error derived atoms are read-only
+        store.set(isChatStreamingEnabledAtom, true);
       }).toThrow();
     });
   });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/experimental-features-dialog/experimental-features.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/experimental-features-dialog/experimental-features.test.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { storedIsA2ATasksEnabledAtom } from '@/atoms/experimental-features';
 import { experimentalFeatureGroups } from '@/components/experimental-features-dialog/experimental-features';
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat.test.ts
@@ -126,7 +126,7 @@ describe('chatService', () => {
         status: { phase: 'pending' },
         metadata: {
           annotations: {
-            'ark.mckinsey.com/streaming-enabled': 'true',
+            'ark.mckinsey.com/streaming-enabled': 'false',
           },
         },
       };
@@ -149,7 +149,7 @@ describe('chatService', () => {
         sessionId: 'session-123',
         metadata: {
           annotations: {
-            'ark.mckinsey.com/streaming-enabled': 'true',
+            'ark.mckinsey.com/streaming-enabled': 'false',
           },
         },
       });

--- a/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
@@ -53,3 +53,15 @@ export const storedIsA2ATasksEnabledAtom = atomWithStorage<boolean>(
 export const isA2ATasksEnabledAtom = atom(get => {
   return get(storedIsA2ATasksEnabledAtom);
 });
+
+export const CHAT_STREAMING_FEATURE_KEY = 'experimental-chat-streaming';
+export const storedIsChatStreamingEnabledAtom = atomWithStorage<boolean>(
+  CHAT_STREAMING_FEATURE_KEY,
+  false,
+  undefined,
+  { getOnInit: true },
+);
+
+export const isChatStreamingEnabledAtom = atom(get => {
+  return get(storedIsChatStreamingEnabledAtom);
+});

--- a/services/ark-dashboard/ark-dashboard/components/experimental-features-dialog/experimental-features.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/experimental-features-dialog/experimental-features.tsx
@@ -1,6 +1,7 @@
 import {
   isExperimentalFeaturesEnabledAtom,
   storedIsA2ATasksEnabledAtom,
+  storedIsChatStreamingEnabledAtom,
   storedIsExperimentalDarkModeEnabledAtom,
   storedIsExperimentalExecutionEngineEnabledAtom,
 } from '@/atoms/experimental-features';
@@ -52,6 +53,17 @@ export const experimentalFeatureGroups: ExperimentalFeatureGroup[] = [
           </span>
         ),
         atom: storedIsA2ATasksEnabledAtom,
+      },
+    ],
+  },
+  {
+    groupKey: 'chat',
+    groupLabel: 'Chat',
+    features: [
+      {
+        feature: 'Chat Streaming',
+        description: 'Enables streaming responses in the chat',
+        atom: storedIsChatStreamingEnabledAtom,
       },
     ],
   },

--- a/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
@@ -170,7 +170,7 @@ export const chatService = {
     if (enableStreaming) {
       queryRequest.metadata = {
         annotations: {
-          [ARK_ANNOTATIONS.STREAMING_ENABLED]: 'true',
+          [ARK_ANNOTATIONS.STREAMING_ENABLED]: 'false',
         },
       };
     }
@@ -209,7 +209,7 @@ export const chatService = {
       const query = await this.getQuery(queryName);
 
       if (!query || !query.status) {
-        return { status: 'unknown', terminal: true };
+        return { status: 'unknown', terminal: false };
       }
 
       const status = query.status;


### PR DESCRIPTION
This PR moves chat streaming under feature gate.
It can be enabled from the experimental features modal

Iternal ticket: [ARKQB-518](https://mckinsey.atlassian.net/browse/ARKQB-518)

When streaming is disabled, response is retrieved by polling on the queries API
When streaming is enabled, response is retrieved in batches with the streaming API

https://github.com/user-attachments/assets/e1113255-cc30-4f99-8832-493c5221c22f

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 