### PR TITLE
feat: add PR preview workflow for docs site

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,26 @@
+name: PR Preview
+
+on: [pull_request]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docs
+        if: github.event.action != 'closed'
+        working-directory: docs
+        env:
+          NEXT_PUBLIC_BASE_PATH: /pr-preview/pr-${{ github.event.number }}
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/out/


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to deploy docs preview for each PR
- Uses `rossjrw/pr-preview-action@v1` to deploy to GitHub Pages at `/pr-preview/pr-{number}/`
- Leverages existing `NEXT_PUBLIC_BASE_PATH` support in docs config