### PR TITLE
feat: enable a2a chunk streaming

### DIFF
--- a/ark/internal/annotations/annotations.go
+++ b/ark/internal/annotations/annotations.go
@@ -14,10 +14,11 @@ const (
 
 // A2A annotations
 const (
-	A2AServerName    = ARKPrefix + "a2a-server-name"
-	A2AServerAddress = ARKPrefix + "a2a-server-address"
-	A2AServerSkills  = ARKPrefix + "a2a-server-skills"
-	A2AContextID     = ARKPrefix + "a2a-context-id"
+	A2AServerName         = ARKPrefix + "a2a-server-name"
+	A2AServerAddress      = ARKPrefix + "a2a-server-address"
+	A2AServerSkills       = ARKPrefix + "a2a-server-skills"
+	A2AContextID          = ARKPrefix + "a2a-context-id"
+	A2AStreamingSupported = ARKPrefix + "a2a-streaming-supported"
 )
 
 // MCP annotations

--- a/ark/internal/controller/a2aserver_controller.go
+++ b/ark/internal/controller/a2aserver_controller.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -255,10 +256,13 @@ func (r *A2AServerReconciler) buildAgentWithSkills(a2aServer *arkv1prealpha1.A2A
 	// Build skills annotation JSON
 	skillsJSON, _ := json.Marshal(agentCard.Skills)
 
+	streamingSupported := agentCard.Capabilities.Streaming != nil && *agentCard.Capabilities.Streaming
+
 	agentAnnotations := map[string]string{
-		annotations.A2AServerName:    a2aServer.Name,
-		annotations.A2AServerAddress: a2aServer.Status.LastResolvedAddress,
-		annotations.A2AServerSkills:  string(skillsJSON),
+		annotations.A2AServerName:         a2aServer.Name,
+		annotations.A2AServerAddress:      a2aServer.Status.LastResolvedAddress,
+		annotations.A2AServerSkills:       string(skillsJSON),
+		annotations.A2AStreamingSupported: strconv.FormatBool(streamingSupported),
 	}
 
 	// Inherit ark.mckinsey.com annotations from A2AServer to Agent

--- a/ark/internal/genai/a2a_execution.go
+++ b/ark/internal/genai/a2a_execution.go
@@ -5,24 +5,23 @@ package genai
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/openai/openai-go"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
 	arkann "mckinsey.com/ark/internal/annotations"
 	"mckinsey.com/ark/internal/eventing"
 )
 
-// A2AExecutionEngine handles execution for agents with the reserved 'a2a' execution engine
 type A2AExecutionEngine struct {
 	client           client.Client
 	eventingRecorder eventing.A2aRecorder
 }
 
-// NewA2AExecutionEngine creates a new A2A execution engine
 func NewA2AExecutionEngine(k8sClient client.Client, eventingRecorder eventing.A2aRecorder) *A2AExecutionEngine {
 	return &A2AExecutionEngine{
 		client:           k8sClient,
@@ -30,18 +29,15 @@ func NewA2AExecutionEngine(k8sClient client.Client, eventingRecorder eventing.A2
 	}
 }
 
-// Execute executes a query against an A2A agent
 func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace string, agentAnnotations map[string]string, contextID string, userInput Message, eventStream EventStreamInterface) (*ExecutionResult, error) {
 	log := logf.FromContext(ctx)
 	log.Info("executing A2A agent", "agent", agentName)
 
-	// Get the A2A server address from annotations
 	a2aAddress, hasAddress := agentAnnotations[arkann.A2AServerAddress]
 	if !hasAddress {
 		return nil, fmt.Errorf("A2A agent missing %s annotation", arkann.A2AServerAddress)
 	}
 
-	// Get the A2AServer name from annotations
 	a2aServerName, hasServerName := agentAnnotations[arkann.A2AServerName]
 	if !hasServerName {
 		return nil, fmt.Errorf("A2A agent missing %s annotation", arkann.A2AServerName)
@@ -60,63 +56,48 @@ func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace s
 		return nil, fmt.Errorf("unable to get A2AServer %v: %w", serverKey, err)
 	}
 
-	// Check if A2AServer has a timeout configured
 	if a2aServer.Spec.Timeout != "" {
 		timeout, err := time.ParseDuration(a2aServer.Spec.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse A2AServer timeout %q: %w", a2aServer.Spec.Timeout, err)
 		}
-		// Create sub-context with A2AServer timeout
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	// Otherwise, use existing context deadline from query
 
-	// Extract content from the userInput message
 	content := ""
 	if userInput.OfUser != nil && userInput.OfUser.Content.OfString.Value != "" {
 		content = userInput.OfUser.Content.OfString.Value
 	}
 
-	// Execute A2A agent
 	queryName := getQueryName(ctx)
+	modelID := fmt.Sprintf("agent/%s", agentName)
+
+	if agentAnnotations[arkann.A2AStreamingSupported] == TrueString && eventStream != nil {
+		result, err := e.executeStreaming(ctx, a2aAddress, a2aServer.Spec.Headers, namespace, content, agentName, queryName, contextID, modelID, eventStream, &a2aServer)
+		if err != nil {
+			log.Error(err, "A2A streaming failed, falling back to blocking", "agent", agentName)
+		} else {
+			e.eventingRecorder.Complete(ctx, "A2AExecution", "A2A execution completed successfully", operationData)
+			return result, nil
+		}
+	}
+
 	a2aResponse, err := ExecuteA2AAgent(ctx, e.client, a2aAddress, a2aServer.Spec.Headers, namespace, content, agentName, queryName, contextID, e.eventingRecorder, &a2aServer)
 	if err != nil {
-		modelID := fmt.Sprintf("agent/%s", agentName)
 		StreamError(ctx, eventStream, err, "a2a_execution_failed", modelID)
 		e.eventingRecorder.Fail(ctx, "A2AExecution", fmt.Sprintf("A2A execution failed: %v", err), err, operationData)
 		return nil, err
 	}
 
-	// Convert response to genai.Message format
 	responseMessage := NewAssistantMessage(a2aResponse.Content)
 
-	// The A2A execution engine does not yet support streaming responses - if streaming
-	// was requested then the final response must be sent as a single chunk, as per the spec.
 	if eventStream != nil {
-		// Use query ID as completion ID (all chunks for a query share the same ID)
 		completionID := getQueryID(ctx)
-		// Use "agent/name" format as per OpenAI-compatible endpoints
-		modelID := fmt.Sprintf("agent/%s", agentName)
-
-		chunk := &openai.ChatCompletionChunk{
-			ID:      completionID,
-			Object:  "chat.completion.chunk",
-			Created: time.Now().Unix(),
-			Model:   modelID,
-			Choices: []openai.ChatCompletionChunkChoice{
-				{
-					Index: 0,
-					Delta: openai.ChatCompletionChunkChoiceDelta{
-						Content: a2aResponse.Content,
-						Role:    "assistant",
-					},
-					FinishReason: "stop",
-				},
-			},
-		}
-
+		chunk := NewContentChunk(completionID, modelID, a2aResponse.Content)
+		chunk.Choices[0].Delta.Role = RoleAssistant
+		chunk.Choices[0].FinishReason = "stop"
 		chunkWithMeta := WrapChunkWithMetadata(ctx, chunk, modelID, nil)
 		if err := eventStream.StreamChunk(ctx, chunkWithMeta); err != nil {
 			log.Error(err, "failed to send A2A response chunk to event stream")
@@ -129,4 +110,156 @@ func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace s
 		Messages:    []Message{responseMessage},
 		A2AResponse: a2aResponse,
 	}, nil
+}
+
+func (e *A2AExecutionEngine) executeStreaming(ctx context.Context, address string, headers []arkv1prealpha1.Header, namespace, input, agentName, queryName, contextID, modelID string, eventStream EventStreamInterface, a2aServer *arkv1prealpha1.A2AServer) (*ExecutionResult, error) {
+	rpcURL := strings.TrimSuffix(address, "/")
+
+	a2aClient, err := CreateA2AClient(ctx, e.client, rpcURL, headers, namespace, agentName, e.eventingRecorder)
+	if err != nil {
+		return nil, err
+	}
+
+	var message protocol.Message
+	if contextID != "" {
+		message = protocol.NewMessageWithContext(protocol.MessageRoleUser, []protocol.Part{
+			protocol.NewTextPart(input),
+		}, nil, &contextID)
+	} else {
+		message = protocol.NewMessage(protocol.MessageRoleUser, []protocol.Part{
+			protocol.NewTextPart(input),
+		})
+	}
+
+	params := protocol.SendMessageParams{
+		RPCID:   protocol.GenerateRPCID(),
+		Message: message,
+	}
+
+	events, err := a2aClient.StreamMessage(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("A2A StreamMessage failed: %w", err)
+	}
+
+	completionID := getQueryID(ctx)
+	return consumeA2AStreamEvents(ctx, e.client, events, eventStream, modelID, completionID, agentName, namespace, queryName, a2aServer)
+}
+
+func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events <-chan protocol.StreamingMessageEvent, eventStream EventStreamInterface, modelID, completionID, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) (*ExecutionResult, error) {
+	var finalContent strings.Builder
+	var a2aResponse A2AResponse
+	received := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case event, ok := <-events:
+			if !ok {
+				if !received {
+					return nil, fmt.Errorf("a2a streaming returned no events")
+				}
+				a2aResponse.Content = finalContent.String()
+				return &ExecutionResult{
+					Messages:    []Message{NewAssistantMessage(a2aResponse.Content)},
+					A2AResponse: &a2aResponse,
+				}, nil
+			}
+			received = true
+			if event.Result == nil {
+				continue
+			}
+
+			switch result := event.Result.(type) {
+			case *protocol.Message:
+				text := extractTextFromParts(result.Parts)
+				if text != "" {
+					finalContent.WriteString(text)
+				}
+				if result.ContextID != nil && *result.ContextID != "" {
+					a2aResponse.ContextID = *result.ContextID
+				}
+				streamContentChunk(ctx, eventStream, completionID, modelID, text)
+
+			case *protocol.Task:
+				a2aResponse.TaskID = result.ID
+				a2aResponse.ContextID = result.ContextID
+				text := extractTextFromTaskStatus(result)
+				if text != "" {
+					finalContent.Reset()
+					finalContent.WriteString(text)
+				}
+				maybeCreateA2ATask(ctx, k8sClient, result, agentName, namespace, queryName, a2aServer)
+				streamContentChunk(ctx, eventStream, completionID, modelID, text)
+
+			case *protocol.TaskStatusUpdateEvent:
+				if a2aResponse.TaskID == "" {
+					a2aResponse.TaskID = result.TaskID
+				}
+				if a2aResponse.ContextID == "" {
+					a2aResponse.ContextID = result.ContextID
+				}
+				var text string
+				if result.Status.Message != nil {
+					text = extractTextFromParts(result.Status.Message.Parts)
+				}
+				if result.Final && text != "" && finalContent.Len() == 0 {
+					finalContent.WriteString(text)
+				}
+				streamContentChunk(ctx, eventStream, completionID, modelID, text)
+				if result.Final {
+					a2aResponse.Content = finalContent.String()
+					return &ExecutionResult{
+						Messages:    []Message{NewAssistantMessage(a2aResponse.Content)},
+						A2AResponse: &a2aResponse,
+					}, nil
+				}
+
+			case *protocol.TaskArtifactUpdateEvent:
+				if a2aResponse.TaskID == "" {
+					a2aResponse.TaskID = result.TaskID
+				}
+				text := extractTextFromParts(result.Artifact.Parts)
+				if text != "" {
+					finalContent.WriteString(text)
+				}
+				streamContentChunk(ctx, eventStream, completionID, modelID, text)
+			}
+		}
+	}
+}
+
+func streamContentChunk(ctx context.Context, eventStream EventStreamInterface, completionID, modelID, content string) {
+	if eventStream == nil || content == "" {
+		return
+	}
+	chunk := NewContentChunk(completionID, modelID, content)
+	chunkWithMeta := WrapChunkWithMetadata(ctx, chunk, modelID, nil)
+	if err := eventStream.StreamChunk(ctx, chunkWithMeta); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to send A2A streaming chunk")
+	}
+}
+
+func extractTextFromTaskStatus(task *protocol.Task) string {
+	if task.Status.Message != nil {
+		if text := extractTextFromParts(task.Status.Message.Parts); text != "" {
+			return text
+		}
+	}
+	for i := len(task.History) - 1; i >= 0; i-- {
+		msg := task.History[i]
+		if msg.Role == protocol.MessageRoleAgent && len(msg.Parts) > 0 {
+			if text := extractTextFromParts(msg.Parts); text != "" {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func maybeCreateA2ATask(ctx context.Context, k8sClient client.Client, task *protocol.Task, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) {
+	if a2aServer == nil || queryName == "" {
+		return
+	}
+	_ = handleA2ATaskResponse(ctx, k8sClient, task, agentName, namespace, queryName, a2aServer)
 }

--- a/ark/internal/genai/a2a_execution.go
+++ b/ark/internal/genai/a2a_execution.go
@@ -146,8 +146,8 @@ func (e *A2AExecutionEngine) executeStreaming(ctx context.Context, address strin
 }
 
 func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events <-chan protocol.StreamingMessageEvent, eventStream EventStreamInterface, modelID, completionID, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) (*ExecutionResult, error) {
-	var finalContent strings.Builder
-	var a2aResponse A2AResponse
+	var content strings.Builder
+	var response A2AResponse
 	received := false
 
 	for {
@@ -159,73 +159,85 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 				if !received {
 					return nil, fmt.Errorf("a2a streaming returned no events")
 				}
-				a2aResponse.Content = finalContent.String()
-				return &ExecutionResult{
-					Messages:    []Message{NewAssistantMessage(a2aResponse.Content)},
-					A2AResponse: &a2aResponse,
-				}, nil
+				return buildA2AStreamResult(&content, &response), nil
 			}
 			received = true
 			if event.Result == nil {
 				continue
 			}
-
 			switch result := event.Result.(type) {
 			case *protocol.Message:
-				text := extractTextFromParts(result.Parts)
-				if text != "" {
-					finalContent.WriteString(text)
-				}
-				if result.ContextID != nil && *result.ContextID != "" {
-					a2aResponse.ContextID = *result.ContextID
-				}
-				streamContentChunk(ctx, eventStream, completionID, modelID, text)
-
+				consumeA2AMessageEvent(ctx, result, &content, &response, eventStream, completionID, modelID)
 			case *protocol.Task:
-				a2aResponse.TaskID = result.ID
-				a2aResponse.ContextID = result.ContextID
-				text := extractTextFromTaskStatus(result)
-				if text != "" {
-					finalContent.Reset()
-					finalContent.WriteString(text)
-				}
-				maybeCreateA2ATask(ctx, k8sClient, result, agentName, namespace, queryName, a2aServer)
-				streamContentChunk(ctx, eventStream, completionID, modelID, text)
-
+				consumeA2ATaskEvent(ctx, k8sClient, result, &content, &response, eventStream, completionID, modelID, agentName, namespace, queryName, a2aServer)
 			case *protocol.TaskStatusUpdateEvent:
-				if a2aResponse.TaskID == "" {
-					a2aResponse.TaskID = result.TaskID
+				if consumeA2AStatusUpdateEvent(ctx, result, &content, &response, eventStream, completionID, modelID) {
+					return buildA2AStreamResult(&content, &response), nil
 				}
-				if a2aResponse.ContextID == "" {
-					a2aResponse.ContextID = result.ContextID
-				}
-				var text string
-				if result.Status.Message != nil {
-					text = extractTextFromParts(result.Status.Message.Parts)
-				}
-				if result.Final && text != "" && finalContent.Len() == 0 {
-					finalContent.WriteString(text)
-				}
-				streamContentChunk(ctx, eventStream, completionID, modelID, text)
-				if result.Final {
-					a2aResponse.Content = finalContent.String()
-					return &ExecutionResult{
-						Messages:    []Message{NewAssistantMessage(a2aResponse.Content)},
-						A2AResponse: &a2aResponse,
-					}, nil
-				}
-
 			case *protocol.TaskArtifactUpdateEvent:
-				if a2aResponse.TaskID == "" {
-					a2aResponse.TaskID = result.TaskID
-				}
-				text := extractTextFromParts(result.Artifact.Parts)
-				if text != "" {
-					finalContent.WriteString(text)
-				}
-				streamContentChunk(ctx, eventStream, completionID, modelID, text)
+				consumeA2AArtifactUpdateEvent(ctx, result, &content, &response, eventStream, completionID, modelID)
 			}
 		}
+	}
+}
+
+func consumeA2AMessageEvent(ctx context.Context, msg *protocol.Message, content *strings.Builder, response *A2AResponse, eventStream EventStreamInterface, completionID, modelID string) {
+	text := extractTextFromParts(msg.Parts)
+	if text != "" {
+		content.WriteString(text)
+	}
+	if msg.ContextID != nil && *msg.ContextID != "" {
+		response.ContextID = *msg.ContextID
+	}
+	streamContentChunk(ctx, eventStream, completionID, modelID, text)
+}
+
+func consumeA2ATaskEvent(ctx context.Context, k8sClient client.Client, task *protocol.Task, content *strings.Builder, response *A2AResponse, eventStream EventStreamInterface, completionID, modelID, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) {
+	response.TaskID = task.ID
+	response.ContextID = task.ContextID
+	text := extractTextFromTaskStatus(task)
+	if text != "" {
+		content.Reset()
+		content.WriteString(text)
+	}
+	maybeCreateA2ATask(ctx, k8sClient, task, agentName, namespace, queryName, a2aServer)
+	streamContentChunk(ctx, eventStream, completionID, modelID, text)
+}
+
+func consumeA2AStatusUpdateEvent(ctx context.Context, event *protocol.TaskStatusUpdateEvent, content *strings.Builder, response *A2AResponse, eventStream EventStreamInterface, completionID, modelID string) bool {
+	if response.TaskID == "" {
+		response.TaskID = event.TaskID
+	}
+	if response.ContextID == "" {
+		response.ContextID = event.ContextID
+	}
+	var text string
+	if event.Status.Message != nil {
+		text = extractTextFromParts(event.Status.Message.Parts)
+	}
+	if event.Final && text != "" && content.Len() == 0 {
+		content.WriteString(text)
+	}
+	streamContentChunk(ctx, eventStream, completionID, modelID, text)
+	return event.Final
+}
+
+func consumeA2AArtifactUpdateEvent(ctx context.Context, event *protocol.TaskArtifactUpdateEvent, content *strings.Builder, response *A2AResponse, eventStream EventStreamInterface, completionID, modelID string) {
+	if response.TaskID == "" {
+		response.TaskID = event.TaskID
+	}
+	text := extractTextFromParts(event.Artifact.Parts)
+	if text != "" {
+		content.WriteString(text)
+	}
+	streamContentChunk(ctx, eventStream, completionID, modelID, text)
+}
+
+func buildA2AStreamResult(content *strings.Builder, response *A2AResponse) *ExecutionResult {
+	response.Content = content.String()
+	return &ExecutionResult{
+		Messages:    []Message{NewAssistantMessage(response.Content)},
+		A2AResponse: response,
 	}
 }
 

--- a/ark/internal/genai/a2a_execution_test.go
+++ b/ark/internal/genai/a2a_execution_test.go
@@ -19,7 +19,7 @@ func (m *mockEventStream) StreamChunk(_ context.Context, chunk interface{}) erro
 }
 
 func (m *mockEventStream) NotifyCompletion(_ context.Context) error { return nil }
-func (m *mockEventStream) Close() error                            { return nil }
+func (m *mockEventStream) Close() error                             { return nil }
 
 func TestConsumeA2AStreamEventsMessage(t *testing.T) {
 	ctx := context.Background()

--- a/ark/internal/genai/a2a_execution_test.go
+++ b/ark/internal/genai/a2a_execution_test.go
@@ -1,0 +1,192 @@
+package genai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+)
+
+type mockEventStream struct {
+	chunks []interface{}
+}
+
+func (m *mockEventStream) StreamChunk(_ context.Context, chunk interface{}) error {
+	m.chunks = append(m.chunks, chunk)
+	return nil
+}
+
+func (m *mockEventStream) NotifyCompletion(_ context.Context) error { return nil }
+func (m *mockEventStream) Close() error                            { return nil }
+
+func TestConsumeA2AStreamEventsMessage(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent, 1)
+	stream := &mockEventStream{}
+
+	contextID := "ctx-1"
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.Message{
+			Role:      protocol.MessageRoleAgent,
+			Parts:     []protocol.Part{protocol.NewTextPart("hello world")},
+			ContextID: &contextID,
+		},
+	}
+	close(events)
+
+	result, err := consumeA2AStreamEvents(ctx, nil, events, stream, "agent/test", "comp-1", "test", "default", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", result.A2AResponse.Content)
+	assert.Equal(t, "ctx-1", result.A2AResponse.ContextID)
+	assert.Len(t, stream.chunks, 1)
+}
+
+func TestConsumeA2AStreamEventsArtifact(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent, 2)
+	stream := &mockEventStream{}
+
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskArtifactUpdateEvent{
+			TaskID: "task-1",
+			Artifact: protocol.Artifact{
+				Parts: []protocol.Part{protocol.NewTextPart("chunk 1")},
+			},
+		},
+	}
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskArtifactUpdateEvent{
+			TaskID: "task-1",
+			Artifact: protocol.Artifact{
+				Parts: []protocol.Part{protocol.NewTextPart("chunk 2")},
+			},
+		},
+	}
+	close(events)
+
+	result, err := consumeA2AStreamEvents(ctx, nil, events, stream, "agent/test", "comp-1", "test", "default", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "chunk 1chunk 2", result.A2AResponse.Content)
+	assert.Equal(t, "task-1", result.A2AResponse.TaskID)
+	assert.Len(t, stream.chunks, 2)
+}
+
+func TestConsumeA2AStreamEventsFinalStatus(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent, 2)
+	stream := &mockEventStream{}
+
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskStatusUpdateEvent{
+			TaskID:    "task-1",
+			ContextID: "ctx-1",
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(TaskStateWorking),
+			},
+		},
+	}
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskStatusUpdateEvent{
+			TaskID:    "task-1",
+			ContextID: "ctx-1",
+			Final:     true,
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(TaskStateCompleted),
+				Message: &protocol.Message{
+					Parts: []protocol.Part{protocol.NewTextPart("done")},
+				},
+			},
+		},
+	}
+
+	result, err := consumeA2AStreamEvents(ctx, nil, events, stream, "agent/test", "comp-1", "test", "default", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result.A2AResponse.Content)
+	assert.Equal(t, "task-1", result.A2AResponse.TaskID)
+	assert.Len(t, stream.chunks, 1)
+}
+
+func TestConsumeA2AStreamEventsNoEvents(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent)
+	close(events)
+
+	_, err := consumeA2AStreamEvents(ctx, nil, events, nil, "agent/test", "comp-1", "test", "default", "", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no events")
+}
+
+func TestConsumeA2AStreamEventsTask(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent, 1)
+	stream := &mockEventStream{}
+
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.Task{
+			ID:        "task-1",
+			ContextID: "ctx-1",
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(TaskStateCompleted),
+				Message: &protocol.Message{
+					Parts: []protocol.Part{protocol.NewTextPart("task result")},
+				},
+			},
+		},
+	}
+	close(events)
+
+	result, err := consumeA2AStreamEvents(ctx, nil, events, stream, "agent/test", "comp-1", "test", "default", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "task result", result.A2AResponse.Content)
+	assert.Equal(t, "task-1", result.A2AResponse.TaskID)
+	assert.Len(t, stream.chunks, 1)
+}
+
+func TestStreamContentChunkSkipsEmpty(t *testing.T) {
+	ctx := context.Background()
+	stream := &mockEventStream{}
+
+	streamContentChunk(ctx, stream, "comp-1", "model-1", "")
+	assert.Empty(t, stream.chunks)
+
+	streamContentChunk(ctx, nil, "comp-1", "model-1", "hello")
+	assert.Empty(t, stream.chunks)
+
+	streamContentChunk(ctx, stream, "comp-1", "model-1", "hello")
+	assert.Len(t, stream.chunks, 1)
+}
+
+func TestExtractTextFromTaskStatus(t *testing.T) {
+	t.Run("from status message", func(t *testing.T) {
+		task := &protocol.Task{
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(TaskStateCompleted),
+				Message: &protocol.Message{
+					Parts: []protocol.Part{protocol.NewTextPart("from status")},
+				},
+			},
+		}
+		assert.Equal(t, "from status", extractTextFromTaskStatus(task))
+	})
+
+	t.Run("from history fallback", func(t *testing.T) {
+		task := &protocol.Task{
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(TaskStateCompleted),
+			},
+			History: []protocol.Message{
+				{Role: protocol.MessageRoleAgent, Parts: []protocol.Part{protocol.NewTextPart("from history")}},
+			},
+		}
+		assert.Equal(t, "from history", extractTextFromTaskStatus(task))
+	})
+
+	t.Run("empty task", func(t *testing.T) {
+		task := &protocol.Task{
+			Status: protocol.TaskStatus{State: protocol.TaskState(TaskStateWorking)},
+		}
+		assert.Equal(t, "", extractTextFromTaskStatus(task))
+	})
+}


### PR DESCRIPTION
## Summary

- Enables real-time streaming of A2A agent responses back to clients, instead of waiting for the full response before sending it.
- Automatically detects streaming capability from the A2A agent card and propagates it as an annotation on the agent resource.
- Falls back gracefully to blocking execution if streaming fails or isn't supported.
- Handles all A2A streaming event types: messages, tasks, status updates, and artifact updates.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #1101  