### PR TITLE
fix: Remove dedicated step to install CRDs as they are synced and included in the chart

### DIFF
--- a/.github/actions/deploy-ark-helmchart/action.yml
+++ b/.github/actions/deploy-ark-helmchart/action.yml
@@ -120,23 +120,6 @@ runs:
       run: |
         kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 
-    - name: Install ARK CustomResourceDefinitions
-      shell: bash
-      run: |
-        kubectl apply -f ark/config/crd/bases
-
-        echo "Waiting for CRDs to be established..."
-        kubectl wait --for=condition=established --timeout=60s crd/agents.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/models.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/tools.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/teams.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/queries.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/memories.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/evaluators.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/mcpservers.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/a2aservers.ark.mckinsey.com
-        kubectl wait --for=condition=established --timeout=60s crd/executionengines.ark.mckinsey.com
-
     - name: Deploy ARK-controller chart
       shell: bash
       run: |

--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   resolve_version:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}

--- a/.github/workflows/deploy_gcp.yml
+++ b/.github/workflows/deploy_gcp.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   resolve_version:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}


### PR DESCRIPTION
… they are synced - no more need to install them separately

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 