### PR TITLE
feat: Adding a separate action for publishing docs

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,0 +1,52 @@
+name: Publish Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to publish docs from (defaults to main)'
+        required: false
+        type: string
+        default: 'main'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Build Docs
+        run: |
+          cd docs
+          npm ci
+          npm i pagefind @pagefind/linux-x64 && npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: ${{ vars.DOCS_SITE_BASE_PATH || '' }}
+
+      - name: Upload Site Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/out
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,6 +1,8 @@
 name: Publish Docs
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,8 +1,6 @@
 name: Publish Docs
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       branch:
@@ -43,6 +41,15 @@ jobs:
           npm i pagefind @pagefind/linux-x64 && npm run build
         env:
           NEXT_PUBLIC_BASE_PATH: ${{ vars.DOCS_SITE_BASE_PATH || '' }}
+      
+      - name: Validate Internal Documentation Links
+        run: |
+          # Rebuild docs without base path for link checking
+          echo "Rebuilding docs without base path for link validation..."
+          npm run build
+          echo "Checking for broken links..."
+          npm run check-links
+        working-directory: docs
 
       - name: Upload Site Artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -2,12 +2,6 @@ name: Publish Docs
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to publish docs from (defaults to main)'
-        required: false
-        type: string
-        default: 'main'
 
 permissions:
   contents: read
@@ -27,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 