### PR TITLE
fix: add left padding to plain text files in file preview

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/file-preview/file-preview-dialog.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/file-preview/file-preview-dialog.tsx
@@ -94,7 +94,7 @@ export function FilePreviewDialog({
               </SyntaxHighlighter>
             </div>
           ) : (
-            <pre className="font-mono text-sm break-words whitespace-pre-wrap">
+            <pre className="pl-4 font-mono text-sm break-words whitespace-pre-wrap">
               {content}
             </pre>
           )}

--- a/services/ark-dashboard/ark-dashboard/components/file-preview/multi-tab-preview-dialog.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/file-preview/multi-tab-preview-dialog.tsx
@@ -142,7 +142,7 @@ export function MultiTabPreviewDialog({
                   </SyntaxHighlighter>
                 </div>
               ) : (
-                <pre className="font-mono text-sm break-words whitespace-pre-wrap">
+                <pre className="pl-4 font-mono text-sm break-words whitespace-pre-wrap">
                   {activeTab.content}
                 </pre>
               )


### PR DESCRIPTION
Add left padding (pl-4) to plain text content in file preview dialogs to prevent text from being too close to the left border.

🤖 Generated with Claude Code

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 