### PR TITLE
feat: add configurable query timeout for CLI and OpenAI API

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
@@ -171,6 +171,10 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
     if request.metadata and "sessionId" in request.metadata:
         session_id = request.metadata["sessionId"]
 
+    timeout = None
+    if request.metadata and "timeout" in request.metadata:
+        timeout = request.metadata["timeout"]
+
     # Parse queryAnnotations if provided (for annotations like A2A context ID)
     if request.metadata and "queryAnnotations" in request.metadata:
         try:
@@ -190,10 +194,12 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
         metadata["annotations"][STREAMING_ENABLED_ANNOTATION] = "true"
 
     try:
-        # Build query spec with optional sessionId
+        # Build query spec with optional sessionId and timeout
         query_spec_dict = {"type": "messages", "input": messages, "targets": [target]}
         if session_id:
             query_spec_dict["sessionId"] = session_id
+        if timeout:
+            query_spec_dict["timeout"] = timeout
         
         # Create the QueryV1alpha1 object with type="messages"
         # Pass messages directly without json.dumps() - SDK handles serialization

--- a/services/ark-api/ark-api/tests/api/test_openai.py
+++ b/services/ark-api/ark-api/tests/api/test_openai.py
@@ -25,8 +25,8 @@ class TestOpenAIChatCompletions(unittest.TestCase):
     @patch('ark_api.api.v1.openai.get_namespace')
     @patch('ark_api.api.v1.openai.parse_model_to_query_target')
     @patch('ark_api.api.v1.openai.watch_query_completion')
-    def test_chat_completions_with_session_id(self, mock_watch, mock_parse_target, mock_get_namespace, mock_with_ark_client):
-        """Test chat completions with session ID in queryAnnotations."""
+    def test_chat_completions_with_metadata(self, mock_watch, mock_parse_target, mock_get_namespace, mock_with_ark_client):
+        """Test chat completions with metadata fields (sessionId, timeout)."""
         # Setup mocks
         mock_get_namespace.return_value = "default"
         mock_parse_target.return_value = {"name": "test-agent", "type": "agent"}
@@ -56,26 +56,25 @@ class TestOpenAIChatCompletions(unittest.TestCase):
         )
         mock_watch.return_value = mock_completion
         
-        # Make the request with session ID directly in metadata
         request_data = {
             "model": "agent/test-agent",
             "messages": [{"role": "user", "content": "Hello"}],
             "metadata": {
-                "sessionId": "test-session-123"
+                "sessionId": "test-session-123",
+                "timeout": "1h"
             }
         }
         response = self.client.post("/openai/v1/chat/completions", json=request_data)
-        
-        # Assert response
+
         self.assertEqual(response.status_code, 200)
-        
-        # Verify that a_create was called with a query that has sessionId in spec
+
         mock_client.queries.a_create.assert_called_once()
         query_resource = mock_client.queries.a_create.call_args[0][0]
-        # Access spec - check both attribute access and dictionary representation
         spec_dict = query_resource.spec.to_dict() if hasattr(query_resource.spec, 'to_dict') else query_resource.spec.__dict__
         session_id = spec_dict.get('sessionId') or spec_dict.get('session_id') or getattr(query_resource.spec, 'session_id', None) or getattr(query_resource.spec, 'sessionId', None)
         self.assertEqual(session_id, "test-session-123")
+        timeout = spec_dict.get('timeout') or getattr(query_resource.spec, 'timeout', None)
+        self.assertEqual(timeout, "1h")
     
     @patch('ark_api.api.v1.openai.with_ark_client')
     @patch('ark_api.api.v1.openai.get_namespace')

--- a/tools/ark-cli/.arkrc.yaml.sample
+++ b/tools/ark-cli/.arkrc.yaml.sample
@@ -1,0 +1,40 @@
+# Ark CLI Configuration
+# Copy to ~/.arkrc.yaml (user config) or .arkrc.yaml (project config)
+# Project config overrides user config, CLI flags override both
+
+# Query timeout for all query operations (ark query, ark agents query, etc.)
+# Also applies to chat completions via the OpenAI-compatible API
+# Can be overridden per-command with --timeout flag
+# Environment variable: ARK_QUERY_TIMEOUT
+queryTimeout: 5m
+
+# Chat settings
+chat:
+  # Enable streaming output (default: true)
+  # Environment variable: ARK_CHAT_STREAMING
+  streaming: true
+
+  # Output format: 'text' or 'markdown' (default: text)
+  # Environment variable: ARK_CHAT_OUTPUT_FORMAT
+  outputFormat: text
+
+# Service overrides for ark install
+services:
+  # Enable localhost-gateway for local development
+  localhost-gateway:
+    enabled: true
+
+  # Override namespace for a service
+  ark-controller:
+    namespace: custom-namespace
+
+  # Pass additional Helm install arguments
+  agents-at-scale:
+    enabled: true
+    installArgs:
+      - --set
+      - containerRegistry.enabled=true
+      - --set
+      - containerRegistry.username=YOUR_USERNAME
+      - --set
+      - containerRegistry.password=YOUR_PASSWORD

--- a/tools/ark-cli/README.md
+++ b/tools/ark-cli/README.md
@@ -76,3 +76,5 @@ services:
 ```
 
 Replace `YOUR_USERNAME` and `YOUR_PASSWORD` with your JFrog credentials.
+
+See [.arkrc.yaml.sample](.arkrc.yaml.sample) for a complete example with all available options.

--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -147,7 +147,8 @@ const defaultArkServices: ServiceCollection = {
   'ark-cluster-memory': {
     name: 'ark-cluster-memory',
     helmReleaseName: 'ark-cluster-memory',
-    description: 'In-memory storage service with streaming support for Ark queries',
+    description:
+      'In-memory storage service with streaming support for Ark queries',
     enabled: true,
     category: 'service',
     // namespace: undefined - uses current context namespace

--- a/tools/ark-cli/src/commands/agents/index.ts
+++ b/tools/ark-cli/src/commands/agents/index.ts
@@ -38,7 +38,7 @@ async function listAgents(options: {output?: string}) {
   }
 }
 
-export function createAgentsCommand(_: ArkConfig): Command {
+export function createAgentsCommand(config: ArkConfig): Command {
   const agentsCommand = new Command('agents');
 
   agentsCommand
@@ -65,13 +65,17 @@ export function createAgentsCommand(_: ArkConfig): Command {
     .description('Query an agent')
     .argument('<name>', 'Agent name')
     .argument('<message>', 'Message to send')
-    .action(async (name: string, message: string) => {
-      await executeQuery({
-        targetType: 'agent',
-        targetName: name,
-        message,
-      });
-    });
+    .option('--timeout <timeout>', 'Query timeout (e.g., 30s, 5m, 1h)')
+    .action(
+      async (name: string, message: string, options: {timeout?: string}) => {
+        await executeQuery({
+          targetType: 'agent',
+          targetName: name,
+          message,
+          timeout: options.timeout || config.queryTimeout,
+        });
+      }
+    );
 
   return agentsCommand;
 }

--- a/tools/ark-cli/src/commands/models/index.ts
+++ b/tools/ark-cli/src/commands/models/index.ts
@@ -39,7 +39,7 @@ async function listModels(options: {output?: string}) {
   }
 }
 
-export function createModelsCommand(_: ArkConfig): Command {
+export function createModelsCommand(config: ArkConfig): Command {
   const modelsCommand = new Command('models');
 
   modelsCommand
@@ -83,13 +83,17 @@ export function createModelsCommand(_: ArkConfig): Command {
     .description('Query a model')
     .argument('<name>', 'Model name (e.g., default)')
     .argument('<message>', 'Message to send')
-    .action(async (name: string, message: string) => {
-      await executeQuery({
-        targetType: 'model',
-        targetName: name,
-        message,
-      });
-    });
+    .option('--timeout <timeout>', 'Query timeout (e.g., 30s, 5m, 1h)')
+    .action(
+      async (name: string, message: string, options: {timeout?: string}) => {
+        await executeQuery({
+          targetType: 'model',
+          targetName: name,
+          message,
+          timeout: options.timeout || config.queryTimeout,
+        });
+      }
+    );
 
   modelsCommand.addCommand(queryCommand);
 

--- a/tools/ark-cli/src/commands/query/index.ts
+++ b/tools/ark-cli/src/commands/query/index.ts
@@ -4,7 +4,7 @@ import type {ArkConfig} from '../../lib/config.js';
 import {executeQuery, parseTarget} from '../../lib/executeQuery.js';
 import {ExitCodes} from '../../lib/errors.js';
 
-export function createQueryCommand(_: ArkConfig): Command {
+export function createQueryCommand(config: ArkConfig): Command {
   const queryCommand = new Command('query');
 
   queryCommand
@@ -15,6 +15,7 @@ export function createQueryCommand(_: ArkConfig): Command {
       '-o, --output <format>',
       'Output format: yaml, json, name or events (shows structured event data)'
     )
+    .option('--timeout <timeout>', 'Query timeout (e.g., 30s, 5m, 1h)')
     .option(
       '--session-id <sessionId>',
       'Session ID to associate with the query for conversation continuity'
@@ -25,6 +26,7 @@ export function createQueryCommand(_: ArkConfig): Command {
         message: string,
         options: {
           output?: string;
+          timeout?: string;
           sessionId?: string;
         }
       ) => {
@@ -43,6 +45,7 @@ export function createQueryCommand(_: ArkConfig): Command {
           targetName: parsed.name,
           message,
           outputFormat: options.output,
+          timeout: options.timeout || config.queryTimeout,
           sessionId: options.sessionId,
         });
       }

--- a/tools/ark-cli/src/commands/teams/index.ts
+++ b/tools/ark-cli/src/commands/teams/index.ts
@@ -37,7 +37,7 @@ async function listTeams(options: {output?: string}) {
   }
 }
 
-export function createTeamsCommand(_: ArkConfig): Command {
+export function createTeamsCommand(config: ArkConfig): Command {
   const teamsCommand = new Command('teams');
 
   teamsCommand
@@ -64,13 +64,17 @@ export function createTeamsCommand(_: ArkConfig): Command {
     .description('Query a team')
     .argument('<name>', 'Team name')
     .argument('<message>', 'Message to send')
-    .action(async (name: string, message: string) => {
-      await executeQuery({
-        targetType: 'team',
-        targetName: name,
-        message,
-      });
-    });
+    .option('--timeout <timeout>', 'Query timeout (e.g., 30s, 5m, 1h)')
+    .action(
+      async (name: string, message: string, options: {timeout?: string}) => {
+        await executeQuery({
+          targetType: 'team',
+          targetName: name,
+          message,
+          timeout: options.timeout || config.queryTimeout,
+        });
+      }
+    );
 
   teamsCommand.addCommand(queryCommand);
 

--- a/tools/ark-cli/src/lib/chatClient.spec.ts
+++ b/tools/ark-cli/src/lib/chatClient.spec.ts
@@ -137,4 +137,3 @@ describe('ChatClient', () => {
     });
   });
 });
-

--- a/tools/ark-cli/src/lib/chatClient.ts
+++ b/tools/ark-cli/src/lib/chatClient.ts
@@ -10,6 +10,7 @@ export interface ChatConfig {
   currentTarget?: QueryTarget;
   a2aContextId?: string;
   sessionId?: string;
+  queryTimeout?: string;
 }
 
 export interface ToolCall {
@@ -64,14 +65,17 @@ export class ChatClient {
     };
 
     // Build metadata object - only add if we have something to include
-    if (config.sessionId || config.a2aContextId) {
+    if (config.sessionId || config.a2aContextId || config.queryTimeout) {
       params.metadata = {};
-      
-      // Add sessionId directly to metadata (goes to spec, not annotations)
+
       if (config.sessionId) {
         params.metadata.sessionId = config.sessionId;
       }
-      
+
+      if (config.queryTimeout) {
+        params.metadata.timeout = config.queryTimeout;
+      }
+
       // Add A2A context ID to queryAnnotations (goes to annotations)
       if (config.a2aContextId) {
         const queryAnnotations: Record<string, string> = {

--- a/tools/ark-cli/src/lib/config.spec.ts
+++ b/tools/ark-cli/src/lib/config.spec.ts
@@ -85,6 +85,27 @@ describe('config', () => {
     expect(config.chat?.outputFormat).toBe('markdown');
   });
 
+  it('loads queryTimeout from config file', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue('yaml');
+    mockYaml.parse.mockReturnValue({queryTimeout: '30m'});
+
+    const config = loadConfig();
+
+    expect(config.queryTimeout).toBe('30m');
+  });
+
+  it('ARK_QUERY_TIMEOUT environment variable overrides config', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue('yaml');
+    mockYaml.parse.mockReturnValue({queryTimeout: '5m'});
+    process.env.ARK_QUERY_TIMEOUT = '1h';
+
+    const config = loadConfig();
+
+    expect(config.queryTimeout).toBe('1h');
+  });
+
   it('throws error for invalid YAML', () => {
     const userConfigPath = path.join(os.homedir(), '.arkrc.yaml');
     mockFs.existsSync.mockImplementation((path) => path === userConfigPath);

--- a/tools/ark-cli/src/lib/config.ts
+++ b/tools/ark-cli/src/lib/config.ts
@@ -13,6 +13,7 @@ export interface ChatConfig {
 export interface ArkConfig {
   chat?: ChatConfig;
   services?: {[serviceName: string]: Partial<ArkService>};
+  queryTimeout?: string;
   // Cluster info - populated during startup if context exists
   clusterInfo?: ClusterInfo;
 }
@@ -75,6 +76,10 @@ export function loadConfig(): ArkConfig {
     }
   }
 
+  if (process.env.ARK_QUERY_TIMEOUT !== undefined) {
+    config.queryTimeout = process.env.ARK_QUERY_TIMEOUT;
+  }
+
   return config;
 }
 
@@ -100,6 +105,10 @@ function mergeConfig(target: ArkConfig, source: ArkConfig): void {
         ...overrides,
       };
     }
+  }
+
+  if (source.queryTimeout !== undefined) {
+    target.queryTimeout = source.queryTimeout;
   }
 }
 

--- a/tools/ark-cli/src/lib/constants.ts
+++ b/tools/ark-cli/src/lib/constants.ts
@@ -13,4 +13,3 @@ export const EVENT_ANNOTATIONS = {
   // Event data annotation for structured event data
   EVENT_DATA: `${ARK_PREFIX}event-data`,
 } as const;
-

--- a/tools/ark-cli/src/lib/executeQuery.spec.ts
+++ b/tools/ark-cli/src/lib/executeQuery.spec.ts
@@ -342,9 +342,14 @@ describe('executeQuery', () => {
     });
 
     it('should include sessionId in query manifest when outputFormat is specified', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let appliedManifest = '';
       mockExeca.mockImplementation(async (command: string, args: string[]) => {
-        if (args.includes('apply') && args.includes('-f') && args.includes('-')) {
+        if (
+          args.includes('apply') &&
+          args.includes('-f') &&
+          args.includes('-')
+        ) {
           // Capture the stdin input
           const stdinIndex = args.indexOf('-');
           if (stdinIndex >= 0 && args[stdinIndex + 1]) {

--- a/tools/ark-cli/src/lib/executeQuery.ts
+++ b/tools/ark-cli/src/lib/executeQuery.ts
@@ -55,13 +55,12 @@ export async function executeQuery(options: QueryOptions): Promise<void> {
     let headerShown = false;
     let firstOutput = true;
 
-    // Get sessionId from option or environment variable
     const sessionId = options.sessionId || process.env.ARK_SESSION_ID;
 
     await chatClient.sendMessage(
       targetId,
       messages,
-      {streamingEnabled: true, sessionId},
+      {streamingEnabled: true, sessionId, queryTimeout: options.timeout},
       (chunk: string, toolCalls?: ToolCall[], arkMetadata?: ArkMetadata) => {
         if (firstOutput) {
           spinner.stop();
@@ -147,12 +146,12 @@ async function executeQueryWithFormat(options: QueryOptions): Promise<void> {
     metadata: {
       name: queryName,
     },
-      spec: {
-        input: options.message,
-        ...(options.timeout && {timeout: options.timeout}),
-        ...((options.sessionId || process.env.ARK_SESSION_ID) && {
-          sessionId: options.sessionId || process.env.ARK_SESSION_ID,
-        }),
+    spec: {
+      input: options.message,
+      ...(options.timeout && {timeout: options.timeout}),
+      ...((options.sessionId || process.env.ARK_SESSION_ID) && {
+        sessionId: options.sessionId || process.env.ARK_SESSION_ID,
+      }),
       targets: [
         {
           type: options.targetType,
@@ -169,7 +168,7 @@ async function executeQueryWithFormat(options: QueryOptions): Promise<void> {
     });
 
     // Give Kubernetes a moment to process the resource before watching
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     if (options.outputFormat === 'events') {
       await watchEventsLive(queryName);

--- a/tools/ark-cli/src/lib/kubectl.ts
+++ b/tools/ark-cli/src/lib/kubectl.ts
@@ -138,6 +138,7 @@ export async function watchEventsLive(queryName: string): Promise<void> {
           }
         }
       }
+      // eslint-disable-next-line no-empty, @typescript-eslint/no-unused-vars
     } catch (error) {}
   };
 
@@ -161,7 +162,7 @@ export async function watchEventsLive(queryName: string): Promise<void> {
   try {
     await waitProcess;
     await pollEvents();
-    await new Promise(resolve => setTimeout(resolve, 200));
+    await new Promise((resolve) => setTimeout(resolve, 200));
     await pollEvents();
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary
- Add `queryTimeout` config option and `ARK_QUERY_TIMEOUT` env var for default query timeout
- Pass timeout via metadata in OpenAI completions endpoint to Query spec
- Add `--timeout` flag to `ark query`, `ark agents query`, `ark models query`, `ark teams query`
- CLI `--timeout` overrides config `queryTimeout`, which overrides env var, which overrides server default (5m)
- Add `.arkrc.yaml.sample` with full configuration documentation