### PR TITLE
fix(ark-cli): auto-uninstall legacy releases before service install

### DIFF
--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -144,6 +144,9 @@ const defaultArkServices: ServiceCollection = {
     k8sDevDeploymentName: 'ark-mcp-devspace',
   },
 
+  // ark-broker replaces ark-cluster-memory (renamed in v0.1.49). The old release
+  // must be uninstalled first to avoid Helm ownership conflicts on shared
+  // resources like the ark-config-streaming ConfigMap.
   'ark-broker': {
     name: 'ark-broker',
     helmReleaseName: 'ark-broker',
@@ -151,9 +154,9 @@ const defaultArkServices: ServiceCollection = {
       'In-memory storage service with streaming support for Ark queries',
     enabled: true,
     category: 'service',
-    // namespace: undefined - uses current context namespace
     chartPath: `${REGISTRY_BASE}/ark-broker`,
     installArgs: [],
+    prerequisiteUninstalls: [{releaseName: 'ark-cluster-memory'}],
     k8sDeploymentName: 'ark-broker',
     k8sDevDeploymentName: 'ark-broker-devspace',
   },

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -25,7 +25,21 @@ import {
 } from '../../lib/waitForReady.js';
 import {parseTimeoutToSeconds} from '../../lib/timeout.js';
 
+async function uninstallPrerequisites(service: ArkService, verbose: boolean = false) {
+  if (!service.prerequisiteUninstalls?.length) return;
+
+  for (const prereq of service.prerequisiteUninstalls) {
+    const helmArgs = ['uninstall', prereq.releaseName, '--ignore-not-found'];
+    if (prereq.namespace) {
+      helmArgs.push('--namespace', prereq.namespace);
+    }
+    await execute('helm', helmArgs, {stdio: 'inherit'}, {verbose});
+  }
+}
+
 async function installService(service: ArkService, verbose: boolean = false) {
+  await uninstallPrerequisites(service, verbose);
+
   const helmArgs = [
     'upgrade',
     '--install',

--- a/tools/ark-cli/src/types/arkService.ts
+++ b/tools/ark-cli/src/types/arkService.ts
@@ -1,3 +1,8 @@
+export interface PrerequisiteUninstall {
+  releaseName: string;
+  namespace?: string;
+}
+
 export interface ArkService {
   name: string;
   helmReleaseName: string;
@@ -7,6 +12,7 @@ export interface ArkService {
   namespace?: string;
   chartPath?: string;
   installArgs?: string[];
+  prerequisiteUninstalls?: PrerequisiteUninstall[];
   k8sServiceName?: string;
   k8sServicePort?: number;
   k8sPortForwardLocalPort?: number;


### PR DESCRIPTION
## Summary
- Adds `prerequisiteUninstalls` field to `ArkService` type for specifying Helm releases to remove before installation
- Configures ark-broker to auto-uninstall ark-cluster-memory (legacy name) before install
- Fixes upgrade failures due to Helm ownership conflicts on shared resources like `ark-config-streaming` ConfigMap