### PR TITLE
feat(dashboard): (depends on #658, #659) add Flow Logs pages for workflow monitoring

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/flow-logs-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/flow-logs-section.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FlowLogsSection } from '@/components/sections/flow-logs-section';
+import * as flowsModule from '@/lib/services/flows';
+
+vi.mock('@/lib/services/flows', () => ({
+  checkArgoAvailable: vi.fn(),
+  getArgoBaseUrl: vi.fn(),
+  workflowTemplatesService: {
+    getAll: vi.fn(),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/flow-logs',
+}));
+
+global.fetch = vi.fn();
+
+describe('FlowLogsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when Argo is not available', () => {
+    it('shows Argo not available message', async () => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(false);
+
+      render(<FlowLogsSection />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Argo Workflows Not Available'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/Flow logs require Argo Workflows to be deployed/),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', { name: /View Argo Setup Documentation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not fetch workflows when Argo is unavailable', async () => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(false);
+
+      render(<FlowLogsSection />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Argo Workflows Not Available'),
+        ).toBeInTheDocument();
+      });
+
+      expect(fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/argo/workflows'),
+      );
+    });
+  });
+
+  describe('when Argo is available', () => {
+    beforeEach(() => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(true);
+      vi.mocked(flowsModule.getArgoBaseUrl).mockResolvedValue(
+        'http://localhost:2746',
+      );
+      vi.mocked(flowsModule.workflowTemplatesService.getAll).mockResolvedValue(
+        [],
+      );
+    });
+
+    it('shows empty state when no workflows exist', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      } as Response);
+
+      render(<FlowLogsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('No workflow runs found')).toBeInTheDocument();
+      });
+    });
+
+    it('shows workflow runs in table', async () => {
+      const mockWorkflows = [
+        {
+          name: 'workflow-abc123',
+          namespace: 'default',
+          templateName: 'my-template',
+          phase: 'Succeeded',
+          startedAt: '2024-01-01T10:00:00Z',
+          finishedAt: '2024-01-01T10:05:00Z',
+        },
+      ];
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => mockWorkflows,
+      } as Response);
+
+      render(<FlowLogsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('workflow-abc123')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('my-template')).toBeInTheDocument();
+      expect(screen.getByText('Succeeded')).toBeInTheDocument();
+    });
+
+    it('shows loading state initially', () => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      render(<FlowLogsSection />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('displays namespace and template filters', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      } as Response);
+
+      render(<FlowLogsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Namespace:')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Template:')).toBeInTheDocument();
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/flows-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/flows-section.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FlowsSection } from '@/components/sections/flows-section';
+import * as flowsModule from '@/lib/services/flows';
+
+vi.mock('@/lib/services/flows', () => ({
+  checkArgoAvailable: vi.fn(),
+  flowsService: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  getArgoBaseUrl: vi.fn(),
+  workflowTemplatesService: {
+    getAll: vi.fn(),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/flows',
+}));
+
+describe('FlowsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when Argo is not available', () => {
+    it('shows Argo not available message', async () => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(false);
+
+      render(<FlowsSection />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Argo Workflows Not Available'),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/Flows require Argo Workflows to be deployed/),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', { name: /View Argo Setup Documentation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not load flows when Argo is unavailable', async () => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(false);
+
+      render(<FlowsSection />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Argo Workflows Not Available'),
+        ).toBeInTheDocument();
+      });
+
+      expect(flowsModule.flowsService.getAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when Argo is available', () => {
+    beforeEach(() => {
+      vi.mocked(flowsModule.checkArgoAvailable).mockResolvedValue(true);
+      vi.mocked(flowsModule.getArgoBaseUrl).mockResolvedValue(
+        'http://localhost:2746',
+      );
+    });
+
+    it('shows empty state when no flows exist', async () => {
+      vi.mocked(flowsModule.flowsService.getAll).mockResolvedValue([]);
+
+      render(<FlowsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('No Flows Yet')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: /Create Flow/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows flow cards when flows exist', async () => {
+      const mockFlows = [
+        {
+          id: 'flow-1',
+          name: 'Test Flow 1',
+          description: 'First test flow',
+          templateName: 'template-1',
+          templateNamespace: 'default',
+          parameters: [],
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 'flow-2',
+          name: 'Test Flow 2',
+          description: 'Second test flow',
+          templateName: 'template-2',
+          templateNamespace: 'default',
+          parameters: [],
+          createdAt: '2024-01-02T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+        },
+      ];
+
+      vi.mocked(flowsModule.flowsService.getAll).mockResolvedValue(mockFlows);
+
+      render(<FlowsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Flow 1')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Test Flow 2')).toBeInTheDocument();
+    });
+
+    it('calls checkArgoAvailable on mount', async () => {
+      vi.mocked(flowsModule.flowsService.getAll).mockResolvedValue([]);
+
+      render(<FlowsSection />);
+
+      await waitFor(() => {
+        expect(flowsModule.checkArgoAvailable).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/flows.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/flows.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+global.fetch = vi.fn();
+
+describe('flows service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('checkArgoAvailable', () => {
+    it('returns true when Argo API responds with OK', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+      } as Response);
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/argo/workflow-templates?namespace=default',
+      );
+    });
+
+    it('returns false when Argo API responds with error', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+      } as Response);
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when fetch throws an error', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const { checkArgoAvailable } = await import('@/lib/services/flows');
+      const result = await checkArgoAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getArgoBaseUrl', () => {
+    it('returns baseUrl from API config', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ baseUrl: 'http://argo.example.com:2746' }),
+      } as Response);
+
+      const { getArgoBaseUrl } = await import('@/lib/services/flows');
+      const result = await getArgoBaseUrl();
+
+      expect(result).toBe('http://argo.example.com:2746');
+    });
+
+    it('returns default URL when API fails', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const { getArgoBaseUrl } = await import('@/lib/services/flows');
+      const result = await getArgoBaseUrl();
+
+      expect(result).toBe('http://localhost:2746');
+    });
+  });
+
+  describe('workflowTemplatesService', () => {
+    it('getAll returns templates from API', async () => {
+      const mockTemplates = [
+        { name: 'template1', namespace: 'default', parameters: [] },
+      ];
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTemplates,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getAll('default');
+
+      expect(result).toEqual(mockTemplates);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/argo/workflow-templates?namespace=default',
+      );
+    });
+
+    it('getAll returns empty array when API fails', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getAll('default');
+
+      expect(result).toEqual([]);
+    });
+
+    it('getByName returns template when found', async () => {
+      const mockTemplate = {
+        name: 'my-template',
+        namespace: 'default',
+        parameters: [],
+      };
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTemplate,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getByName(
+        'my-template',
+        'default',
+      );
+
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('getByName returns null when not found', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const { workflowTemplatesService } = await import('@/lib/services/flows');
+      const result = await workflowTemplatesService.getByName(
+        'non-existent',
+        'default',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/flow-logs/[namespace]/[name]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/flow-logs/[namespace]/[name]/page.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ExternalLink,
+  Loader2,
+  XCircle,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import type { BreadcrumbElement } from '@/components/common/page-header';
+import { PageHeader } from '@/components/common/page-header';
+import { Button } from '@/components/ui/button';
+import { getArgoBaseUrl } from '@/lib/services/flows';
+import type { WorkflowDetail, WorkflowNode } from '@/lib/types/flow';
+
+type PhaseType = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Error';
+
+const phaseIcons: Record<PhaseType, React.ReactNode> = {
+  Pending: <Clock className="h-5 w-5 text-gray-500" />,
+  Running: <Loader2 className="h-5 w-5 animate-spin text-blue-500" />,
+  Succeeded: <CheckCircle2 className="h-5 w-5 text-green-500" />,
+  Failed: <XCircle className="h-5 w-5 text-red-500" />,
+  Error: <XCircle className="h-5 w-5 text-red-500" />,
+};
+
+function isSystemLog(line: string): boolean {
+  return (
+    line.startsWith('query.ark.') ||
+    line.includes(' created') ||
+    line.includes(' condition met') ||
+    line.includes('completed:') ||
+    line.includes('written to') ||
+    line.includes('level=info') ||
+    line.includes('sub-process exited') ||
+    line.startsWith('time=')
+  );
+}
+
+interface ParsedLog {
+  time?: string;
+  level?: string;
+  message: string;
+  error?: string;
+}
+
+function parseSystemLog(line: string): ParsedLog {
+  const timeMatch = line.match(/time="([^"]+)"/);
+  const levelMatch = line.match(/level=(\w+)/);
+  const msgMatch = line.match(/msg="([^"]+)"/);
+  const errorMatch = line.match(/error="([^"]+)"/);
+
+  if (timeMatch || msgMatch) {
+    return {
+      time: timeMatch ? timeMatch[1] : undefined,
+      level: levelMatch ? levelMatch[1] : undefined,
+      message: msgMatch ? msgMatch[1] : line,
+      error: errorMatch ? errorMatch[1] : undefined,
+    };
+  }
+
+  return { message: line };
+}
+
+function SystemLogLine({ line }: { line: string }) {
+  const parsed = parseSystemLog(line);
+
+  if (parsed.time) {
+    const time = new Date(parsed.time).toLocaleTimeString();
+    const hasError = parsed.error && parsed.error !== '<nil>';
+
+    return (
+      <div className="flex items-start gap-3 py-1">
+        <span className="shrink-0 text-white">{time}</span>
+        <span className="text-gray-300">{parsed.message}</span>
+        {hasError && (
+          <span className="text-red-400">Error: {parsed.error}</span>
+        )}
+      </div>
+    );
+  }
+
+  return <div className="py-1 text-gray-300">{parsed.message}</div>;
+}
+
+function StepLogs({
+  node,
+  logs,
+  defaultExpanded,
+}: {
+  node: WorkflowNode;
+  logs: string[];
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [viewRaw, setViewRaw] = useState(false);
+  const phase = node.phase as PhaseType;
+  const icon = phaseIcons[phase] || phaseIcons.Pending;
+
+  const duration =
+    node.startedAt && node.finishedAt
+      ? Math.round(
+          (new Date(node.finishedAt).getTime() -
+            new Date(node.startedAt).getTime()) /
+            1000,
+        )
+      : null;
+
+  const systemLogs = logs.filter(l => isSystemLog(l));
+  const contentLogs = logs.filter(l => !isSystemLog(l) && l.trim() !== '');
+
+  const outputParamName = node.outputs?.parameters?.[0]?.name;
+
+  return (
+    <div className="border-b border-gray-200 dark:border-gray-800">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-900/30">
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-gray-500" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-gray-500" />
+        )}
+        {icon}
+        <span className="flex-1 font-medium">{node.displayName}</span>
+        <span className="text-muted-foreground text-sm">
+          {duration !== null ? `${duration}s` : '-'}
+        </span>
+        <span
+          className={`rounded px-2 py-0.5 text-xs ${
+            phase === 'Succeeded'
+              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+              : phase === 'Failed' || phase === 'Error'
+                ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                : phase === 'Running'
+                  ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+                  : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+          }`}>
+          {phase}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="space-y-3 p-4">
+          {systemLogs.length > 0 && (
+            <div className="rounded border border-gray-700 bg-gray-900 p-3">
+              <div className="mb-2 text-sm font-semibold text-gray-200">
+                System Logs
+              </div>
+              <div className="font-mono text-xs">
+                {systemLogs.map((line, i) => (
+                  <SystemLogLine key={i} line={line} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {contentLogs.length > 0 && (
+            <div className="rounded border bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+              <div className="mb-3 flex items-center justify-between">
+                <div className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+                  Step Output
+                  <span className="ml-2 font-mono text-xs font-normal text-gray-500">
+                    {outputParamName
+                      ? `(output reference: ${node.displayName}.outputs.parameters.${outputParamName})`
+                      : '(no named output)'}
+                  </span>
+                </div>
+                <button
+                  onClick={() => setViewRaw(!viewRaw)}
+                  className="rounded border px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800">
+                  {viewRaw ? 'View Formatted' : 'View Raw'}
+                </button>
+              </div>
+              {viewRaw ? (
+                <pre className="max-h-[500px] overflow-auto font-mono text-xs whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+                  {contentLogs.join('\n')}
+                </pre>
+              ) : (
+                <div className="prose prose-sm dark:prose-invert max-w-none">
+                  <ReactMarkdown>{contentLogs.join('\n')}</ReactMarkdown>
+                </div>
+              )}
+            </div>
+          )}
+
+          {logs.length === 0 && (
+            <p className="text-muted-foreground text-sm italic">
+              No logs available
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function WorkflowDetailPage() {
+  const params = useParams();
+  const namespace = params.namespace as string;
+  const name = params.name as string;
+
+  const [workflow, setWorkflow] = useState<WorkflowDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [argoBaseUrl, setArgoBaseUrl] = useState('http://localhost:2746');
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const baseUrl = await getArgoBaseUrl();
+        setArgoBaseUrl(baseUrl);
+
+        const response = await fetch(
+          `/api/argo/workflows/${namespace}/${name}`,
+        );
+        if (!response.ok) {
+          throw new Error('Failed to fetch workflow');
+        }
+        const data = await response.json();
+        setWorkflow(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [namespace, name]);
+
+  const breadcrumbs: BreadcrumbElement[] = [
+    { href: '/', label: 'ARK Dashboard' },
+    { href: '/flow-logs', label: 'Flow Logs' },
+  ];
+
+  const getLogsForNode = (node: WorkflowNode): string[] => {
+    if (!workflow?.logsByPod) return [];
+
+    for (const [podName, logs] of Object.entries(workflow.logsByPod)) {
+      if (podName.includes(node.id.split('-').pop() || '')) {
+        return logs;
+      }
+    }
+    return [];
+  };
+
+  if (loading) {
+    return (
+      <>
+        <PageHeader breadcrumbs={breadcrumbs} currentPage="Loading..." />
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+        </div>
+      </>
+    );
+  }
+
+  if (error || !workflow) {
+    return (
+      <>
+        <PageHeader breadcrumbs={breadcrumbs} currentPage="Error" />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4">
+          <p className="text-red-500">{error || 'Workflow not found'}</p>
+          <Link href="/flow-logs">
+            <Button variant="outline">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Flow Logs
+            </Button>
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const phase = workflow.phase as PhaseType;
+  const icon = phaseIcons[phase] || phaseIcons.Pending;
+
+  return (
+    <>
+      <PageHeader
+        breadcrumbs={breadcrumbs}
+        currentPage={workflow.name}
+        actions={
+          <Button
+            variant="outline"
+            onClick={() =>
+              window.open(
+                `${argoBaseUrl}/workflows/${namespace}/${name}`,
+                '_blank',
+              )
+            }>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            View in Argo
+          </Button>
+        }
+      />
+
+      <div className="flex flex-1 flex-col gap-6 p-6">
+        <div className="flex items-center gap-4 rounded-lg border p-4">
+          {icon}
+          <div className="flex-1">
+            <h2 className="font-mono text-lg font-semibold">{workflow.name}</h2>
+            <p className="text-muted-foreground text-sm">
+              Template: {workflow.templateName || '-'} • Namespace:{' '}
+              {workflow.namespace}
+            </p>
+          </div>
+          <div
+            className={`rounded px-3 py-1 text-sm font-medium ${
+              phase === 'Succeeded'
+                ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                : phase === 'Failed' || phase === 'Error'
+                  ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                  : phase === 'Running'
+                    ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+                    : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+            }`}>
+            {phase}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto rounded-lg border">
+          <div className="border-b bg-gray-50 px-4 py-2 dark:bg-gray-900/50">
+            <h3 className="font-medium">Steps ({workflow.nodes.length})</h3>
+          </div>
+
+          {workflow.nodes.length === 0 ? (
+            <div className="text-muted-foreground p-8 text-center">
+              No steps found
+            </div>
+          ) : (
+            workflow.nodes.map((node, index) => (
+              <StepLogs
+                key={node.id}
+                node={node}
+                logs={getLogsForNode(node)}
+                defaultExpanded={index === 0}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/flow-logs/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/flow-logs/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { BreadcrumbElement } from '@/components/common/page-header';
+import { PageHeader } from '@/components/common/page-header';
+import { FlowLogsSection } from '@/components/sections/flow-logs-section';
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: 'ARK Dashboard' },
+];
+
+export default function FlowLogsPage() {
+  return (
+    <>
+      <PageHeader breadcrumbs={breadcrumbs} currentPage="Flow Logs" />
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <FlowLogsSection />
+      </div>
+    </>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/flows/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/flows/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useRef } from 'react';
+
+import type { BreadcrumbElement } from '@/components/common/page-header';
+import { PageHeader } from '@/components/common/page-header';
+import {
+  FlowsSection,
+  type FlowsSectionRef,
+} from '@/components/sections/flows-section';
+import { Button } from '@/components/ui/button';
+
+const breadcrumbs: BreadcrumbElement[] = [
+  { href: '/', label: 'ARK Dashboard' },
+];
+
+export default function FlowsPage() {
+  const flowsSectionRef = useRef<FlowsSectionRef>(null);
+
+  return (
+    <>
+      <PageHeader
+        breadcrumbs={breadcrumbs}
+        currentPage="Flows"
+        actions={
+          <Button onClick={() => flowsSectionRef.current?.openAddEditor()}>
+            <Plus className="h-4 w-4" />
+            Create Flow
+          </Button>
+        }
+      />
+      <div className="flex flex-1 flex-col">
+        <FlowsSection ref={flowsSectionRef} />
+      </div>
+    </>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/config/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/config/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET() {
+  return NextResponse.json({
+    baseUrl: ARGO_SERVER_URL,
+  });
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/namespaces/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/namespaces/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json(['default', 'argo-workflows']);
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/[name]/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/[name]/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || 'default';
+
+  try {
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflow-templates/${namespace}/${name}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json(
+          { error: 'Workflow template not found' },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json(
+        { error: 'Failed to fetch workflow template' },
+        { status: response.status },
+      );
+    }
+
+    const item = await response.json();
+
+    const template = {
+      name: item.metadata.name,
+      namespace: item.metadata.namespace,
+      description:
+        item.metadata.annotations?.['workflows.argoproj.io/description'],
+      parameters: item.spec.arguments?.parameters || [],
+    };
+
+    return NextResponse.json(template);
+  } catch (error) {
+    console.error('Error fetching workflow template:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflow-templates/route.ts
@@ -1,0 +1,70 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || 'default';
+
+  try {
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflow-templates/${namespace}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const data = await response.json();
+
+    if (!response.ok || data.code) {
+      console.warn(
+        `Argo API error for namespace ${namespace}:`,
+        data.message || response.status,
+      );
+      return NextResponse.json([]);
+    }
+
+    const templates = (data.items || []).map(
+      (item: {
+        metadata: {
+          name: string;
+          namespace: string;
+          annotations?: Record<string, string>;
+        };
+        spec: {
+          arguments?: {
+            parameters?: Array<{
+              name: string;
+              default?: string;
+              description?: string;
+            }>;
+          };
+          templates?: Array<{ name: string }>;
+        };
+      }) => ({
+        name: item.metadata.name,
+        namespace: item.metadata.namespace,
+        description:
+          item.metadata.annotations?.['workflows.argoproj.io/description'],
+        parameters: (item.spec.arguments?.parameters || []).map(p => ({
+          name: p.name,
+          value: p.default || '',
+          description: p.description,
+        })),
+      }),
+    );
+
+    return NextResponse.json(templates);
+  } catch (error) {
+    console.error('Error fetching workflow templates:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/[namespace]/[name]/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/[namespace]/[name]/route.ts
@@ -1,0 +1,114 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+interface WorkflowNode {
+  id: string;
+  displayName: string;
+  type: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  templateName?: string;
+  outputs?: {
+    parameters?: Array<{ name: string; value?: string }>;
+    exitCode?: string;
+  };
+}
+
+interface RouteContext {
+  params: Promise<{ namespace: string; name: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { namespace, name } = await context.params;
+
+  try {
+    const workflowResponse = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}/${name}`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    if (!workflowResponse.ok) {
+      return NextResponse.json(
+        { error: 'Workflow not found' },
+        { status: workflowResponse.status },
+      );
+    }
+
+    const workflow = await workflowResponse.json();
+
+    const nodes: WorkflowNode[] = [];
+    if (workflow.status?.nodes) {
+      for (const [id, node] of Object.entries(
+        workflow.status.nodes as Record<string, WorkflowNode>,
+      )) {
+        nodes.push({
+          id,
+          displayName: (node as WorkflowNode).displayName,
+          type: (node as WorkflowNode).type,
+          phase: (node as WorkflowNode).phase,
+          startedAt: (node as WorkflowNode).startedAt,
+          finishedAt: (node as WorkflowNode).finishedAt,
+          message: (node as WorkflowNode).message,
+          templateName: (node as WorkflowNode).templateName,
+          outputs: (node as WorkflowNode).outputs,
+        });
+      }
+    }
+
+    nodes.sort(
+      (a, b) =>
+        new Date(a.startedAt || 0).getTime() -
+        new Date(b.startedAt || 0).getTime(),
+    );
+
+    const logsResponse = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}/${name}/log?logOptions.container=main`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const logsByPod: Record<string, string[]> = {};
+
+    if (logsResponse.ok) {
+      const logsText = await logsResponse.text();
+      const lines = logsText.trim().split('\n');
+
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line);
+          const podName = parsed.result?.podName || 'unknown';
+          const content = parsed.result?.content;
+          if (content !== undefined) {
+            if (!logsByPod[podName]) logsByPod[podName] = [];
+            logsByPod[podName].push(content);
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+    }
+
+    return NextResponse.json({
+      name: workflow.metadata.name,
+      namespace: workflow.metadata.namespace,
+      templateName: workflow.spec.workflowTemplateRef?.name,
+      phase: workflow.status?.phase || 'Pending',
+      startedAt: workflow.status?.startedAt,
+      finishedAt: workflow.status?.finishedAt,
+      message: workflow.status?.message,
+      nodes: nodes.filter(n => n.type === 'Pod'),
+      logsByPod,
+    });
+  } catch (error) {
+    console.error('Error fetching workflow:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch workflow' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/argo/workflows/route.ts
@@ -1,0 +1,156 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ARGO_SERVER_URL =
+  process.env.ARGO_SERVER_URL ||
+  'http://argo-workflows-server.argo-workflows.svc.cluster.local:2746';
+
+interface SubmitWorkflowRequest {
+  templateName: string;
+  namespace: string;
+  parameters: Array<{ name: string; value: string }>;
+  labels?: Record<string, string>;
+}
+
+interface ArgoWorkflow {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    workflowTemplateRef?: { name: string };
+  };
+  status?: {
+    phase?: string;
+    startedAt?: string;
+    finishedAt?: string;
+    message?: string;
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const namespace = searchParams.get('namespace') || '';
+  const templateName = searchParams.get('templateName') || '';
+  const labelSelector = searchParams.get('labelSelector') || '';
+
+  try {
+    const namespaces = namespace ? [namespace] : ['default', 'argo-workflows'];
+
+    const allWorkflows: ArgoWorkflow[] = [];
+
+    for (const ns of namespaces) {
+      let url = `${ARGO_SERVER_URL}/api/v1/workflows/${ns}`;
+      if (labelSelector) {
+        url += `?listOptions.labelSelector=${encodeURIComponent(labelSelector)}`;
+      }
+
+      const response = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        allWorkflows.push(...(data.items || []));
+      }
+    }
+
+    let workflows = allWorkflows.map((w: ArgoWorkflow) => ({
+      name: w.metadata.name,
+      namespace: w.metadata.namespace,
+      templateName: w.spec.workflowTemplateRef?.name || '',
+      phase: w.status?.phase || 'Pending',
+      startedAt: w.status?.startedAt || w.metadata.creationTimestamp,
+      finishedAt: w.status?.finishedAt,
+      message: w.status?.message,
+      labels: w.metadata.labels,
+    }));
+
+    if (templateName) {
+      workflows = workflows.filter(w => w.templateName === templateName);
+    }
+
+    workflows.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    );
+
+    return NextResponse.json(workflows);
+  } catch (error) {
+    console.error('Error fetching workflows:', error);
+    return NextResponse.json(
+      { error: 'Failed to connect to Argo server' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: SubmitWorkflowRequest = await request.json();
+    const { templateName, namespace, parameters, labels } = body;
+
+    const nonEmptyParameters = parameters.filter(p => p.value !== '');
+
+    const workflowSpec = {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Workflow',
+      metadata: {
+        generateName: `${templateName}-`,
+        namespace,
+        labels: {
+          ...labels,
+          'ark-managed': 'true',
+        },
+      },
+      spec: {
+        workflowTemplateRef: {
+          name: templateName,
+        },
+        ...(nonEmptyParameters.length > 0 && {
+          arguments: {
+            parameters: nonEmptyParameters.map(p => ({
+              name: p.name,
+              value: p.value,
+            })),
+          },
+        }),
+      },
+    };
+
+    const response = await fetch(
+      `${ARGO_SERVER_URL}/api/v1/workflows/${namespace}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ workflow: workflowSpec }),
+      },
+    );
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Argo API error:', errorData);
+      return NextResponse.json(
+        { error: 'Failed to submit workflow', details: errorData },
+        { status: response.status },
+      );
+    }
+
+    const result = await response.json();
+    return NextResponse.json({
+      name: result.metadata.name,
+      namespace: result.metadata.namespace,
+      status: result.status?.phase || 'Pending',
+    });
+  } catch (error) {
+    console.error('Error submitting workflow:', error);
+    return NextResponse.json(
+      { error: 'Failed to submit workflow' },
+      { status: 500 },
+    );
+  }
+}

--- a/services/ark-dashboard/ark-dashboard/components/cards/flow-card.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/cards/flow-card.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { GitBranch, Pencil, Play, Trash2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import type { Flow } from '@/lib/types/flow';
+
+import { BaseCard, type BaseCardAction } from './base-card';
+
+interface FlowCardProps {
+  flow: Flow;
+  onRun: (flow: Flow) => void;
+  onEdit: (flow: Flow) => void;
+  onDelete: (flow: Flow) => void;
+}
+
+export function FlowCard({ flow, onRun, onEdit, onDelete }: FlowCardProps) {
+  const actions: BaseCardAction[] = [
+    {
+      icon: Play,
+      label: 'Run flow',
+      onClick: () => onRun(flow),
+      className: 'text-green-600',
+    },
+    {
+      icon: Pencil,
+      label: 'Edit flow',
+      onClick: () => onEdit(flow),
+    },
+    {
+      icon: Trash2,
+      label: 'Delete flow',
+      onClick: () => onDelete(flow),
+      className: 'text-destructive',
+    },
+  ];
+
+  return (
+    <BaseCard
+      title={flow.name}
+      icon={GitBranch}
+      actions={actions}
+      description={flow.description}
+      footer={
+        <div className="flex w-full items-center justify-between pt-2 pb-4">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary" className="text-xs">
+              {flow.templateName}
+            </Badge>
+            <span className="text-muted-foreground text-xs">
+              {flow.parameters.length} parameter
+              {flow.parameters.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+          <span className="text-muted-foreground text-xs">
+            {flow.templateNamespace}
+          </span>
+        </div>
+      }>
+      {flow.parameters.length > 0 && (
+        <div className="space-y-1">
+          {flow.parameters.slice(0, 3).map(param => (
+            <div key={param.name} className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground font-mono text-xs">
+                {param.name}:
+              </span>
+              <span className="truncate text-xs">
+                {param.value || '(empty)'}
+              </span>
+            </div>
+          ))}
+          {flow.parameters.length > 3 && (
+            <span className="text-muted-foreground text-xs">
+              +{flow.parameters.length - 3} more
+            </span>
+          )}
+        </div>
+      )}
+    </BaseCard>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/editors/flow-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/flow-editor.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { Plus, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { workflowTemplatesService } from '@/lib/services/flows';
+import type { Flow, FlowParameter, WorkflowTemplate } from '@/lib/types/flow';
+import { getKubernetesNameError } from '@/lib/utils/kubernetes-validation';
+
+interface FlowEditorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  flow?: Flow | null;
+  onSave: (flow: Omit<Flow, 'id' | 'createdAt' | 'updatedAt'>) => void;
+}
+
+export function FlowEditor({
+  open,
+  onOpenChange,
+  flow,
+  onSave,
+}: Readonly<FlowEditorProps>) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [templateName, setTemplateName] = useState('');
+  const [templateNamespace, setTemplateNamespace] = useState('argo-workflows');
+  const [parameters, setParameters] = useState<FlowParameter[]>([]);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const [templates, setTemplates] = useState<WorkflowTemplate[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+
+  const [namespaces, setNamespaces] = useState<string[]>([]);
+  const [namespacesLoading, setNamespacesLoading] = useState(false);
+
+  const isEditing = !!flow;
+
+  const loadNamespaces = useCallback(async () => {
+    setNamespacesLoading(true);
+    try {
+      const response = await fetch('/api/argo/namespaces');
+      if (response.ok) {
+        const data = await response.json();
+        setNamespaces(data);
+      }
+    } catch (error) {
+      console.error('Failed to load namespaces:', error);
+      setNamespaces(['default', 'argo-workflows']);
+    } finally {
+      setNamespacesLoading(false);
+    }
+  }, []);
+
+  const loadTemplates = useCallback(async (namespace: string) => {
+    setTemplatesLoading(true);
+    try {
+      const data = await workflowTemplatesService.getAll(namespace);
+      setTemplates(data);
+    } catch (error) {
+      console.error('Failed to load templates:', error);
+    } finally {
+      setTemplatesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      loadNamespaces();
+      if (flow) {
+        setName(flow.name);
+        setDescription(flow.description || '');
+        setTemplateName(flow.templateName);
+        setTemplateNamespace(flow.templateNamespace);
+        setParameters(flow.parameters);
+        loadTemplates(flow.templateNamespace);
+      } else {
+        setName('');
+        setDescription('');
+        setTemplateName('');
+        setTemplateNamespace('argo-workflows');
+        setParameters([]);
+        loadTemplates('argo-workflows');
+      }
+      setNameError(null);
+    }
+  }, [open, flow, loadNamespaces, loadTemplates]);
+
+  const handleNamespaceChange = (namespace: string) => {
+    setTemplateNamespace(namespace);
+    setTemplateName('');
+    setParameters([]);
+    loadTemplates(namespace);
+  };
+
+  const handleTemplateChange = (selectedTemplate: string) => {
+    setTemplateName(selectedTemplate);
+    const template = templates.find(t => t.name === selectedTemplate);
+    if (template) {
+      setParameters(
+        template.parameters.map(p => ({
+          name: p.name,
+          value: p.value || '',
+          description: p.description,
+        })),
+      );
+    }
+  };
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    const error = getKubernetesNameError(value);
+    setNameError(error);
+  };
+
+  const handleParameterChange = (index: number, value: string) => {
+    const updated = [...parameters];
+    updated[index] = { ...updated[index], value };
+    setParameters(updated);
+  };
+
+  const handleAddParameter = () => {
+    setParameters([...parameters, { name: '', value: '' }]);
+  };
+
+  const handleRemoveParameter = (index: number) => {
+    setParameters(parameters.filter((_, i) => i !== index));
+  };
+
+  const handleParameterNameChange = (index: number, paramName: string) => {
+    const updated = [...parameters];
+    updated[index] = { ...updated[index], name: paramName };
+    setParameters(updated);
+  };
+
+  const handleSave = () => {
+    if (!name || nameError || !templateName) return;
+
+    onSave({
+      name,
+      description: description || undefined,
+      templateName,
+      templateNamespace,
+      parameters,
+    });
+
+    onOpenChange(false);
+  };
+
+  const isValid = name && !nameError && templateName;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit Flow' : 'Create Flow'}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update flow configuration and default parameters.'
+              : 'Select a workflow template to create a new flow.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="namespace">Namespace</Label>
+            <Select
+              value={templateNamespace}
+              onValueChange={handleNamespaceChange}
+              disabled={namespacesLoading || isEditing}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    namespacesLoading
+                      ? 'Loading namespaces...'
+                      : 'Select a namespace'
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {namespaces.map(ns => (
+                  <SelectItem key={ns} value={ns}>
+                    {ns}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="template">Workflow Template</Label>
+            <Select
+              value={templateName}
+              onValueChange={handleTemplateChange}
+              disabled={templatesLoading || isEditing}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    templatesLoading
+                      ? 'Loading templates...'
+                      : templates.length === 0
+                        ? 'No templates in this namespace'
+                        : 'Select a template'
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {templates.map(template => (
+                  <SelectItem key={template.name} value={template.name}>
+                    {template.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {templateName &&
+              templates.find(t => t.name === templateName)?.description && (
+                <p className="text-muted-foreground text-sm">
+                  {templates.find(t => t.name === templateName)?.description}
+                </p>
+              )}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="name">Flow Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={e => handleNameChange(e.target.value)}
+              placeholder="my-flow"
+              disabled={isEditing}
+            />
+            {nameError && (
+              <p className="text-destructive text-sm">{nameError}</p>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="What does this flow do?"
+              rows={2}
+            />
+          </div>
+
+          {parameters.length > 0 && (
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between">
+                <Label>Default Parameters</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleAddParameter}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Add
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {parameters.map((param, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      value={param.name}
+                      onChange={e =>
+                        handleParameterNameChange(index, e.target.value)
+                      }
+                      placeholder="Parameter name"
+                      className="w-1/3 font-mono text-sm"
+                    />
+                    <Input
+                      value={param.value}
+                      onChange={e =>
+                        handleParameterChange(index, e.target.value)
+                      }
+                      placeholder="Default value"
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemoveParameter(index)}>
+                      <Trash2 className="text-destructive h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {parameters.length === 0 && templateName && (
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between">
+                <Label>Parameters</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleAddParameter}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Add Parameter
+                </Button>
+              </div>
+              <p className="text-muted-foreground text-sm">
+                No parameters defined. Add custom parameters or select a
+                template with parameters.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!isValid}>
+            {isEditing ? 'Save Changes' : 'Create Flow'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/editors/flow-runner.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/flow-runner.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { ExternalLink, Loader2, Play } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { flowRunsService } from '@/lib/services/flows';
+import type { Flow, FlowParameter, FlowRun } from '@/lib/types/flow';
+
+interface FlowRunnerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  flow: Flow | null;
+}
+
+export function FlowRunner({
+  open,
+  onOpenChange,
+  flow,
+}: Readonly<FlowRunnerProps>) {
+  const [parameters, setParameters] = useState<FlowParameter[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [lastRun, setLastRun] = useState<FlowRun | null>(null);
+
+  useEffect(() => {
+    if (open && flow) {
+      setParameters(flow.parameters.map(p => ({ ...p })));
+      setLastRun(null);
+    }
+  }, [open, flow]);
+
+  const handleParameterChange = (index: number, value: string) => {
+    const updated = [...parameters];
+    updated[index] = { ...updated[index], value };
+    setParameters(updated);
+  };
+
+  const handleRun = async () => {
+    if (!flow) return;
+
+    setIsRunning(true);
+    try {
+      const run = await flowRunsService.run(flow, parameters);
+      setLastRun(run);
+      toast.success('Flow started successfully', {
+        description: `Workflow ${run.name} is now running.`,
+        action: {
+          label: 'View in Argo',
+          onClick: () => window.open(run.argoUrl, '_blank'),
+        },
+      });
+    } catch (error) {
+      console.error('Failed to run flow:', error);
+      toast.error('Failed to start flow', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  if (!flow) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Play className="h-5 w-5" />
+            Run: {flow.name}
+          </DialogTitle>
+          <DialogDescription>
+            Configure parameters and run this flow. You can override the default
+            values below.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="text-muted-foreground text-sm">
+            <span className="font-medium">Template:</span> {flow.templateName}
+            <span className="mx-2">•</span>
+            <span className="font-medium">Namespace:</span>{' '}
+            {flow.templateNamespace}
+          </div>
+
+          {parameters.length > 0 ? (
+            <div className="space-y-3">
+              <Label>Parameters</Label>
+              {parameters.map((param, index) => (
+                <div key={param.name} className="grid gap-1">
+                  <Label
+                    htmlFor={`param-${index}`}
+                    className="text-muted-foreground font-mono text-xs">
+                    {param.name}
+                  </Label>
+                  <Input
+                    id={`param-${index}`}
+                    value={param.value}
+                    onChange={e => handleParameterChange(index, e.target.value)}
+                    placeholder={`Enter ${param.name}`}
+                  />
+                  {param.description && (
+                    <p className="text-muted-foreground text-xs">
+                      {param.description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              This flow has no parameters to configure.
+            </p>
+          )}
+
+          {lastRun && (
+            <div className="bg-muted/50 rounded-lg border p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">
+                    Last run: {lastRun.name}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Status: {lastRun.status}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => window.open(lastRun.argoUrl, '_blank')}>
+                  <ExternalLink className="mr-1 h-4 w-4" />
+                  View in Argo
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          <Button onClick={handleRun} disabled={isRunning}>
+            {isRunning ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Starting...
+              </>
+            ) : (
+              <>
+                <Play className="mr-2 h-4 w-4" />
+                Run Flow
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/sections/flow-logs-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/flow-logs-section.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { ArrowUpRight, ExternalLink, FileText, RefreshCw } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  checkArgoAvailable,
+  getArgoBaseUrl,
+  workflowTemplatesService,
+} from '@/lib/services/flows';
+import type { WorkflowRun, WorkflowTemplate } from '@/lib/types/flow';
+import { formatAge } from '@/lib/utils/time';
+
+const ARGO_DOCS_URL =
+  'https://github.com/mckinsey/agents-at-scale/tree/main/services/argo-workflows';
+
+type PhaseType = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Error';
+
+const phaseColors: Record<PhaseType, string> = {
+  Pending: 'bg-gray-500',
+  Running: 'bg-blue-500 animate-pulse',
+  Succeeded: 'bg-green-500',
+  Failed: 'bg-red-500',
+  Error: 'bg-red-500',
+};
+
+export function FlowLogsSection() {
+  const [workflows, setWorkflows] = useState<WorkflowRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [argoBaseUrl, setArgoBaseUrl] = useState('http://localhost:2746');
+  const [argoAvailable, setArgoAvailable] = useState<boolean | null>(null);
+
+  const [namespaces] = useState(['default', 'argo-workflows']);
+  const [selectedNamespace, setSelectedNamespace] = useState('__all__');
+
+  const [templates, setTemplates] = useState<WorkflowTemplate[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState('__all__');
+
+  const loadTemplates = async () => {
+    const [defaultTemplates, argoTemplates] = await Promise.all([
+      workflowTemplatesService.getAll('default'),
+      workflowTemplatesService.getAll('argo-workflows'),
+    ]);
+    setTemplates([...defaultTemplates, ...argoTemplates]);
+  };
+
+  const loadWorkflows = async (namespace: string, template: string) => {
+    try {
+      const params = new URLSearchParams();
+      if (namespace !== '__all__') params.set('namespace', namespace);
+      if (template !== '__all__') params.set('templateName', template);
+
+      const response = await fetch(`/api/argo/workflows?${params.toString()}`);
+      if (response.ok) {
+        const data = await response.json();
+        setWorkflows(data);
+      }
+    } catch (error) {
+      console.error('Failed to load workflows:', error);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      setLoading(true);
+      const available = await checkArgoAvailable();
+      setArgoAvailable(available);
+      if (!available) {
+        setLoading(false);
+        return;
+      }
+      const baseUrl = await getArgoBaseUrl();
+      setArgoBaseUrl(baseUrl);
+      await loadTemplates();
+      await loadWorkflows('__all__', '__all__');
+      setLoading(false);
+    };
+    init();
+  }, []);
+
+  const handleNamespaceChange = async (value: string) => {
+    setSelectedNamespace(value);
+    setSelectedTemplate('__all__');
+    await loadWorkflows(value, '__all__');
+  };
+
+  const handleTemplateChange = async (value: string) => {
+    setSelectedTemplate(value);
+    await loadWorkflows(selectedNamespace, value);
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await loadWorkflows(selectedNamespace, selectedTemplate);
+    setRefreshing(false);
+  };
+
+  const getArgoUrl = (workflow: WorkflowRun) => {
+    return `${argoBaseUrl}/workflows/${workflow.namespace}/${workflow.name}`;
+  };
+
+  const filteredTemplates =
+    selectedNamespace === '__all__'
+      ? templates
+      : templates.filter(t => t.namespace === selectedNamespace);
+  const uniqueTemplates = [...new Set(filteredTemplates.map(t => t.name))];
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  if (argoAvailable === false) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <FileText className="h-10 w-10" />
+          </EmptyMedia>
+          <EmptyTitle>Argo Workflows Not Available</EmptyTitle>
+          <EmptyDescription>
+            Flow logs require Argo Workflows to be deployed in your cluster.
+            Once Argo is installed, you can view workflow execution logs here.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button variant="outline" asChild>
+            <a href={ARGO_DOCS_URL} target="_blank" rel="noopener noreferrer">
+              View Argo Setup Documentation
+              <ArrowUpRight className="ml-2 h-4 w-4" />
+            </a>
+          </Button>
+        </EmptyContent>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col space-y-4">
+      <div className="flex items-center justify-between border-b pb-4">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">Namespace:</span>
+            <Select
+              value={selectedNamespace}
+              onValueChange={handleNamespaceChange}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="All namespaces" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">All namespaces</SelectItem>
+                {namespaces.map(ns => (
+                  <SelectItem key={ns} value={ns}>
+                    {ns}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">Template:</span>
+            <Select
+              value={selectedTemplate}
+              onValueChange={handleTemplateChange}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="All templates" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">All templates</SelectItem>
+                {uniqueTemplates.map(name => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <Button onClick={handleRefresh} disabled={refreshing}>
+          <RefreshCw
+            className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Namespace
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Template
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Started
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Duration
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {workflows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="text-muted-foreground px-4 py-8 text-center">
+                    No workflow runs found
+                  </td>
+                </tr>
+              ) : (
+                workflows.map(workflow => {
+                  const phase = workflow.phase as PhaseType;
+                  const phaseColor = phaseColors[phase] || 'bg-gray-400';
+                  const duration = workflow.finishedAt
+                    ? Math.round(
+                        (new Date(workflow.finishedAt).getTime() -
+                          new Date(workflow.startedAt).getTime()) /
+                          1000,
+                      )
+                    : null;
+
+                  return (
+                    <tr
+                      key={`${workflow.namespace}-${workflow.name}`}
+                      className="border-b border-gray-100 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-900/30">
+                      <td className="px-4 py-3 font-mono text-sm">
+                        <Link
+                          href={`/flow-logs/${workflow.namespace}/${workflow.name}`}
+                          className="text-blue-600 hover:underline dark:text-blue-400">
+                          {workflow.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <span className="rounded bg-gray-100 px-2 py-1 text-xs dark:bg-gray-800">
+                          {workflow.namespace}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {workflow.templateName || '-'}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className={`h-2 w-2 rounded-full ${phaseColor}`}
+                          />
+                          <span>{workflow.phase}</span>
+                        </div>
+                      </td>
+                      <td className="text-muted-foreground px-4 py-3 text-sm">
+                        {formatAge(workflow.startedAt)}
+                      </td>
+                      <td className="text-muted-foreground px-4 py-3 text-sm">
+                        {duration !== null ? `${duration}s` : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            window.open(getArgoUrl(workflow), '_blank')
+                          }>
+                          <ExternalLink className="mr-1 h-4 w-4" />
+                          View in Argo
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/sections/flows-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/flows-section.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { ArrowUpRight, GitBranch, Plus } from 'lucide-react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from 'react';
+import { toast } from 'sonner';
+
+import { FlowCard } from '@/components/cards/flow-card';
+import { FlowEditor } from '@/components/editors/flow-editor';
+import { FlowRunner } from '@/components/editors/flow-runner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import { useDelayedLoading } from '@/lib/hooks/use-delayed-loading';
+import {
+  checkArgoAvailable,
+  flowsService,
+  getArgoBaseUrl,
+} from '@/lib/services/flows';
+import type { Flow } from '@/lib/types/flow';
+
+const ARGO_DOCS_URL =
+  'https://github.com/mckinsey/agents-at-scale/tree/main/services/argo-workflows';
+
+export interface FlowsSectionRef {
+  openAddEditor: () => void;
+}
+
+export const FlowsSection = forwardRef<FlowsSectionRef>(
+  function FlowsSection(_props, ref) {
+    const [flows, setFlows] = useState<Flow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const showLoading = useDelayedLoading(loading);
+    const [argoBaseUrl, setArgoBaseUrl] = useState('http://localhost:2746');
+    const [argoAvailable, setArgoAvailable] = useState<boolean | null>(null);
+
+    const [editorOpen, setEditorOpen] = useState(false);
+    const [editingFlow, setEditingFlow] = useState<Flow | null>(null);
+
+    const [runnerOpen, setRunnerOpen] = useState(false);
+    const [runningFlow, setRunningFlow] = useState<Flow | null>(null);
+
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [deletingFlow, setDeletingFlow] = useState<Flow | null>(null);
+
+    const loadFlows = useCallback(async () => {
+      setLoading(true);
+      try {
+        const data = await flowsService.getAll();
+        setFlows(data);
+      } catch (error) {
+        console.error('Failed to load flows:', error);
+        toast.error('Failed to load flows');
+      } finally {
+        setLoading(false);
+      }
+    }, []);
+
+    useEffect(() => {
+      const init = async () => {
+        const available = await checkArgoAvailable();
+        setArgoAvailable(available);
+        if (available) {
+          loadFlows();
+          getArgoBaseUrl().then(setArgoBaseUrl);
+        } else {
+          setLoading(false);
+        }
+      };
+      init();
+    }, [loadFlows]);
+
+    useImperativeHandle(ref, () => ({
+      openAddEditor: () => {
+        setEditingFlow(null);
+        setEditorOpen(true);
+      },
+    }));
+
+    const handleSave = async (
+      flowData: Omit<Flow, 'id' | 'createdAt' | 'updatedAt'>,
+    ) => {
+      try {
+        if (editingFlow) {
+          await flowsService.update(editingFlow.id, flowData);
+          toast.success('Flow updated');
+        } else {
+          await flowsService.create(flowData);
+          toast.success('Flow created');
+        }
+        loadFlows();
+      } catch (error) {
+        console.error('Failed to save flow:', error);
+        toast.error('Failed to save flow');
+      }
+    };
+
+    const handleEdit = (flow: Flow) => {
+      setEditingFlow(flow);
+      setEditorOpen(true);
+    };
+
+    const handleRun = (flow: Flow) => {
+      setRunningFlow(flow);
+      setRunnerOpen(true);
+    };
+
+    const handleDeleteClick = (flow: Flow) => {
+      setDeletingFlow(flow);
+      setDeleteDialogOpen(true);
+    };
+
+    const handleDeleteConfirm = async () => {
+      if (!deletingFlow) return;
+
+      try {
+        await flowsService.delete(deletingFlow.id);
+        toast.success('Flow deleted');
+        loadFlows();
+      } catch (error) {
+        console.error('Failed to delete flow:', error);
+        toast.error('Failed to delete flow');
+      } finally {
+        setDeleteDialogOpen(false);
+        setDeletingFlow(null);
+      }
+    };
+
+    if (showLoading) {
+      return (
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-muted-foreground">Loading flows...</div>
+        </div>
+      );
+    }
+
+    if (argoAvailable === false) {
+      return (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <GitBranch className="h-10 w-10" />
+            </EmptyMedia>
+            <EmptyTitle>Argo Workflows Not Available</EmptyTitle>
+            <EmptyDescription>
+              Flows require Argo Workflows to be deployed in your cluster. Once
+              Argo is installed, you can create and run workflow-based flows.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button variant="outline" asChild>
+              <a href={ARGO_DOCS_URL} target="_blank" rel="noopener noreferrer">
+                View Argo Setup Documentation
+                <ArrowUpRight className="ml-2 h-4 w-4" />
+              </a>
+            </Button>
+          </EmptyContent>
+        </Empty>
+      );
+    }
+
+    if (flows.length === 0) {
+      return (
+        <>
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <GitBranch className="h-10 w-10" />
+              </EmptyMedia>
+              <EmptyTitle>No Flows Yet</EmptyTitle>
+              <EmptyDescription>
+                Flows are saved workflow configurations that you can run with
+                custom parameters. Create a flow from an Argo workflow template
+                to get started.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button onClick={() => setEditorOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create Flow
+              </Button>
+            </EmptyContent>
+            <Button variant="link" asChild>
+              <a
+                href={`${argoBaseUrl}/workflow-templates`}
+                target="_blank"
+                rel="noopener noreferrer">
+                View Workflow Templates in Argo
+                <ArrowUpRight className="ml-1 h-4 w-4" />
+              </a>
+            </Button>
+          </Empty>
+
+          <FlowEditor
+            open={editorOpen}
+            onOpenChange={setEditorOpen}
+            flow={editingFlow}
+            onSave={handleSave}
+          />
+        </>
+      );
+    }
+
+    return (
+      <>
+        <div className="grid gap-4 p-6 sm:grid-cols-2 lg:grid-cols-3">
+          {flows.map(flow => (
+            <FlowCard
+              key={flow.id}
+              flow={flow}
+              onRun={handleRun}
+              onEdit={handleEdit}
+              onDelete={handleDeleteClick}
+            />
+          ))}
+        </div>
+
+        <FlowEditor
+          open={editorOpen}
+          onOpenChange={setEditorOpen}
+          flow={editingFlow}
+          onSave={handleSave}
+        />
+
+        <FlowRunner
+          open={runnerOpen}
+          onOpenChange={setRunnerOpen}
+          flow={runningFlow}
+        />
+
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Flow</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete &quot;{deletingFlow?.name}
+                &quot;? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDeleteConfirm}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    );
+  },
+);

--- a/services/ark-dashboard/ark-dashboard/lib/constants/dashboard-icons.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/constants/dashboard-icons.ts
@@ -6,9 +6,11 @@ import {
   CheckCircle,
   ClipboardList,
   Database,
+  GitBranch,
   Key,
   Lock,
   type LucideIcon,
+  ScrollText,
   Search,
   Server,
   Settings,
@@ -62,6 +64,12 @@ export const DASHBOARD_SECTIONS: Record<string, DashboardSection> = {
     icon: CheckCircle,
     group: 'configurations',
   },
+  flows: {
+    key: 'flows',
+    title: 'Flows',
+    icon: GitBranch,
+    group: 'configurations',
+  },
 
   // Operations
   queries: {
@@ -86,6 +94,12 @@ export const DASHBOARD_SECTIONS: Record<string, DashboardSection> = {
     key: 'memory',
     title: 'Memory',
     icon: Database,
+    group: 'operations',
+  },
+  'flow-logs': {
+    key: 'flow-logs',
+    title: 'Flow Logs',
+    icon: ScrollText,
     group: 'operations',
   },
   tasks: {

--- a/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
@@ -1,3 +1,19 @@
+/**
+ * Flows Service
+ *
+ * This service manages "Flows" - saved configurations of Argo WorkflowTemplates
+ * with pre-filled parameters. Flows act as shortcuts for running common workflows.
+ *
+ * STORAGE: Flows are stored in localStorage (client-side only).
+ * This is an intentional MVP design choice:
+ * - Flows are personal workflow shortcuts, not shared team resources
+ * - No database schema changes required
+ * - Simple to implement and test
+ * - Easy to migrate to server-side storage later if needed
+ *
+ * If flows need to be shared across users or persisted server-side,
+ * add a /api/flows endpoint backed by a database.
+ */
 import type {
   Flow,
   FlowParameter,
@@ -26,6 +42,11 @@ async function getArgoBaseUrl(): Promise<string> {
 
 export { getArgoBaseUrl };
 
+/**
+ * Check if Argo Workflows is deployed and accessible.
+ * Used for graceful degradation - shows helpful setup message instead of errors
+ * when Argo is not installed.
+ */
 async function checkArgoAvailable(): Promise<boolean> {
   try {
     const response = await fetch(
@@ -152,6 +173,7 @@ export const flowRunsService = {
       const response = await fetch('/api/argo/workflows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        // Labels link workflow runs back to the originating Flow for tracking
         body: JSON.stringify({
           templateName: flow.templateName,
           namespace: flow.templateNamespace,

--- a/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
@@ -1,4 +1,11 @@
-import type { WorkflowTemplate } from '@/lib/types/flow';
+import type {
+  Flow,
+  FlowParameter,
+  FlowRun,
+  WorkflowTemplate,
+} from '@/lib/types/flow';
+
+const FLOWS_STORAGE_KEY = 'ark-flows';
 
 let cachedArgoBaseUrl: string | null = null;
 
@@ -32,6 +39,74 @@ async function checkArgoAvailable(): Promise<boolean> {
 
 export { checkArgoAvailable };
 
+function generateId(): string {
+  return `flow-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function getFlowsFromStorage(): Flow[] {
+  if (typeof window === 'undefined') return [];
+  const stored = localStorage.getItem(FLOWS_STORAGE_KEY);
+  return stored ? JSON.parse(stored) : [];
+}
+
+function saveFlowsToStorage(flows: Flow[]): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(FLOWS_STORAGE_KEY, JSON.stringify(flows));
+}
+
+export const flowsService = {
+  async getAll(): Promise<Flow[]> {
+    return getFlowsFromStorage();
+  },
+
+  async getById(id: string): Promise<Flow | null> {
+    const flows = getFlowsFromStorage();
+    return flows.find(f => f.id === id) || null;
+  },
+
+  async create(
+    data: Omit<Flow, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<Flow> {
+    const flows = getFlowsFromStorage();
+    const now = new Date().toISOString();
+    const newFlow: Flow = {
+      ...data,
+      id: generateId(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    flows.push(newFlow);
+    saveFlowsToStorage(flows);
+    return newFlow;
+  },
+
+  async update(
+    id: string,
+    data: Partial<Omit<Flow, 'id' | 'createdAt'>>,
+  ): Promise<Flow | null> {
+    const flows = getFlowsFromStorage();
+    const index = flows.findIndex(f => f.id === id);
+    if (index === -1) return null;
+
+    const updated: Flow = {
+      ...flows[index],
+      ...data,
+      updatedAt: new Date().toISOString(),
+    };
+    flows[index] = updated;
+    saveFlowsToStorage(flows);
+    return updated;
+  },
+
+  async delete(id: string): Promise<boolean> {
+    const flows = getFlowsFromStorage();
+    const filtered = flows.filter(f => f.id !== id);
+    if (filtered.length === flows.length) return false;
+    saveFlowsToStorage(filtered);
+    return true;
+  },
+};
+
 export const workflowTemplatesService = {
   async getAll(namespace: string = 'default'): Promise<WorkflowTemplate[]> {
     try {
@@ -63,5 +138,95 @@ export const workflowTemplatesService = {
       console.warn('Error fetching workflow template:', error);
       return null;
     }
+  },
+};
+
+export const flowRunsService = {
+  async run(
+    flow: Flow,
+    parameterOverrides?: FlowParameter[],
+  ): Promise<FlowRun> {
+    const parameters = parameterOverrides || flow.parameters;
+
+    try {
+      const response = await fetch('/api/argo/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          templateName: flow.templateName,
+          namespace: flow.templateNamespace,
+          parameters: parameters.map(p => ({ name: p.name, value: p.value })),
+          labels: {
+            'ark-flow-id': flow.id,
+            'ark-flow-name': flow.name,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to submit workflow');
+      }
+
+      const result = await response.json();
+      const baseUrl = await getArgoBaseUrl();
+
+      return {
+        name: result.name,
+        flowId: flow.id,
+        flowName: flow.name,
+        status: 'Pending',
+        startedAt: new Date().toISOString(),
+        argoUrl: `${baseUrl}/workflows/${flow.templateNamespace}/${result.name}`,
+      };
+    } catch (error) {
+      console.error('Error running flow:', error);
+      throw error;
+    }
+  },
+
+  async getRecentRuns(
+    flowId?: string,
+    namespace: string = 'default',
+  ): Promise<FlowRun[]> {
+    try {
+      const labelSelector = flowId ? `ark-flow-id=${flowId}` : 'ark-flow-id';
+      const response = await fetch(
+        `/api/argo/workflows?namespace=${namespace}&labelSelector=${encodeURIComponent(labelSelector)}`,
+      );
+
+      if (!response.ok) return [];
+
+      const workflows = await response.json();
+      const baseUrl = await getArgoBaseUrl();
+      return workflows.map(
+        (w: {
+          metadata: {
+            name: string;
+            labels?: Record<string, string>;
+            creationTimestamp: string;
+          };
+          status?: { phase?: string; finishedAt?: string };
+        }) => ({
+          name: w.metadata.name,
+          flowId: w.metadata.labels?.['ark-flow-id'] || '',
+          flowName: w.metadata.labels?.['ark-flow-name'] || '',
+          status: w.status?.phase || 'Pending',
+          startedAt: w.metadata.creationTimestamp,
+          finishedAt: w.status?.finishedAt,
+          argoUrl: `${baseUrl}/workflows/${namespace}/${w.metadata.name}`,
+        }),
+      );
+    } catch (error) {
+      console.warn('Error fetching workflow runs:', error);
+      return [];
+    }
+  },
+
+  async getArgoUrl(
+    workflowName: string,
+    namespace: string = 'default',
+  ): Promise<string> {
+    const baseUrl = await getArgoBaseUrl();
+    return `${baseUrl}/workflows/${namespace}/${workflowName}`;
   },
 };

--- a/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/flows.ts
@@ -1,0 +1,67 @@
+import type { WorkflowTemplate } from '@/lib/types/flow';
+
+let cachedArgoBaseUrl: string | null = null;
+
+async function getArgoBaseUrl(): Promise<string> {
+  if (cachedArgoBaseUrl) return cachedArgoBaseUrl;
+  try {
+    const response = await fetch('/api/argo/config');
+    if (response.ok) {
+      const config = await response.json();
+      cachedArgoBaseUrl = config.baseUrl;
+      return config.baseUrl;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch Argo config:', error);
+  }
+  return 'http://localhost:2746';
+}
+
+export { getArgoBaseUrl };
+
+async function checkArgoAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch(
+      '/api/argo/workflow-templates?namespace=default',
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export { checkArgoAvailable };
+
+export const workflowTemplatesService = {
+  async getAll(namespace: string = 'default'): Promise<WorkflowTemplate[]> {
+    try {
+      const response = await fetch(
+        `/api/argo/workflow-templates?namespace=${namespace}`,
+      );
+      if (!response.ok) {
+        console.warn('Failed to fetch workflow templates, using empty list');
+        return [];
+      }
+      return response.json();
+    } catch (error) {
+      console.warn('Error fetching workflow templates:', error);
+      return [];
+    }
+  },
+
+  async getByName(
+    name: string,
+    namespace: string = 'default',
+  ): Promise<WorkflowTemplate | null> {
+    try {
+      const response = await fetch(
+        `/api/argo/workflow-templates/${name}?namespace=${namespace}`,
+      );
+      if (!response.ok) return null;
+      return response.json();
+    } catch (error) {
+      console.warn('Error fetching workflow template:', error);
+      return null;
+    }
+  },
+};

--- a/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
@@ -1,3 +1,30 @@
+export interface FlowParameter {
+  name: string;
+  value: string;
+  description?: string;
+}
+
+export interface Flow {
+  id: string;
+  name: string;
+  description?: string;
+  templateName: string;
+  templateNamespace: string;
+  parameters: FlowParameter[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FlowRun {
+  name: string;
+  flowId: string;
+  flowName: string;
+  status: 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Error';
+  startedAt: string;
+  finishedAt?: string;
+  argoUrl: string;
+}
+
 export interface WorkflowRun {
   name: string;
   namespace: string;

--- a/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/types/flow.ts
@@ -1,0 +1,48 @@
+export interface WorkflowRun {
+  name: string;
+  namespace: string;
+  templateName: string;
+  phase: string;
+  startedAt: string;
+  finishedAt?: string;
+  message?: string;
+  labels?: Record<string, string>;
+}
+
+export interface WorkflowNode {
+  id: string;
+  displayName: string;
+  type: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  templateName?: string;
+  outputs?: {
+    parameters?: Array<{ name: string; value?: string }>;
+    exitCode?: string;
+  };
+}
+
+export interface WorkflowDetail {
+  name: string;
+  namespace: string;
+  templateName?: string;
+  phase: string;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+  nodes: WorkflowNode[];
+  logsByPod: Record<string, string[]>;
+}
+
+export interface WorkflowTemplate {
+  name: string;
+  namespace: string;
+  description?: string;
+  parameters: {
+    name: string;
+    value?: string;
+    description?: string;
+  }[];
+}

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -12,9 +12,18 @@ async function middleware(request: NextRequest) {
 
   // Proxy anything starting with /api/ to the backend, stripping the /api prefix
   // This includes: /api/v1/*, /api/docs, /api/openapi.json
+  //
+  // TEMPORARY: /api/argo/* routes are handled by Next.js API routes for the Flows feature.
+  // These routes proxy to Argo Workflows server. Once the Flows feature is accepted,
+  // this routing should be harmonized - either by adding Argo proxy routes to ark-api,
+  // or by formalizing the Next.js API routes as the standard approach.
   const apiPath = `${basePath}/api/`;
+  const argoApiPath = `${basePath}/api/argo/`;
 
-  if (request.nextUrl.pathname.startsWith(apiPath)) {
+  if (
+    request.nextUrl.pathname.startsWith(apiPath) &&
+    !request.nextUrl.pathname.startsWith(argoApiPath)
+  ) {
     const token = await getToken({
       req: request,
       secret: process.env.AUTH_SECRET,


### PR DESCRIPTION
> **Stacked PR Series** - Please review in order:
> 1. PR #658 - Argo API integration
> 2. PR #659 - Flows page
> 3. This PR #660 - Flow Logs pages ← you are here (includes commits from 1 and 2)

## Summary
This PR adds a view to the dashboard that shows the argo run logs in a single place. The flow logs page shows a filterable list of flows and their status. Clicking on a flow shows a flow details page, which shows the system logs, as well as logs any output values from each stage. 

- Add Flow Logs page for listing all Argo workflow runs
- Add Workflow Detail page showing DAG steps with live logs
- Add namespace filtering and status indicators
- Add step output display showing parameter references
- Add graceful messaging when Argo Workflows is not deployed
- Add unit tests for flow-logs-section component

## Testing

### Prerequisites

Port forward the required services:

```bash
# Terminal 1: Argo Workflows (required for Flow Logs feature)
kubectl port-forward -n argo-workflows svc/argo-workflows-server 2746:2746

# Terminal 2: Ark API (required for other dashboard features)
kubectl port-forward -n default svc/ark-api 8000:80
```

### Run the dashboard

```bash
cd services/ark-dashboard/ark-dashboard
ARGO_SERVER_URL=http://localhost:2746 npm run dev
```

### Test the Flow Logs page

1. Navigate to http://localhost:3000/flow-logs
2. Verify workflow runs are listed with status indicators
3. Use the namespace filter to switch between namespaces
4. Click on a workflow to view the detail page

### Test the Workflow Detail page

1. Click on any workflow run from the Flow Logs list
2. Verify the DAG steps are displayed
3. Click on a step to view its logs
4. Check that step outputs show parameter references (e.g., "output reference: step.outputs.parameters.result")

### Test graceful degradation

Stop the Argo port-forward and refresh the Flow Logs page - you should see a helpful message about Argo not being available with a link to setup docs.

## Demo video


https://github.com/user-attachments/assets/b05b6682-9491-4674-a46e-5bb20fdb34c5


## Checklist

- [X] Follow the [contributor guide](./CONTRIBUTING.md)
- [X] End-to-end tests pass
- [X] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 