### PR TITLE
feat: enabled chat streaming by default

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/experimental-features.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/experimental-features.test.ts
@@ -67,15 +67,15 @@ describe('A2A Tasks Feature Flag Atoms', () => {
   });
 
   describe('experimental-chat-streaming', () => {
-    it('should default to false', () => {
+    it('should default to true', () => {
       expect(CHAT_STREAMING_FEATURE_KEY).toBe('experimental-chat-streaming');
-      expect(store.get(storedIsChatStreamingEnabledAtom)).toBe(false);
+      expect(store.get(storedIsChatStreamingEnabledAtom)).toBe(true);
     });
 
-    it('should return true when storedIsChatStreamingEnabledAtom is true', () => {
-      store.set(storedIsChatStreamingEnabledAtom, true);
+    it('should return true when storedIsChatStreamingEnabledAtom is false', () => {
+      store.set(storedIsChatStreamingEnabledAtom, false);
       const value = store.get(storedIsChatStreamingEnabledAtom);
-      expect(value).toBe(true);
+      expect(value).toBe(false);
     });
 
     it('should be read-only (derived atom)', () => {

--- a/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
@@ -57,7 +57,7 @@ export const isA2ATasksEnabledAtom = atom(get => {
 export const CHAT_STREAMING_FEATURE_KEY = 'experimental-chat-streaming';
 export const storedIsChatStreamingEnabledAtom = atomWithStorage<boolean>(
   CHAT_STREAMING_FEATURE_KEY,
-  false,
+  true,
   undefined,
   { getOnInit: true },
 );


### PR DESCRIPTION
This PR enables chat streaming by default. It's still possible to disable this feature from experimental settings



## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 