### PR TITLE
fix: change '&' to '?' in evaluations URL query parameter

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/evaluation/evaluation-status-indicator.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/evaluation/evaluation-status-indicator.tsx
@@ -115,7 +115,7 @@ export function EvaluationStatusIndicator({
     // Navigate to evaluations page with query filter
     const enhancedParam = enhanced ? '&enhanced=true' : '';
     router.push(
-      `/evaluations&query=${encodeURIComponent(queryName)}${enhancedParam}`,
+      `/evaluations?query=${encodeURIComponent(queryName)}${enhancedParam}`,
     );
   };
 

--- a/services/ark-dashboard/ark-dashboard/components/query-actions/query-evaluation-actions.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/query-actions/query-evaluation-actions.tsx
@@ -102,7 +102,7 @@ export function QueryEvaluationActions({
   }, [queryName]);
 
   const handleViewEvaluations = () => {
-    router.push(`/evaluations&query=${encodeURIComponent(queryName)}`);
+    router.push(`/evaluations?query=${encodeURIComponent(queryName)}`);
   };
 
   const handleCreateEvaluation = (evaluatorName?: string) => {


### PR DESCRIPTION
Fixed bug where clicking on evaluations popup incorrectly navigated to /evaluations&query=... instead of /evaluations?query=...

Changes:
- query-evaluation-actions.tsx: Fixed handleViewEvaluations URL
- evaluation-status-indicator.tsx: Fixed handleViewEvaluations URL

## Checklist

- [X] Follow the [contributor guide](./CONTRIBUTING.md)
- [X] End-to-end tests pass
- [X] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 