### PR TITLE
feat: enable Noah agent by default in ark CLI

### DIFF
--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -46,6 +46,11 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
 webhooks:
   - name: vagent-v1.kb.io
+    objectSelector:
+      matchExpressions:
+      - key: "ark.mckinsey.com/skip-webhook-validation"
+        operator: "NotIn"
+        values: ["true"]
     clientConfig:
       service:
         name: ark-webhook-service

--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -12,6 +12,11 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
 webhooks:
   - name: magent-v1.kb.io
+    objectSelector:
+      matchExpressions:
+      - key: "ark.mckinsey.com/skip-webhook-validation"
+        operator: "NotIn"
+        values: ["true"]
     clientConfig:
       service:
         name: ark-webhook-service

--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -186,7 +186,7 @@ const defaultArkServices: ServiceCollection = {
     name: 'noah',
     helmReleaseName: 'noah',
     description: 'Runtime administration agent with cluster privileges',
-    enabled: false,
+    enabled: true,
     category: 'service',
     chartPath: `${getMarketplaceRegistry()}/noah`,
     installArgs: [],


### PR DESCRIPTION
Noah is now installed by default when running `ark install`.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 