### PR TITLE
feat: add operation events to broker page

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -93,8 +93,8 @@ func main() {
 		}
 	}()
 
-	// Initialize eventing provider
-	eventingProvider := eventingconfig.NewProvider(mgr)
+	// Initialize eventing provider with direct client for broker discovery
+	eventingProvider := eventingconfig.NewProvider(mgr, directClient)
 
 	setupControllers(mgr, telemetryProvider, eventingProvider)
 	setupWebhooks(mgr)

--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -1,0 +1,125 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/eventing"
+	"mckinsey.com/ark/internal/telemetry/routing"
+)
+
+var log = logf.Log.WithName("eventing.broker")
+
+type Event struct {
+	Timestamp string                 `json:"timestamp"`
+	EventType string                 `json:"eventType"`
+	Reason    string                 `json:"reason"`
+	Message   string                 `json:"message"`
+	Data      map[string]interface{} `json:"data"`
+}
+
+type BrokerEventEmitter struct {
+	httpClient *http.Client
+	endpoints  map[string]string
+}
+
+func NewBrokerEventEmitter(endpoints []routing.BrokerEndpoint) eventing.EventEmitter {
+	endpointMap := make(map[string]string)
+	for _, ep := range endpoints {
+		endpointMap[ep.Namespace] = ep.Endpoint + "/events"
+	}
+
+	return &BrokerEventEmitter{
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+		endpoints: endpointMap,
+	}
+}
+
+func (e *BrokerEventEmitter) getEndpointForNamespace(namespace string) string {
+	if endpoint, ok := e.endpoints[namespace]; ok {
+		return endpoint
+	}
+	return ""
+}
+
+func (e *BrokerEventEmitter) EmitNormal(ctx context.Context, obj runtime.Object, reason, message string) {
+	e.EmitStructured(ctx, obj, corev1.EventTypeNormal, reason, message, nil)
+}
+
+func (e *BrokerEventEmitter) EmitWarning(ctx context.Context, obj runtime.Object, reason, message string) {
+	e.EmitStructured(ctx, obj, corev1.EventTypeWarning, reason, message, nil)
+}
+
+func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Object, eventType, reason, message string, data any) {
+	query, ok := obj.(*arkv1alpha1.Query)
+	if !ok {
+		return
+	}
+
+	endpoint := e.getEndpointForNamespace(query.Namespace)
+	if endpoint == "" {
+		return
+	}
+
+	dataMap, ok := data.(map[string]string)
+	if !ok && data != nil {
+		return
+	}
+
+	eventData := make(map[string]interface{})
+	for k, v := range dataMap {
+		eventData[k] = v
+	}
+
+	event := Event{
+		Timestamp: time.Now().Format(time.RFC3339Nano),
+		EventType: eventType,
+		Reason:    reason,
+		Message:   message,
+		Data:      eventData,
+	}
+
+	go e.sendEvent(endpoint, event)
+}
+
+func (e *BrokerEventEmitter) sendEvent(endpoint string, event Event) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		log.Error(err, "failed to marshal event")
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create request", "endpoint", endpoint)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send event to broker", "endpoint", endpoint)
+		return
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(err, "failed to close response body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		log.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "failed to send event to broker", "endpoint", endpoint)
+	}
+}

--- a/ark/internal/eventing/config/provider.go
+++ b/ark/internal/eventing/config/provider.go
@@ -40,7 +40,9 @@ func NewProvider(mgr ctrl.Manager, k8sClient client.Client) *Provider {
 
 		switch {
 		case err != nil:
-			log.Error(err, "failed to discover broker endpoints, using Kubernetes events for operations")
+			log.Error(err, "failed to discover broker endpoints, using Kubernetes events for operations",
+				"troubleshooting", "check RBAC permissions for listing ConfigMaps",
+				"configmap", "ark-config-broker")
 		case len(endpoints) > 0:
 			namespaces := make([]string, 0, len(endpoints))
 			for _, ep := range endpoints {

--- a/ark/internal/eventing/config/provider.go
+++ b/ark/internal/eventing/config/provider.go
@@ -1,12 +1,20 @@
 package config
 
 import (
+	"context"
+
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"mckinsey.com/ark/internal/eventing"
+	brokereventing "mckinsey.com/ark/internal/eventing/broker"
 	k8seventing "mckinsey.com/ark/internal/eventing/kubernetes"
 	recorders "mckinsey.com/ark/internal/eventing/recorder"
+	"mckinsey.com/ark/internal/telemetry/routing"
 )
+
+var log = logf.Log.WithName("eventing.config")
 
 type Provider struct {
 	modelRecorder           eventing.ModelRecorder
@@ -20,20 +28,41 @@ type Provider struct {
 	memoryRecorder          eventing.MemoryRecorder
 }
 
-func NewProvider(mgr ctrl.Manager) *Provider {
+func NewProvider(mgr ctrl.Manager, k8sClient client.Client) *Provider {
 	recorder := mgr.GetEventRecorderFor("ark-controller")
-	emitter := k8seventing.NewKubernetesEventEmitter(recorder)
+	k8sEmitter := k8seventing.NewKubernetesEventEmitter(recorder)
+
+	operationEmitter := k8sEmitter
+
+	if k8sClient != nil {
+		ctx := context.Background()
+		endpoints, err := routing.DiscoverBrokerEndpoints(ctx, k8sClient)
+
+		switch {
+		case err != nil:
+			log.Error(err, "failed to discover broker endpoints, using Kubernetes events for operations")
+		case len(endpoints) > 0:
+			namespaces := make([]string, 0, len(endpoints))
+			for _, ep := range endpoints {
+				namespaces = append(namespaces, ep.Namespace)
+			}
+			log.Info("broker endpoints discovered, using broker for operation events", "count", len(endpoints), "namespaces", namespaces)
+			operationEmitter = brokereventing.NewBrokerEventEmitter(endpoints)
+		default:
+			log.Info("no broker endpoints found, using Kubernetes events for operations")
+		}
+	}
 
 	return &Provider{
-		modelRecorder:           recorders.NewModelRecorder(emitter),
-		a2aRecorder:             recorders.NewA2aRecorder(emitter),
-		agentRecorder:           recorders.NewAgentRecorder(emitter),
-		teamRecorder:            recorders.NewTeamRecorder(emitter),
-		executionEngineRecorder: recorders.NewExecutionEngineRecorder(emitter),
-		mcpServerRecorder:       recorders.NewMCPServerRecorder(emitter),
-		queryRecorder:           recorders.NewQueryRecorder(emitter),
-		toolRecorder:            recorders.NewToolRecorder(emitter),
-		memoryRecorder:          recorders.NewMemoryRecorder(emitter),
+		modelRecorder:           recorders.NewModelRecorder(k8sEmitter, operationEmitter),
+		a2aRecorder:             recorders.NewA2aRecorder(k8sEmitter, operationEmitter),
+		agentRecorder:           recorders.NewAgentRecorder(k8sEmitter, operationEmitter),
+		teamRecorder:            recorders.NewTeamRecorder(k8sEmitter, operationEmitter),
+		executionEngineRecorder: recorders.NewExecutionEngineRecorder(k8sEmitter, operationEmitter),
+		mcpServerRecorder:       recorders.NewMCPServerRecorder(k8sEmitter),
+		queryRecorder:           recorders.NewQueryRecorder(k8sEmitter, operationEmitter),
+		toolRecorder:            recorders.NewToolRecorder(k8sEmitter, operationEmitter),
+		memoryRecorder:          recorders.NewMemoryRecorder(k8sEmitter, operationEmitter),
 	}
 }
 

--- a/ark/internal/eventing/noop/provider.go
+++ b/ark/internal/eventing/noop/provider.go
@@ -17,10 +17,10 @@ func NewProvider() eventing.Provider {
 	emitter := NewNoopEventEmitter()
 	return &noopProvider{
 		queryRecorder: NewQueryRecorder(),
-		modelRecorder: recorder.NewModelRecorder(emitter),
-		agentRecorder: recorder.NewAgentRecorder(emitter),
-		teamRecorder:  recorder.NewTeamRecorder(emitter),
-		toolRecorder:  recorder.NewToolRecorder(emitter),
+		modelRecorder: recorder.NewModelRecorder(emitter, emitter),
+		agentRecorder: recorder.NewAgentRecorder(emitter, emitter),
+		teamRecorder:  recorder.NewTeamRecorder(emitter, emitter),
+		toolRecorder:  recorder.NewToolRecorder(emitter, emitter),
 	}
 }
 
@@ -62,5 +62,5 @@ func (p *noopProvider) MemoryRecorder() eventing.MemoryRecorder {
 
 func NewModelRecorder() eventing.ModelRecorder {
 	emitter := NewNoopEventEmitter()
-	return recorder.NewModelRecorder(emitter)
+	return recorder.NewModelRecorder(emitter, emitter)
 }

--- a/ark/internal/eventing/recorder/a2a_recorder.go
+++ b/ark/internal/eventing/recorder/a2a_recorder.go
@@ -14,10 +14,10 @@ type a2aRecorder struct {
 	operations.OperationTracker
 }
 
-func NewA2aRecorder(emitter eventing.EventEmitter) eventing.A2aRecorder {
+func NewA2aRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.A2aRecorder {
 	return &a2aRecorder{
 		emitter:          emitter,
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 	}
 }
 

--- a/ark/internal/eventing/recorder/agent_recorder.go
+++ b/ark/internal/eventing/recorder/agent_recorder.go
@@ -14,10 +14,10 @@ type agentRecorder struct {
 	operations.OperationTracker
 }
 
-func NewAgentRecorder(emitter eventing.EventEmitter) eventing.AgentRecorder {
+func NewAgentRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.AgentRecorder {
 	return &agentRecorder{
 		emitter:          emitter,
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 	}
 }
 

--- a/ark/internal/eventing/recorder/execution_engine_recorder.go
+++ b/ark/internal/eventing/recorder/execution_engine_recorder.go
@@ -14,10 +14,10 @@ type executionEngineRecorder struct {
 	operations.OperationTracker
 }
 
-func NewExecutionEngineRecorder(emitter eventing.EventEmitter) eventing.ExecutionEngineRecorder {
+func NewExecutionEngineRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.ExecutionEngineRecorder {
 	return &executionEngineRecorder{
 		emitter:          emitter,
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 	}
 }
 

--- a/ark/internal/eventing/recorder/memory_recorder.go
+++ b/ark/internal/eventing/recorder/memory_recorder.go
@@ -10,9 +10,9 @@ type memoryRecorder struct {
 	emitter eventing.EventEmitter
 }
 
-func NewMemoryRecorder(emitter eventing.EventEmitter) eventing.MemoryRecorder {
+func NewMemoryRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.MemoryRecorder {
 	return &memoryRecorder{
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 		emitter:          emitter,
 	}
 }

--- a/ark/internal/eventing/recorder/model_recorder.go
+++ b/ark/internal/eventing/recorder/model_recorder.go
@@ -16,10 +16,10 @@ type modelRecorder struct {
 	emitter eventing.EventEmitter
 }
 
-func NewModelRecorder(emitter eventing.EventEmitter) eventing.ModelRecorder {
+func NewModelRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.ModelRecorder {
 	return &modelRecorder{
 		TokenCollector:   tokens.NewTokenCollector(),
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 		emitter:          emitter,
 	}
 }

--- a/ark/internal/eventing/recorder/query_recorder.go
+++ b/ark/internal/eventing/recorder/query_recorder.go
@@ -17,10 +17,10 @@ type queryRecorder struct {
 	emitter eventing.EventEmitter
 }
 
-func NewQueryRecorder(emitter eventing.EventEmitter) eventing.QueryRecorder {
+func NewQueryRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.QueryRecorder {
 	return &queryRecorder{
 		TokenCollector:   tokens.NewTokenCollector(),
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 		emitter:          emitter,
 	}
 }

--- a/ark/internal/eventing/recorder/team_recorder.go
+++ b/ark/internal/eventing/recorder/team_recorder.go
@@ -12,10 +12,10 @@ type teamRecorder struct {
 	emitter eventing.EventEmitter
 }
 
-func NewTeamRecorder(emitter eventing.EventEmitter) eventing.TeamRecorder {
+func NewTeamRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.TeamRecorder {
 	return &teamRecorder{
 		TokenCollector:   tokens.NewTokenCollector(),
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 		emitter:          emitter,
 	}
 }

--- a/ark/internal/eventing/recorder/tool_recorder.go
+++ b/ark/internal/eventing/recorder/tool_recorder.go
@@ -10,9 +10,9 @@ type toolRecorder struct {
 	emitter eventing.EventEmitter
 }
 
-func NewToolRecorder(emitter eventing.EventEmitter) eventing.ToolRecorder {
+func NewToolRecorder(emitter, operationEmitter eventing.EventEmitter) eventing.ToolRecorder {
 	return &toolRecorder{
-		OperationTracker: operations.NewOperationTracker(emitter),
+		OperationTracker: operations.NewOperationTracker(operationEmitter),
 		emitter:          emitter,
 	}
 }

--- a/ark/internal/telemetry/routing/discovery.go
+++ b/ark/internal/telemetry/routing/discovery.go
@@ -158,7 +158,7 @@ func buildEndpoint(namespace string, serviceRef ServiceRef) (string, error) {
 		port = "443"
 	}
 
-	endpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:%s/v1/traces",
+	endpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:%s",
 		serviceRef.Name, namespace, port)
 
 	return endpoint, nil

--- a/ark/internal/telemetry/routing/processor.go
+++ b/ark/internal/telemetry/routing/processor.go
@@ -28,11 +28,12 @@ func NewRoutingSpanProcessor(ctx context.Context, endpoints []BrokerEndpoint) (*
 	}
 
 	for _, endpoint := range endpoints {
-		exporter, err := createExporter(ctx, endpoint.Endpoint)
+		otlpEndpoint := endpoint.Endpoint + "/v1/traces"
+		exporter, err := createExporter(ctx, otlpEndpoint)
 		if err != nil {
 			log.Error(err, "failed to create exporter",
 				"namespace", endpoint.Namespace,
-				"endpoint", endpoint.Endpoint)
+				"endpoint", otlpEndpoint)
 			continue
 		}
 

--- a/services/ark-api/ark-api/tests/api/test_broker.py
+++ b/services/ark-api/ark-api/tests/api/test_broker.py
@@ -311,6 +311,165 @@ class TestBrokerAPI(unittest.TestCase):
         self.assertIn("error", data)
         self.assertEqual(data["error"]["type"], "connection_error")
 
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_get_events_success(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"events": []}
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.get("/v1/broker/events")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"events": []})
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    def test_get_events_memory_not_available(self, mock_get_broker_url):
+        mock_get_broker_url.return_value = None
+
+        response = self.client.get("/v1/broker/events?memory=unavailable")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "service_unavailable")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_get_events_connection_error(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.get("/v1/broker/events")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "connection_error")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_get_events_generic_error(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(side_effect=Exception("Generic error"))
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.get("/v1/broker/events")
+
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "server_error")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.proxy_sse_stream')
+    def test_get_events_watch(self, mock_proxy_sse, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        async def mock_stream():
+            yield "data: event\n\n"
+
+        mock_proxy_sse.return_value = mock_stream()
+
+        response = self.client.get("/v1/broker/events?watch=true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "text/event-stream; charset=utf-8")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_get_events_with_query_id(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"events": [{"id": "1"}]}
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.get("/v1/broker/events?query-id=query-123")
+
+        self.assertEqual(response.status_code, 200)
+        mock_client_instance.get.assert_called_once()
+        call_args = mock_client_instance.get.call_args[0][0]
+        self.assertIn("events/query-123", call_args)
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.proxy_sse_stream')
+    def test_get_events_watch_with_query_id(self, mock_proxy_sse, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        async def mock_stream():
+            yield "data: event\n\n"
+
+        mock_proxy_sse.return_value = mock_stream()
+
+        response = self.client.get("/v1/broker/events?watch=true&query-id=query-123")
+
+        self.assertEqual(response.status_code, 200)
+        mock_proxy_sse.assert_called_once()
+        call_args = mock_proxy_sse.call_args[0][0]
+        self.assertIn("events/query-123", call_args)
+        self.assertIn("watch=true", call_args)
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_purge_events_success(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"success": True}
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.delete("/v1/broker/events")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    def test_purge_events_memory_not_available(self, mock_get_broker_url):
+        mock_get_broker_url.return_value = None
+
+        response = self.client.delete("/v1/broker/events?memory=unavailable")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "service_unavailable")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_purge_events_connection_error(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.delete("/v1/broker/events")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "connection_error")
+
 
 class TestHelperFunctions(unittest.IsolatedAsyncioTestCase):
 

--- a/services/ark-broker/ark-broker/src/event-store.ts
+++ b/services/ark-broker/ark-broker/src/event-store.ts
@@ -1,3 +1,6 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
 /**
  * Operation event emitted by the Ark controller during query lifecycle.
  * Events track operation start, completion, and failure states.
@@ -39,6 +42,12 @@ export class EventStore {
   private subscribers: Map<string, Set<(event: Event) => void>> = new Map();
   private allSubscribers: Set<(event: Event) => void> = new Set();
   private maxEvents = 10000;
+  private readonly eventFilePath?: string;
+
+  constructor() {
+    this.eventFilePath = process.env.EVENT_FILE_PATH;
+    this.loadFromFile();
+  }
 
   addEvent(event: Event): void {
     this.events.push(event);
@@ -104,6 +113,54 @@ export class EventStore {
 
   purge(): void {
     this.events = [];
-    console.log('Event store purged');
+    this.saveToFile();
+    console.log('[EVENT PURGE] Cleared all events');
+  }
+
+  private loadFromFile(): void {
+    if (!this.eventFilePath) {
+      console.log('[EVENT LOAD] File persistence disabled - events will not be saved');
+      return;
+    }
+
+    try {
+      if (existsSync(this.eventFilePath)) {
+        const data = readFileSync(this.eventFilePath, 'utf-8');
+        const parsed = JSON.parse(data);
+
+        if (parsed && Array.isArray(parsed.events)) {
+          this.events = parsed.events;
+          console.log(`[EVENT LOAD] Loaded ${this.events.length} events from ${this.eventFilePath}`);
+        } else {
+          console.warn('[EVENT LOAD] Invalid data format in event file, starting fresh');
+        }
+      } else {
+        console.log(`[EVENT LOAD] Event file not found at ${this.eventFilePath}, starting with 0 events`);
+      }
+    } catch (error) {
+      console.error(`[EVENT LOAD] Failed to load events from file: ${error}`);
+    }
+  }
+
+  private saveToFile(): void {
+    if (!this.eventFilePath) return;
+
+    try {
+      const dir = dirname(this.eventFilePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      const dataToSave = {
+        events: this.events
+      };
+      writeFileSync(this.eventFilePath, JSON.stringify(dataToSave, null, 2));
+    } catch (error) {
+      console.error(`[EVENT SAVE] Failed to save events to file: ${error}`);
+    }
+  }
+
+  public saveEvents(): void {
+    this.saveToFile();
   }
 }

--- a/services/ark-broker/ark-broker/src/event-store.ts
+++ b/services/ark-broker/ark-broker/src/event-store.ts
@@ -1,17 +1,35 @@
+/**
+ * Operation event emitted by the Ark controller during query lifecycle.
+ * Events track operation start, completion, and failure states.
+ */
 export interface Event {
+  /** ISO 8601 timestamp when the event was created */
   timestamp: string;
+  /** Event type (Normal, Warning) */
   eventType: string;
+  /** Short reason code for the event (e.g., OperationStarted, OperationCompleted, OperationFailed) */
   reason: string;
+  /** Human-readable event message */
   message: string;
+  /** Structured event data containing context and metadata */
   data: {
+    /** Unique identifier for the query that generated this event */
     queryId: string;
+    /** Name of the query resource */
     queryName: string;
+    /** Kubernetes namespace containing the query */
     queryNamespace: string;
+    /** Session identifier for grouping related operations */
     sessionId: string;
+    /** Optional conversation identifier for multi-turn interactions */
     conversationId?: string;
+    /** Operation name being tracked (e.g., tool execution, model invocation) */
     operation?: string;
+    /** Duration of completed operations in milliseconds */
     durationMs?: string;
+    /** Error message for failed operations */
     error?: string;
+    /** Additional event-specific metadata */
     [key: string]: any;
   };
 }

--- a/services/ark-broker/ark-broker/src/event-store.ts
+++ b/services/ark-broker/ark-broker/src/event-store.ts
@@ -1,0 +1,91 @@
+export interface Event {
+  timestamp: string;
+  eventType: string;
+  reason: string;
+  message: string;
+  data: {
+    queryId: string;
+    queryName: string;
+    queryNamespace: string;
+    sessionId: string;
+    conversationId?: string;
+    operation?: string;
+    durationMs?: string;
+    error?: string;
+    [key: string]: any;
+  };
+}
+
+export class EventStore {
+  private events: Event[] = [];
+  private subscribers: Map<string, Set<(event: Event) => void>> = new Map();
+  private allSubscribers: Set<(event: Event) => void> = new Set();
+  private maxEvents = 10000;
+
+  addEvent(event: Event): void {
+    this.events.push(event);
+
+    if (this.events.length > this.maxEvents) {
+      this.events = this.events.slice(-this.maxEvents);
+    }
+
+    const queryId = event.data.queryId;
+    if (queryId) {
+      const querySubscribers = this.subscribers.get(queryId);
+      if (querySubscribers) {
+        for (const callback of querySubscribers) {
+          try {
+            callback(event);
+          } catch (error) {
+            console.error('Error in query subscriber callback:', error);
+          }
+        }
+      }
+    }
+
+    for (const callback of this.allSubscribers) {
+      try {
+        callback(event);
+      } catch (error) {
+        console.error('Error in all-events subscriber callback:', error);
+      }
+    }
+  }
+
+  getEvents(): Event[] {
+    return this.events;
+  }
+
+  getEventsByQuery(queryId: string): Event[] {
+    return this.events.filter(event => event.data.queryId === queryId);
+  }
+
+  subscribeToQuery(queryId: string, callback: (event: Event) => void): () => void {
+    if (!this.subscribers.has(queryId)) {
+      this.subscribers.set(queryId, new Set());
+    }
+    this.subscribers.get(queryId)!.add(callback);
+
+    return () => {
+      const querySubscribers = this.subscribers.get(queryId);
+      if (querySubscribers) {
+        querySubscribers.delete(callback);
+        if (querySubscribers.size === 0) {
+          this.subscribers.delete(queryId);
+        }
+      }
+    };
+  }
+
+  subscribeToAll(callback: (event: Event) => void): () => void {
+    this.allSubscribers.add(callback);
+    return () => {
+      this.allSubscribers.delete(callback);
+    };
+  }
+
+  purge(): void {
+    this.events = [];
+    console.log('Event store purged');
+  }
+}

--- a/services/ark-broker/ark-broker/src/main.ts
+++ b/services/ark-broker/ark-broker/src/main.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'module';
-import app, { memory, stream } from './server.js';
+import app, { memory, stream, events } from './server.js';
 import { setupSwagger } from './swagger.js';
 
 // Get version from package.json
@@ -20,6 +20,9 @@ const server = app.listen(parseInt(PORT), HOST, () => {
   if (process.env.STREAM_FILE_PATH) {
     console.log(`Stream persistence enabled at: ${process.env.STREAM_FILE_PATH}`);
   }
+  if (process.env.EVENT_FILE_PATH) {
+    console.log(`Event persistence enabled at: ${process.env.EVENT_FILE_PATH}`);
+  }
 });
 
 // Memory will be saved on graceful shutdown only
@@ -33,9 +36,10 @@ const gracefulShutdown = (): void => {
     clearInterval(saveInterval);
   }
 
-  // Save memory and streams before exit
+  // Save memory, streams, and events before exit
   memory.saveMemory();
   stream.saveStreams();
+  events.saveEvents();
 
   server.close(() => {
     console.log('Process terminated');

--- a/services/ark-broker/ark-broker/src/main.ts
+++ b/services/ark-broker/ark-broker/src/main.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'module';
-import app, { memory, stream, events } from './server.js';
+import app, { memory, stream, traces, events } from './server.js';
 import { setupSwagger } from './swagger.js';
 
 // Get version from package.json
@@ -20,6 +20,9 @@ const server = app.listen(parseInt(PORT), HOST, () => {
   if (process.env.STREAM_FILE_PATH) {
     console.log(`Stream persistence enabled at: ${process.env.STREAM_FILE_PATH}`);
   }
+  if (process.env.TRACE_FILE_PATH) {
+    console.log(`Trace persistence enabled at: ${process.env.TRACE_FILE_PATH}`);
+  }
   if (process.env.EVENT_FILE_PATH) {
     console.log(`Event persistence enabled at: ${process.env.EVENT_FILE_PATH}`);
   }
@@ -36,9 +39,10 @@ const gracefulShutdown = (): void => {
     clearInterval(saveInterval);
   }
 
-  // Save memory, streams, and events before exit
+  // Save memory, streams, traces, and events before exit
   memory.saveMemory();
   stream.saveStreams();
+  traces.saveTraces();
   events.saveEvents();
 
   server.close(() => {

--- a/services/ark-broker/ark-broker/src/routes/events.ts
+++ b/services/ark-broker/ark-broker/src/routes/events.ts
@@ -1,0 +1,94 @@
+import { Router } from 'express';
+import { EventStore } from '../event-store.js';
+import { streamSSE } from '../sse.js';
+
+export function createEventsRouter(events: EventStore): Router {
+  const router = Router();
+
+  router.get('/', (req, res) => {
+    const watch = req.query['watch'] === 'true';
+
+    if (watch) {
+      console.log('[EVENTS] GET /events?watch=true - starting SSE stream for all events');
+      streamSSE({
+        res,
+        req,
+        tag: 'EVENTS',
+        itemName: 'events',
+        subscribe: (callback) => events.subscribeToAll(callback)
+      });
+    } else {
+      try {
+        const allEvents = events.getEvents();
+        res.json({
+          total_events: allEvents.length,
+          events: allEvents
+        });
+      } catch (error) {
+        console.error('[EVENTS] Failed to get events:', error);
+        const err = error as Error;
+        res.status(500).json({ error: err.message });
+      }
+    }
+  });
+
+  router.get('/:query_id', (req, res) => {
+    const { query_id } = req.params;
+    const watch = req.query['watch'] === 'true';
+    const fromBeginning = req.query['from-beginning'] === 'true';
+
+    if (watch) {
+      console.log(`[EVENTS] GET /events/${query_id}?watch=true - starting SSE stream`);
+      streamSSE({
+        res,
+        req,
+        tag: 'EVENTS',
+        itemName: 'events',
+        subscribe: (callback) => events.subscribeToQuery(query_id, callback),
+        replayItems: fromBeginning ? events.getEventsByQuery(query_id) : undefined,
+        identifier: `Query ${query_id}`
+      });
+    } else {
+      try {
+        const queryEvents = events.getEventsByQuery(query_id);
+        res.json({
+          query_id,
+          event_count: queryEvents.length,
+          events: queryEvents
+        });
+      } catch (error) {
+        console.error(`[EVENTS] Failed to get events for query ${query_id}:`, error);
+        const err = error as Error;
+        res.status(500).json({ error: err.message });
+      }
+    }
+  });
+
+  router.post('/', (req, res) => {
+    try {
+      const event = req.body;
+      if (!event || !event.data || !event.data.queryId) {
+        res.status(400).json({ error: 'Invalid event' });
+        return;
+      }
+      events.addEvent(event);
+      res.status(201).json({ status: 'success' });
+    } catch (error) {
+      console.error('[EVENTS] Failed to add event:', error);
+      const err = error as Error;
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.delete('/', (_req, res) => {
+    try {
+      events.purge();
+      res.json({ status: 'success', message: 'Event data purged' });
+    } catch (error) {
+      console.error('Event purge failed:', error);
+      res.status(500).json({ error: 'Failed to purge event data' });
+    }
+  });
+
+  return router;
+}

--- a/services/ark-broker/ark-broker/src/server.ts
+++ b/services/ark-broker/ark-broker/src/server.ts
@@ -3,15 +3,18 @@ import cors from 'cors';
 import { MemoryStore } from './memory-store.js';
 import { StreamStore } from './stream-store.js';
 import { TraceStore } from './trace-store.js';
+import { EventStore } from './event-store.js';
 import { createMemoryRouter } from './routes/memory.js';
 import { createStreamRouter } from './routes/stream.js';
 import { createTracesRouter } from './routes/traces.js';
+import { createEventsRouter } from './routes/events.js';
 import { createOTLPRouter } from './routes/otlp.js';
 
 const app = express();
 const memory = new MemoryStore();
 const stream = new StreamStore();
 const traces = new TraceStore();
+const events = new EventStore();
 
 // Middleware
 app.use(cors());
@@ -119,6 +122,7 @@ app.get('/stream-statistics', (req, res) => {
 app.use('/', createMemoryRouter(memory));
 app.use('/stream', createStreamRouter(stream));
 app.use('/traces', createTracesRouter(traces));
+app.use('/events', createEventsRouter(events));
 app.use('/v1', createOTLPRouter(traces));
 
 // Error handling
@@ -133,4 +137,4 @@ app.use((req, res) => {
 });
 
 export default app;
-export { memory, stream, traces };
+export { memory, stream, traces, events };

--- a/services/ark-broker/ark-broker/src/sse.ts
+++ b/services/ark-broker/ark-broker/src/sse.ts
@@ -42,6 +42,8 @@ export const streamSSE = (options: SSEStreamOptions): void => {
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('Access-Control-Allow-Origin', '*');
 
+  res.write(': connected\n\n');
+
   const heartbeat = startSSEHeartbeat(res);
 
   let itemCount = 0;

--- a/services/ark-broker/chart/templates/deployment.yaml
+++ b/services/ark-broker/chart/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
               value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.memoryFileName }}"
             - name: STREAM_FILE_PATH
               value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.streamFileName }}"
+            - name: TRACE_FILE_PATH
+              value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.traceFileName }}"
+            - name: EVENT_FILE_PATH
+              value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.eventFileName }}"
             {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:

--- a/services/ark-broker/chart/values.yaml
+++ b/services/ark-broker/chart/values.yaml
@@ -59,12 +59,16 @@ persistence:
   accessMode: ReadWriteOnce
   # Size of the persistent volume
   size: 1Gi
-  # Path where memory data will be stored
+  # Path where data will be stored
   mountPath: /data
   # Filename for the memory data
   memoryFileName: memory.json
   # Filename for the stream data
   streamFileName: stream.json
+  # Filename for the trace data
+  traceFileName: traces.json
+  # Filename for the event data
+  eventFileName: events.json
   # Use existing PVC instead of creating a new one
   existingClaim: ""
 

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -211,6 +211,7 @@ export default function BrokerPage() {
   const traces = useSSEStream('/v1/broker/traces', selectedMemory);
   const messages = useSSEStream('/v1/broker/messages', selectedMemory);
   const chunks = useSSEStream('/v1/broker/chunks', selectedMemory);
+  const events = useSSEStream('/v1/broker/events', selectedMemory);
 
   useEffect(() => {
     async function fetchMemories() {
@@ -259,6 +260,7 @@ export default function BrokerPage() {
               <TabsTrigger value="traces">OTEL Traces</TabsTrigger>
               <TabsTrigger value="messages">Messages</TabsTrigger>
               <TabsTrigger value="chunks">LLM Chunks</TabsTrigger>
+              <TabsTrigger value="events">Events</TabsTrigger>
             </TabsList>
           </div>
           <TabsContent value="traces" className="mt-4 flex-1">
@@ -286,6 +288,15 @@ export default function BrokerPage() {
               isConnected={chunks.isConnected}
               error={chunks.error}
               onClear={chunks.clear}
+            />
+          </TabsContent>
+          <TabsContent value="events" className="mt-4 flex-1">
+            <StreamView
+              title="Operation Events"
+              entries={events.entries}
+              isConnected={events.isConnected}
+              error={events.error}
+              onClear={events.clear}
             />
           </TabsContent>
         </Tabs>

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -1319,6 +1319,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/broker/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Events
+         * @description Get or stream operation events from the broker.
+         */
+        get: operations["get_events_v1_broker_events_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Purge Events
+         * @description Purge all events from the broker.
+         */
+        delete: operations["purge_events_v1_broker_events_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/openai/v1/chat/completions": {
         parameters: {
             query?: never;
@@ -7057,6 +7081,74 @@ export interface operations {
                 watch?: boolean;
                 /** @description Filter by query ID */
                 "query-id"?: string;
+                /** @description Memory resource name */
+                memory?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_events_v1_broker_events_get: {
+        parameters: {
+            query?: {
+                /** @description Stream events via SSE */
+                watch?: boolean;
+                /** @description Filter by query ID */
+                "query-id"?: string;
+                /** @description Memory resource name */
+                memory?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_events_v1_broker_events_delete: {
+        parameters: {
+            query?: {
                 /** @description Memory resource name */
                 memory?: string;
             };


### PR DESCRIPTION
## Summary

- Transport OperationTracker events from ark controller to broker via HTTP POST, with one-time endpoint discovery at startup and fallback to Kubernetes events when broker unavailable
- Add EventStore to ark-broker service with SSE streaming endpoints for real-time operation event delivery (`/events` and `/events/:query_id`)
- Add `/v1/broker/events` proxy endpoint in ark-api to stream operation events from broker to clients using Server-Sent Events
- Add Events tab to dashboard broker page for real-time visualization of operation events (Start, Complete, Fail) alongside existing traces, messages, and chunks
- Update 8 recorder constructors to accept separate emitters for regular events (K8s only) and operation events (broker with K8s fallback)

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues [ARKQB-571](https://mckinsey.atlassian.net/browse/ARKQB-571)