### PR TITLE
fix: Remove low timeouts for team-round-robin test

### DIFF
--- a/tests/team-round-robin/chainsaw-test.yaml
+++ b/tests/team-round-robin/chainsaw-test.yaml
@@ -36,35 +36,30 @@ spec:
             conditions:
             - type: ModelAvailable
               status: "True"
-        timeout: 30s
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
           kind: Agent
           metadata:
             name: brainstormer
-        timeout: 10s
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
           kind: Agent
           metadata:
             name: critic
-        timeout: 10s
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
           kind: Agent
           metadata:
             name: coordinator
-        timeout: 10s
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
           kind: Team
           metadata:
             name: round-robin-brainstorm-team
-        timeout: 10s
 
   - name: wait-for-query-completion
     try:


### PR DESCRIPTION
30 seconds doesn't seem to be long enough a lot of the time; this test will fail somewhat randomly for reasons not related to the branch being tested.

Removes these timeouts. The test should fallback to the configured default timeout of 360s for asserts, which should be plenty. The team-round-robin-max-turns test behaves like this and doesn't fail the way this one does.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 