### PR TITLE
docs: document CVE-2026-0994 protobuf vulnerability (no patch available)

### DIFF
--- a/.github/actions/jfrog-xray-scan/tolerated_violations.txt
+++ b/.github/actions/jfrog-xray-scan/tolerated_violations.txt
@@ -7,3 +7,9 @@ XRAY-913110 - CVE-2026-0621
 XRAY-934751 - CVE-2024-58340
 - LangChain versions up to and including 0.3.1 contain a regular expression denial-of-service (ReDoS) vulnerability in the MRKLOutputParser.parse() method (libs/langchain/langchain/agents/mrkl/output_parser.py). The parser applies a backtracking-prone regular expression when extracting tool actions from model output. An attacker who can supply or influence the parsed text (for example via prompt injection in downstream applications that pass LLM output directly into MRKLOutputParser.parse()) can trigger excessive CPU consumption by providing a crafted payload, causing significant parsing delays and a denial-of-service condition.
 - We appear to be using newer LangChain versions than the vulnerable oens and we aren't using the vulnerable method.
+XRAY-932472 - CVE-2026-0994
+- A denial-of-service vulnerability exists in google.protobuf (Python) versions up to 6.33.4 where json_format.ParseDict() allows max_recursion_depth bypass via nested google.protobuf.Any messages, causing Python recursion stack exhaustion. Severity: High (CVSS 8.2).
+- No patched version is available yet. The fix is merged to protobuf master (PR #25239) but not released to PyPI. Latest available version is 6.33.4 (still vulnerable).
+- Mitigations applied: (1) Pinned protobuf>=6.33.4 in ark-api and langchain-weather-agent, (2) Updated langchain-weather-agent from 6.33.0 to 6.33.4, (3) Documented vulnerability and upgrade path in CVE-2026-0994.md.
+- Used in services/ark-api/ark-api and samples/a2a/langchain-weather-agent via a2a-sdk dependency.
+- Will upgrade immediately when patched version is released to PyPI.

--- a/.github/actions/jfrog-xray-scan/tolerated_violations.txt
+++ b/.github/actions/jfrog-xray-scan/tolerated_violations.txt
@@ -7,7 +7,7 @@ XRAY-913110 - CVE-2026-0621
 XRAY-934751 - CVE-2024-58340
 - LangChain versions up to and including 0.3.1 contain a regular expression denial-of-service (ReDoS) vulnerability in the MRKLOutputParser.parse() method (libs/langchain/langchain/agents/mrkl/output_parser.py). The parser applies a backtracking-prone regular expression when extracting tool actions from model output. An attacker who can supply or influence the parsed text (for example via prompt injection in downstream applications that pass LLM output directly into MRKLOutputParser.parse()) can trigger excessive CPU consumption by providing a crafted payload, causing significant parsing delays and a denial-of-service condition.
 - We appear to be using newer LangChain versions than the vulnerable oens and we aren't using the vulnerable method.
-XRAY-932472 - CVE-2026-0994
+XRAY-935637 - CVE-2026-0994
 - A denial-of-service vulnerability exists in google.protobuf (Python) versions up to 6.33.4 where json_format.ParseDict() allows max_recursion_depth bypass via nested google.protobuf.Any messages, causing Python recursion stack exhaustion. Severity: High (CVSS 8.2).
 - No patched version is available yet. The fix is merged to protobuf master (PR #25239) but not released to PyPI. Latest available version is 6.33.4 (still vulnerable).
 - Mitigations applied: (1) Pinned protobuf>=6.33.4 in ark-api and langchain-weather-agent, (2) Updated langchain-weather-agent from 6.33.0 to 6.33.4, (3) Documented vulnerability and upgrade path in CVE-2026-0994.md.

--- a/CVE-2026-0994.md
+++ b/CVE-2026-0994.md
@@ -1,0 +1,67 @@
+# CVE-2026-0994: Protobuf Recursion Depth Bypass
+
+**Status:** VULNERABLE (No patch available as of 2026-01-26)
+
+## Vulnerability Details
+
+- **CVE:** CVE-2026-0994
+- **Component:** Python `google.protobuf`
+- **Severity:** High (CVSS 8.2)
+- **Vulnerable Versions:** All versions ≤ 6.33.4
+- **Patched Version:** Not yet released (fix merged to master but not published to PyPI)
+
+## Description
+
+A denial-of-service (DoS) vulnerability exists in `google.protobuf.json_format.ParseDict()` where the `max_recursion_depth` limit can be bypassed when parsing nested `google.protobuf.Any` messages. The vulnerability allows an attacker to supply deeply nested Any structures that bypass the intended recursion limit, eventually exhausting Python's recursion stack and causing a `RecursionError`.
+
+## Affected Ark Components
+
+1. **services/ark-api/ark-api**
+   - Uses: `a2a-sdk>=0.2.12` (depends on protobuf)
+   - Current version: protobuf 6.33.4 (vulnerable)
+
+2. **samples/a2a/langchain-weather-agent**
+   - Uses: `a2a-sdk[http-server]>=0.2.6` (depends on protobuf)
+   - Updated: protobuf 6.33.0 → 6.33.4 (still vulnerable but latest available)
+
+## Current Mitigation
+
+Since no patched version is available yet:
+
+1. **Version pinning:** Explicitly pinned to `protobuf>=6.33.4` in pyproject.toml files
+2. **Ready for upgrade:** When patched version is released, run:
+   ```bash
+   cd services/ark-api/ark-api && uv lock --upgrade-package protobuf
+   cd samples/a2a/langchain-weather-agent && uv lock --upgrade-package protobuf
+   ```
+
+## Risk Assessment
+
+- **Attack Vector:** Requires attacker-controlled input to `json_format.ParseDict()` with nested Any messages
+- **Impact:** Denial-of-service (Python process crash)
+- **Exploitability:** Moderate (requires specific input conditions)
+- **Data Risk:** None (DoS only, no data exfiltration)
+
+## Workarounds
+
+Until a patch is available:
+
+1. **Avoid untrusted input:** Don't parse JSON from untrusted sources using `json_format.ParseDict()`
+2. **Input validation:** Validate and sanitize JSON before passing to protobuf parsers
+3. **Rate limiting:** Implement rate limiting on endpoints that accept protobuf JSON input
+
+## References
+
+- [CVE-2026-0994 Details](https://www.cvedetails.com/cve/CVE-2026-0994/)
+- [GitHub Fix PR #25239](https://github.com/protocolbuffers/protobuf/pull/25239)
+- [Snyk Advisory](https://security.snyk.io/vuln/SNYK-PYTHON-PROTOBUF-15090738)
+- [GitLab Advisory](https://advisories.gitlab.com/pkg/pypi/protobuf/CVE-2026-0994/)
+- [DEV Community Analysis](https://dev.to/cverports/cve-2026-0994-recursive-hell-breaking-python-protobuf-with-nested-any-messages-36fj)
+
+## Action Items
+
+- [x] Pin protobuf to >=6.33.4 in affected services
+- [x] Update langchain-weather-agent from 6.33.0 to 6.33.4
+- [ ] Monitor protobuf releases for patched version
+- [ ] Update to patched version when available
+- [ ] Review A2A SDK usage for json_format.ParseDict() calls

--- a/samples/a2a/langchain-weather-agent/pyproject.toml
+++ b/samples/a2a/langchain-weather-agent/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "httpx>=0.25.0",
     "click>=8.0.0",
     "urllib3>=2.6.0",
+    "protobuf>=6.33.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/samples/a2a/langchain-weather-agent/uv.lock
+++ b/samples/a2a/langchain-weather-agent/uv.lock
@@ -540,6 +540,7 @@ dependencies = [
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-openai" },
+    { name = "protobuf" },
     { name = "python-dotenv" },
     { name = "starlette" },
     { name = "urllib3" },
@@ -565,6 +566,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.1.0" },
     { name = "langchain-openai", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "protobuf", specifier = ">=6.33.4" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "starlette", specifier = ">=0.27.0" },
     { name = "urllib3", specifier = ">=2.6.0" },
@@ -770,17 +772,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.0"
+version = "6.33.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/ff/64a6c8f420818bb873713988ca5492cba3a7946be57e027ac63495157d97/protobuf-6.33.0.tar.gz", hash = "sha256:140303d5c8d2037730c548f8c7b93b20bb1dc301be280c378b82b8894589c954", size = 443463, upload-time = "2025-10-15T20:39:52.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/b8/cda15d9d46d03d4aa3a67cb6bffe05173440ccf86a9541afaf7ac59a1b6b/protobuf-6.33.4.tar.gz", hash = "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91", size = 444346, upload-time = "2026-01-12T18:33:40.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/ee/52b3fa8feb6db4a833dfea4943e175ce645144532e8a90f72571ad85df4e/protobuf-6.33.0-cp310-abi3-win32.whl", hash = "sha256:d6101ded078042a8f17959eccd9236fb7a9ca20d3b0098bbcb91533a5680d035", size = 425593, upload-time = "2025-10-15T20:39:40.29Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c6/7a465f1825872c55e0341ff4a80198743f73b69ce5d43ab18043699d1d81/protobuf-6.33.0-cp310-abi3-win_amd64.whl", hash = "sha256:9a031d10f703f03768f2743a1c403af050b6ae1f3480e9c140f39c45f81b13ee", size = 436882, upload-time = "2025-10-15T20:39:42.841Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a9/b6eee662a6951b9c3640e8e452ab3e09f117d99fc10baa32d1581a0d4099/protobuf-6.33.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:905b07a65f1a4b72412314082c7dbfae91a9e8b68a0cc1577515f8df58ecf455", size = 427521, upload-time = "2025-10-15T20:39:43.803Z" },
-    { url = "https://files.pythonhosted.org/packages/10/35/16d31e0f92c6d2f0e77c2a3ba93185130ea13053dd16200a57434c882f2b/protobuf-6.33.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e0697ece353e6239b90ee43a9231318302ad8353c70e6e45499fa52396debf90", size = 324445, upload-time = "2025-10-15T20:39:44.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/eb/2a981a13e35cda8b75b5585aaffae2eb904f8f351bdd3870769692acbd8a/protobuf-6.33.0-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:e0a1715e4f27355afd9570f3ea369735afc853a6c3951a6afe1f80d8569ad298", size = 339159, upload-time = "2025-10-15T20:39:46.186Z" },
-    { url = "https://files.pythonhosted.org/packages/21/51/0b1cbad62074439b867b4e04cc09b93f6699d78fd191bed2bbb44562e077/protobuf-6.33.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:35be49fd3f4fefa4e6e2aacc35e8b837d6703c37a2168a55ac21e9b1bc7559ef", size = 323172, upload-time = "2025-10-15T20:39:47.465Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d1/0a28c21707807c6aacd5dc9c3704b2aa1effbf37adebd8caeaf68b17a636/protobuf-6.33.0-py3-none-any.whl", hash = "sha256:25c9e1963c6734448ea2d308cfa610e692b801304ba0908d7bfa564ac5132995", size = 170477, upload-time = "2025-10-15T20:39:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/be/24ef9f3095bacdf95b458543334d0c4908ccdaee5130420bf064492c325f/protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d", size = 425612, upload-time = "2026-01-12T18:33:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ad/e5693e1974a28869e7cd244302911955c1cebc0161eb32dfa2b25b6e96f0/protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc", size = 436962, upload-time = "2026-01-12T18:33:31.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/15/6ee23553b6bfd82670207ead921f4d8ef14c107e5e11443b04caeb5ab5ec/protobuf-6.33.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0", size = 427612, upload-time = "2026-01-12T18:33:32.646Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/48/d301907ce6d0db75f959ca74f44b475a9caa8fcba102d098d3c3dd0f2d3f/protobuf-6.33.4-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e", size = 324484, upload-time = "2026-01-12T18:33:33.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1c/e53078d3f7fe710572ab2dcffd993e1e3b438ae71cfc031b71bae44fcb2d/protobuf-6.33.4-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6", size = 339256, upload-time = "2026-01-12T18:33:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8e/971c0edd084914f7ee7c23aa70ba89e8903918adca179319ee94403701d5/protobuf-6.33.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9", size = 323311, upload-time = "2026-01-12T18:33:36.305Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b1/1dc83c2c661b4c62d56cc081706ee33a4fc2835bd90f965baa2663ef7676/protobuf-6.33.4-py3-none-any.whl", hash = "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc", size = 170532, upload-time = "2026-01-12T18:33:39.199Z" },
 ]
 
 [[package]]

--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "urllib3>=2.6.0",
     "pytest-asyncio>=1.3.0",
     "ark-sdk",
+    "protobuf>=6.33.4",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Document CVE-2026-0994 (Python protobuf recursion depth bypass vulnerability)
- Pin protobuf to >=6.33.4 in affected services
- Update langchain-weather-agent from protobuf 6.33.0 → 6.33.4

## Vulnerability Details

**CVE-2026-0994** affects Python `google.protobuf` library through recursion depth bypass in `json_format.ParseDict()`. All versions up to 6.33.4 are vulnerable.

- **Severity:** High (CVSS 8.2)
- **Attack Vector:** DoS via deeply nested Any messages
- **Patched Version:** Not yet released (fix merged to master, awaiting PyPI release)

## Affected Ark Components

1. **services/ark-api/ark-api** - uses protobuf via a2a-sdk dependency
2. **samples/a2a/langchain-weather-agent** - uses protobuf via a2a-sdk dependency

## Changes Made

Since no patched version exists:
- Added explicit `protobuf>=6.33.4` constraint to pyproject.toml files
- Updated langchain-weather-agent to latest available version (6.33.4)
- Created `CVE-2026-0994.md` with full documentation and mitigation strategies
- Prepared for easy upgrade when patched version is released

## Risk Assessment

- **Impact:** DoS only (no data exfiltration)
- **Exploitability:** Requires attacker-controlled JSON input to protobuf parser
- **Workaround:** Input validation and rate limiting on affected endpoints

## Next Steps

When patched version is released:
```bash
cd services/ark-api/ark-api && uv lock --upgrade-package protobuf
cd samples/a2a/langchain-weather-agent && uv lock --upgrade-package protobuf
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)