### PR TITLE
ci: Let jfrog run in parallel with e2e tests

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -34,7 +34,6 @@ concurrency:
 jobs:
   # Setup job to determine container cache registry
   setup-container-cache-registry:
-    needs: [jfrog-xray-scan]
     runs-on: ubuntu-24.04
     outputs:
       ci-cache-registry: ${{ steps.setup-registry.outputs.ci-cache-registry }}
@@ -224,7 +223,7 @@ jobs:
         with:
           node-version: "22.x"
 
-      - run: make -j24 build-all
+      - run: make -j24 services-build-all
 
       - name: Check generated types are unchanged
         run: |
@@ -1188,6 +1187,7 @@ jobs:
         e2e-cli-tests,
         e2e-ark-cli,
         e2e-tests-llm,
+        jfrog-xray-scan,
         xray-container-scan,
         build-and-test-ark,
         build-and-test-services,


### PR DESCRIPTION
This will allow more of the tests to run in parallel which should speed the whole process up, and still mean that fixing vulnerabilities is high priority since PRs will fail if vulnerabilities are found.

Also tweaks build-and-test-services to actually only build services (which was probably what was intended, since it does indeed only test services). This probably won't save a lot of time since it's the services that take the longest to build, but it at least removes some extra work.

Addresses issue #1096 

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 