### PR TITLE
fix: Fix broken import

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/query.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/query.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from ark_sdk.client import V1_ALPHA1, with_ark_client
 from ark_sdk.models.query_v1alpha1 import QueryV1alpha1
 from ark_sdk.models.query_v1alpha1_spec import QueryV1alpha1Spec
-from ark_sdk.models.query_v1alpha1_spec_target import QueryV1alpha1SpecTarget
+from ark_sdk.models.query_v1alpha1_spec_targets_inner import QueryV1alpha1SpecTargetsInner
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ async def post_query(
         # Create query spec
         query_spec = QueryV1alpha1Spec(
             input=query,
-            target=QueryV1alpha1SpecTarget(name=target, type=target_type),
+            target=QueryV1alpha1SpecTargetsInner(name=target, type=target_type),
             timeout=f"{timeout}s",
         )
 

--- a/services/ark-api/ark-api/src/ark_api/utils/query_targets.py
+++ b/services/ark-api/ark-api/src/ark_api/utils/query_targets.py
@@ -1,19 +1,19 @@
 """Query target utilities for parsing model strings."""
 
-from ark_sdk import QueryV1alpha1SpecTarget
+from ark_sdk import QueryV1alpha1SpecTargetsInner
 from fastapi import HTTPException
 
 
-def parse_model_to_query_target(model: str) -> QueryV1alpha1SpecTarget:
+def parse_model_to_query_target(model: str) -> QueryV1alpha1SpecTargetsInner:
     """Parse model string to QueryTarget, supporting agent/, team/, model/, and tool/ prefixes."""
     if model.startswith("agent/"):
-        return QueryV1alpha1SpecTarget(type="agent", name=model[6:])
+        return QueryV1alpha1SpecTargetsInner(type="agent", name=model[6:])
     elif model.startswith("team/"):
-        return QueryV1alpha1SpecTarget(type="team", name=model[5:])
+        return QueryV1alpha1SpecTargetsInner(type="team", name=model[5:])
     elif model.startswith("model/"):
-        return QueryV1alpha1SpecTarget(type="model", name=model[6:])
+        return QueryV1alpha1SpecTargetsInner(type="model", name=model[6:])
     elif model.startswith("tool/"):
-        return QueryV1alpha1SpecTarget(type="tool", name=model[5:])
+        return QueryV1alpha1SpecTargetsInner(type="tool", name=model[5:])
     else:
         raise HTTPException(
             status_code=400,


### PR DESCRIPTION
This rename was done in the last big merge and I assume in the medium term we probably do want it to be called QueryV1alpha1SpecTarget, but this quick fix should get things working again.
