### PR TITLE
fix: Add padding to tool calls in dashboard chat

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/floating-chat.tsx
@@ -451,26 +451,33 @@ export default function FloatingChat({
                     <div key={index} className="contents">
                       {toolCalls &&
                         toolCalls.map((toolCall, toolIndex) => (
-                          <ChatMessage
+                          <div
                             key={`${index}-tool-${toolIndex}`}
-                            role="assistant"
-                            content=""
-                            viewMode={viewMode}
-                            toolCalls={[
-                              toolCall as {
-                                id: string;
-                                type: 'function';
-                                function: { name: string; arguments: string };
-                              },
-                            ]}
-                          />
+                            className={toolIndex > 0 ? 'mt-2' : ''}>
+                            <ChatMessage
+                              role="assistant"
+                              content=""
+                              viewMode={viewMode}
+                              toolCalls={[
+                                toolCall as {
+                                  id: string;
+                                  type: 'function';
+                                  function: { name: string; arguments: string };
+                                },
+                              ]}
+                            />
+                          </div>
                         ))}
                       {content && (
-                        <ChatMessage
-                          role={message.role as 'user' | 'assistant' | 'system'}
-                          content={content}
-                          viewMode={viewMode}
-                        />
+                        <div className={toolCalls ? 'mt-2' : ''}>
+                          <ChatMessage
+                            role={
+                              message.role as 'user' | 'assistant' | 'system'
+                            }
+                            content={content}
+                            viewMode={viewMode}
+                          />
+                        </div>
                       )}
                     </div>
                   );


### PR DESCRIPTION
Adds a little more padding between tool calls:

<img width="709" height="295" alt="Screenshot 2026-01-12 at 12 08 18" src="https://github.com/user-attachments/assets/d8ae69b3-944d-47ee-bfab-9163a8b6cbd0" />
