### PR TITLE
fix: Allow for editing MCP server URLs & trim whitespace

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/editors/mcp-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/mcp-editor.tsx
@@ -213,7 +213,7 @@ export function McpEditor({
         description: values.description,
         transport: values.transport,
         address: {
-          value: values.baseUrl,
+          value: values.baseUrl.trim(),
         },
         headers: modifiedHeaders,
       },
@@ -292,6 +292,7 @@ export function McpEditor({
                         placeholder="https:/github.com/v1"
                         disabled={!!mcpServer || form.formState.isSubmitting}
                         {...field}
+                        onChange={e => field.onChange(e.target.value.trim())}
                       />
                     </FormControl>
                     <FormMessage />

--- a/services/ark-dashboard/ark-dashboard/components/editors/mcp-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/mcp-editor.tsx
@@ -290,7 +290,7 @@ export function McpEditor({
                     <FormControl>
                       <Input
                         placeholder="https:/github.com/v1"
-                        disabled={!!mcpServer || form.formState.isSubmitting}
+                        disabled={form.formState.isSubmitting}
                         {...field}
                         onChange={e => field.onChange(e.target.value.trim())}
                       />


### PR DESCRIPTION
- Allows for updating the URLs on an existing MCP server entry, which is especially useful after the change to MCP server URL handling
- Trims the whitespace from MCP server URLs as leading or trailing whitespace will currently cause the MCP server to fail to connect