### PR TITLE
fix: use locally built images when testing ark-cli instead of ghcr.io

### DIFF
--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -17,11 +17,23 @@ inputs:
   model-api-version:
     description: Model API version (Azure only)
     required: true
+  ci-cache-registry:
+    description: CI cache registry URL
+    required: true
+  ci-cache-registry-hostname:
+    description: CI cache registry hostname
+    required: true
   ci-cache-registry-username:
     description: Username for CI cache registry
     required: true
   ci-cache-registry-password:
     description: Password for CI cache registry
+    required: true
+  ark-image-tag:
+    description: Tag for Ark images
+    required: true
+  is-fork-pr:
+    description: Whether this is a fork PR
     required: true
 
 runs:
@@ -41,6 +53,23 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: '24.x'
+
+    - name: Configure K3s registry authentication
+      if: ${{ inputs.is-fork-pr == 'false' }}
+      shell: bash
+      run: |
+        sudo mkdir -p /etc/rancher/k3s
+        cat <<EOF | sudo tee /etc/rancher/k3s/registries.yaml
+        mirrors:
+          ${{ inputs.ci-cache-registry-hostname }}:
+            endpoint:
+              - "https://${{ inputs.ci-cache-registry-hostname }}"
+        configs:
+          ${{ inputs.ci-cache-registry-hostname }}:
+            auth:
+              username: ${{ inputs.ci-cache-registry-username }}
+              password: ${{ inputs.ci-cache-registry-password }}
+        EOF
 
     - name: Setup K3s cluster
       uses: ./.github/actions/setup-k3s
@@ -78,6 +107,12 @@ runs:
         sudo k3s ctr images import /tmp/ark-controller-ci.tar
         rm /tmp/ark-controller-ci.tar
 
+    - name: Login to Docker Registry
+      if: ${{ inputs.is-fork-pr == 'false' }}
+      shell: bash
+      run: |
+        echo "${{ inputs.ci-cache-registry-password }}" | docker login ${{ inputs.ci-cache-registry-hostname }} -u "${{ inputs.ci-cache-registry-username }}" --password-stdin
+
     - name: Install Ark from local charts
       shell: bash
       run: |
@@ -107,11 +142,17 @@ runs:
         # Install ark-api from local chart
         helm upgrade --install ark-api services/ark-api/chart \
           --namespace default \
+          --set app.image.repository="${{ inputs.ci-cache-registry }}/ark-api" \
+          --set app.image.tag="${{ inputs.ark-image-tag }}" \
+          --set app.image.pullPolicy="Always" \
           --wait --timeout=5m
 
         # Install ark-dashboard from local chart
         helm upgrade --install ark-dashboard services/ark-dashboard/chart \
           --namespace default \
+          --set app.image.repository="${{ inputs.ci-cache-registry }}/ark-dashboard" \
+          --set app.image.tag="${{ inputs.ark-image-tag }}" \
+          --set app.image.pullPolicy="Always" \
           --wait --timeout=5m
 
         ark --version

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -493,7 +493,8 @@ jobs:
           fark agent sample-agent "confirm you have read this message"
 
   e2e-ark-cli:
-    needs: [build-ark-cli]
+    needs: [setup-container-cache-registry, build-containers, build-ark-cli]
+    if: ${{ needs.setup-container-cache-registry.outputs.is-fork-pr == 'false' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -505,8 +506,12 @@ jobs:
           model-type: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL && 'azure' || 'openai' }}
           model-name: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL && 'gpt-4.1-mini' || 'gpt-4' }}
           model-api-version: 2024-12-01-preview
+          ci-cache-registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
+          ci-cache-registry-hostname: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry-hostname }}
           ci-cache-registry-username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           ci-cache-registry-password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+          ark-image-tag: ${{ github.sha }}
+          is-fork-pr: ${{ needs.setup-container-cache-registry.outputs.is-fork-pr }}
 
   e2e-smoke-test:
     needs: [setup-container-cache-registry, build-containers]


### PR DESCRIPTION
## Checklist

This would break things during a release because it tries to 
 - Install through local helm chart 
 - helm chart defaults to {{ Repo }}{{ ChartVersion }}
 - Because chart version i.e. 0.51 has not been released yet, it fails to download from ghcr.io causing timeout
 
Also the intention behind using the local helm charts to install the ark-cli was that we want to test the state of the current repo, not images that exist in ghcr

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 