### PR TITLE
fix: override security context in devspace for dev mode

### DIFF
--- a/services/ark-api/devspace.yaml
+++ b/services/ark-api/devspace.yaml
@@ -42,6 +42,22 @@ deployments:
             requests:
               memory: "256Mi"
               cpu: "200m"
+          # Override security context for dev mode to allow DevSpace sync
+          podSecurityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            fsGroup: 0
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+            capabilities:
+              add:
+                - SETUID
+                - SETGID
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
         httpRoute:
           enabled: true
 

--- a/services/ark-broker/devspace.yaml
+++ b/services/ark-broker/devspace.yaml
@@ -33,6 +33,22 @@ deployments:
             requests:
               memory: "256Mi"
               cpu: "200m"
+        # Override security context for dev mode to allow DevSpace sync
+        podSecurityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          fsGroup: 0
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: false
+          capabilities:
+            add:
+              - SETUID
+              - SETGID
+              - CHOWN
+              - FOWNER
+              - DAC_OVERRIDE
         memory:
           setAsDefault: true
         persistence:

--- a/services/ark-dashboard/devspace.yaml
+++ b/services/ark-dashboard/devspace.yaml
@@ -34,6 +34,22 @@ deployments:
             requests:
               memory: "256Mi"
               cpu: "200m"
+          # Override security context for dev mode to allow DevSpace sync
+          podSecurityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            fsGroup: 0
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+            capabilities:
+              add:
+                - SETUID
+                - SETGID
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
         httpRoute:
           enabled: true
 

--- a/services/ark-evaluator/devspace.yaml
+++ b/services/ark-evaluator/devspace.yaml
@@ -43,6 +43,22 @@ deployments:
             cpu: 500m
             memory: 512Mi
             ephemeral-storage: 100Mi
+        # Override security context for dev mode to allow DevSpace sync
+        podSecurityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          fsGroup: 0
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: false
+          capabilities:
+            add:
+              - SETUID
+              - SETGID
+              - CHOWN
+              - FOWNER
+              - DAC_OVERRIDE
 
 dev:
   ark-evaluator:

--- a/services/ark-mcp/devspace.yaml
+++ b/services/ark-mcp/devspace.yaml
@@ -41,6 +41,22 @@ deployments:
             requests:
               memory: "128Mi"
               cpu: "100m"
+          # Override security context for dev mode to allow DevSpace sync
+          podSecurityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            fsGroup: 0
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
+            capabilities:
+              add:
+                - SETUID
+                - SETGID
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
         httpRoute:
           enabled: true
 

--- a/services/executor-langchain/devspace.yaml
+++ b/services/executor-langchain/devspace.yaml
@@ -45,6 +45,22 @@ deployments:
             cpu: 500m
             memory: 512Mi
             ephemeral-storage: 100Mi
+        # Override security context for dev mode to allow DevSpace sync
+        podSecurityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          fsGroup: 0
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: false
+          capabilities:
+            add:
+              - SETUID
+              - SETGID
+              - CHOWN
+              - FOWNER
+              - DAC_OVERRIDE
 
 dev:
   executor-langchain:


### PR DESCRIPTION
- Set runAsUser: 0 and fsGroup: 0 for dev containers
- Add capabilities (SETUID, SETGID, CHOWN, FOWNER, DAC_OVERRIDE)
- Allow privilege escalation for apt-get to work
- Fixes permission errors after security hardening in PR #626

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 