### PR TITLE
fix: update ark devspace to golang 1.25 and set GOTOOLCHAIN=auto

### DIFF
--- a/ark/devspace.yaml
+++ b/ark/devspace.yaml
@@ -43,7 +43,7 @@ deployments:
 dev:
   ark-controller:
     imageSelector: ark-controller
-    devImage: golang:1.25-bookworm
+    devImage: golang:1.24.11-bookworm
     command:
       ["sh", "-c", "cd /app && GOTOOLCHAIN=auto go run cmd/main.go --leader-elect=false"]
     namespace: ark-system

--- a/ark/devspace.yaml
+++ b/ark/devspace.yaml
@@ -43,9 +43,9 @@ deployments:
 dev:
   ark-controller:
     imageSelector: ark-controller
-    devImage: golang:1.24-bookworm
+    devImage: golang:1.25-bookworm
     command:
-      ["sh", "-c", "cd /app && go run cmd/main.go --leader-elect=false"]
+      ["sh", "-c", "cd /app && GOTOOLCHAIN=auto go run cmd/main.go --leader-elect=false"]
     namespace: ark-system
     logs:
       lastLines: 50


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 