### PR TITLE
feat: add marketplace/agents path for noah installation

### DIFF
--- a/tools/ark-cli/src/commands/completion/index.ts
+++ b/tools/ark-cli/src/commands/completion/index.ts
@@ -89,14 +89,12 @@ _ark_completion() {
           return 0
           ;;
         install)
-          # Suggest marketplace services with marketplace/services/ prefix
-          opts="marketplace/services/phoenix marketplace/services/langfuse"
+          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
         uninstall)
-          # Suggest marketplace services with marketplace/services/ prefix
-          opts="marketplace/services/phoenix marketplace/services/langfuse"
+          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -13,9 +13,9 @@ import {
 } from '../../arkServices.js';
 import {
   isMarketplaceService,
-  extractMarketplaceServiceName,
-  getMarketplaceService,
+  getMarketplaceItem,
   getAllMarketplaceServices,
+  getAllMarketplaceAgents,
 } from '../../marketplaceServices.js';
 import {printNextSteps} from '../../lib/nextSteps.js';
 import ora from 'ora';
@@ -69,24 +69,24 @@ export async function installArk(
 
   // If a specific service is requested, install only that service
   if (serviceName) {
-    // Check if it's a marketplace service
     if (isMarketplaceService(serviceName)) {
-      const marketplaceServiceName = extractMarketplaceServiceName(serviceName);
-      const service = getMarketplaceService(marketplaceServiceName);
+      const service = getMarketplaceItem(serviceName);
 
       if (!service) {
-        output.error(
-          `marketplace service '${marketplaceServiceName}' not found`
-        );
-        output.info('available marketplace services:');
-        const marketplaceServices = getAllMarketplaceServices();
-        for (const serviceName of Object.keys(marketplaceServices)) {
-          output.info(`  marketplace/services/${serviceName}`);
+        output.error(`marketplace item '${serviceName}' not found`);
+        output.info('available marketplace items:');
+        const services = getAllMarketplaceServices();
+        for (const name of Object.keys(services)) {
+          output.info(`  marketplace/services/${name}`);
+        }
+        const agents = getAllMarketplaceAgents();
+        for (const name of Object.keys(agents)) {
+          output.info(`  marketplace/agents/${name}`);
         }
         process.exit(1);
       }
 
-      output.info(`installing marketplace service ${service.name}...`);
+      output.info(`installing marketplace item ${service.name}...`);
       try {
         await installService(service, options.verbose);
         output.success(`${service.name} installed successfully`);

--- a/tools/ark-cli/src/commands/marketplace/index.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.ts
@@ -1,7 +1,10 @@
 import {Command} from 'commander';
 import chalk from 'chalk';
 import type {ArkConfig} from '../../lib/config.js';
-import {getAllMarketplaceServices} from '../../marketplaceServices.js';
+import {
+  getAllMarketplaceServices,
+  getAllMarketplaceAgents,
+} from '../../marketplaceServices.js';
 
 function createMarketplaceCommand(_config: ArkConfig): Command {
   const marketplace = new Command('marketplace');
@@ -23,8 +26,9 @@ Registry: ${chalk.cyan('ghcr.io/mckinsey/agents-at-scale-marketplace/charts')}
 ${chalk.cyan('Examples:')}
   ${chalk.yellow('ark marketplace list')}                        # List available services
   ${chalk.yellow('ark install marketplace/services/phoenix')}    # Install Phoenix
+  ${chalk.yellow('ark install marketplace/agents/noah')}         # Install Noah agent
   ${chalk.yellow('ark uninstall marketplace/services/phoenix')}  # Uninstall Phoenix
-  
+
 ${chalk.cyan('Available Services:')}
   • phoenix  - AI/ML observability and evaluation platform
   • langfuse - Open-source LLM observability and analytics
@@ -36,15 +40,16 @@ ${chalk.cyan('Available Services:')}
   const list = new Command('list');
   list
     .alias('ls')
-    .description('List available marketplace services')
+    .description('List available marketplace services and agents')
     .action(() => {
       const services = getAllMarketplaceServices();
+      const agents = getAllMarketplaceAgents();
 
-      console.log(chalk.blue('\n🏪 ARK Marketplace Services\n'));
+      console.log(chalk.blue('\n🏪 ARK Marketplace\n'));
+
+      console.log(chalk.bold('Services:'));
       console.log(
-        chalk.gray(
-          'Install with: ark install marketplace/services/<service-name>\n'
-        )
+        chalk.gray('Install with: ark install marketplace/services/<name>\n')
       );
 
       for (const [key, service] of Object.entries(services)) {
@@ -55,6 +60,23 @@ ${chalk.cyan('Available Services:')}
           `${icon} ${chalk.green(serviceName)} ${chalk.gray(serviceDesc)}`
         );
         const namespaceInfo = `namespace: ${service.namespace || 'default'}`;
+        console.log(`   ${chalk.dim(namespaceInfo)}`);
+        console.log();
+      }
+
+      console.log(chalk.bold('Agents:'));
+      console.log(
+        chalk.gray('Install with: ark install marketplace/agents/<name>\n')
+      );
+
+      for (const [key, agent] of Object.entries(agents)) {
+        const icon = '🤖';
+        const agentName = `marketplace/agents/${key.padEnd(12)}`;
+        const agentDesc = agent.description;
+        console.log(
+          `${icon} ${chalk.green(agentName)} ${chalk.gray(agentDesc)}`
+        );
+        const namespaceInfo = `namespace: ${agent.namespace || 'default'}`;
         console.log(`   ${chalk.dim(namespaceInfo)}`);
         console.log();
       }

--- a/tools/ark-cli/src/commands/uninstall/index.ts
+++ b/tools/ark-cli/src/commands/uninstall/index.ts
@@ -8,9 +8,9 @@ import output from '../../lib/output.js';
 import {getInstallableServices, type ArkService} from '../../arkServices.js';
 import {
   isMarketplaceService,
-  extractMarketplaceServiceName,
-  getMarketplaceService,
+  getMarketplaceItem,
   getAllMarketplaceServices,
+  getAllMarketplaceAgents,
 } from '../../marketplaceServices.js';
 
 async function uninstallService(service: ArkService, verbose: boolean = false) {
@@ -43,24 +43,24 @@ async function uninstallArk(
 
   // If a specific service is requested, uninstall only that service
   if (serviceName) {
-    // Check if it's a marketplace service
     if (isMarketplaceService(serviceName)) {
-      const marketplaceServiceName = extractMarketplaceServiceName(serviceName);
-      const service = getMarketplaceService(marketplaceServiceName);
+      const service = getMarketplaceItem(serviceName);
 
       if (!service) {
-        output.error(
-          `marketplace service '${marketplaceServiceName}' not found`
-        );
-        output.info('available marketplace services:');
-        const marketplaceServices = getAllMarketplaceServices();
-        for (const serviceName of Object.keys(marketplaceServices)) {
-          output.info(`  marketplace/services/${serviceName}`);
+        output.error(`marketplace item '${serviceName}' not found`);
+        output.info('available marketplace items:');
+        const services = getAllMarketplaceServices();
+        for (const name of Object.keys(services)) {
+          output.info(`  marketplace/services/${name}`);
+        }
+        const agents = getAllMarketplaceAgents();
+        for (const name of Object.keys(agents)) {
+          output.info(`  marketplace/agents/${name}`);
         }
         process.exit(1);
       }
 
-      output.info(`uninstalling marketplace service ${service.name}...`);
+      output.info(`uninstalling marketplace item ${service.name}...`);
       try {
         await uninstallService(service, options.verbose);
         output.success(`${service.name} uninstalled successfully`);

--- a/tools/ark-cli/src/marketplaceServices.spec.ts
+++ b/tools/ark-cli/src/marketplaceServices.spec.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  getMarketplaceItem,
+  getAllMarketplaceServices,
+  getAllMarketplaceAgents,
+  isMarketplaceService,
+} from './marketplaceServices.js';
+
+describe('marketplaceServices', () => {
+  describe('getMarketplaceItem', () => {
+    it('should return a service for marketplace/services/ path', () => {
+      const result = getMarketplaceItem('marketplace/services/phoenix');
+      expect(result).toBeDefined();
+      expect(result?.name).toBe('phoenix');
+    });
+
+    it('should return an agent for marketplace/agents/ path', () => {
+      const result = getMarketplaceItem('marketplace/agents/noah');
+      expect(result).toBeDefined();
+      expect(result?.name).toBe('noah');
+    });
+
+    it('should return undefined for non-existent service', () => {
+      const result = getMarketplaceItem('marketplace/services/nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent agent', () => {
+      const result = getMarketplaceItem('marketplace/agents/nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for invalid path', () => {
+      const result = getMarketplaceItem('invalid/path');
+      expect(result).toBeUndefined();
+    });
+
+    it('should not return noah from services path', () => {
+      const result = getMarketplaceItem('marketplace/services/noah');
+      expect(result).toBeUndefined();
+    });
+
+    it('should not return phoenix from agents path', () => {
+      const result = getMarketplaceItem('marketplace/agents/phoenix');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAllMarketplaceServices', () => {
+    it('should return all marketplace services', () => {
+      const services = getAllMarketplaceServices();
+      expect(services).toBeDefined();
+      expect(services.phoenix).toBeDefined();
+      expect(services.langfuse).toBeDefined();
+      expect(services.noah).toBeUndefined();
+    });
+  });
+
+  describe('getAllMarketplaceAgents', () => {
+    it('should return all marketplace agents', () => {
+      const agents = getAllMarketplaceAgents();
+      expect(agents).toBeDefined();
+      expect(agents.noah).toBeDefined();
+      expect(agents.phoenix).toBeUndefined();
+      expect(agents.langfuse).toBeUndefined();
+    });
+  });
+
+  describe('isMarketplaceService', () => {
+    it('should return true for marketplace/services/ paths', () => {
+      expect(isMarketplaceService('marketplace/services/phoenix')).toBe(true);
+      expect(isMarketplaceService('marketplace/services/langfuse')).toBe(true);
+    });
+
+    it('should return true for marketplace/agents/ paths', () => {
+      expect(isMarketplaceService('marketplace/agents/noah')).toBe(true);
+    });
+
+    it('should return false for other paths', () => {
+      expect(isMarketplaceService('phoenix')).toBe(false);
+      expect(isMarketplaceService('services/phoenix')).toBe(false);
+      expect(isMarketplaceService('marketplace/phoenix')).toBe(false);
+    });
+  });
+});

--- a/tools/ark-cli/src/marketplaceServices.ts
+++ b/tools/ark-cli/src/marketplaceServices.ts
@@ -42,6 +42,13 @@ export const marketplaceServices: ServiceCollection = {
     k8sServicePort: 3000,
     k8sDeploymentName: 'langfuse-web',
   },
+};
+
+/**
+ * Available marketplace agents
+ * Charts are published to: oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts
+ */
+export const marketplaceAgents: ServiceCollection = {
   noah: {
     name: 'noah',
     helmReleaseName: 'noah',
@@ -58,19 +65,29 @@ export const marketplaceServices: ServiceCollection = {
   },
 };
 
-export function getMarketplaceService(name: string): ArkService | undefined {
-  return marketplaceServices[name];
+export function getMarketplaceItem(path: string): ArkService | undefined {
+  if (path.startsWith('marketplace/services/')) {
+    const name = path.replace(/^marketplace\/services\//, '');
+    return marketplaceServices[name];
+  }
+  if (path.startsWith('marketplace/agents/')) {
+    const name = path.replace(/^marketplace\/agents\//, '');
+    return marketplaceAgents[name];
+  }
+  return undefined;
 }
 
 export function getAllMarketplaceServices(): ServiceCollection {
   return marketplaceServices;
 }
 
-export function isMarketplaceService(name: string): boolean {
-  return name.startsWith('marketplace/services/');
+export function getAllMarketplaceAgents(): ServiceCollection {
+  return marketplaceAgents;
 }
 
-export function extractMarketplaceServiceName(path: string): string {
-  // Extract service name from marketplace/services/phoenix
-  return path.replace(/^marketplace\/services\//, '');
+export function isMarketplaceService(name: string): boolean {
+  return (
+    name.startsWith('marketplace/services/') ||
+    name.startsWith('marketplace/agents/')
+  );
 }


### PR DESCRIPTION
- Create separate marketplaceAgents collection for agent-type marketplace items
- Add getMarketplaceItem() function to resolve items from correct collection based on path prefix
- Update install/uninstall commands to support both marketplace/services/ and marketplace/agents/ paths
- Update marketplace list command to display services and agents separately
- Update bash completion to include marketplace/agents/noah
- Noah now only installable via marketplace/agents/noah (not marketplace/services/noah)
- Phoenix and Langfuse remain service-only (marketplace/services/ path)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 