### PR TITLE
feat(dashboard): add Argo Workflows API integration

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/flows.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/flows.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+global.fetch = vi.fn();
+
+describe('flows service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('checkArgoAvailable', () => {
+    it('returns true when Argo API responds with OK', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/argo/workflow-templates?namespace=default',
+      );
+    });
+
+    it('returns false when Argo API responds with error', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+      } as Response);
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when fetch throws an error', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getArgoBaseUrl', () => {
+    it('returns baseUrl from API config', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ baseUrl: 'http://argo.example.com:2746' }),
+      } as Response);
+
+      const { getArgoBaseUrl } = await import('@/lib/services/flows');
+      const result = await getArgoBaseUrl();
+
+      expect(result).toBe('http://argo.example.com:2746');
+    });
+
+    it('returns default URL when API fails', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const { getArgoBaseUrl } = await import('@/lib/services/flows');
+      const result = await getArgoBaseUrl();
+
+      expect(result).toBe('http://localhost:2746');
+    });
+  });
+
+  describe('workflowTemplatesService', () => {
+    it('getAll returns templates from API', async () => {
+      const mockTemplates = [
+        { name: 'template1', namespace: 'default', parameters: [] },
+      ];
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTemplates,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getAll('default');
+
+      expect(result).toEqual(mockTemplates);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/argo/workflow-templates?namespace=default',
+      );
+    });
+
+    it('getAll returns empty array when API fails', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getAll('default');
+
+      expect(result).toEqual([]);
+    });
+
+    it('getByName returns template when found', async () => {
+      const mockTemplate = {
+        name: 'my-template',
+        namespace: 'default',
+        parameters: [],
+      };
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTemplate,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getByName(
+        'my-template',
+        'default',
+      );
+
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('getByName returns null when not found', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getByName(
+        'non-existent',
+        'default',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/config/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/config/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET() {
+  return NextResponse.json({
+    baseUrl: ARGO_SERVER_URL,
+  });
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/namespaces/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/namespaces/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json(['default', 'argo-workflows']);
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/[name]/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/[name]/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || 'default';
+
+  try {
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflow-templates/${namespace}/${name}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json(
+          { error: 'Workflow template not found' },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json(
+        { error: 'Failed to fetch workflow template' },
+        { status: response.status },
+      );
+    }
+
+    const item = await response.json();
+
+    const template = {
+      name: item.metadata.name,
+      namespace: item.metadata.namespace,
+      description:
+        item.metadata.annotations?.['workflows.argoproj.io/description'],
+      parameters: item.spec.arguments?.parameters || [],
+    };
+
+    return NextResponse.json(template);
+  } catch (error) {
+    console.error('Error fetching workflow template:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/route.ts
@@ -1,0 +1,70 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || 'default';
+
+  try {
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflow-templates/${namespace}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const data = await response.json();
+
+    if (!response.ok || data.code) {
+      console.warn(
+        `Argo API error for namespace ${namespace}:`,
+        data.message || response.status,
+      );
+      return NextResponse.json([]);
+    }
+
+    const templates = (data.items || []).map(
+      (item: {
+        metadata: {
+          name: string;
+          namespace: string;
+          annotations?: Record<string, string>;
+        };
+        spec: {
+          arguments?: {
+            parameters?: Array<{
+              name: string;
+              default?: string;
+              description?: string;
+            }>;
+          };
+          templates?: Array<{ name: string }>;
+        };
+      }) => ({
+        name: item.metadata.name,
+        namespace: item.metadata.namespace,
+        description:
+          item.metadata.annotations?.['workflows.argoproj.io/description'],
+        parameters: (item.spec.arguments?.parameters || []).map(p => ({
+          name: p.name,
+          value: p.default || '',
+          description: p.description,
+        })),
+      }),
+    );
+
+    return NextResponse.json(templates);
+  } catch (error) {
+    console.error('Error fetching workflow templates:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/[namespace]/[name]/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/[namespace]/[name]/route.ts
@@ -1,0 +1,114 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+interface WorkflowNode {
+  id: string;
+  displayName: string;
+  type: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  templateName?: string;
+  outputs?: {
+    parameters?: Array<{ name: string; value?: string }>;
+    exitCode?: string;
+  };
+}
+
+interface RouteContext {
+  params: Promise<{ namespace: string; name: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { namespace, name } = await context.params;
+
+  try {
+    const workflowResponse = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}/${name}`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    if (!workflowResponse.ok) {
+      return NextResponse.json(
+        { error: 'Workflow not found' },
+        { status: workflowResponse.status },
+      );
+    }
+
+    const workflow = await workflowResponse.json();
+
+    const nodes: WorkflowNode[] = [];
+    if (workflow.status?.nodes) {
+      for (const [id, node] of Object.entries(
+        workflow.status.nodes as Record<string, WorkflowNode>,
+      )) {
+        nodes.push({
+          id,
+          displayName: (node as WorkflowNode).displayName,
+          type: (node as WorkflowNode).type,
+          phase: (node as WorkflowNode).phase,
+          startedAt: (node as WorkflowNode).startedAt,
+          finishedAt: (node as WorkflowNode).finishedAt,
+          message: (node as WorkflowNode).message,
+          templateName: (node as WorkflowNode).templateName,
+          outputs: (node as WorkflowNode).outputs,
+        });
+      }
+    }
+
+    nodes.sort(
+      (a, b) =>
+        new Date(a.startedAt || 0).getTime() -
+        new Date(b.startedAt || 0).getTime(),
+    );
+
+    const logsResponse = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}/${name}/log?logOptions.container=main`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const logsByPod: Record<string, string[]> = {};
+
+    if (logsResponse.ok) {
+      const logsText = await logsResponse.text();
+      const lines = logsText.trim().split('\n');
+
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line);
+          const podName = parsed.result?.podName || 'unknown';
+          const content = parsed.result?.content;
+          if (content !== undefined) {
+            if (!logsByPod[podName]) logsByPod[podName] = [];
+            logsByPod[podName].push(content);
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+    }
+
+    return NextResponse.json({
+      name: workflow.metadata.name,
+      namespace: workflow.metadata.namespace,
+      templateName: workflow.spec.workflowTemplateRef?.name,
+      phase: workflow.status?.phase || 'Pending',
+      startedAt: workflow.status?.startedAt,
+      finishedAt: workflow.status?.finishedAt,
+      message: workflow.status?.message,
+      nodes: nodes.filter(n => n.type === 'Pod'),
+      logsByPod,
+    });
+  } catch (error) {
+    console.error('Error fetching workflow:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch workflow' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/route.ts
@@ -1,0 +1,156 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+interface SubmitWorkflowRequest {
+  templateName: string;
+  namespace: string;
+  parameters: Array<{ name: string; value: string }>;
+  labels?: Record<string, string>;
+}
+
+interface ArgoWorkflow {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    workflowTemplateRef?: { name: string };
+  };
+  status?: {
+    phase?: string;
+    startedAt?: string;
+    finishedAt?: string;
+    message?: string;
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || '';
+  const templateName = searchParams.get('templateName') || '';
+  const labelSelector = searchParams.get('labelSelector') || '';
+
+  try {
+    const namespaces = namespace ? [namespace] : ['default', 'argo-workflows'];
+
+    const allWorkflows: ArgoWorkflow[] = [];
+
+    for (const ns of namespaces) {
+      let url = `${ARGO_SERVER_URL}/api/v1/workflows/${ns}`;
+      if (labelSelector) {
+        url += `?listOptions.labelSelector=${encodeURIComponent(labelSelector)}`;
+      }
+
+      const response = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        allWorkflows.push(...(data.items || []));
+      }
+    }
+
+    let workflows = allWorkflows.map((w: ArgoWorkflow) => ({
+      name: w.metadata.name,
+      namespace: w.metadata.namespace,
+      templateName: w.spec.workflowTemplateRef?.name || '',
+      phase: w.status?.phase || 'Pending',
+      startedAt: w.status?.startedAt || w.metadata.creationTimestamp,
+      finishedAt: w.status?.finishedAt,
+      message: w.status?.message,
+      labels: w.metadata.labels,
+    }));
+
+    if (templateName) {
+      workflows = workflows.filter(w => w.templateName === templateName);
+    }
+
+    workflows.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    );
+
+    return NextResponse.json(workflows);
+  } catch (error) {
+    console.error('Error fetching workflows:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: SubmitWorkflowRequest = await request.json();
+    const { templateName, namespace, parameters, labels } = body;
+
+    const nonEmptyParameters = parameters.filter(p => p.value !== '');
+
+    const workflowSpec = {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Workflow',
+      metadata: {
+        generateName: `${templateName}-`,
+        namespace,
+        labels: {
+          ...labels,
+          'ark-managed': 'true',
+        },
+      },
+      spec: {
+        workflowTemplateRef: {
+          name: templateName,
+        },
+        ...(nonEmptyParameters.length > 0 && {
+          arguments: {
+            parameters: nonEmptyParameters.map(p => ({
+              name: p.name,
+              value: p.value,
+            })),
+          },
+        }),
+      },
+    };
+
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ workflow: workflowSpec }),
+      },
+    );
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Argo API error:', errorData);
+      return NextResponse.json(
+        { error: 'Failed to submit workflow', details: errorData },
+        { status: response.status },
+      );
+    }
+
+    const result = await response.json();
+    return NextResponse.json({
+      name: result.metadata.name,
+      namespace: result.metadata.namespace,
+      status: result.status?.phase || 'Pending',
+    });
+  } catch (error) {
+    console.error('Error submitting workflow:', error);
+    return NextResponse.json(
+      { error: 'Failed to submit workflow' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
@@ -1,0 +1,67 @@
+import type { WorkflowTemplate } from '@/lib/types/flow';
+
+let cachedArgoBaseUrl: string | null = null;
+
+async function getArgoBaseUrl(): Promise<string> {
+  if (cachedArgoBaseUrl) return cachedArgoBaseUrl;
+  try {
+    const response = await fetch('/api/argo/config');
+    if (response.ok) {
+      const config = await response.json();
+      cachedArgoBaseUrl = config.baseUrl;
+      return config.baseUrl;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch Argo config:', error);
+  }
+  return 'http://localhost:2746';
+}
+
+export { getArgoBaseUrl };
+
+async function checkArgoAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch(
+      '/api/argo/workflow-templates?namespace=default',
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export { checkArgoAvailable };
+
+export const workflowTemplatesService = {
+  async getAll(namespace: string = 'default'): Promise<WorkflowTemplate[]> {
+    try {
+      const response = await fetch(
+        `/api/argo/workflow-templates?namespace=${namespace}`,
+      );
+      if (!response.ok) {
+        console.warn('Failed to fetch workflow templates, using empty list');
+        return [];
+      }
+      return response.json();
+    } catch (error) {
+      console.warn('Error fetching workflow templates:', error);
+      return [];
+    }
+  },
+
+  async getByName(
+    name: string,
+    namespace: string = 'default',
+  ): Promise<WorkflowTemplate | null> {
+    try {
+      const response = await fetch(
+        `/api/argo/workflow-templates/${name}?namespace=${namespace}`,
+      );
+      if (!response.ok) return null;
+      return response.json();
+    } catch (error) {
+      console.warn('Error fetching workflow template:', error);
+      return null;
+    }
+  },
+};

--- a/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
@@ -1,0 +1,48 @@
+export interface WorkflowRun {
+  name: string;
+  namespace: string;
+  templateName: string;
+  phase: string;
+  startedAt: string;
+  finishedAt?: string;
+  message?: string;
+  labels?: Record<string, string>;
+}
+
+export interface WorkflowNode {
+  id: string;
+  displayName: string;
+  type: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  templateName?: string;
+  outputs?: {
+    parameters?: Array<{ name: string; value?: string }>;
+    exitCode?: string;
+  };
+}
+
+export interface WorkflowDetail {
+  name: string;
+  namespace: string;
+  templateName?: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  nodes: WorkflowNode[];
+  logsByPod: Record<string, string[]>;
+}
+
+export interface WorkflowTemplate {
+  name: string;
+  namespace: string;
+  description?: string;
+  parameters: {
+    name: string;
+    value?: string;
+    description?: string;
+  }[];
+}

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -12,9 +12,18 @@ async function middleware(request: NextRequest) {
 
   // Proxy anything starting with /api/ to the backend, stripping the /api prefix
   // This includes: /api/v1/*, /api/docs, /api/openapi.json
+  //
+  // TEMPORARY: /api/argo/* routes are handled by Next.js API routes for the Flows feature.
+  // These routes proxy to Argo Workflows server. Once the Flows feature is accepted,
+  // this routing should be harmonized - either by adding Argo proxy routes to ark-api,
+  // or by formalizing the Next.js API routes as the standard approach.
   const apiPath = `${basePath}/api/`;
+  const argoApiPath = `${basePath}/api/argo/`;
 
-  if (request.nextUrl.pathname.startsWith(apiPath)) {
+  if (
+    request.nextUrl.pathname.startsWith(apiPath) &&
+    !request.nextUrl.pathname.startsWith(argoApiPath)
+  ) {
     const token = await getToken({
       req: request,
       secret: process.env.AUTH_SECRET,


### PR DESCRIPTION
**Note: this branch establishes the foundation for two other feature branches - feat/flows-page and on top of that, feat/flow-logs-pages**

> **Stacked PR Series** - Please review in order:
> 1. PR #658 - Argo API integration ← you are here 
> 2. PR #659 - Flows page
> 3. PR #660 - Flow Logs pages 

Add Next.js API routes to proxy requests to Argo Workflows server. This enables the dashboard to interact with Argo for workflow management.

## Changes
- Add /api/argo/* routes for Argo Workflows integration
- Add middleware exception to route /api/argo/* to Next.js instead of ark-api
- Add checkArgoAvailable() to detect if Argo is deployed
- Add workflow template service for fetching templates
- Add TypeScript types for workflow data structures
- Add unit tests for flows service

## API Routes
- GET /api/argo/config - Returns Argo server URL
- GET /api/argo/namespaces - Returns available namespaces
- GET /api/argo/workflow-templates - List workflow templates
- GET /api/argo/workflow-templates/[name] - Get template details
- GET /api/argo/workflows - List workflow runs
- POST /api/argo/workflows - Submit new workflow
- GET /api/argo/workflows/[namespace]/[name] - Get workflow details with logs

## Configuration
Set ARGO_SERVER_URL environment variable to point to your Argo server. Default: http://argo-workflows-server.argo-workflows.svc.cluster.local:2746


## Testing

```bash
# Terminal 1: Port forward Argo Workflows
kubectl port-forward -n argo-workflows svc/argo-workflows-server 2746:2746

# Terminal 2: Run dev server
cd services/ark-dashboard/ark-dashboard
ARGO_SERVER_URL=http://localhost:2746 npm run dev
```

Then test the API routes:

```bash
# Get Argo config
curl http://localhost:3000/api/argo/config

# List namespaces
curl http://localhost:3000/api/argo/namespaces

# List workflow templates
curl "http://localhost:3000/api/argo/workflow-templates?namespace=default"

# Get a specific template
curl "http://localhost:3000/api/argo/workflow-templates/YOUR_TEMPLATE?namespace=default"

# List workflows
curl "http://localhost:3000/api/argo/workflows?namespace=default"

# Get workflow details with logs
curl http://localhost:3000/api/argo/workflows/default/YOUR_WORKFLOW_NAME
```

## Demo
https://github.com/user-attachments/assets/4d43c3a7-b5c4-4c20-8fb1-81e2edfbcaa1

## Checklist
- [X] Follow the [contributor guide](./CONTRIBUTING.md)
- [X] End-to-end tests pass
- [X] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 

