### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/docs/content/developer-guide/claude.mdx
+++ b/docs/content/developer-guide/claude.mdx
@@ -25,6 +25,15 @@ claude plugin marketplace add ./
 claude plugin install ark@agents-at-scale-ark
 ```
 
+### sk
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc.).
+
+```bash
+sk pkg add claude-plugin ark@mckinsey/agents-at-scale-ark
+sk sync
+```
+
 ## Plugin: ark
 
 **Examples**


### PR DESCRIPTION
Adds installation instructions for the sk tool.

sk is a cross-agent skill installer that works with Claude Code, Codex, OpenCode, Factory, and other compatible agents.

Learn more: https://skills.supply