### PR TITLE
rfc: embedding model types

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,323 @@
+# Plan: Model Provider/Type Migration
+
+## Summary
+
+Complete the Model schema split where `spec.provider` is the AI client (openai/azure/bedrock) and `spec.type` is the API capability (completions, future: embeddings). Add a mutating webhook to auto-migrate existing models when annotated.
+
+## Current State
+
+- **CRD**: Has both `spec.provider` and `spec.type` fields ✓
+- **Printer columns**: Show PROVIDER and TYPE ✓ (but PROVIDER empty for old models)
+- **Operator code**: Uses `GetProvider()` fallback logic to handle old format
+- **ark-api**: Uses `get_provider_from_spec()` fallback logic
+- **Dashboard**: Updated to use `provider` field ✓
+- **Existing models**: Have `spec.type: openai` (old format), no `spec.provider`
+
+## Problem
+
+Existing models show empty PROVIDER column in kubectl/k9s because they don't have `spec.provider` set. The fallback logic in code handles this at runtime, but the raw CRD data is unchanged.
+
+## Solution
+
+Add a **mutating webhook** that migrates old format to new format on create/update. Users trigger migration for existing models via annotation. After migration, remove fallback logic from operator and API code.
+
+---
+
+## Tasks
+
+### 1. Add Mutating Webhook for Model
+
+**File**: `ark/internal/webhook/v1/model_webhook.go`
+
+Add `ModelCustomDefaulter` that:
+- Detects old format: `spec.provider == ""` AND `spec.type` is a provider value
+- Migrates: `spec.provider = spec.type`, `spec.type = "completions"`
+
+```go
+// +kubebuilder:webhook:path=/mutate-ark-mckinsey-com-v1alpha1-model,mutating=true,failurePolicy=fail,sideEffects=None,groups=ark.mckinsey.com,resources=models,verbs=create;update,versions=v1alpha1,name=mmodel-v1.kb.io,admissionReviewVersions=v1
+
+type ModelCustomDefaulter struct{}
+
+var _ webhook.CustomDefaulter = &ModelCustomDefaulter{}
+
+func (d *ModelCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+    model, ok := obj.(*arkv1alpha1.Model)
+    if !ok {
+        return fmt.Errorf("expected a Model object but got %T", obj)
+    }
+
+    // Migrate deprecated format: spec.type contained provider value
+    // For upgrade details, see docs/content/reference/upgrading.mdx
+    if model.Spec.Provider == "" && genai.IsDeprecatedProviderInType(model.Spec.Type) {
+        model.Spec.Provider = model.Spec.Type
+        model.Spec.Type = genai.ModelTypeCompletions
+    }
+
+    return nil
+}
+```
+
+Update `SetupModelWebhookWithManager` to include `.WithDefaulter(&ModelCustomDefaulter{})`.
+
+### 2. Regenerate Webhook Manifests
+
+```bash
+cd ark && make manifests
+```
+
+This generates the mutating webhook configuration in `config/webhook/`.
+
+### 3. Update Upgrading Documentation
+
+**File**: `docs/content/reference/upgrading.mdx`
+
+Add section for this version (e.g., v0.1.50):
+
+```markdown
+## v0.1.50
+
+### Model Provider Field
+
+Prior to `v0.1.50`, the `spec.type` field on Models was overloaded to specify both:
+- The AI provider client (openai, azure, bedrock)
+- The API capability type
+
+From `v0.1.50`, these are separate fields:
+- `spec.provider`: The AI provider client (openai, azure, bedrock)
+- `spec.type`: The API capability (completions, embeddings in future)
+
+**New models** should use the new format:
+```yaml
+spec:
+  provider: openai
+  type: completions  # optional, defaults to completions
+```
+
+**Existing models** using the old format (`spec.type: openai`) will continue to work but show a deprecation warning. On any update, they are automatically migrated to the new format.
+
+To migrate all existing models:
+
+```bash
+# View current models - PROVIDER column may be empty for old format
+kubectl get models
+
+# Trigger migration by annotating all models
+kubectl annotate models --all 'ark.mckinsey.com/migrate-provider=done' --overwrite
+
+# Verify migration - PROVIDER column now populated
+kubectl get models
+```
+
+This is a **non-breaking** change for new/updated resources. Existing models require the annotation trigger to migrate.
+```
+
+### 4. Add Webhook Tests
+
+**File**: `ark/internal/webhook/v1/model_webhook_test.go`
+
+Add tests for the defaulter:
+
+```go
+func TestModelCustomDefaulter_MigratesOldFormat(t *testing.T) {
+    // Test: old format (type: openai, no provider) -> migrated
+    model := &arkv1alpha1.Model{
+        Spec: arkv1alpha1.ModelSpec{
+            Type: "openai",
+            // Provider is empty
+        },
+    }
+
+    defaulter := &ModelCustomDefaulter{}
+    err := defaulter.Default(context.Background(), model)
+
+    assert.NoError(t, err)
+    assert.Equal(t, "openai", model.Spec.Provider)
+    assert.Equal(t, "completions", model.Spec.Type)
+}
+
+func TestModelCustomDefaulter_PreservesNewFormat(t *testing.T) {
+    // Test: new format (provider: openai, type: completions) -> unchanged
+    model := &arkv1alpha1.Model{
+        Spec: arkv1alpha1.ModelSpec{
+            Provider: "azure",
+            Type:     "completions",
+        },
+    }
+
+    defaulter := &ModelCustomDefaulter{}
+    err := defaulter.Default(context.Background(), model)
+
+    assert.NoError(t, err)
+    assert.Equal(t, "azure", model.Spec.Provider)
+    assert.Equal(t, "completions", model.Spec.Type)
+}
+
+func TestModelCustomDefaulter_HandlesAllProviders(t *testing.T) {
+    for _, provider := range []string{"openai", "azure", "bedrock"} {
+        model := &arkv1alpha1.Model{
+            Spec: arkv1alpha1.ModelSpec{
+                Type: provider,
+            },
+        }
+
+        defaulter := &ModelCustomDefaulter{}
+        err := defaulter.Default(context.Background(), model)
+
+        assert.NoError(t, err)
+        assert.Equal(t, provider, model.Spec.Provider)
+        assert.Equal(t, "completions", model.Spec.Type)
+    }
+}
+```
+
+### 5. Keep Deprecation Warning in Validator
+
+The validator already emits a deprecation warning. After migration, this warning won't appear (because the model is migrated before validation). But if someone manually creates a model with old format via raw API (bypassing webhook), the warning still helps.
+
+**Current code** (keep as-is for safety):
+```go
+if genai.IsDeprecatedProviderInType(model.Spec.Type) {
+    warnings = append(warnings, fmt.Sprintf(
+        "spec.type=%q is deprecated; use spec.provider=%q instead (will be removed in 1.0)",
+        model.Spec.Type, model.Spec.Type))
+}
+```
+
+### 6. Remove Fallback Logic (After Migration Rollout)
+
+Once all users have migrated, remove the fallback logic:
+
+**File**: `ark/internal/genai/constants.go`
+- Keep `IsDeprecatedProviderInType()` for webhook use
+- Remove or simplify `GetProvider()` fallback
+
+**File**: `ark/internal/genai/model.go`
+- Use `spec.Provider` directly instead of `GetProvider()`
+
+**File**: `services/ark-api/ark-api/src/ark_api/models/models.py`
+- Remove `DEPRECATED_PROVIDER_TYPES` constant
+- Remove `get_provider_from_spec()` fallback function
+
+**File**: `services/ark-api/ark-api/src/ark_api/api/v1/models.py`
+- Use `spec.get("provider")` directly
+
+**Note**: This cleanup can be a separate PR after the migration webhook has been deployed and users have had time to migrate.
+
+### 7. Update Chainsaw Tests (If Needed)
+
+The chainsaw tests were already updated to use new format. Verify they still pass:
+
+```bash
+cd tests && chainsaw test --selector 'standard'
+```
+
+### 8. Verify Printer Columns Work
+
+After migration, kubectl should show:
+
+```
+NAME                 PROVIDER   TYPE          MODEL        AVAILABLE
+azure-gpt-4          azure      completions   gpt-4        True
+claude-sonnet        openai     completions   claude-3.5   True
+```
+
+---
+
+## Migration Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     User triggers migration                      │
+│  kubectl annotate models --all 'ark.mckinsey.com/migrate-provider=done' │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   Kubernetes updates model                       │
+│            (annotation change triggers update)                   │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                 Mutating Webhook intercepts                      │
+│                                                                  │
+│  if spec.provider == "" && spec.type in [openai,azure,bedrock]: │
+│      spec.provider = spec.type                                   │
+│      spec.type = "completions"                                   │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                 Validating Webhook runs                          │
+│           (no deprecation warning - already migrated)            │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Model saved to etcd                           │
+│         spec.provider: openai, spec.type: completions            │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                kubectl get models shows correctly                │
+│            PROVIDER: openai, TYPE: completions                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## What Happens to Non-Migrated Models?
+
+Until migrated:
+- **Controller**: Uses `GetProvider()` fallback - model works correctly
+- **API**: Uses `get_provider_from_spec()` fallback - returns correct provider
+- **Dashboard**: Shows provider correctly (from API response)
+- **kubectl**: Shows empty PROVIDER column, TYPE shows provider value
+
+After migration:
+- All fields populated correctly
+- No fallback logic needed
+- Clear separation of provider vs type
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `ark/internal/webhook/v1/model_webhook.go` | Add mutating webhook |
+| `ark/internal/webhook/v1/model_webhook_test.go` | Add defaulter tests |
+| `docs/content/reference/upgrading.mdx` | Add migration docs |
+| `ark/config/webhook/` | Auto-generated by `make manifests` |
+
+## Files to Clean Up Later (Separate PR)
+
+| File | Change |
+|------|--------|
+| `ark/internal/genai/constants.go` | Simplify `GetProvider()` |
+| `ark/internal/genai/model.go` | Remove fallback |
+| `services/ark-api/.../models.py` | Remove fallback constants |
+| `services/ark-api/.../api/v1/models.py` | Remove fallback function |
+
+---
+
+## Testing Checklist
+
+- [ ] `make manifests` generates mutating webhook config
+- [ ] `make test` passes in ark/
+- [ ] New model with old format gets migrated on create
+- [ ] Existing model gets migrated when annotated
+- [ ] New model with new format is unchanged
+- [ ] kubectl shows PROVIDER and TYPE columns correctly after migration
+- [ ] Dashboard shows provider correctly
+- [ ] Deprecation warning appears if webhook is bypassed
+- [ ] Chainsaw tests pass
+
+---
+
+## Open Questions
+
+1. **Version number**: What version should this be documented under in upgrading.mdx?
+2. **Fallback removal timeline**: When can we safely remove the fallback logic? After one release cycle?
+3. **Should we auto-migrate in controller?**: The current plan uses annotation trigger. Alternative: controller could auto-migrate on reconcile (more aggressive).

--- a/scratch/model-providers.md
+++ b/scratch/model-providers.md
@@ -1,0 +1,154 @@
+# Model Provider/Type Schema Split - Statement of Work
+
+**Issue:** https://github.com/mckinsey/agents-at-scale-ark/issues/37
+**Scope:** Pre-work for embedding model support
+
+## Background
+
+The Model CRD currently uses `spec.type` for two purposes:
+1. Which client library to use (OpenAI, Azure, Bedrock)
+2. Which API the model implements (implicitly: chat completions)
+
+This conflation prevents supporting embedding models. We need to split `spec.type` into two fields.
+
+## Schema Change
+
+```yaml
+# Current (deprecated)
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+spec:
+  type: openai  # Overloaded meaning
+
+# New
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+spec:
+  type: completions      # API type: completions | embeddings (default: completions)
+  provider: openai       # Client: openai | azure | bedrock
+```
+
+## Deliverables
+
+### 1. Model CRD Update
+
+**File:** `ark/api/v1alpha1/model_types.go`
+
+- Add `spec.provider` field (enum: `openai`, `azure`, `bedrock`)
+- Change `spec.type` to new semantics (enum: `completions`, `embeddings`)
+- `spec.type` defaults to `completions` if omitted
+- Regenerate CRD manifests (`make manifests`)
+
+### 2. Mutating Webhook
+
+**File:** `ark/internal/webhook/model_webhook.go` (create or extend)
+
+Migration logic:
+- If `spec.provider` is empty AND `spec.type` is one of (`openai`, `azure`, `bedrock`):
+  - Set `spec.provider` = old `spec.type` value
+  - Set `spec.type` = `completions`
+  - Emit deprecation warning in webhook response
+
+Deprecation warning text:
+```
+Model.spec.type "openai", "azure", or "bedrock" is deprecated in favour of Model.spec.provider
+```
+
+### 3. Controller Updates
+
+**Files:**
+- `ark/internal/controller/query_controller.go`
+- `ark/internal/genai/*.go`
+
+- Update model client construction to use `spec.provider` instead of `spec.type`
+- Existing completion logic continues to work (no behavior change yet)
+
+### 4. Unit Tests
+
+**Files:** `ark/internal/controller/*_test.go`, `ark/internal/webhook/*_test.go`
+
+Test cases:
+- New schema: `provider: openai, type: completions` works correctly
+- New schema: `provider: azure, type: completions` works correctly
+- New schema: `provider: bedrock, type: completions` works correctly
+- Default: `provider: openai` with no `type` defaults to `completions`
+- Migration: old `type: openai` converts to `provider: openai, type: completions`
+- Migration: old `type: azure` converts to `provider: azure, type: completions`
+- Migration: old `type: bedrock` converts to `provider: bedrock, type: completions`
+- Webhook returns deprecation warning for migrated resources
+
+### 5. Chainsaw E2E Tests
+
+**Directory:** `tests/e2e/`
+
+Update existing tests:
+- Migrate sample Model resources to new schema format
+- Verify existing query flows work with new schema
+
+Add migration tests:
+- Apply Model with old schema, verify webhook converts it
+- Verify deprecation warning appears in kubectl output or events
+
+### 7. SDK Update
+
+- ark sdk must be updated
+
+### 8. Ark API Updates
+
+- ark apis must be updated
+
+### 9. Dashboard Updates
+
+- ark dashboard must be updated
+
+### 10. CLI updates
+
+- ark CLI must be upated
+- fark CLI must be updated
+
+### 6. Sample Updates
+
+**Directory:** `samples/`
+
+- Update all Model YAML files to use new `provider`/`type` schema
+- Add comment noting the old format is deprecated
+
+### 7. Documentation
+
+**Files:** `docs/` (relevant Model reference pages)
+
+- Document new `spec.provider` field
+- Document new `spec.type` semantics
+- Add migration guide section explaining the change
+- Note deprecation timeline (if any) and deprecated notes page
+
+## Validation Criteria
+
+- [ ] All existing Model resources continue to work (backward compatible)
+- [ ] New Models can be created with `provider`/`type` schema
+- [ ] Old Models trigger deprecation warning on create/update
+- [ ] `make test` passes in `ark/` directory
+- [ ] Chainsaw tests pass
+- [ ] Docs build successfully
+
+## Out of Scope
+
+- EmbeddingsQueryReconciler implementation (separate work item)
+- QueryReconciler interface extraction (separate work item)
+- Query targets simplification (separate issue #635)
+
+## Files Changed (Expected)
+
+```
+ark/api/v1alpha1/model_types.go
+ark/api/v1alpha1/zz_generated.deepcopy.go
+ark/config/crd/bases/ark.mckinsey.com_models.yaml
+ark/internal/webhook/model_webhook.go
+ark/internal/controller/query_controller.go
+ark/internal/genai/openai.go (or equivalent)
+ark/internal/controller/*_test.go
+ark/internal/webhook/*_test.go
+tests/e2e/model-*.yaml (various)
+samples/models/*.yaml
+docs/pages/reference/model.mdx (or equivalent)
+```

--- a/tasks/001-embedding-model-types/00-plan.md
+++ b/tasks/001-embedding-model-types/00-plan.md
@@ -1,0 +1,43 @@
+---
+owner: ark-protocol-orchestrator
+description: Add embedding model support via provider/type schema split and pluggable query reconcilers
+---
+
+# Embedding Model Types - Plan
+
+**GitHub Issue:** https://github.com/mckinsey/agents-at-scale-ark/issues/37
+
+## Tasks
+
+- [x] Define objectives
+- [ ] Design architecture → ark-architect
+- [ ] Build verifiable prototype → ark-prototyper
+- [ ] Document outcome
+
+## Pre-work (can be done independently)
+
+- [ ] Eliminate multiple query targets ([#635](https://github.com/mckinsey/agents-at-scale-ark/issues/635)) - simplifies routing to reconcilers
+- [ ] Model CRD: Add `spec.provider`, migrate `spec.type` semantics, mutating webhook
+- [ ] Extract `QueryReconciler` interface wrapping existing completion logic
+
+## Phases
+
+### Phase 1: Extract Interface/Registry
+- Extract `QueryReconciler` interface from existing code
+- Create `QueryReconcilerRegistry` for routing
+- Wrap existing logic in `CompletionsQueryReconciler`
+- No behavior change, pure refactor
+
+### Phase 2: Embedding Support
+- Add `EmbeddingsQueryReconciler`
+- Extend Model CRD with `spec.provider` and `spec.type` fields
+- Add mutating webhook for migration
+
+## Open Decisions
+
+- [ ] Embeddings response format: separate field vs encoded in Message
+
+## Findings
+
+Discoveries tracked in `99-findings/`:
+- (none yet)

--- a/tasks/001-embedding-model-types/01-objectives.md
+++ b/tasks/001-embedding-model-types/01-objectives.md
@@ -1,0 +1,48 @@
+---
+owner: ark-protocol-orchestrator
+description: Objectives for embedding model type support
+---
+
+# Embedding Model Types - Objectives
+
+**GitHub Issue:** https://github.com/mckinsey/agents-at-scale-ark/issues/37
+
+## Overview
+
+Models currently assume all are chat completion models. This feature adds support for embedding models and establishes patterns for other non-completion model types. The approach splits `spec.type` into `spec.provider` (client construction) and `spec.type` (model capability), with pluggable query reconcilers handling different model types.
+
+## Goals
+
+1. **Support embedding models** - Allow queries to target embedding models with appropriate API calls
+2. **Clean schema separation** - `spec.provider` for client (openai/azure/bedrock), `spec.type` for capability (completion/embedding)
+3. **Pluggable reconcilers** - Route queries to appropriate handlers without monolithic switch statements
+4. **Backward compatibility** - Migrate existing resources via mutating webhook with deprecation warnings
+
+## Use Cases
+
+- Generate embeddings for RAG pipelines using OpenAI, Azure, or Bedrock embedding models
+- Mix completion and embedding models in the same Ark deployment
+- Migrate existing Model resources without breaking changes
+
+## Future Extensibility
+
+The QueryReconciler pattern supports additional model types. Likely candidates:
+
+| Type | API | Use Case |
+|------|-----|----------|
+| `response` | `/v1/responses` | OpenAI's agentic API with built-in tool handling |
+| `image` | `/v1/images/generations` | Image generation (DALL-E) |
+| `audio` | `/v1/audio/transcriptions` | Speech-to-text (Whisper) |
+| `tts` | `/v1/audio/speech` | Text-to-speech |
+| `rerank` | varies | Reranking for RAG pipelines |
+
+The `response` type is most likely to follow `completion` and `embedding`, as it represents OpenAI's newer approach to agentic workflows.
+
+## Success Criteria
+
+- Queries targeting embedding models receive embedding API responses
+- Query status accurately reflects embedding-specific outcomes
+- Main query controller remains focused on orchestration
+- Mutating webhook converts old format with deprecation warning
+- Existing Model resources continue to work after migration
+- One step closer to an architecture that allows us to break out query reconciliation into its own services

--- a/tasks/001-embedding-model-types/02-architecture.md
+++ b/tasks/001-embedding-model-types/02-architecture.md
@@ -1,0 +1,172 @@
+---
+owner: ark-architect
+description: Technical design for embedding model type support
+---
+
+# Embedding Model Types - Architecture
+
+**Status:** Draft
+
+## Overview
+
+This feature separates `spec.type` into `spec.provider` (client construction) and `spec.type` (model capability). A QueryReconcilerRegistry routes queries to type-specific reconcilers (completions, embeddings) that call the appropriate API endpoints.
+
+## Query Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      QueryController                            │
+│                                                                 │
+│  ┌─────────────┐    ┌──────────────────────────────────────┐   │
+│  │   Query     │───▶│         executeModel()                │   │
+│  │  (target:   │    │                                       │   │
+│  │   model)    │    │  1. Load Model CRD                    │   │
+│  └─────────────┘    │  2. Get reconciler from registry      │   │
+│                     │  3. Delegate to reconciler            │   │
+│                     └───────────────┬──────────────────────┘   │
+│                                     │                           │
+│                     ┌───────────────▼───────────────┐           │
+│                     │   QueryReconcilerRegistry     │           │
+│                     │   GetReconciler(model.type)   │           │
+│                     └───────────────┬───────────────┘           │
+│                                     │                           │
+│                    ┌────────────────┼────────────────┐          │
+│                    ▼                ▼                ▼          │
+│            ┌────────────┐  ┌────────────┐   ┌────────────┐     │
+│            │Completions │  │Embeddings  │   │ (future)   │     │
+│            │Query       │  │Query       │   │ Responses  │     │
+│            │Reconciler  │  │Reconciler  │   │ Reconciler │     │
+│            └─────┬──────┘  └─────┬──────┘   └────────────┘     │
+│                  │               │                              │
+│                  ▼               ▼                              │
+│           /chat/completions  /embeddings                        │
+│                  │               │                              │
+│                  ▼               ▼                              │
+│             Response:       Response:                           │
+│             .content        .raw (float[])                      │
+│             .raw            .content ("")                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Schema Change
+
+```yaml
+# Before (current)
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+spec:
+  type: openai  # Overloaded: means both "use OpenAI client" and "chat completions"
+
+# After
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+spec:
+  provider: openai           # Client construction
+  type: completions          # API type (default if omitted)
+```
+
+### Model CRD Fields
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `spec.provider` | `openai`, `azure`, `bedrock` | Which client library to use |
+| `spec.type` | `completions` (default), `embeddings` | Which API the model implements |
+
+## File Structure
+
+```
+ark/internal/genai/
+    query_reconciler.go             # QueryReconciler interface
+    query_reconciler_registry.go    # Registry for type-based routing
+    completions_query_reconciler.go # Wraps existing completion logic
+    embeddings_query_reconciler.go  # New embeddings handler
+
+ark/internal/controller/
+    query_controller.go             # Inject registry, delegate in executeModel
+```
+
+## Input/Output Handling
+
+### Current Query Input Types
+
+The Query CRD supports two input formats via `spec.type`:
+- `user` (default): String input converted to single user message
+- `messages`: Array of OpenAI ChatCompletionMessageParamUnion objects
+
+### Embedding Input
+
+Embeddings use simpler input than completions. For embeddings:
+- Use `spec.type: user` with a string input
+- The embedding API accepts text directly, not a conversation array
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+spec:
+  type: user
+  input: "Text to embed"
+  targets:
+    - type: model
+      name: text-embedding-ada-002
+```
+
+### Embedding Output
+
+The existing Response struct already has the right fields:
+
+```go
+type Response struct {
+    Target  QueryTarget `json:"target,omitempty"`
+    Content string      `json:"content,omitempty"`   # Empty for embeddings
+    Raw     string      `json:"raw,omitempty"`       # JSON array of floats
+    Phase   string      `json:"phase,omitempty"`
+}
+```
+
+For embeddings:
+- `content`: Empty string (embeddings have no text content)
+- `raw`: JSON-serialized embedding vector `"[0.123, -0.456, ...]"`
+
+Example response:
+```yaml
+status:
+  phase: done
+  responses:
+    - target:
+        type: model
+        name: text-embedding-ada-002
+      content: ""
+      raw: "[0.0023064255,-0.009327292,...]"
+      phase: done
+```
+
+## One-Way Decisions
+
+1. **Should `spec.type` default to `completions`?** Yes - existing Models work without changes.
+
+2. **Mutating webhook for migration?** Yes - auto-converts old format with deprecation warning.
+
+## Open Questions
+
+**Should the Query specify intent rather than the Model declaring its type?**
+
+A single provider (e.g., OpenAI) can serve completions, embeddings, AND responses via the same credentials. The Model CRD just configures the connection. Two approaches:
+
+| Approach | How it works | Trade-off |
+|----------|--------------|-----------|
+| **Model declares type** (current) | `Model.spec.type: embeddings` | Simple routing, but requires separate Model CRDs per API type |
+| **Query declares intent** | `Query.spec.responseType: embeddings` | One Model serves multiple purposes, but Query becomes more complex |
+
+Current design uses Model-declares-type for simplicity. Future work may revisit if users need one Model to serve multiple API types.
+
+## Implementation Phases
+
+1. **Schema update**: Add `spec.provider` field, make `spec.type` enum with `completions`/`embeddings`
+2. **Mutating webhook**: Convert old `spec.type` values to new schema with deprecation warning
+3. **QueryReconciler interface**: Extract interface and registry, wrap existing logic
+4. **EmbeddingsQueryReconciler**: Implement embeddings handler with OpenAI
+5. **Azure/Bedrock**: Add embeddings support for remaining providers
+
+## Reference
+
+See `01-objectives.md` for goals and success criteria.

--- a/tasks/001-embedding-model-types/03-verifiable-prototype.md
+++ b/tasks/001-embedding-model-types/03-verifiable-prototype.md
@@ -1,0 +1,18 @@
+---
+owner: ark-prototyper
+description: Implementation journal for embedding model type support
+---
+
+# Embedding Model Types - Verifiable Prototype
+
+**Status:** Pending
+
+This document will be produced by the ark-prototyper agent.
+
+## Checkpoints
+
+Implementation progress will be tracked here with verification steps.
+
+## Reference
+
+See `01-objectives.md` for goals and `02-architecture.md` for technical design.

--- a/tasks/001-embedding-model-types/04-outcome.md
+++ b/tasks/001-embedding-model-types/04-outcome.md
@@ -1,0 +1,21 @@
+---
+owner: ark-protocol-orchestrator
+description: Results and next steps for embedding model type support
+---
+
+# Embedding Model Types - Outcome
+
+**Status:** Pending
+
+This document will be completed after prototype verification.
+
+## Results
+
+- What worked
+- What didn't
+- Decisions made
+
+## Next Steps
+
+- Follow-on work
+- Items for backlog


### PR DESCRIPTION
## Summary
RFC for separating model provider from model type to support embedding models and other model types in the future.

## Tasks
- [x] #667 - Add Model provider field with backward-compatible migration
- [ ] Add embedding model type support
- [ ] Update documentation for new model types