### PR TITLE
feat: minimize floating chat

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
@@ -279,6 +279,202 @@ describe('FloatingChat', () => {
     });
   });
 
+  describe('window state management', () => {
+    beforeEach(() => {
+      vi.mocked(useAtomValue).mockReturnValue(true);
+    });
+
+    describe('floating state (default)', () => {
+      it('should start in floating state with visible content', () => {
+        render(<FloatingChat {...defaultProps} />);
+
+        expect(
+          screen.getByPlaceholderText('Type your message...'),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/start a conversation with the agent/i),
+        ).toBeInTheDocument();
+      });
+
+      it('should show minimize button in floating state', () => {
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        expect(minimizeButton).toBeInTheDocument();
+      });
+
+      it('should show maximize button in floating state', () => {
+        render(<FloatingChat {...defaultProps} />);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        expect(maximizeButton).toBeInTheDocument();
+      });
+    });
+
+    describe('minimized state', () => {
+      it('should hide chat content when minimized', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        expect(
+          screen.queryByPlaceholderText('Type your message...'),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/start a conversation with the agent/i),
+        ).not.toBeInTheDocument();
+      });
+
+      it('should keep the chat name visible when minimized', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        expect(screen.getByText('Test Agent')).toBeInTheDocument();
+      });
+
+      it('should keep close button visible when minimized', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        const closeButton = screen.getByRole('button', { name: /close chat/i });
+        expect(closeButton).toBeInTheDocument();
+      });
+
+      it('should allow normalizing from minimized state', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        const restoreButton = screen.getByRole('button', {
+          name: /restore chat/i,
+        });
+        await user.click(restoreButton);
+
+        expect(
+          screen.getByPlaceholderText('Type your message...'),
+        ).toBeInTheDocument();
+      });
+
+      it('should allow maximizing from minimized state', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        await user.click(maximizeButton);
+
+        expect(
+          screen.getByPlaceholderText('Type your message...'),
+        ).toBeInTheDocument();
+        const restoreSizeButton = screen.getByRole('button', {
+          name: /restore size/i,
+        });
+        expect(restoreSizeButton).toBeInTheDocument();
+      });
+    });
+
+    describe('maximized state', () => {
+      it('should show restore size button when maximized', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        await user.click(maximizeButton);
+
+        const restoreSizeButton = screen.getByRole('button', {
+          name: /restore size/i,
+        });
+        expect(restoreSizeButton).toBeInTheDocument();
+      });
+
+      it('should allow normalizing from maximized state', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        await user.click(maximizeButton);
+
+        const restoreSizeButton = screen.getByRole('button', {
+          name: /restore size/i,
+        });
+        await user.click(restoreSizeButton);
+
+        const maximizeAgainButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        expect(maximizeAgainButton).toBeInTheDocument();
+      });
+
+      it('should allow minimizing from maximized state', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        await user.click(maximizeButton);
+
+        const minimizeButton = screen.getByRole('button', {
+          name: /minimize chat/i,
+        });
+        await user.click(minimizeButton);
+
+        expect(
+          screen.queryByPlaceholderText('Type your message...'),
+        ).not.toBeInTheDocument();
+        const restoreButton = screen.getByRole('button', {
+          name: /restore chat/i,
+        });
+        expect(restoreButton).toBeInTheDocument();
+      });
+
+      it('should keep close button visible when maximized', async () => {
+        const user = userEvent.setup();
+        render(<FloatingChat {...defaultProps} />);
+
+        const maximizeButton = screen.getByRole('button', {
+          name: /maximize chat/i,
+        });
+        await user.click(maximizeButton);
+
+        const closeButton = screen.getByRole('button', { name: /close chat/i });
+        expect(closeButton).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('streaming disabled', () => {
     it('should poll for response when feature flag is disabled', async () => {
       // Mock feature flag to false

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
@@ -284,8 +284,8 @@ describe('FloatingChat', () => {
       vi.mocked(useAtomValue).mockReturnValue(true);
     });
 
-    describe('floating state (default)', () => {
-      it('should start in floating state with visible content', () => {
+    describe('default state', () => {
+      it('should start in default state with visible content', () => {
         render(<FloatingChat {...defaultProps} />);
 
         expect(
@@ -296,7 +296,7 @@ describe('FloatingChat', () => {
         ).toBeInTheDocument();
       });
 
-      it('should show minimize button in floating state', () => {
+      it('should show minimize button in default state', () => {
         render(<FloatingChat {...defaultProps} />);
 
         const minimizeButton = screen.getByRole('button', {
@@ -305,7 +305,7 @@ describe('FloatingChat', () => {
         expect(minimizeButton).toBeInTheDocument();
       });
 
-      it('should show maximize button in floating state', () => {
+      it('should show maximize button in default state', () => {
         render(<FloatingChat {...defaultProps} />);
 
         const maximizeButton = screen.getByRole('button', {

--- a/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
@@ -32,7 +32,7 @@ import {
 import { chatService } from '@/lib/services';
 
 type ChatType = 'model' | 'team' | 'agent';
-type WindowState = 'floating' | 'minimized' | 'maximized';
+type WindowState = 'default' | 'minimized' | 'maximized';
 
 interface FloatingChatProps {
   id: string;
@@ -54,7 +54,7 @@ export default function FloatingChat({
   const [currentMessage, setCurrentMessage] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [windowState, setWindowState] = useState<WindowState>('floating');
+  const [windowState, setWindowState] = useState<WindowState>('default');
   const [viewMode, setViewMode] = useState<'text' | 'markdown'>('markdown');
   const [sessionId] = useState(() => `session-${Date.now()}`);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -247,7 +247,7 @@ export default function FloatingChat({
         return 'fixed inset-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 transition-all duration-300';
       case 'minimized':
         return 'fixed bottom-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 w-[400px] h-auto min-h-0 transition-all duration-300';
-      case 'floating':
+      case 'default':
       default:
         return 'fixed bottom-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 w-[400px] h-[500px] transition-all duration-300';
     }
@@ -285,7 +285,7 @@ export default function FloatingChat({
                 variant="ghost"
                 size="sm"
                 onClick={() =>
-                  setWindowState(isMinimized ? 'floating' : 'minimized')
+                  setWindowState(isMinimized ? 'default' : 'minimized')
                 }
                 className="h-6 w-6 p-0"
                 aria-label={isMinimized ? 'Restore chat' : 'Minimize chat'}>
@@ -299,7 +299,7 @@ export default function FloatingChat({
                 variant="ghost"
                 size="sm"
                 onClick={() =>
-                  setWindowState(isMaximized ? 'floating' : 'maximized')
+                  setWindowState(isMaximized ? 'default' : 'maximized')
                 }
                 className="h-6 w-6 p-0"
                 aria-label={isMaximized ? 'Restore size' : 'Maximize chat'}>
@@ -371,12 +371,10 @@ export default function FloatingChat({
                 )}
 
                 {chatMessages.map((message, index) => {
-                  // Extract string content from message
                   let content = '';
                   if (typeof message.content === 'string') {
                     content = message.content;
                   } else if (Array.isArray(message.content)) {
-                    // For multimodal content, extract text parts
                     content = message.content
                       .filter(
                         part =>

--- a/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
@@ -5,8 +5,10 @@ import {
   AlertCircle,
   Expand,
   MessageCircle,
+  Minus,
   Send,
   Shrink,
+  Square,
   X,
 } from 'lucide-react';
 import type {
@@ -30,6 +32,7 @@ import {
 import { chatService } from '@/lib/services';
 
 type ChatType = 'model' | 'team' | 'agent';
+type WindowState = 'floating' | 'minimized' | 'maximized';
 
 interface FloatingChatProps {
   id: string;
@@ -51,7 +54,7 @@ export default function FloatingChat({
   const [currentMessage, setCurrentMessage] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isMaximized, setIsMaximized] = useState(false);
+  const [windowState, setWindowState] = useState<WindowState>('floating');
   const [viewMode, setViewMode] = useState<'text' | 'markdown'>('markdown');
   const [sessionId] = useState(() => `session-${Date.now()}`);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -237,10 +240,22 @@ export default function FloatingChat({
   // Calculate position - each window is 420px wide (400px + 20px gap)
   const rightPosition = 16 + position * 420;
 
-  // Handle maximize/minimize styling
-  const cardStyles = isMaximized
-    ? 'fixed inset-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 transition-all duration-300'
-    : 'fixed bottom-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 w-[400px] h-[500px] transition-all duration-300';
+  // Handle window state styling
+  const getCardStyles = () => {
+    switch (windowState) {
+      case 'maximized':
+        return 'fixed inset-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 transition-all duration-300';
+      case 'minimized':
+        return 'fixed bottom-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 w-[400px] h-auto min-h-0 transition-all duration-300';
+      case 'floating':
+      default:
+        return 'fixed bottom-4 shadow-2xl dark:shadow-[0_10px_30px_rgba(0,0,0,0.8)] z-50 w-[400px] h-[500px] transition-all duration-300';
+    }
+  };
+
+  const isMinimized = windowState === 'minimized';
+  const isMaximized = windowState === 'maximized';
+  const cardStyles = getCardStyles();
 
   return (
     <Card
@@ -269,9 +284,25 @@ export default function FloatingChat({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setIsMaximized(!isMaximized)}
+                onClick={() =>
+                  setWindowState(isMinimized ? 'floating' : 'minimized')
+                }
                 className="h-6 w-6 p-0"
-                title={isMaximized ? 'Minimize chat' : 'Maximize chat'}>
+                aria-label={isMinimized ? 'Restore chat' : 'Minimize chat'}>
+                {isMinimized ? (
+                  <Square className="h-3 w-3" />
+                ) : (
+                  <Minus className="h-3 w-3" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  setWindowState(isMaximized ? 'floating' : 'maximized')
+                }
+                className="h-6 w-6 p-0"
+                aria-label={isMaximized ? 'Restore size' : 'Maximize chat'}>
                 {isMaximized ? (
                   <Shrink className="h-3 w-3" />
                 ) : (
@@ -283,129 +314,141 @@ export default function FloatingChat({
                 size="sm"
                 onClick={onClose}
                 className="h-6 w-6 p-0"
-                title="Close chat">
+                aria-label="Close chat">
                 <X className="h-3 w-3" />
               </Button>
             </div>
           </div>
 
-          <Separator />
+          {!isMinimized && (
+            <>
+              <Separator />
 
-          {/* Controls Row */}
-          <div className="flex justify-end px-3 py-1.5">
-            <div className="flex items-center gap-1 text-xs">
-              <button
-                className={`rounded px-2 py-1 transition-colors ${
-                  viewMode === 'text'
-                    ? 'bg-secondary text-secondary-foreground font-medium'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
-                }`}
-                onClick={() => setViewMode('text')}>
-                Text
-              </button>
-              <button
-                className={`rounded px-2 py-1 transition-colors ${
-                  viewMode === 'markdown'
-                    ? 'bg-secondary text-secondary-foreground font-medium'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
-                }`}
-                onClick={() => setViewMode('markdown')}>
-                Markdown
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-4" style={{ minHeight: 0 }}>
-          <div className="space-y-4">
-            {error && (
-              <div className="text-destructive bg-destructive/10 flex items-center gap-2 rounded-md p-3 text-sm">
-                <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                <span>{error}</span>
-              </div>
-            )}
-
-            {chatMessages.length === 0 && !error && (
-              <div className="text-muted-foreground py-8 text-center">
-                Start a conversation with the {type}
-              </div>
-            )}
-
-            {chatMessages.map((message, index) => {
-              // Extract string content from message
-              let content = '';
-              if (typeof message.content === 'string') {
-                content = message.content;
-              } else if (Array.isArray(message.content)) {
-                // For multimodal content, extract text parts
-                content = message.content
-                  .filter(
-                    part =>
-                      typeof part === 'object' &&
-                      part !== null &&
-                      'type' in part &&
-                      part.type === 'text',
-                  )
-                  .map(part =>
-                    typeof part === 'object' && part !== null && 'text' in part
-                      ? part.text
-                      : '',
-                  )
-                  .join('\n');
-              }
-
-              return content ? (
-                <ChatMessage
-                  key={index}
-                  role={message.role as 'user' | 'assistant' | 'system'}
-                  content={content}
-                  viewMode={viewMode}
-                />
-              ) : null;
-            })}
-
-            {/* Show typing indicator when processing */}
-            {isProcessing && (
-              <div className="flex justify-start">
-                <div className="bg-muted max-w-[80%] rounded-lg px-3 py-2">
-                  <div className="flex space-x-1">
-                    <div className="h-2 w-2 animate-bounce rounded-full bg-gray-400"></div>
-                    <div
-                      className="h-2 w-2 animate-bounce rounded-full bg-gray-400"
-                      style={{ animationDelay: '0.1s' }}></div>
-                    <div
-                      className="h-2 w-2 animate-bounce rounded-full bg-gray-400"
-                      style={{ animationDelay: '0.2s' }}></div>
-                  </div>
+              {/* Controls Row */}
+              <div className="flex justify-end px-3 py-1.5">
+                <div className="flex items-center gap-1 text-xs">
+                  <button
+                    className={`rounded px-2 py-1 transition-colors ${
+                      viewMode === 'text'
+                        ? 'bg-secondary text-secondary-foreground font-medium'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                    }`}
+                    onClick={() => setViewMode('text')}>
+                    Text
+                  </button>
+                  <button
+                    className={`rounded px-2 py-1 transition-colors ${
+                      viewMode === 'markdown'
+                        ? 'bg-secondary text-secondary-foreground font-medium'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                    }`}
+                    onClick={() => setViewMode('markdown')}>
+                    Markdown
+                  </button>
                 </div>
               </div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
+            </>
+          )}
         </div>
 
-        <div className="flex flex-shrink-0 gap-2 border-t p-4">
-          <div className="relative flex-1">
-            <Input
-              ref={inputRef}
-              placeholder={
-                isProcessing ? 'Processing...' : 'Type your message...'
-              }
-              value={currentMessage}
-              onChange={e => setCurrentMessage(e.target.value)}
-              onKeyPress={handleKeyPress}
-              disabled={isProcessing}
-            />
-          </div>
-          <Button
-            onClick={handleSendMessage}
-            disabled={!currentMessage.trim() || isProcessing}
-            size="sm"
-            variant="default"
-            aria-label="Send message">
-            <Send className="h-4 w-4" />
-          </Button>
-        </div>
+        {!isMinimized && (
+          <>
+            <div
+              className="flex-1 overflow-y-auto p-4"
+              style={{ minHeight: 0 }}>
+              <div className="space-y-4">
+                {error && (
+                  <div className="text-destructive bg-destructive/10 flex items-center gap-2 rounded-md p-3 text-sm">
+                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                    <span>{error}</span>
+                  </div>
+                )}
+
+                {chatMessages.length === 0 && !error && (
+                  <div className="text-muted-foreground py-8 text-center">
+                    Start a conversation with the {type}
+                  </div>
+                )}
+
+                {chatMessages.map((message, index) => {
+                  // Extract string content from message
+                  let content = '';
+                  if (typeof message.content === 'string') {
+                    content = message.content;
+                  } else if (Array.isArray(message.content)) {
+                    // For multimodal content, extract text parts
+                    content = message.content
+                      .filter(
+                        part =>
+                          typeof part === 'object' &&
+                          part !== null &&
+                          'type' in part &&
+                          part.type === 'text',
+                      )
+                      .map(part =>
+                        typeof part === 'object' &&
+                        part !== null &&
+                        'text' in part
+                          ? part.text
+                          : '',
+                      )
+                      .join('\n');
+                  }
+
+                  return content ? (
+                    <ChatMessage
+                      key={index}
+                      role={message.role as 'user' | 'assistant' | 'system'}
+                      content={content}
+                      viewMode={viewMode}
+                    />
+                  ) : null;
+                })}
+
+                {/* Show typing indicator when processing */}
+                {isProcessing && (
+                  <div className="flex justify-start">
+                    <div className="bg-muted max-w-[80%] rounded-lg px-3 py-2">
+                      <div className="flex space-x-1">
+                        <div className="h-2 w-2 animate-bounce rounded-full bg-gray-400"></div>
+                        <div
+                          className="h-2 w-2 animate-bounce rounded-full bg-gray-400"
+                          style={{ animationDelay: '0.1s' }}></div>
+                        <div
+                          className="h-2 w-2 animate-bounce rounded-full bg-gray-400"
+                          style={{ animationDelay: '0.2s' }}></div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+                <div ref={messagesEndRef} />
+              </div>
+            </div>
+
+            <div className="flex flex-shrink-0 gap-2 border-t p-4">
+              <div className="relative flex-1">
+                <Input
+                  ref={inputRef}
+                  placeholder={
+                    isProcessing ? 'Processing...' : 'Type your message...'
+                  }
+                  value={currentMessage}
+                  onChange={e => setCurrentMessage(e.target.value)}
+                  onKeyPress={handleKeyPress}
+                  disabled={isProcessing}
+                />
+              </div>
+              <Button
+                onClick={handleSendMessage}
+                disabled={!currentMessage.trim() || isProcessing}
+                size="sm"
+                variant="default"
+                aria-label="Send message">
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </Card>
   );


### PR DESCRIPTION
This PR allows to minimize the floating chat

While the agent is still responding, user can freely work on other stuff and then resume the conversation in any moment.


https://github.com/user-attachments/assets/ea5087c9-8655-4919-8a16-8a0c31f9849d


Internal ticket: [ARKQB-531](https://mckinsey.atlassian.net/browse/ARKQB-531)

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 