### PR TITLE
chore(terraform): update terraform-google-modules

### DIFF
--- a/infrastructure/providers/gcp/gke.tf
+++ b/infrastructure/providers/gcp/gke.tf
@@ -1,6 +1,6 @@
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google"
-  version = "~> 38.0"
+  version = "~> 43.0"
 
   project_id             = var.gcp_project_id
   name                   = var.cluster_name


### PR DESCRIPTION
This is a manual recreation of a dependabot change as a temporary workaround for an issue with github action secrets. The original PR was here: https://github.com/mckinsey/agents-at-scale-ark/pull/808