### PR TITLE
fix: timeout parsing in openai.py to prevent backend errors

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
@@ -228,7 +228,7 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
 
             # Extract timeout from query spec
             query_timeout_str = query_resource.spec.timeout
-            timeout_seconds = int(parse_duration_to_seconds(query_timeout_str) or 300)
+            timeout_seconds = parse_duration_to_seconds(query_timeout_str) or 300
 
             # If the caller didn't request streaming, we can simply poll for
             # the response.

--- a/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
@@ -1,27 +1,29 @@
+from __future__ import annotations
+
 import json
 import logging
 import time
 import uuid
 
-from ark_sdk import QueryV1alpha1Spec
-from ark_sdk.models.query_v1alpha1 import QueryV1alpha1
-from ark_sdk.streaming_config import get_streaming_config, get_streaming_base_url
-from ark_sdk.k8s import get_namespace
-from fastapi import APIRouter
-from fastapi.responses import StreamingResponse, JSONResponse
-from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
-from openai.types import Model
-from pydantic import BaseModel, ValidationError
 import httpx
-from kubernetes_asyncio import client as k8s_client
-
+from ark_sdk import QueryV1alpha1Spec
 from ark_sdk.client import with_ark_client
+from ark_sdk.k8s import get_namespace
+from ark_sdk.models.query_v1alpha1 import QueryV1alpha1
+from ark_sdk.streaming_config import get_streaming_base_url, get_streaming_config
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse, StreamingResponse
+from kubernetes_asyncio import client as k8s_client
+from openai.types import Model
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+from pydantic import BaseModel, ValidationError
+
+from ...constants.annotations import STREAMING_ENABLED_ANNOTATION
 from ...models.queries import ArkOpenAICompletionsMetadata
+from ...utils.parse_duration import parse_duration_to_seconds
 from ...utils.query_targets import parse_model_to_query_target
 from ...utils.query_watch import watch_query_completion
 from ...utils.streaming import StreamingErrorResponse, create_single_chunk_sse_response
-from ...utils.parse_duration import parse_duration_to_seconds
-from ...constants.annotations import STREAMING_ENABLED_ANNOTATION
 
 router = APIRouter(prefix="/openai/v1", tags=["OpenAI"])
 logger = logging.getLogger(__name__)
@@ -56,7 +58,9 @@ class ChatCompletionRequest(BaseModel):
     temperature: float = 1.0
     max_tokens: int | None = None
     stream: bool = False
-    metadata: dict | None = None  # Supports queryAnnotations: JSON string of K8s annotations
+    metadata: dict | None = (
+        None  # Supports queryAnnotations: JSON string of K8s annotations
+    )
 
 
 def process_request_metadata(
@@ -107,21 +111,28 @@ async def proxy_streaming_response(streaming_url: str):
                 try:
                     response_text = await response.aread()
                     response_json = json.loads(response_text.decode("utf-8"))
-                    
+
                     # Expected structure: {"error": {"message": "...", "type": "...", "code": "..."}}
-                    if not isinstance(response_json, dict) or "error" not in response_json:
+                    if (
+                        not isinstance(response_json, dict)
+                        or "error" not in response_json
+                    ):
                         raise ValueError("Response missing 'error' field")
-                    
+
                     error_obj = response_json["error"]
                     if not isinstance(error_obj, dict):
                         raise ValueError("'error' field must be an object")
-                    
-                    if "message" not in error_obj or not isinstance(error_obj["message"], str):
+
+                    if "message" not in error_obj or not isinstance(
+                        error_obj["message"], str
+                    ):
                         raise ValueError("'error.message' field missing or invalid")
-                    
-                    if "type" not in error_obj or not isinstance(error_obj["type"], str):
+
+                    if "type" not in error_obj or not isinstance(
+                        error_obj["type"], str
+                    ):
                         raise ValueError("'error.type' field missing or invalid")
-                    
+
                     # Use the error structure from response, with status code added
                     error_data: StreamingErrorResponse = {
                         "error": {
@@ -133,7 +144,9 @@ async def proxy_streaming_response(streaming_url: str):
                     }
                 except (json.JSONDecodeError, ValueError, KeyError) as e:
                     # If we can't parse the expected structure, create a default error
-                    logger.warning(f"Failed to parse error response structure: {e}, using default error format")
+                    logger.warning(
+                        f"Failed to parse error response structure: {e}, using default error format"
+                    )
                     error_data: StreamingErrorResponse = {
                         "error": {
                             "status": response.status_code,
@@ -200,7 +213,7 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
             query_spec_dict["sessionId"] = session_id
         if timeout:
             query_spec_dict["timeout"] = timeout
-        
+
         # Create the QueryV1alpha1 object with type="messages"
         # Pass messages directly without json.dumps() - SDK handles serialization
         query_resource = QueryV1alpha1(
@@ -215,7 +228,7 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
 
             # Extract timeout from query spec
             query_timeout_str = query_resource.spec.timeout
-            timeout_seconds = parse_duration_to_seconds(query_timeout_str) or 300
+            timeout_seconds = int(parse_duration_to_seconds(query_timeout_str) or 300)
 
             # If the caller didn't request streaming, we can simply poll for
             # the response.
@@ -249,9 +262,7 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
 
             # Streaming is enabled - get the base URL and construct full URL
             base_url = await get_streaming_base_url(streaming_config, namespace, v1)
-            streaming_url = (
-                f"{base_url}/stream/{query_name}?from-beginning=true&wait-for-query={timeout_seconds}"
-            )
+            streaming_url = f"{base_url}/stream/{query_name}?from-beginning=true&wait-for-query={timeout_seconds}"
 
             # Proxy to the streaming endpoint
             logger.info(f"Streaming available for query: {query_name}")

--- a/services/ark-api/ark-api/src/ark_api/utils/parse_duration.py
+++ b/services/ark-api/ark-api/src/ark_api/utils/parse_duration.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import re
 
 
-def parse_duration_to_seconds(duration_str: str | None) -> float | None:
+def parse_duration_to_seconds(duration_str: str | None) -> int | None:
     """Parse a Kubernetes duration string to seconds.
 
-    Matches K8s duration format exactly: "500ms", "30s", "5m", "1h", "5m0s", "1h30m0s"
+    Matches K8s duration format exactly: "1000ms", "30s", "5m", "1h", "5m0s", "1h30m0s"
     Note: K8s rejects 'd' (days) - we match this behavior.
 
-    Returns None if the input is None or empty.
+    Returns None if the input is None or empty otherwise seconds as an integer.
     Raises ValueError if the format is invalid.
     """
     if not duration_str:
@@ -17,7 +19,9 @@ def parse_duration_to_seconds(duration_str: str | None) -> float | None:
     if not duration_str:
         return None
 
-    match = re.match(r'^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+)s)?(?:(\d+)ms)?$', duration_str)
+    match = re.match(
+        r"^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+)s)?(?:(\d+)ms)?$", duration_str
+    )
     if not match or not any(match.groups()):
         raise ValueError(f"Invalid duration format: {duration_str}")
 

--- a/services/ark-api/ark-api/src/ark_api/utils/parse_duration.py
+++ b/services/ark-api/ark-api/src/ark_api/utils/parse_duration.py
@@ -29,4 +29,4 @@ def parse_duration_to_seconds(duration_str: str | None) -> int | None:
     minutes = int(match.group(2) or 0)
     seconds = int(match.group(3) or 0)
     milliseconds = int(match.group(4) or 0)
-    return hours * 3600 + minutes * 60 + seconds + milliseconds / 1000
+    return int(hours * 3600 + minutes * 60 + seconds + milliseconds / 1000)

--- a/services/ark-api/ark-api/tests/test_parse_duration.py
+++ b/services/ark-api/ark-api/tests/test_parse_duration.py
@@ -20,8 +20,8 @@ class TestParseDurationToSeconds:
         assert parse_duration_to_seconds("2h") == 7200
 
     def test_milliseconds(self):
-        assert parse_duration_to_seconds("500ms") == 0.0
-        assert parse_duration_to_seconds("1000ms") == 1.0
+        assert parse_duration_to_seconds("500ms") == 0
+        assert parse_duration_to_seconds("1000ms") == 1
 
     def test_k8s_compound_format(self):
         assert parse_duration_to_seconds("5m0s") == 300

--- a/services/ark-api/ark-api/tests/test_parse_duration.py
+++ b/services/ark-api/ark-api/tests/test_parse_duration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from ark_api.utils.parse_duration import parse_duration_to_seconds
 
@@ -18,7 +20,7 @@ class TestParseDurationToSeconds:
         assert parse_duration_to_seconds("2h") == 7200
 
     def test_milliseconds(self):
-        assert parse_duration_to_seconds("500ms") == 0.5
+        assert parse_duration_to_seconds("500ms") == 0.0
         assert parse_duration_to_seconds("1000ms") == 1.0
 
     def test_k8s_compound_format(self):


### PR DESCRIPTION
This PR updates the timeout parsing logic in `parse_duration.py` to ensure the timeout value is always converted to an integer number of seconds using `parse_duration_to_seconds`. 

This change is necessary because the previous implementation could result in a float value (e.g., `"300.0"`), which caused backend errors in the Go service (`strconv.ParseInt: parsing "300.0": invalid syntax`). By explicitly casting to `int`, we guarantee the timeout is always a valid integer, preventing parsing errors and ensuring reliable agent execution. This fix addresses issues with agent queries failing due to invalid timeout formatting.

#### Tests Results:
<img width="876" height="217" alt="image" src="https://github.com/user-attachments/assets/51f353d9-17d1-43cf-a043-54687b76a45c" />


## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 