### PR TITLE
fix: Treat dependabot as a forked PR

### DIFF
--- a/.github/actions/setup-container-cache-registry/action.yml
+++ b/.github/actions/setup-container-cache-registry/action.yml
@@ -44,16 +44,22 @@ runs:
           echo "PR Author: ${{ github.event.pull_request.user.login }}"
         fi
         
-        # Check if this is a PR from a fork
+        # Check if this is a PR from a fork or from dependabot
         if [[ "${{ github.event_name }}" == "pull_request" ]] && \
            [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
           # EXTERNAL PR: Use a temp registry
           # The fork owner's GITHUB_TOKEN has write access to their own namespace
           # Example: ttl.sh/forked-owner/forked-repo-name
-        
+
           REGISTRY="ttl.sh/${{ github.event.pull_request.head.repo.full_name }}"
           IS_FORK_PR="true"
           echo "External PR detected - using fork's registry: $REGISTRY"
+        elif [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          # DEPENDABOT PR: Treat like a fork PR (no access to secrets)
+          # Use a temp registry since dependabot can't access organization secrets
+          REGISTRY="ttl.sh/${{ github.repository }}"
+          IS_FORK_PR="true"
+          echo "Dependabot PR detected - using temp registry: $REGISTRY"
         else
           # INTERNAL PR or PUSH: Use the organization's registry
           # Default format: ghcr.io/organization/repository


### PR DESCRIPTION
This fixes build failures as dependabot cannot access GitHub secrets

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 