### PR TITLE
feat: add Model provider field with backward-compatible migration

### DIFF
--- a/ark/CLAUDE.md
+++ b/ark/CLAUDE.md
@@ -95,6 +95,26 @@ Dynamic prompt/input processing using Go templates with resource context.
 - HTTP fetcher tools for API integration
 - MCP server tools for external service integration
 
+### Migration Warnings
+When deprecating fields or changing resource formats, use the migration warning pattern:
+
+1. **Mutating webhook** detects old format and migrates it
+2. **Add annotation** `annotations.MigrationWarningPrefix + "name"` with warning message
+3. **Validating webhook** calls `collectMigrationWarnings()` to return warnings to user
+
+```go
+// In mutating webhook (CustomDefaulter)
+model.Annotations[annotations.MigrationWarningPrefix+"provider"] = fmt.Sprintf(
+    "spec.type is deprecated for provider values - migrated '%s' to spec.provider",
+    originalType,
+)
+
+// In validating webhook (CustomValidator)
+return collectMigrationWarnings(model.Annotations), nil
+```
+
+See `internal/annotations/annotations.go` for `MigrationWarningPrefix` and `internal/webhook/v1/model_webhook.go` for implementation.
+
 ## Testing
 
 ### Unit Tests

--- a/ark/api/v1alpha1/model_types.go
+++ b/ark/api/v1alpha1/model_types.go
@@ -70,9 +70,17 @@ type BedrockModelConfig struct {
 type ModelSpec struct {
 	// +kubebuilder:validation:Required
 	Model ValueSource `json:"model"`
+	// Type specifies the API capability of the model (e.g., completions, embeddings).
+	// Deprecated: The values "openai", "azure", "bedrock" are accepted for backward
+	// compatibility but will be removed in release 1.0. Use spec.provider instead.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=completions;openai;azure;bedrock
+	// +kubebuilder:default=completions
+	Type string `json:"type,omitempty"`
+	// Provider specifies the AI provider client to use (openai, azure, bedrock).
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=openai;azure;bedrock
-	Type string `json:"type,omitempty"`
+	Provider string `json:"provider"`
 	// +kubebuilder:validation:Required
 	Config ModelConfig `json:"config"`
 	// +kubebuilder:validation:Optional
@@ -91,6 +99,7 @@ type ModelStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider`
 // +kubebuilder:printcolumn:name="Model",type=string,JSONPath=`.spec.model.value`
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="ModelAvailable")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/ark/config/crd/bases/ark.mckinsey.com_models.yaml
+++ b/ark/config/crd/bases/ark.mckinsey.com_models.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
     - jsonPath: .spec.model.value
       name: Model
       type: string
@@ -1589,8 +1592,22 @@ spec:
               pollInterval:
                 default: 1m
                 type: string
-              type:
+              provider:
+                description: Provider specifies the AI provider client to use (openai,
+                  azure, bedrock).
                 enum:
+                - openai
+                - azure
+                - bedrock
+                type: string
+              type:
+                default: completions
+                description: |-
+                  Type specifies the API capability of the model (e.g., completions, embeddings).
+                  Deprecated: The values "openai", "azure", "bedrock" are accepted for backward
+                  compatibility but will be removed in release 1.0. Use spec.provider instead.
+                enum:
+                - completions
                 - openai
                 - azure
                 - bedrock
@@ -1598,7 +1615,7 @@ spec:
             required:
             - config
             - model
-            - type
+            - provider
             type: object
           status:
             properties:

--- a/ark/config/webhook/manifests.yaml
+++ b/ark/config/webhook/manifests.yaml
@@ -24,6 +24,26 @@ webhooks:
     resources:
     - agents
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-ark-mckinsey-com-v1alpha1-model
+  failurePolicy: Fail
+  name: mmodel-v1.kb.io
+  rules:
+  - apiGroups:
+    - ark.mckinsey.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - models
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_models.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_models.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
     - jsonPath: .spec.model.value
       name: Model
       type: string
@@ -1595,8 +1598,22 @@ spec:
               pollInterval:
                 default: 1m
                 type: string
-              type:
+              provider:
+                description: Provider specifies the AI provider client to use (openai,
+                  azure, bedrock).
                 enum:
+                - openai
+                - azure
+                - bedrock
+                type: string
+              type:
+                default: completions
+                description: |-
+                  Type specifies the API capability of the model (e.g., completions, embeddings).
+                  Deprecated: The values "openai", "azure", "bedrock" are accepted for backward
+                  compatibility but will be removed in release 1.0. Use spec.provider instead.
+                enum:
+                - completions
                 - openai
                 - azure
                 - bedrock
@@ -1604,7 +1621,7 @@ spec:
             required:
             - config
             - model
-            - type
+            - provider
             type: object
           status:
             properties:

--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -37,6 +37,27 @@ webhooks:
           - v1alpha1
         resources:
           - agents
+  - name: mmodel-v1.kb.io
+    clientConfig:
+      service:
+        name: ark-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-ark-mckinsey-com-v1alpha1-model
+    failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds | default 10 }}
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - ark.mckinsey.com
+        apiVersions:
+          - v1alpha1
+        resources:
+          - models
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/ark/internal/annotations/annotations.go
+++ b/ark/internal/annotations/annotations.go
@@ -57,3 +57,10 @@ const (
 	StreamingEnabled = ARKPrefix + "streaming-enabled"
 	StreamingURL     = ARKPrefix + "streaming-url"
 )
+
+// Migration annotations - used by mutating webhooks to record deprecation warnings.
+// The validating webhook collects annotations matching this prefix and returns them
+// as admission warnings.
+const (
+	MigrationWarningPrefix = ARKPrefix + "migration-warning-"
+)

--- a/ark/internal/controller/model_controller.go
+++ b/ark/internal/controller/model_controller.go
@@ -95,7 +95,7 @@ func (r *ModelReconciler) probeModel(ctx context.Context, model arkv1alpha1.Mode
 	if err != nil {
 		return genai.ProbeResult{
 			Available:     false,
-			Message:       "Failed to load model configuration",
+			Message:       err.Error(),
 			DetailedError: err,
 		}
 	}

--- a/ark/internal/controller/model_controller_test.go
+++ b/ark/internal/controller/model_controller_test.go
@@ -40,7 +40,8 @@ var _ = Describe("Model Controller", func() {
 						Namespace: "default",
 					},
 					Spec: arkv1alpha1.ModelSpec{
-						Type: "openai",
+						Provider: "openai",
+						Type:     "completions",
 						Model: arkv1alpha1.ValueSource{
 							Value: "gpt-4",
 						},

--- a/ark/internal/genai/constants.go
+++ b/ark/internal/genai/constants.go
@@ -5,12 +5,33 @@ const (
 	TrueString = "true"
 )
 
-// Model type constants
+// Provider constants - specifies which AI provider client to use.
 const (
-	ModelTypeAzure   = "azure"
-	ModelTypeOpenAI  = "openai"
-	ModelTypeBedrock = "bedrock"
+	ProviderAzure   = "azure"
+	ProviderOpenAI  = "openai"
+	ProviderBedrock = "bedrock"
 )
+
+// Model type constants - specifies the API capability of the model.
+// New types can be added in the future (e.g., embeddings, responses).
+// See: https://github.com/mckinsey/agents-at-scale-ark/issues/37
+const (
+	ModelTypeCompletions = "completions"
+)
+
+// Deprecated: Ark < 0.50 used spec.type for provider selection.
+// Use Provider* constants instead. Will be removed in release 1.0.
+const (
+	ModelTypeAzure   = ProviderAzure
+	ModelTypeOpenAI  = ProviderOpenAI
+	ModelTypeBedrock = ProviderBedrock
+)
+
+// IsDeprecatedProviderInType returns true if the type value is a provider name.
+// Deprecated format (spec.type as provider) will be removed in release 1.0.
+func IsDeprecatedProviderInType(typeValue string) bool {
+	return typeValue == ProviderOpenAI || typeValue == ProviderAzure || typeValue == ProviderBedrock
+}
 
 // Agent tool type constants
 const (

--- a/ark/internal/genai/model.go
+++ b/ark/internal/genai/model.go
@@ -69,21 +69,27 @@ func LoadModel(ctx context.Context, k8sClient client.Client, modelSpec interface
 		eventingRecorder:  eventingRecorder,
 	}
 
-	switch modelCRD.Spec.Type {
-	case ModelTypeAzure:
+	switch modelCRD.Spec.Provider {
+	case ProviderAzure:
 		if err := loadAzureConfig(ctx, resolver, modelCRD.Spec.Config.Azure, namespace, modelInstance, additionalHeaders); err != nil {
 			return nil, err
 		}
-	case ModelTypeOpenAI:
+	case ProviderOpenAI:
 		if err := loadOpenAIConfig(ctx, resolver, modelCRD.Spec.Config.OpenAI, namespace, modelInstance, additionalHeaders); err != nil {
 			return nil, err
 		}
-	case ModelTypeBedrock:
+	case ProviderBedrock:
 		if err := loadBedrockConfig(ctx, resolver, modelCRD.Spec.Config.Bedrock, namespace, model, modelInstance); err != nil {
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unsupported model type: %s", modelCRD.Spec.Type)
+		if modelCRD.Spec.Provider == "" {
+			if IsDeprecatedProviderInType(modelCRD.Spec.Type) {
+				return nil, fmt.Errorf("provider is required - update model to migrate '%s' from spec.type to spec.provider", modelCRD.Spec.Type)
+			}
+			return nil, fmt.Errorf("provider is required")
+		}
+		return nil, fmt.Errorf("unsupported provider: %s", modelCRD.Spec.Provider)
 	}
 
 	return modelInstance, nil

--- a/docs/content/reference/upgrading.mdx
+++ b/docs/content/reference/upgrading.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Upgrading
 
 Ark uses [Semantic Versioning](https://semver.org/). The technical details are in the [semantic versioning specification](https://semver.org/). Briefly, they are:
@@ -9,6 +11,60 @@ Ark uses [Semantic Versioning](https://semver.org/). The technical details are i
 5. Minor releases prior to `v0.1.0` (e.g. `v0.3.0` to `v0.4.0`) may introduce backwards incompatible behavior changes, which are documented in this guide with migration instructions.
 
 A detailed record of every change is documented in [`CHANGELOG.md`](https://github.com/mckinsey/agents-at-scale-ark/blob/main/.github/CHANGELOG.md).
+
+## v0.1.50
+
+### Model Provider Field
+
+Prior to `v0.1.50`, the `spec.type` field on Models specified the AI provider (openai, azure, bedrock).
+
+From `v0.1.50`, provider and type are separate fields:
+- `spec.provider`: The model provider (`openai`, `azure`, or `bedrock`)
+- `spec.type`: The model type (`completions` for a OpenAI V1 Chat Completions API compliant model)
+
+**New models** should use the new format:
+
+```yaml
+spec:
+  provider: openai
+  type: completions  # optional, defaults to completions
+```
+
+**Existing models** using the old format (such as `spec.type: openai`) will show as unavailable with a clear error message:
+
+```
+provider is required - update model to migrate 'openai' from spec.type to spec.provider
+```
+
+On create or update, models are automatically migrated to the new format by the admission webhook.
+
+<Callout type="warning">
+The automatic migration will be removed in v1.0.0. Update your manifests to the new format before upgrading to v1.0.0.
+</Callout>
+
+To migrate existing models:
+
+```bash
+# View current models - PROVIDER column may be empty for old format, and models
+# which have not been migated will have the 'type' set to openai/azure/etc.
+kubectl get models
+
+# e.g:
+# NAME         TYPE          PROVIDER   MODEL   AVAILABLE   AGE
+# my-model     openai                   gpt-4   False       2d16h
+
+# Trigger migration by annotating all models
+kubectl annotate models --all 'ark.mckinsey.com/migrate-provider-0.1.50=done' --overwrite
+
+# Verify migration - PROVIDER column now populated and TYPE set correctly.
+kubectl get models
+
+# e.g:
+# NAME         TYPE          PROVIDER   MODEL   AVAILABLE   AGE
+# my-model     completions   openai     gpt-4   True        2d16h
+```
+
+This is a **breaking** change for existing models that have not been updated. They will remain unavailable until migrated.
 
 ## v0.1.34
 

--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 package = true
 
 [tool.uv.sources]
-ark-sdk = { path = "out/ark_sdk-0.1.48-py3-none-any.whl" }
+ark-sdk = { path = "out/ark_sdk-0.1.49-py3-none-any.whl" }
 
 [tool.coverage.run]
 data_file = "coverage/.coverage"

--- a/services/ark-api/ark-api/src/ark_api/models/models.py
+++ b/services/ark-api/ark-api/src/ark_api/models/models.py
@@ -6,6 +6,22 @@ from pydantic import BaseModel, Field
 from .common import AvailabilityStatus
 from .agents import AgentHeader
 
+# Provider constants
+PROVIDER_OPENAI = "openai"
+PROVIDER_AZURE = "azure"
+PROVIDER_BEDROCK = "bedrock"
+
+# Model type constants
+MODEL_TYPE_COMPLETIONS = "completions"
+
+# Type aliases for Pydantic models
+ProviderType = Literal["openai", "azure", "bedrock"]
+ModelTypeType = Literal["completions"]
+
+# Deprecated: spec.type values that were used as provider before the provider field was added.
+# Will be removed in release 1.0.
+DEPRECATED_PROVIDER_TYPES = {PROVIDER_OPENAI, PROVIDER_AZURE, PROVIDER_BEDROCK}
+
 
 class ModelValueSource(BaseModel):
     """ValueSource for model configuration (supports direct value or valueFrom)."""
@@ -50,7 +66,8 @@ class ModelResponse(BaseModel):
     """Model resource response model."""
     name: str
     namespace: str
-    type: Literal["openai", "azure", "bedrock"]
+    type: ModelTypeType = MODEL_TYPE_COMPLETIONS
+    provider: ProviderType
     model: str
     available: Optional[AvailabilityStatus] = None
     annotations: Optional[Dict[str, str]] = None
@@ -65,7 +82,7 @@ class ModelListResponse(BaseModel):
 class ModelCreateRequest(BaseModel):
     """Request model for creating a model."""
     name: str
-    type: Literal["openai", "azure", "bedrock"]
+    provider: ProviderType
     model: str
     config: ModelConfig
 
@@ -80,7 +97,8 @@ class ModelDetailResponse(BaseModel):
     """Detailed model response model."""
     name: str
     namespace: str
-    type: Literal["openai", "azure", "bedrock"]
+    type: ModelTypeType = MODEL_TYPE_COMPLETIONS
+    provider: ProviderType
     model: str
     config: Dict[str, Dict[str, Union[str, Dict[str, Any], List[Any]]]]
     available: Optional[AvailabilityStatus] = None

--- a/services/ark-api/ark-api/tests/api/test_routes.py
+++ b/services/ark-api/ark-api/tests/api/test_routes.py
@@ -1101,13 +1101,15 @@ class TestModelsEndpoint(unittest.TestCase):
         
         # Check first model
         self.assertEqual(data["items"][0]["name"], "gpt-4-model")
-        self.assertEqual(data["items"][0]["type"], "openai")
+        self.assertEqual(data["items"][0]["provider"], "openai")
+        self.assertEqual(data["items"][0]["type"], "completions")
         self.assertEqual(data["items"][0]["model"], "gpt-4")
         self.assertEqual(data["items"][0]["available"], "True")
 
         # Check second model
         self.assertEqual(data["items"][1]["name"], "claude-model")
-        self.assertEqual(data["items"][1]["type"], "bedrock")
+        self.assertEqual(data["items"][1]["provider"], "bedrock")
+        self.assertEqual(data["items"][1]["type"], "completions")
         self.assertEqual(data["items"][1]["model"], "anthropic.claude-v2")
         self.assertEqual(data["items"][1]["available"], "False")
     
@@ -1142,7 +1144,8 @@ class TestModelsEndpoint(unittest.TestCase):
         mock_model.to_dict.return_value = {
             "metadata": {"name": "gpt-4-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "type": "completions",
+                "provider": "openai",
                 "model": {"value": "gpt-4"},
                 "config": {
                     "openai": {
@@ -1152,13 +1155,13 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_client.models.a_create = AsyncMock(return_value=mock_model)
-        
+
         # Make the request
         request_data = {
             "name": "gpt-4-model",
-            "type": "openai",
+            "provider": "openai",
             "model": "gpt-4",
             "config": {
                 "openai": {
@@ -1168,12 +1171,13 @@ class TestModelsEndpoint(unittest.TestCase):
             }
         }
         response = self.client.post("/v1/models?namespace=default", json=request_data)
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["name"], "gpt-4-model")
-        self.assertEqual(data["type"], "openai")
+        self.assertEqual(data["provider"], "openai")
+        self.assertEqual(data["type"], "completions")
         self.assertEqual(data["model"], "gpt-4")
         self.assertEqual(data["config"]["openai"]["apiKey"]["value"], "sk-test")
         self.assertEqual(data["config"]["openai"]["baseUrl"]["value"], "https://api.openai.com/v1")
@@ -1184,13 +1188,14 @@ class TestModelsEndpoint(unittest.TestCase):
         # Setup async context manager mock
         mock_client = AsyncMock()
         mock_ark_client.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock the created model response
         mock_model = Mock()
         mock_model.to_dict.return_value = {
             "metadata": {"name": "azure-gpt", "namespace": "default"},
             "spec": {
-                "type": "azure",
+                "type": "completions",
+                "provider": "azure",
                 "model": {"value": "gpt-35-turbo"},
                 "config": {
                     "azure": {
@@ -1201,13 +1206,13 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_client.models.a_create = AsyncMock(return_value=mock_model)
-        
+
         # Make the request
         request_data = {
             "name": "azure-gpt",
-            "type": "azure",
+            "provider": "azure",
             "model": "gpt-35-turbo",
             "config": {
                 "azure": {
@@ -1218,12 +1223,13 @@ class TestModelsEndpoint(unittest.TestCase):
             }
         }
         response = self.client.post("/v1/models?namespace=default", json=request_data)
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["name"], "azure-gpt")
-        self.assertEqual(data["type"], "azure")
+        self.assertEqual(data["provider"], "azure")
+        self.assertEqual(data["type"], "completions")
         self.assertEqual(data["config"]["azure"]["apiVersion"]["value"], "2023-05-15")
     
     @patch('ark_api.api.v1.models.with_ark_client')
@@ -1232,13 +1238,14 @@ class TestModelsEndpoint(unittest.TestCase):
         # Setup async context manager mock
         mock_client = AsyncMock()
         mock_ark_client.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock the created model response
         mock_model = Mock()
         mock_model.to_dict.return_value = {
             "metadata": {"name": "claude-bedrock", "namespace": "default"},
             "spec": {
-                "type": "bedrock",
+                "type": "completions",
+                "provider": "bedrock",
                 "model": {"value": "anthropic.claude-v2"},
                 "config": {
                     "bedrock": {
@@ -1251,13 +1258,13 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_client.models.a_create = AsyncMock(return_value=mock_model)
-        
+
         # Make the request
         request_data = {
             "name": "claude-bedrock",
-            "type": "bedrock",
+            "provider": "bedrock",
             "model": "anthropic.claude-v2",
             "config": {
                 "bedrock": {
@@ -1270,12 +1277,13 @@ class TestModelsEndpoint(unittest.TestCase):
             }
         }
         response = self.client.post("/v1/models?namespace=default", json=request_data)
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["name"], "claude-bedrock")
-        self.assertEqual(data["type"], "bedrock")
+        self.assertEqual(data["provider"], "bedrock")
+        self.assertEqual(data["type"], "completions")
         self.assertEqual(data["config"]["bedrock"]["region"]["value"], "us-east-1")
         self.assertEqual(data["config"]["bedrock"]["maxTokens"]["value"], "1000")
         self.assertEqual(data["config"]["bedrock"]["temperature"]["value"], "0.7")
@@ -1286,13 +1294,14 @@ class TestModelsEndpoint(unittest.TestCase):
         # Setup async context manager mock
         mock_client = AsyncMock()
         mock_ark_client.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock the model response
         mock_model = Mock()
         mock_model.to_dict.return_value = {
             "metadata": {"name": "gpt-4-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "type": "completions",
+                "provider": "openai",
                 "model": {"value": "gpt-4"},
                 "config": {
                     "openai": {
@@ -1308,17 +1317,18 @@ class TestModelsEndpoint(unittest.TestCase):
                 "resolvedAddress": "https://api.openai.com/v1"
             }
         }
-        
+
         mock_client.models.a_get = AsyncMock(return_value=mock_model)
-        
+
         # Make the request
         response = self.client.get("/v1/models/gpt-4-model?namespace=default")
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["name"], "gpt-4-model")
-        self.assertEqual(data["type"], "openai")
+        self.assertEqual(data["provider"], "openai")
+        self.assertEqual(data["type"], "completions")
         self.assertEqual(data["model"], "gpt-4")
         self.assertEqual(data["available"], "True")
         self.assertEqual(data["resolved_address"], "https://api.openai.com/v1")
@@ -1336,7 +1346,8 @@ class TestModelsEndpoint(unittest.TestCase):
         existing_model.to_dict.return_value = {
             "metadata": {"name": "gpt-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "provider": "openai",
+                "type": "completions",
                 "model": {"value": "gpt-3.5-turbo"},
                 "config": {
                     "openai": {
@@ -1346,13 +1357,14 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         # Mock updated model
         updated_model = Mock()
         updated_model.to_dict.return_value = {
             "metadata": {"name": "gpt-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "provider": "openai",
+                "type": "completions",
                 "model": {"value": "gpt-4"},
                 "config": {
                     "openai": {
@@ -1362,10 +1374,10 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_client.models.a_get = AsyncMock(return_value=existing_model)
         mock_client.models.a_update = AsyncMock(return_value=updated_model)
-        
+
         # Make the request
         request_data = {
             "model": "gpt-4",
@@ -1377,7 +1389,7 @@ class TestModelsEndpoint(unittest.TestCase):
             }
         }
         response = self.client.put("/v1/models/gpt-model?namespace=default", json=request_data)
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -1391,13 +1403,14 @@ class TestModelsEndpoint(unittest.TestCase):
         # Setup async context manager mock
         mock_client = AsyncMock()
         mock_ark_client.return_value.__aenter__.return_value = mock_client
-        
+
         # Mock existing model
         existing_model = Mock()
         existing_model.to_dict.return_value = {
             "metadata": {"name": "gpt-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "provider": "openai",
+                "type": "completions",
                 "model": {"value": "gpt-3.5-turbo"},
                 "config": {
                     "openai": {
@@ -1407,13 +1420,14 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         # Mock updated model
         updated_model = Mock()
         updated_model.to_dict.return_value = {
             "metadata": {"name": "gpt-model", "namespace": "default"},
             "spec": {
-                "type": "openai",
+                "provider": "openai",
+                "type": "completions",
                 "model": {"value": "gpt-4"},
                 "config": {
                     "openai": {
@@ -1423,14 +1437,14 @@ class TestModelsEndpoint(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_client.models.a_get = AsyncMock(return_value=existing_model)
         mock_client.models.a_update = AsyncMock(return_value=updated_model)
-        
+
         # Make the request - only update model
         request_data = {"model": "gpt-4"}
         response = self.client.put("/v1/models/gpt-model?namespace=default", json=request_data)
-        
+
         # Assert response
         self.assertEqual(response.status_code, 200)
         data = response.json()

--- a/services/ark-dashboard/ark-dashboard/components/cards/model-card.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/cards/model-card.tsx
@@ -8,6 +8,7 @@ import { ConfirmationDialog } from '@/components/dialogs/confirmation-dialog';
 import { AvailabilityStatusBadge } from '@/components/ui/availability-status-badge';
 import { ARK_ANNOTATIONS } from '@/lib/constants/annotations';
 import { DASHBOARD_SECTIONS } from '@/lib/constants/dashboard-icons';
+import { getModelTypeDisplayName } from '@/lib/constants/model-types';
 import type { Model } from '@/lib/services';
 import { getCustomIcon } from '@/lib/utils/icon-resolver';
 
@@ -49,7 +50,7 @@ export function ModelCard({ model, onDelete }: ModelCardProps) {
 
   const description = (
     <span className="text-sm">
-      {model.type} • {model.model}
+      {getModelTypeDisplayName(model.type)} • {model.provider} • {model.model}
     </span>
   );
 

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/create-model-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/create-model-form.tsx
@@ -28,14 +28,14 @@ export function CreateModelForm({ defaultName }: CreateModelFormProps) {
     resolver: zodResolver(schema),
     defaultValues: {
       name: defaultName || '',
-      type: 'openai',
+      provider: 'openai',
       model: '',
       secret: '',
       baseUrl: '',
     },
   });
 
-  const type = form.watch('type');
+  const provider = form.watch('provider');
 
   const handleSuccess = useCallback(() => {
     router.push('/models');
@@ -49,13 +49,13 @@ export function CreateModelForm({ defaultName }: CreateModelFormProps) {
     const currentValues = form.getValues();
     form.reset(getResetValues(currentValues));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [type]);
+  }, [provider]);
 
   const onSubmit = (formValues: FormValues) => {
     const config = createConfig(formValues);
     mutate({
       name: formValues.name,
-      type: formValues.type,
+      provider: formValues.provider,
       model: formValues.model,
       config,
     });
@@ -66,7 +66,7 @@ export function CreateModelForm({ defaultName }: CreateModelFormProps) {
       value={{
         formId,
         form,
-        type,
+        provider,
         onSubmit,
         isSubmitPending: isPending,
       }}>

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form-context.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form-context.tsx
@@ -12,7 +12,7 @@ export type DisabledFields = Partial<Record<KeysOfUnion<FormValues>, boolean>>;
 interface ModelConfigurationFormContext {
   formId: string;
   form: UseFormReturn<FormValues>;
-  type: FormValues['type'];
+  provider: FormValues['provider'];
   onSubmit: (formValues: FormValues) => void;
   isSubmitPending: boolean;
   disabledFields?: DisabledFields;

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
@@ -43,6 +43,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
+import { getModelTypeDisplayName } from '@/lib/constants/model-types';
 import type { Secret } from '@/lib/services';
 import type { SecretDetailResponse } from '@/lib/services/secrets';
 import {
@@ -56,7 +57,7 @@ import { useModelConfigurationForm } from './model-configuration-form-context';
 import type { FormValues } from './schema';
 
 export function ModelConfiguratorForm() {
-  const { form, formId, onSubmit, type, disabledFields } =
+  const { form, formId, onSubmit, provider, disabledFields } =
     useModelConfigurationForm();
 
   const {
@@ -101,16 +102,26 @@ export function ModelConfiguratorForm() {
               </FormItem>
             )}
           />
+          <FormItem>
+            <FormLabel>Type</FormLabel>
+            <FormControl>
+              <Input
+                value={getModelTypeDisplayName('completions')}
+                disabled={true}
+                className="bg-muted"
+              />
+            </FormControl>
+          </FormItem>
           <FormField
             control={form.control}
-            name="type"
+            name="provider"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Type</FormLabel>
+                <FormLabel>Provider</FormLabel>
                 <Select
                   onValueChange={field.onChange}
                   value={field.value}
-                  disabled={disabledFields?.type}>
+                  disabled={disabledFields?.provider}>
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue />
@@ -136,9 +147,9 @@ export function ModelConfiguratorForm() {
                   <Input
                     {...field}
                     placeholder={
-                      type === 'openai'
+                      provider === 'openai'
                         ? 'e.g., gpt-4-turbo-preview'
-                        : type === 'azure'
+                        : provider === 'azure'
                           ? 'e.g., gpt-4'
                           : 'e.g., anthropic.claude-v2'
                     }
@@ -148,21 +159,21 @@ export function ModelConfiguratorForm() {
               </FormItem>
             )}
           />
-          {type === 'openai' && (
+          {provider === 'openai' && (
             <OpenAISpecificFields
               isSecretsPending={isSecretsPending}
               secrets={secrets}
               control={form.control}
             />
           )}
-          {type === 'azure' && (
+          {provider === 'azure' && (
             <AzureSpecificFields
               isSecretsPending={isSecretsPending}
               secrets={secrets}
               control={form.control}
             />
           )}
-          {type === 'bedrock' && (
+          {provider === 'bedrock' && (
             <AWSBedrockSpecificFields
               isSecretsPending={isSecretsPending}
               secrets={secrets}

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/schema.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/schema.ts
@@ -4,7 +4,7 @@ import { kubernetesNameSchema } from '@/lib/utils/kubernetes-validation';
 
 const openaiSchema = z.object({
   name: kubernetesNameSchema,
-  type: z.literal('openai'),
+  provider: z.literal('openai'),
   model: z.string().min(1, { message: 'Model is required' }),
   secret: z.string().min(1, { message: 'API Key is required' }),
   baseUrl: z.string().min(1, { message: 'Base URL is required' }),
@@ -12,7 +12,7 @@ const openaiSchema = z.object({
 
 const azureSchema = z.object({
   name: kubernetesNameSchema,
-  type: z.literal('azure'),
+  provider: z.literal('azure'),
   model: z.string().min(1, { message: 'Model is required' }),
   secret: z.string().min(1, { message: 'API Key is required' }),
   baseUrl: z.string().min(1, { message: 'Base URL is required' }),
@@ -21,7 +21,7 @@ const azureSchema = z.object({
 
 const bedrockSchema = z.object({
   name: kubernetesNameSchema,
-  type: z.literal('bedrock'),
+  provider: z.literal('bedrock'),
   model: z.string().min(1, { message: 'Model is required' }),
   bedrockAccessKeyIdSecretName: z
     .string()
@@ -33,7 +33,7 @@ const bedrockSchema = z.object({
   modelARN: z.string().nullish(),
 });
 
-export const schema = z.discriminatedUnion('type', [
+export const schema = z.discriminatedUnion('provider', [
   openaiSchema,
   azureSchema,
   bedrockSchema,

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
@@ -21,7 +21,7 @@ const formId = 'model-update-form';
 
 const disabledFields: DisabledFields = {
   name: true,
-  type: true,
+  provider: true,
 };
 
 type UpdateModelFormProps = {
@@ -59,7 +59,7 @@ export function UpdateModelForm({ model }: UpdateModelFormProps) {
         form,
         onSubmit,
         isSubmitPending: isPending,
-        type: defaultValues.type,
+        provider: defaultValues.provider,
         disabledFields,
         formId,
       }}>

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
@@ -10,7 +10,7 @@ export function createConfig(
   formValues: FormValues,
 ): ModelCreateRequest['config'] {
   const config: ModelCreateRequest['config'] = {};
-  switch (formValues.type) {
+  switch (formValues.provider) {
     case 'openai':
       config.openai = {
         apiKey: {
@@ -72,11 +72,11 @@ export function createModelUpdateConfig(
 }
 
 export function getResetValues(currentFormValues: FormValues): FormValues {
-  switch (currentFormValues.type) {
+  switch (currentFormValues.provider) {
     case 'openai':
       return {
         name: currentFormValues.name,
-        type: currentFormValues.type,
+        provider: currentFormValues.provider,
         model: currentFormValues.model,
         secret: currentFormValues.secret ?? '',
         baseUrl: currentFormValues.baseUrl ?? '',
@@ -84,7 +84,7 @@ export function getResetValues(currentFormValues: FormValues): FormValues {
     case 'azure':
       return {
         name: currentFormValues.name,
-        type: currentFormValues.type,
+        provider: currentFormValues.provider,
         model: currentFormValues.model,
         secret: currentFormValues.secret ?? '',
         baseUrl: currentFormValues.baseUrl ?? '',
@@ -93,7 +93,7 @@ export function getResetValues(currentFormValues: FormValues): FormValues {
     case 'bedrock':
       return {
         name: currentFormValues.name,
-        type: currentFormValues.type,
+        provider: currentFormValues.provider,
         model: currentFormValues.model,
         bedrockAccessKeyIdSecretName: '',
         bedrockSecretAccessKeySecretName: '',
@@ -127,11 +127,11 @@ function getConfigValue<T = unknown>(
 }
 
 export function getDefaultValuesForUpdate(model: Model): FormValues {
-  switch (model.type) {
+  switch (model.provider) {
     case 'openai':
       return {
         name: model.name,
-        type: model.type,
+        provider: model.provider,
         model: model.model,
         secret:
           getConfigValue<string>(model.config, [
@@ -151,7 +151,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
     case 'azure':
       return {
         name: model.name,
-        type: model.type,
+        provider: model.provider,
         model: model.model,
         secret:
           getConfigValue<string>(model.config, [
@@ -174,7 +174,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
     case 'bedrock':
       return {
         name: model.name,
-        type: model.type,
+        provider: model.provider,
         model: model.model,
         bedrockAccessKeyIdSecretName:
           getConfigValue<string>(model.config, [

--- a/services/ark-dashboard/ark-dashboard/components/rows/model-row.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/rows/model-row.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/tooltip';
 import { ARK_ANNOTATIONS } from '@/lib/constants/annotations';
 import { DASHBOARD_SECTIONS } from '@/lib/constants/dashboard-icons';
+import { getModelTypeDisplayName } from '@/lib/constants/model-types';
 import type { Model } from '@/lib/services';
 import { getCustomIcon } from '@/lib/utils/icon-resolver';
 
@@ -44,8 +45,9 @@ export function ModelRow({ model, onDelete }: ModelRowProps) {
             </p>
             <p
               className="text-muted-foreground truncate text-xs"
-              title={`${model.type} • ${model.model}`}>
-              {model.type} • {model.model}
+              title={`${getModelTypeDisplayName(model.type)} • ${model.provider} • ${model.model}`}>
+              {getModelTypeDisplayName(model.type)} • {model.provider} •{' '}
+              {model.model}
             </p>
           </div>
         </div>

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -3619,10 +3619,10 @@ export interface components {
             /** Name */
             name: string;
             /**
-             * Type
+             * Provider
              * @enum {string}
              */
-            type: "openai" | "azure" | "bedrock";
+            provider: "openai" | "azure" | "bedrock";
         };
         /**
          * ModelDetailResponse
@@ -3648,13 +3648,19 @@ export interface components {
             name: string;
             /** Namespace */
             namespace: string;
+            /**
+             * Provider
+             * @enum {string}
+             */
+            provider: "openai" | "azure" | "bedrock";
             /** Resolved Address */
             resolved_address?: string | null;
             /**
              * Type
-             * @enum {string}
+             * @default completions
+             * @constant
              */
-            type: "openai" | "azure" | "bedrock";
+            type: "completions";
         };
         /**
          * ModelListResponse
@@ -3693,10 +3699,16 @@ export interface components {
             /** Namespace */
             namespace: string;
             /**
-             * Type
+             * Provider
              * @enum {string}
              */
-            type: "openai" | "azure" | "bedrock";
+            provider: "openai" | "azure" | "bedrock";
+            /**
+             * Type
+             * @default completions
+             * @constant
+             */
+            type: "completions";
         };
         /**
          * ModelUpdateRequest

--- a/services/ark-dashboard/ark-dashboard/lib/constants/index.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './dashboard-icons';
+export * from './model-types';

--- a/services/ark-dashboard/ark-dashboard/lib/constants/model-types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/constants/model-types.ts
@@ -1,0 +1,10 @@
+// Model type display names
+// Maps internal model type values to user-friendly display names
+export const MODEL_TYPE_DISPLAY_NAMES: Record<string, string> = {
+  completions: 'Chat Completions (OpenAI V1)',
+};
+
+export function getModelTypeDisplayName(type: string | undefined): string {
+  if (!type) return 'Unknown';
+  return MODEL_TYPE_DISPLAY_NAMES[type] ?? type;
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,152 +1,109 @@
 # Chainsaw Testing Guide
 
-This document covers best practices for writing chainsaw tests in the ARK project.
+## Test Structure
 
-### Basic Test Layout
 ```
-tests/
-├── test-name/
-│   ├── chainsaw-test.yaml
-│   ├── README.md             # Required test documentation
-│   └── manifests/
-│       ├── a00-rbac.yaml
-│       ├── a01-secrets.yaml
-│       ├── a02-configmaps.yaml
-│       ├── a03-model.yaml
-│       ├── a04-agent.yaml
-│       └── a05-query.yaml
+tests/test-name/
+├── chainsaw-test.yaml      # Test definition
+├── mock-llm-values.yaml    # Mock LLM config (optional)
+├── README.md               # Required documentation
+└── manifests/
+    ├── a03-agent.yaml
+    ├── a04-team.yaml       # Optional
+    └── a05-query.yaml
 ```
 
-### README Documentation
-Each test directory MUST include a `README.md` file with this format:
-
+### README Format
 ```markdown
 # Test Name
 
-Brief description of what the test validates.
+Brief description.
 
 ## What it tests
-- Specific functionality being tested
-- Key components or integrations
-- Expected behaviors or outcomes
+- Functionality being tested
 
 ## Running
 ```bash
-chainsaw test
+chainsaw test ./tests/test-name
+```
 ```
 
-One sentence explaining what successful test completion validates.
-```
+## Test Setup
 
-### File Naming Convention
-- Use `a00-`, `a01-`, etc. prefixes to control application order
-- RBAC files should be first (`a00-rbac.yaml`)
-- Dependencies should come before dependents (models before agents, agents before queries)
-
-## RBAC Requirements
-
-### Essential Pattern
-All tests that create queries MUST include RBAC configuration:
+### Mock LLM and Tenant
+Modern tests use Helm charts for setup:
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: query-test-role
-rules:
-- apiGroups: ["ark.mckinsey.com"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: query-test-rolebinding
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: ($namespace)
-roleRef:
-  kind: Role
-  name: query-test-role
-  apiGroup: rbac.authorization.k8s.io
+steps:
+- name: setup
+  try:
+  - script:
+      content: |
+        helm install mock-llm oci://ghcr.io/dwmkerr/charts/mock-llm \
+          --version 0.1.25 \
+          --namespace $NAMESPACE \
+          --values mock-llm-values.yaml \
+          --wait --timeout=120s
+      env:
+      - name: NAMESPACE
+        value: ($namespace)
+  - script:
+      content: |
+        helm install ark-tenant ../../charts/ark-tenant --namespace $NAMESPACE --wait
+      env:
+      - name: NAMESPACE
+        value: ($namespace)
 ```
 
-### Key Points
-- Use default service account, not custom ones
-- Grant full permissions to `ark.mckinsey.com` resources
-- Include `secrets` and `configmaps` access for parameter resolution
-- Use `($namespace)` template for namespace references
-
-## Parameter Templating
-
-### Template Syntax
-Use Go template syntax: `{{.parameter_name}}`
-
-### Parameter Sources
-- **Direct values**: `{{.agent_name}}`
-- **ConfigMap references**: `{{.response_style}}`
-- **Secret references**: `{{.special_instruction}}`
-
-### Example Agent with Parameters
+### Mock LLM Values
 ```yaml
-spec:
-  prompt: |
-    You are {{.agent_name}} running in {{.test_mode}} mode.
-    Your role is: {{.agent_role}}
-    Response style: {{.response_style}}
-    Maximum tokens per response: {{.max_tokens}}
-    API endpoint for additional data: {{.api_endpoint}}
-    Special instructions: {{.special_instruction}}
+# mock-llm-values.yaml
+ark:
+  model:
+    enabled: true
+    name: test-model
+    provider: openai
+    model: gpt-4
+    apiKey: mock-api-key
+
+config:
+  rules:
+    - path: "/v1/chat/completions"
+      response:
+        status: 200
+        content: '{"choices":[{"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}]}'
 ```
 
-## Resource Assertions
+## Assertions
 
-### Agent Assertions
-Agents don't have a `status.phase` field, so only assert existence:
-```yaml
-- assert:
-    resource:
-      apiVersion: ark.mckinsey.com/v1alpha1
-      kind: Agent
-      metadata:
-        name: test-agent
-```
+Use conditions for resource readiness:
 
-### Query Assertions
-Queries should assert `phase: done` for successful completion:
 ```yaml
-- assert:
-    resource:
-      apiVersion: ark.mckinsey.com/v1alpha1
-      kind: Query
-      metadata:
-        name: test-query
-      status:
-        phase: done
-```
-
-### Model Assertions
-Models should assert existence and readiness:
-```yaml
+# Model ready
 - assert:
     resource:
       apiVersion: ark.mckinsey.com/v1alpha1
       kind: Model
       metadata:
         name: test-model
-```
+      status:
+        conditions:
+        - type: ModelAvailable
+          status: "True"
 
-## Query Response Validation
+# Agent ready
+- assert:
+    resource:
+      apiVersion: ark.mckinsey.com/v1alpha1
+      kind: Agent
+      metadata:
+        name: test-agent
+      status:
+        conditions:
+        - type: Available
+          status: "True"
 
-### Using JP Functions
-Use Chainsaw's JP functions for response validation instead of shell scripts:
-
-```yaml
-# Validate response count
+# Query completed
 - assert:
     resource:
       apiVersion: ark.mckinsey.com/v1alpha1
@@ -154,9 +111,10 @@ Use Chainsaw's JP functions for response validation instead of shell scripts:
       metadata:
         name: test-query
       status:
-        (length(responses)): 2
+        (conditions[?type == 'Completed']):
+        - status: 'True'
 
-# Validate specific agent responded
+# Response validation
 - assert:
     resource:
       apiVersion: ark.mckinsey.com/v1alpha1
@@ -164,333 +122,13 @@ Use Chainsaw's JP functions for response validation instead of shell scripts:
       metadata:
         name: test-query
       status:
-        (contains(responses[*].target.name, 'expected-agent')): true
-
-# Validate agent did NOT respond
-- assert:
-    resource:
-      apiVersion: ark.mckinsey.com/v1alpha1
-      kind: Query
-      metadata:
-        name: test-query
-      status:
-        (contains(responses[*].target.name, 'excluded-agent')): false
-
-# Validate response content length
-- assert:
-    resource:
-      apiVersion: ark.mckinsey.com/v1alpha1
-      kind: Query
-      metadata:
-        name: test-query
-      status:
-        (length(join('', responses[*].content)) > `50`): true
+        (length(responses)): 1
+        (contains(responses[0].content, 'expected-text')): true
 ```
 
-### Label Selector Testing
-Test queries with label selectors to validate target selection:
+## Catch Blocks
 
-```yaml
-# Query with matchLabels selector
-apiVersion: ark.mckinsey.com/v1alpha1
-kind: Query
-metadata:
-  name: test-query-selector
-spec:
-  input: Test query for label selection
-  selector:
-    matchLabels:
-      environment: production
-      type: specialist
-```
-
-## Environment Variables
-
-### Required Variables
-Tests use these environment variables for Azure OpenAI:
-- `E2E_TEST_AZURE_OPENAI_KEY`
-- `E2E_TEST_AZURE_OPENAI_BASE_URL`
-
-### Script Setup Pattern
-```yaml
-- script:
-    skipLogOutput: true
-    content: |
-      set -u
-      echo "{\"token\": \"$E2E_TEST_AZURE_OPENAI_KEY\", \"url\": \"$E2E_TEST_AZURE_OPENAI_BASE_URL\"}"
-    outputs:
-    - name: azure
-      value: (json_parse($stdout))
-```
-
-### Secret Template Pattern
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: test-model-token
-type: Opaque
-data:
-  token: (base64_encode($azure.token))
-```
-
-## Resource Dependencies
-
-### Dependency Order
-1. RBAC (Role, RoleBinding)
-2. Secrets and ConfigMaps
-3. Models
-4. Agents (depend on Models)
-5. Queries (depend on Agents)
-
-### Model Reference Pattern
-```yaml
-# Model - CORRECT v1alpha1 format
-metadata:
-  name: test-model
-spec:
-  type: azure
-  model:
-    value: gpt-4.1-mini
-  config:
-    azure:
-      baseUrl:
-        value: ($azure.url)
-      apiKey:
-        valueFrom:
-          secretKeyRef:
-            name: test-model-token
-            key: token
-      apiVersion:
-        value: "2024-12-01-preview"
-
-# Agent references model - use modelRef
-spec:
-  modelRef:
-    name: test-model
-  
-# Query references agent
-spec:
-  agent: test-agent
-```
-
-## Debugging and Troubleshooting
-
-### Keep Resources for Investigation
-Use `--skip-delete` flag to keep resources after test failure:
-```bash
-chainsaw test tests/queries/ --skip-delete
-```
-
-### Check Kubernetes Events
-When queries fail, examine events to understand the issue:
-```bash
-kubectl get events --sort-by='.lastTimestamp'
-kubectl describe query test-query
-```
-
-### Common Event Messages
-- `agents.ark.mckinsey.com "test-agent" is forbidden` - Missing RBAC permissions
-- `secrets "test-token" is forbidden` - Missing secrets access in RBAC
-- Query stuck in `phase: error` - Check agent/model dependencies
-
-## Common Pitfalls and Spec Errors
-
-### Don't Use Labels
-Avoid adding labels to resources unless specifically required:
-```yaml
-# Bad
-metadata:
-  name: test-agent
-  labels:
-    test: "true"
-
-# Good  
-metadata:
-  name: test-agent
-```
-
-### Resource Spec Format Errors
-
-#### Secret Template Syntax
-```yaml
-# Wrong - will cause template parse error
-data:
-  token: (($azure.token) | @base64)
-
-# Correct - use chainsaw function
-data:
-  token: (base64_encode($azure.token))
-```
-
-#### Model Spec Format
-```yaml
-# Wrong - old format causes "unknown field" errors
-spec:
-  provider: azure-openai
-  model: gpt-4.1-mini
-  baseURL: ($azure.url)
-  auth:
-    tokenSecret:
-      name: test-model-token
-      key: token
-
-# Correct - current v1alpha1 format
-spec:
-  type: azure
-  model:
-    value: gpt-4.1-mini
-  config:
-    azure:
-      baseUrl:
-        value: ($azure.url)
-      apiKey:
-        valueFrom:
-          secretKeyRef:
-            name: test-model-token
-            key: token
-      apiVersion:
-        value: "2024-12-01-preview"
-```
-
-#### Agent Model Reference
-```yaml
-# Wrong - causes "unknown field spec.model" error
-spec:
-  model: test-model
-
-# Correct - use modelRef
-spec:
-  modelRef:
-    name: test-model
-```
-
-#### Team Members vs Targets
-```yaml
-# Wrong - causes "unknown field spec.targets" error
-spec:
-  strategy: sequential
-  targets:
-    - type: agent
-      name: test-agent
-
-# Correct - use members
-spec:
-  strategy: sequential
-  members:
-    - type: agent
-      name: test-agent
-```
-
-### Missing RBAC
-Query tests will fail with forbidden errors without proper RBAC configuration.
-
-### Wrong Phase Assertion
-Don't assert `status.phase` on resources that don't have it (like Agents).
-
-### Parameter Resolution
-Ensure ConfigMaps and Secrets exist before resources that reference them.
-
-## Testing Services with Helm Charts
-
-### MCP Services Pattern
-For MCP services and other services that have Helm chart packaging, use this deployment pattern:
-
-```yaml
-# Deploy service using Helm chart
-- name: deploy-service-with-helm
-  try:
-  - script:
-      content: |
-        helm install service-name ../chart --namespace $NAMESPACE --wait --timeout=30s
-      env:
-      - name: NAMESPACE
-        value: ($namespace)
-```
-
-### Service Test Structure
-```
-mcp/service-name/test/
-├── chainsaw-test.yaml
-├── README.md
-└── manifests/
-    ├── a00-rbac.yaml
-    ├── a04-secret.yaml
-    ├── a05-model.yaml
-    ├── a06-agent.yaml
-    └── a07-query.yaml
-```
-
-### MCPServer Integration
-Services deployed via Helm that create MCPServer resources require:
-
-1. **Wait for MCPServer readiness**:
-```yaml
-- assert:
-    resource:
-      apiVersion: ark.mckinsey.com/v1alpha1
-      kind: MCPServer
-      metadata:
-        name: service-name
-```
-
-2. **Agent tools reference auto-generated Tool resources**:
-```yaml
-spec:
-  tools:
-  - name: service-name-tool-1
-    type: custom
-  - name: service-name-tool-2
-    type: custom
-```
-
-3. **Additional RBAC for service discovery**:
-```yaml
-rules:
-- apiGroups: ["ark.mckinsey.com"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["secrets", "configmaps", "services"]
-  verbs: ["get", "list", "watch"]
-```
-
-### Response Content Validation
-For functional testing, validate that service operations actually worked:
-
-```yaml
-- name: validate-response-content
-  try:
-  - assert:
-      resource:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        metadata:
-          name: test-query
-        status:
-          # Validate response mentions expected operations
-          (contains(responses[0].content, 'operation-evidence')): true
-  - script:
-      content: |
-        RESPONSE=$(kubectl -n $NAMESPACE get query test-query -o jsonpath='{.status.responses[0].content}')
-        
-        echo "=== Query Response Content ==="
-        echo "$RESPONSE"
-        echo "=========================="
-        
-        # Validate specific operations mentioned in response
-        if echo "$RESPONSE" | grep -qi "expected-operation"; then
-          echo "✓ Response mentions expected operation"
-        else
-          echo "✗ Response missing expected operation"
-          exit 1
-        fi
-```
-
-## Error Handling and Verbosity
-
-### Standard Catch Blocks
-All chainsaw tests with Query assertions should include catch blocks to reduce verbosity and provide debugging information:
+Add catch blocks for debugging:
 
 ```yaml
 catch:
@@ -498,144 +136,66 @@ catch:
 - describe:
     apiVersion: ark.mckinsey.com/v1alpha1
     kind: Query
-    name: query-name
+    name: test-query
 ```
 
-### Catch Block Purpose
-- `events: {}` - Suppresses detailed event logging noise during normal operation
-- `describe:` - Provides structured debugging information for Query resources when failures occur
-
-### Event Validation Best Practices
-When validating events in tests, check for presence rather than exact counts to avoid flakiness:
+## Model Reference Pattern
 
 ```yaml
-# Good - robust presence checking
-if [ "$target_execution_complete" -gt 0 ]; then
-  echo "✓ TargetExecutionComplete events found"
-fi
+# Model with provider
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: test-model
+spec:
+  provider: azure
+  model:
+    value: gpt-4.1-mini
+  config:
+    azure:
+      baseUrl:
+        value: "https://example.openai.azure.com"
+      apiKey:
+        valueFrom:
+          secretKeyRef:
+            name: api-key-secret
+            key: token
 
-# Bad - exact count matching (flaky)
-if [ "$target_execution_complete" -eq 1 ]; then
-  echo "✓ Exactly 1 TargetExecutionComplete event"
-fi
+# Agent references model
+spec:
+  modelRef:
+    name: test-model
+
+# Query references agent
+spec:
+  agent: test-agent
 ```
 
-### Test Structure for Timing
-Separate query completion waiting from validation steps to ensure proper timing:
+## Environment Variables
 
-```yaml
-- name: wait-for-query-completion
-  try:
-  - assert:
-      resource:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        metadata:
-          name: test-query
-        status:
-          phase: done
+For real LLM tests (not mock-llm):
+- `E2E_TEST_AZURE_OPENAI_KEY`
+- `E2E_TEST_AZURE_OPENAI_BASE_URL`
 
-- name: validate-response
-  try:
-  - assert:
-      resource:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        metadata:
-          name: test-query
-        status:
-          (length(responses)): 1
+## Debugging
+
+```bash
+# Keep resources after failure
+chainsaw test tests/test-name --skip-delete
+
+# Pause on failure
+chainsaw test tests/test-name --pause-on-failure
+
+# Check events
+kubectl get events --sort-by='.lastTimestamp'
 ```
 
 ## HTTP API Testing with Hurl
 
-### Overview
-Hurl is used for HTTP API testing of services within chainsaw tests. It provides comprehensive HTTP client functionality with JSON path validation and test assertions.
+For services with HTTP APIs, use Hurl inside a test pod:
 
-### Hurl Test File Structure
-```
-services/{service-name}/test/
-├── test.hurl              # HTTP test definitions
-├── chainsaw-test.yaml     # Chainsaw integration
-└── manifests/
-    ├── pod-{service}-test.yaml   # Test pod with hurl image
-    └── configmap.yaml            # ConfigMap mounting hurl files
-```
-
-### Basic Hurl Test Patterns
-
-#### Health Check Testing
-```hurl
-# Test service health endpoint
-GET http://service-name/health
-HTTP 200
-[Asserts]
-body == "OK"
-```
-
-#### JSON API Testing
-```hurl
-# Test JSON endpoint with validation
-GET http://service-name/api/endpoint
-HTTP 200
-[Asserts]
-jsonpath "$.status" == "ready"
-jsonpath "$.data" exists
-jsonpath "$.data.items" count >= 1
-```
-
-#### POST Request with JSON Body
-```hurl
-# Send JSON data to API
-PUT http://service-name/api/resource/session-id
-Content-Type: application/json
-{
-  "data": {
-    "field": "value",
-    "items": ["item1", "item2"]
-  }
-}
-HTTP 200
-[Asserts]
-jsonpath "$.success" == true
-```
-
-#### Complex JSON Structure Testing
-```hurl
-# Test complex nested JSON responses
-GET http://service-name/api/complex
-HTTP 200
-[Asserts]
-jsonpath "$.messages" count == 3
-jsonpath "$.messages[0].role" == "user"
-jsonpath "$.messages[0].content" == "Expected content"
-jsonpath "$.messages[0].tool_calls" exists
-jsonpath "$.messages[0].tool_calls[0].id" == "call_123"
-jsonpath "$.messages[0].tool_calls[0].function.name" == "function_name"
-```
-
-#### Error Handling Testing
-```hurl
-# Test error responses
-GET http://service-name/api/nonexistent
-HTTP 404
-
-POST http://service-name/api/endpoint
-Content-Type: application/json
-{
-  "invalid": "request"
-}
-HTTP 400
-[Asserts]
-jsonpath "$.error.code" == -32600
-jsonpath "$.error.message" exists
-```
-
-### Chainsaw Integration Pattern
-
-#### ConfigMap for Hurl Files
 ```yaml
-# Mount hurl test files into test pod
+# Mount hurl test file
 - script:
     skipLogOutput: true
     content: cat test.hurl
@@ -650,11 +210,8 @@ jsonpath "$.error.message" exists
         name: hurl-test-files
       data:
         test.hurl: ($test_script)
-```
 
-#### Test Pod Setup
-```yaml
-# Pod with hurl Docker image
+# Test pod with hurl
 - apply:
     resource:
       apiVersion: v1
@@ -674,160 +231,25 @@ jsonpath "$.error.message" exists
           configMap:
             name: hurl-test-files
         restartPolicy: Never
-        terminationGracePeriodSeconds: 0
+
+# Execute tests
+- script:
+    content: |
+      kubectl exec service-test -n $NAMESPACE -- hurl --test /tests/test.hurl
+    env:
+    - name: NAMESPACE
+      value: ($namespace)
 ```
 
-#### Test Execution
-```yaml
-# Execute hurl tests inside pod
-- name: run-hurl-tests
-  try:
-  - script:
-      content: |
-        kubectl exec service-test -n $NAMESPACE -- hurl --test /tests/test.hurl
-      env:
-      - name: NAMESPACE
-        value: ($namespace)
-      timeout: 120s
-```
-
-### Service-Specific Examples
-
-#### PostgreSQL Memory Service Pattern
-Based on `services/postgres-memory/test/test.hurl`:
-
+### Hurl Test Example
 ```hurl
-# Test message storage and retrieval
-PUT http://postgres-memory/message/test-session
+GET http://service-name/health
+HTTP 200
+
+POST http://service-name/api/endpoint
 Content-Type: application/json
-{
-  "message": {
-    "role": "user",
-    "content": "Test message"
-  }
-}
-HTTP 200
-
-# Verify message retrieval
-GET http://postgres-memory/message/test-session
+{"data": "value"}
 HTTP 200
 [Asserts]
-jsonpath "$.messages" count == 1
-jsonpath "$.messages[0].role" == "user"
-jsonpath "$.messages[0].content" == "Test message"
-
-# Test session isolation
-GET http://postgres-memory/message/other-session
-HTTP 200
-[Asserts]
-jsonpath "$.messages" == null
+jsonpath "$.status" == "success"
 ```
-
-#### A2A Gateway Service Pattern
-Based on `services/a2agw/test/test.hurl`:
-
-```hurl
-# Test agent discovery
-GET http://a2agw:8080/agents
-HTTP 200
-[Asserts]
-jsonpath "$" count >= 1
-jsonpath "$[*]" contains "agent-name"
-
-# Test agent capabilities
-GET http://a2agw:8080/agent/agent-name/.well-known/agent.json
-HTTP 200
-[Asserts]
-jsonpath "$.name" == "agent-name"
-jsonpath "$.skills" count >= 1
-jsonpath "$.skills[0].id" exists
-
-# Test JSON-RPC messaging
-POST http://a2agw:8080/agent/agent-name/jsonrpc
-Content-Type: application/json
-{
-  "jsonrpc": "2.0",
-  "method": "message/send",
-  "params": {
-    "message": {
-      "kind": "message",
-      "messageId": "test-1",
-      "role": "user",
-      "parts": [{"text": "Test message"}]
-    }
-  },
-  "id": 1
-}
-HTTP 200
-[Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 1
-jsonpath "$.result.messageId" exists
-```
-
-### Best Practices
-
-#### Test Organization
-- Group related tests logically in single .hurl file
-- Use descriptive comments for each test section
-- Test happy path first, then error conditions
-- Include session isolation tests for stateful services
-
-#### Assertion Strategies
-- Test response structure with `jsonpath` exists/count
-- Validate specific values with exact matches
-- Use `contains` for flexible array content validation
-- Test null values explicitly where expected
-
-#### Service URLs
-- Use service names for internal Kubernetes DNS resolution
-- Include port numbers when services don't use standard ports
-- Test both primary endpoints and health checks
-
-#### Error Testing
-- Test invalid endpoints (404 responses)
-- Test malformed requests (400 responses)
-- Validate error response structure and codes
-- Test authentication/authorization failures where applicable
-
-### Integration with ARK Testing
-
-#### Combined HTTP and ARK Testing
-```yaml
-# First test HTTP endpoints directly
-- name: run-hurl-tests
-  try:
-  - script:
-      content: kubectl exec test-pod -- hurl --test /tests/test.hurl
-
-# Then test ARK integration
-- name: test-ark-integration
-  try:
-  - assert:
-      resource:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        status:
-          phase: done
-```
-
-This pattern validates both the service's HTTP API functionality and its integration with the ARK platform.
-
-## Test Execution
-
-### Local Testing
-```bash
-# Run all tests
-chainsaw test tests/
-
-# Run specific test
-chainsaw test tests/queries/
-
-# Debug mode with cleanup disabled 
-chainsaw test tests/ --test-dir tests/queries --pause-on-failure
-```
-
-### Validation
-- Each test should pass independently when run individually
-- Query tests should reach `phase: done`
-- No RBAC permission errors in events

--- a/tests/admission-failures/chainsaw-test.yaml
+++ b/tests/admission-failures/chainsaw-test.yaml
@@ -6,18 +6,18 @@ spec:
   description: Comprehensive test of admission controller validation failures for invalid ARK resources
   steps:
   # Model validation failures
-  - name: test-model-missing-type
+  - name: test-model-missing-provider
     try:
     - error:
-        file: manifests/invalid-model-missing-type.yaml
+        file: manifests/invalid-model-missing-provider.yaml
   - name: test-model-missing-config
     try:
     - error:
         file: manifests/invalid-model-missing-config.yaml
-  - name: test-model-invalid-type
+  - name: test-model-invalid-provider
     try:
     - error:
-        file: manifests/invalid-model-invalid-type.yaml
+        file: manifests/invalid-model-invalid-provider.yaml
   
   # Agent validation failures  
   - name: test-agent-missing-prompt

--- a/tests/admission-failures/manifests/invalid-model-invalid-provider.yaml
+++ b/tests/admission-failures/manifests/invalid-model-invalid-provider.yaml
@@ -1,9 +1,9 @@
 apiVersion: ark.mckinsey.com/v1alpha1
 kind: Model
 metadata:
-  name: invalid-model-missing-type
+  name: invalid-model-invalid-provider
 spec:
-  # Missing required 'type' field - should fail admission
+  provider: unsupported  # Invalid provider - should fail admission
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/admission-failures/manifests/invalid-model-missing-config.yaml
+++ b/tests/admission-failures/manifests/invalid-model-missing-config.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: invalid-model-missing-config
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   # Missing required 'config' section - should fail admission

--- a/tests/admission-failures/manifests/invalid-model-missing-provider.yaml
+++ b/tests/admission-failures/manifests/invalid-model-missing-provider.yaml
@@ -1,9 +1,9 @@
 apiVersion: ark.mckinsey.com/v1alpha1
 kind: Model
 metadata:
-  name: invalid-model-invalid-type
+  name: invalid-model-missing-provider
 spec:
-  type: unsupported  # Invalid model type - should fail admission
+  # Missing required 'provider' field - should fail admission
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/agent-default-model/chainsaw-test.yaml
+++ b/tests/agent-default-model/chainsaw-test.yaml
@@ -80,7 +80,8 @@ spec:
             name: default
             namespace: $NAMESPACE
           spec:
-            type: openai
+            type: completions
+            provider: openai
             model:
               value: gpt-4.1
             pollInterval: 3s

--- a/tests/agent-overrides/manifests/a03-model.yaml
+++ b/tests/agent-overrides/manifests/a03-model.yaml
@@ -6,7 +6,8 @@ metadata:
     environment: test
     override-target: "true"
 spec:
-  type: openai
+  type: completions
+  provider: openai
   model:
     value: gpt-5
   pollInterval: 3s

--- a/tests/agent-parameters/manifests/a04-model.yaml
+++ b/tests/agent-parameters/manifests/a04-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/agent-partial-tool-invalid/mock-llm-values.yaml
+++ b/tests/agent-partial-tool-invalid/mock-llm-values.yaml
@@ -3,7 +3,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4o-mini
     pollInterval: 3s
     config:

--- a/tests/agent-partial-tool-valuefrom/mock-llm-values.yaml
+++ b/tests/agent-partial-tool-valuefrom/mock-llm-values.yaml
@@ -4,7 +4,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4o-mini
     pollInterval: 3s
     config:

--- a/tests/agent-partial-tool/mock-llm-values.yaml
+++ b/tests/agent-partial-tool/mock-llm-values.yaml
@@ -3,7 +3,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4o-mini
     pollInterval: 3s
     config:

--- a/tests/agent-structured-output/manifests/a02-model.yaml
+++ b/tests/agent-structured-output/manifests/a02-model.yaml
@@ -4,7 +4,8 @@ metadata:
   name: structured-output-test-model
   namespace: ($namespace)
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/agent-tools-lifecycle/manifests/a02-model.yaml
+++ b/tests/agent-tools-lifecycle/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/agent-tools/mock-llm-values.yaml
+++ b/tests/agent-tools/mock-llm-values.yaml
@@ -3,7 +3,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4
     apiKey: mock-api-key
 

--- a/tests/agents/manifests/a02-model.yaml
+++ b/tests/agents/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-baseline/manifests/a02-model.yaml
+++ b/tests/evaluation-baseline/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-baseline-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-direct-ragas/manifests/a02-model.yaml
+++ b/tests/evaluation-direct-ragas/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: direct-evaluation-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-direct/manifests/a02-model.yaml
+++ b/tests/evaluation-direct/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: direct-evaluation-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-event-basic/manifests/a02-model.yaml
+++ b/tests/evaluation-event-basic/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-event-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-parameters-priority/manifests/a02-model.yaml
+++ b/tests/evaluation-parameters-priority/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: priority-evaluation-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluation-query/manifests/a02-model.yaml
+++ b/tests/evaluation-query/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-query-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluator-context-enhanced/manifests/a03-model.yaml
+++ b/tests/evaluator-context-enhanced/manifests/a03-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: context-enhanced-evaluation-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/evaluator-selector/manifests/a02-model.yaml
+++ b/tests/evaluator-selector/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: selector-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/filesystem-mcp/manifests/a05-model.yaml
+++ b/tests/filesystem-mcp/manifests/a05-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/jq-filter-test/manifests/a02-model.yaml
+++ b/tests/jq-filter-test/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: default
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/model-custom-headers/mock-llm-values.yaml
+++ b/tests/model-custom-headers/mock-llm-values.yaml
@@ -5,7 +5,8 @@ ark:
   model:
     enabled: true
     name: test-model-custom-headers
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-5
     apiKey: mock-api-key
     headers:

--- a/tests/model-deprecated-type/README.md
+++ b/tests/model-deprecated-type/README.md
@@ -1,0 +1,15 @@
+# Model Deprecated Type Format
+
+Tests that the deprecated `spec.type` field (used for provider in Ark < 0.50) still works but emits a deprecation warning.
+
+## What it tests
+- Model with old format (`type: openai` instead of `provider: openai`) is accepted
+- Model becomes available and functional
+- Deprecation warning is emitted by the webhook
+
+## Running
+```bash
+chainsaw test ./tests/model-deprecated-type
+```
+
+Successful completion validates backward compatibility with deprecation notice.

--- a/tests/model-deprecated-type/chainsaw-test.yaml
+++ b/tests/model-deprecated-type/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: model-deprecated-type
+  labels:
+    standard: "true"
+spec:
+  description: Verify that models using deprecated type field are migrated to use provider field
+  steps:
+    - name: setup
+      try:
+        - script:
+            content: |
+              helm install ark-tenant ../../charts/ark-tenant --namespace $NAMESPACE --wait
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+
+    - name: apply-model-with-deprecated-format
+      try:
+        - apply:
+            resource:
+              apiVersion: ark.mckinsey.com/v1alpha1
+              kind: Model
+              metadata:
+                name: deprecated-format-model
+              spec:
+                type: openai
+                model:
+                  value: gpt-4
+                config:
+                  openai:
+                    baseUrl:
+                      value: "https://api.openai.com"
+                    apiKey:
+                      value: "mock-key"
+
+    - name: verify-migration
+      try:
+        - assert:
+            resource:
+              apiVersion: ark.mckinsey.com/v1alpha1
+              kind: Model
+              metadata:
+                name: deprecated-format-model
+              spec:
+                provider: openai
+                type: completions

--- a/tests/model-properties/manifests/a02-model-with-properties.yaml
+++ b/tests/model-properties/manifests/a02-model-with-properties.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model-properties
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/model-token-usage/manifests/a02-model.yaml
+++ b/tests/model-token-usage/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: model-token-test
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/models/manifests/a02-model.yaml
+++ b/tests/models/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: default
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/queries-ttl-timeout/manifests/a02-model.yaml
+++ b/tests/queries-ttl-timeout/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model-openai
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/queries/manifests/a02-model.yaml
+++ b/tests/queries/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-event-recorder/manifests/a02-model.yaml
+++ b/tests/query-event-recorder/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-input-type/manifests/a02-model.yaml
+++ b/tests/query-input-type/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-label-selector/manifests/a02-model.yaml
+++ b/tests/query-label-selector/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-model-target/manifests/a02-model.yaml
+++ b/tests/query-model-target/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-multiple-targets/manifests/a02-model.yaml
+++ b/tests/query-multiple-targets/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-overrides/manifests/a03-model.yaml
+++ b/tests/query-overrides/manifests/a03-model.yaml
@@ -6,7 +6,8 @@ metadata:
     environment: test
     query-override-target: "true"
 spec:
-  type: openai
+  type: completions
+  provider: openai
   model:
     value: gpt-5
   pollInterval: 3s

--- a/tests/query-parameter-ref/mock-llm-values.yaml
+++ b/tests/query-parameter-ref/mock-llm-values.yaml
@@ -5,7 +5,8 @@ ark:
   model:
     enabled: true
     name: mock-gpt-4.1
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4.1
     pollInterval: 3s
     apiKey: mock-api-key

--- a/tests/query-parameters/manifests/a04-model.yaml
+++ b/tests/query-parameters/manifests/a04-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-partial-success/manifests/a02-model.yaml
+++ b/tests/query-partial-success/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-partial-success/manifests/a03-model-failing-auth.yaml
+++ b/tests/query-partial-success/manifests/a03-model-failing-auth.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model-failing-auth
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/query-token-usage/mock-llm-values.yaml
+++ b/tests/query-token-usage/mock-llm-values.yaml
@@ -5,7 +5,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4.1-mini
     pollInterval: 3s
     apiKey: mock-api-key

--- a/tests/team-graph-selector/manifests/a02-model.yaml
+++ b/tests/team-graph-selector/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-graph/manifests/a02-model.yaml
+++ b/tests/team-graph/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-of-teams/manifests/a02-model.yaml
+++ b/tests/team-of-teams/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-round-robin-max-turns/manifests/a02-model.yaml
+++ b/tests/team-round-robin-max-turns/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-round-robin/manifests/a02-model.yaml
+++ b/tests/team-round-robin/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-selector/manifests/a02-model.yaml
+++ b/tests/team-selector/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: test-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/team-sequential/mock-llm-values.yaml
+++ b/tests/team-sequential/mock-llm-values.yaml
@@ -3,7 +3,8 @@ ark:
   model:
     enabled: true
     name: test-model
-    type: openai
+    type: completions
+    provider: openai
     model: gpt-4
     apiKey: mock-api-key
 

--- a/tests/weather-chicago-tools/manifests/a02-model.yaml
+++ b/tests/weather-chicago-tools/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: weather-default-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:

--- a/tests/weather-chicago/manifests/a02-model.yaml
+++ b/tests/weather-chicago/manifests/a02-model.yaml
@@ -3,7 +3,8 @@ kind: Model
 metadata:
   name: weather-default-model
 spec:
-  type: azure
+  type: completions
+  provider: azure
   model:
     value: gpt-4.1-mini
   config:


### PR DESCRIPTION
## Summary
- Add `spec.provider` field to Model CRD to separate provider (openai, azure, bedrock) from model type (completions)
- Add mutating webhook to auto-migrate old format (`type: openai`) to new format (`provider: openai, type: completions`)
- Add migration warning system using annotations to surface deprecation warnings
- Update ark-api endpoints and dashboard UI to support provider field
- Update all chainsaw tests to use new format
- Add model-deprecated-type test for migration behavior

The automatic migration will be removed in v1.0.0.