### PR TITLE
fix: High level timestamps on the broker page should show data time

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/extractItemTimestamp.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/extractItemTimestamp.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+
+function extractItemTimestamp(item: unknown): string {
+  if (!item) {
+    return new Date().toISOString();
+  }
+  const typedItem = item as Record<string, unknown>;
+  if (typedItem.timestamp) {
+    return typedItem.timestamp as string;
+  }
+  let unixTimestamp = '';
+  if (typedItem?.startTimeUnixNano) {
+    unixTimestamp = typedItem.startTimeUnixNano as string;
+  }
+  const spans = typedItem?.spans as Array<Record<string, unknown>>;
+  if (!unixTimestamp && spans && spans.length > 0) {
+    unixTimestamp = spans[0].startTimeUnixNano as string;
+  }
+  if (unixTimestamp) {
+    return new Date(parseInt(unixTimestamp.substring(0, 13))).toISOString();
+  }
+
+  return new Date().toISOString();
+}
+
+describe('extractItemTimestamp', () => {
+  describe('when item has timestamp property', () => {
+    it('should return the timestamp property directly', () => {
+      const item = {
+        timestamp: '2024-01-15T10:30:00.000Z',
+        startTimeUnixNano: '1705318200000000000',
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T10:30:00.000Z');
+    });
+  });
+
+  describe('when item has startTimeUnixNano property', () => {
+    it('should convert startTimeUnixNano to ISO string', () => {
+      const item = {
+        startTimeUnixNano: '1705318200000000000',
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T11:30:00.000Z');
+    });
+
+    it('should handle startTimeUnixNano with millisecond precision', () => {
+      const item = {
+        startTimeUnixNano: '1705318200123000000',
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T11:30:00.123Z');
+    });
+  });
+
+  describe('when item has spans with startTimeUnixNano', () => {
+    it('should extract startTimeUnixNano from first span', () => {
+      const item = {
+        spans: [
+          {
+            startTimeUnixNano: '1705318200000000000',
+          },
+        ],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T11:30:00.000Z');
+    });
+
+    it('should use first span even when multiple spans exist', () => {
+      const item = {
+        spans: [
+          {
+            startTimeUnixNano: '1705318200000000000',
+          },
+          {
+            startTimeUnixNano: '1705318300000000000',
+          },
+        ],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T11:30:00.000Z');
+    });
+
+    it('should prefer direct startTimeUnixNano over spans', () => {
+      const item = {
+        startTimeUnixNano: '1705318200000000000',
+        spans: [
+          {
+            startTimeUnixNano: '1705318300000000000',
+          },
+        ],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T11:30:00.000Z');
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('should return current timestamp when no timestamp data exists', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = {
+        data: 'some other data',
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+
+    it('should return current timestamp when item is empty object', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = {};
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+
+    it('should return current timestamp when spans array is empty', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = {
+        spans: [],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+
+    it('should return current timestamp when item is null', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = null;
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle spans that exist but first span has no startTimeUnixNano', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = {
+        spans: [
+          {
+            name: 'some-span',
+          },
+        ],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+
+    it('should handle undefined startTimeUnixNano values', () => {
+      const mockDate = new Date('2024-01-15T12:00:00.000Z');
+      vi.setSystemTime(mockDate);
+
+      const item = {
+        startTimeUnixNano: undefined,
+        spans: [
+          {
+            startTimeUnixNano: undefined,
+          },
+        ],
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+
+      vi.useRealTimers();
+    });
+
+    it('should handle very short unixTimestamp strings', () => {
+      const item = {
+        startTimeUnixNano: '1234567890',
+      };
+
+      const result = extractItemTimestamp(item);
+
+      expect(result).toBe('1970-01-15T06:56:07.890Z');
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -39,6 +39,9 @@ interface PaginatedResponse<T> {
 const PAGE_SIZE = 100;
 
 function extractItemTimestamp(item: unknown): string {
+  if (!item) {
+    return new Date().toISOString();
+  }
   const typedItem = item as Record<string, unknown>;
   if (typedItem.timestamp) {
     return typedItem.timestamp as string;
@@ -52,9 +55,7 @@ function extractItemTimestamp(item: unknown): string {
     unixTimestamp = spans[0].startTimeUnixNano as string;
   }
   if (unixTimestamp) {
-      return new Date(
-        parseInt(unixTimestamp.substring(0, 13)),
-      ).toISOString();
+    return new Date(parseInt(unixTimestamp.substring(0, 13))).toISOString();
   }
 
   return new Date().toISOString();

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -38,6 +38,28 @@ interface PaginatedResponse<T> {
 
 const PAGE_SIZE = 100;
 
+function extractItemTimestamp(item: unknown): string {
+  const typedItem = item as Record<string, unknown>;
+  if (typedItem.timestamp) {
+    return typedItem.timestamp as string;
+  }
+  let unixTimestamp = '';
+  if (typedItem?.startTimeUnixNano) {
+    unixTimestamp = typedItem.startTimeUnixNano as string;
+  }
+  const spans = typedItem?.spans as Array<Record<string, unknown>>;
+  if (!unixTimestamp && spans && spans.length > 0) {
+    unixTimestamp = spans[0].startTimeUnixNano as string;
+  }
+  if (unixTimestamp) {
+      return new Date(
+        parseInt(unixTimestamp.substring(0, 13)),
+      ).toISOString();
+  }
+
+  return new Date().toISOString();
+}
+
 function useSSEStream(endpoint: string, memory: string) {
   const [streamedEntries, setStreamedEntries] = useState<StreamEntry[]>([]);
   const [fetchedEntries, setFetchedEntries] = useState<StreamEntry[]>([]);
@@ -86,7 +108,7 @@ function useSSEStream(endpoint: string, memory: string) {
           }
           const entry: StreamEntry = {
             id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-            timestamp: new Date().toISOString(),
+            timestamp: extractItemTimestamp(data),
             data,
           };
           setStreamedEntries(prev => [entry, ...prev.slice(0, 499)]);
@@ -136,7 +158,7 @@ function useSSEStream(endpoint: string, memory: string) {
         }
         const newEntries: StreamEntry[] = data.items.map((item, i) => ({
           id: `fetched-${cursor ?? 0}-${i}-${Math.random().toString(36).substring(2, 11)}`,
-          timestamp: new Date().toISOString(),
+          timestamp: extractItemTimestamp(item),
           data: item,
         }));
         if (mountedRef.current) {


### PR DESCRIPTION
Currently the broker page shows the time that the data was loaded into the page, so they change every time the page is refreshed. This fix searches for a timestamp in the data and uses that instead. This covers all the data that the broker currently gets, though it can easily be expanded if other data structures are added later. In a pinch, it will fall back to the current date.

Before fix, showing the time the page was refreshed for all spans:
<img width="520" height="298" alt="Screenshot 2026-01-09 at 11 46 33" src="https://github.com/user-attachments/assets/4a1a5a70-0f0a-4586-951f-7de7bb2caa74" />

After fix, showing the accurate start time for the spans, including both those loaded by SSE and those from memory:
<img width="810" height="321" alt="Screenshot 2026-01-09 at 17 33 55" src="https://github.com/user-attachments/assets/00a95447-966e-4f71-9f8d-d6b016f73069" />
