### PR TITLE
fix(ark): handle nil AgentModelRef pointer in ResolveModelSpec

### DIFF
--- a/ark/internal/genai/memory.go
+++ b/ark/internal/genai/memory.go
@@ -101,7 +101,7 @@ func NewMemoryForQuery(ctx context.Context, k8sClient client.Client, memoryRef *
 			// If default memory doesn't exist, use noop memory
 			return NewNoopMemory(), nil
 		}
-		memoryName, memoryNamespace = "default", namespace
+		memoryName, memoryNamespace = "default", namespace //nolint:goconst // "default" here is memory name, not model
 	} else {
 		memoryName = memoryRef.Name
 		memoryNamespace = resolveNamespace(memoryRef.Namespace, namespace)

--- a/ark/internal/genai/model.go
+++ b/ark/internal/genai/model.go
@@ -23,6 +23,9 @@ func ResolveModelSpec(modelSpec any, defaultNamespace string) (string, string, e
 	}
 	switch spec := modelSpec.(type) {
 	case *arkv1alpha1.AgentModelRef:
+		if spec == nil {
+			return "", "", fmt.Errorf("AgentModelRef pointer is nil")
+		}
 		modelName := spec.Name
 		namespace := spec.Namespace
 		if namespace == "" {

--- a/ark/internal/genai/model_test.go
+++ b/ark/internal/genai/model_test.go
@@ -1,0 +1,72 @@
+package genai
+
+import (
+	"strings"
+	"testing"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestResolveModelSpec_NilModelSpec(t *testing.T) {
+	_, _, err := ResolveModelSpec(nil, "default")
+	if err == nil || !strings.Contains(err.Error(), "model spec is nil") {
+		t.Errorf("expected 'model spec is nil' error, got: %v", err)
+	}
+}
+
+func TestResolveModelSpec_NilAgentModelRefPointer(t *testing.T) {
+	_, _, err := ResolveModelSpec((*arkv1alpha1.AgentModelRef)(nil), "default")
+	if err == nil || !strings.Contains(err.Error(), "AgentModelRef pointer is nil") {
+		t.Errorf("expected 'AgentModelRef pointer is nil' error, got: %v", err)
+	}
+}
+
+func TestResolveModelSpec_ValidAgentModelRef(t *testing.T) {
+	modelName, namespace, err := ResolveModelSpec(&arkv1alpha1.AgentModelRef{
+		Name:      "my-model",
+		Namespace: "custom-ns",
+	}, "default")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if modelName != "my-model" || namespace != "custom-ns" {
+		t.Errorf("got (%q, %q), want (my-model, custom-ns)", modelName, namespace)
+	}
+}
+
+func TestResolveModelSpec_AgentModelRefUsesDefaultNamespace(t *testing.T) {
+	modelName, namespace, err := ResolveModelSpec(&arkv1alpha1.AgentModelRef{Name: "my-model"}, "default")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if modelName != "my-model" || namespace != "default" {
+		t.Errorf("got (%q, %q), want (my-model, default)", modelName, namespace)
+	}
+}
+
+func TestResolveModelSpec_StringModelSpec(t *testing.T) {
+	modelName, namespace, err := ResolveModelSpec("string-model", "default")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if modelName != "string-model" || namespace != "default" {
+		t.Errorf("got (%q, %q), want (string-model, default)", modelName, namespace)
+	}
+}
+
+func TestResolveModelSpec_EmptyStringUsesDefaultModel(t *testing.T) {
+	modelName, namespace, err := ResolveModelSpec("", "default")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if modelName != "default" || namespace != "default" {
+		t.Errorf("got (%q, %q), want (default, default)", modelName, namespace)
+	}
+}
+
+func TestResolveModelSpec_UnsupportedType(t *testing.T) {
+	_, _, err := ResolveModelSpec(123, "default")
+	if err == nil || !strings.Contains(err.Error(), "unsupported model spec type") {
+		t.Errorf("expected 'unsupported model spec type' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent panic when modelSpec interface contains a nil *AgentModelRef pointer
- Add unit tests for ResolveModelSpec

## Scenario
Query targets an Agent with no model configured. The controller passes a typed nil pointer (`(*AgentModelRef)(nil)`) to `ResolveModelSpec`. The existing `modelSpec == nil` check passes because the interface is not nil (it has a type), but dereferencing `spec.Name` panics.

## Stack trace
```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 509 [running]:
mckinsey.com/ark/internal/genai.ResolveModelSpec(...)
    /app/internal/genai/model.go:26 +0x4c
```