### PR TITLE
fix: correct argo-workflows resource names in post-install hook

### DIFF
--- a/services/argo-workflows/chart/templates/workflow-controller-configmap-patch.yaml
+++ b/services/argo-workflows/chart/templates/workflow-controller-configmap-patch.yaml
@@ -24,7 +24,7 @@ spec:
 
           apk add --no-cache yq
 
-          kubectl get configmap {{ .Release.Name }}-argo-workflows-workflow-controller-configmap -n {{ .Release.Namespace }} -o yaml > /tmp/config.yaml
+          kubectl get configmap {{ .Release.Name }}-workflow-controller-configmap -n {{ .Release.Namespace }} -o yaml > /tmp/config.yaml
 
           yq eval '.data.config |= (. | from_yaml | .workflowDefaults.spec.artifactRepositoryRef = {"configMap": "artifact-repositories", "key": "default"} | to_yaml)' -i /tmp/config.yaml
 
@@ -32,7 +32,7 @@ spec:
 
           echo "Artifact repository configuration complete"
 
-          kubectl rollout restart deployment {{ .Release.Name }}-argo-workflows-workflow-controller -n {{ .Release.Namespace }} || true
+          kubectl rollout restart deployment {{ .Release.Name }}-workflow-controller -n {{ .Release.Namespace }} || true
 
           echo "Waiting for controller to restart..."
           sleep 5


### PR DESCRIPTION
## Summary
- Fix doubled `argo-workflows` prefix in the Minio artifact repo configuration hook job
- The configmap and deployment names used `{{ .Release.Name }}-argo-workflows-workflow-controller-*` which resolved to `argo-workflows-argo-workflows-workflow-controller-*`, but the actual resources are named `argo-workflows-workflow-controller-*` since the subchart deduplicates the name when the release name matches the chart name
- This caused the post-install hook to CrashLoopBackOff on `kubectl get configmap` failure, which made the entire `helm install` time out

🤖 Generated with [Claude Code](https://claude.com/claude-code)