### PR TITLE
feat: ark query tools doc update

### DIFF
--- a/docs/content/developer-guide/ark-cli.mdx
+++ b/docs/content/developer-guide/ark-cli.mdx
@@ -68,6 +68,9 @@ ark models query default "What is 2+2?"
 # Shorthand verb syntax, more natural for some of the more essential commands.
 ark query model/default "What is 2+2?"
 
+# Query a tool directly
+ark query tool/get_weather '{"location": "New York"}'
+
 # Sorthand for calling evaluation
 ark evaluation ark-evaluator --input "What is 2+2?" --output "5"
 

--- a/docs/content/reference/resources/memory.mdx
+++ b/docs/content/reference/resources/memory.mdx
@@ -31,23 +31,33 @@ Memory can be specified in a query resource. If a Memory resource named `default
 
 Memory works with all query target types — agents, models, and tools. When a `conversationId` is provided, messages are persisted to the memory chain regardless of the target type.
 
-Memory in a query resource:
+Memory in a query to a tool:
 
 ```yaml
 apiVersion: ark.mckinsey.com/v1alpha1
 kind: Query
 metadata:
-  name: chat-with-memory
+  name: tool-with-memory
 spec:
-  input: "What did we discuss earlier?"
+  input: "Remember this message for later"
   target:
-    - name: my-agent
-  memory:
-    name: ark-broker
-  # Optional: specify session ID to group related queries for tracking
-  sessionId: "my-session"
-  # Optional: specify conversation ID for memory continuity
-  # If not provided, a new conversation ID will be generated
+    type: tool
+    name: noop
+  conversationId: "my-conversation"
+```
+
+A follow-up query to an agent on the same conversation ID will have access to the tool query's messages:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: follow-up-agent-query
+spec:
+  input: "What was the last message?"
+  target:
+    type: agent
+    name: my-agent
   conversationId: "my-conversation"
 ```
 
@@ -58,8 +68,8 @@ Memory can also be specified via the CLIs:
 fark query --input "Start our conversation" --conversation-id "my-conversation" my-agent
 
 # Using ark
-ark query tool/noop "Print this message" --conversation-id "my-conversation" 
-ark query agent/my-agent "What was the last message?" --conversation-id "my-conversation" # The last message was "Print this message"
+ark query tool/noop "Remember this message for later" --conversation-id "my-conversation" 
+ark query agent/my-agent "What was the last message?" --conversation-id "my-conversation"
 ```
 
 **Session ID vs Conversation ID:**

--- a/docs/content/reference/resources/memory.mdx
+++ b/docs/content/reference/resources/memory.mdx
@@ -29,6 +29,8 @@ spec:
 
 Memory can be specified in a query resource. If a Memory resource named `default` exists in the namespace, it will be automatically selected for queries that don't explicitly specify a memory.
 
+Memory works with all query target types — agents, models, and tools. When a `conversationId` is provided, messages are persisted to the memory chain regardless of the target type.
+
 Memory in a query resource:
 
 ```yaml

--- a/docs/content/reference/resources/memory.mdx
+++ b/docs/content/reference/resources/memory.mdx
@@ -55,10 +55,11 @@ Memory can also be specified via the CLIs:
 
 ```bash
 # Using fark
-fark query --input "Continue our conversation" --session-id "my-session" --conversation-id "my-conversation" my-agent
+fark query --input "Start our conversation" --conversation-id "my-conversation" my-agent
 
 # Using ark
-ark query agent/my-agent "Continue our conversation" --session-id "my-session" --conversation-id "my-conversation"
+ark query tool/noop "Print this message" --conversation-id "my-conversation" 
+ark query agent/my-agent "What was the last message?" --conversation-id "my-conversation" # The last message was "Print this message"
 ```
 
 **Session ID vs Conversation ID:**

--- a/docs/content/user-guide/queries.mdx
+++ b/docs/content/user-guide/queries.mdx
@@ -9,11 +9,11 @@ Queries are how you interact with models, tools, agents and teams in ARK. A quer
 
 ## What is a Query?
 
-A query is a request to execute a task using an agent or team. It contains:
+A query is a request to execute a task using an agent, team, model, or tool. It contains:
 
 - **Input**: The prompt or question you want to ask
-- **Target**: Which agent or team should process the request
-- **Output**: The response from the agent or team
+- **Target**: Which agent, team, model, or tool should process the request
+- **Output**: The response from the target
 
 Queries support [overrides](/user-guide/overrides) to dynamically inject headers when interacting with models and MCP servers.
 
@@ -109,6 +109,12 @@ Query a team:
 
 ```bash
 fark team team-seq "Analyze this data and provide recommendations"
+```
+
+Query a tool directly:
+
+```bash
+fark tool get_weather '{"location": "New York"}'
 ```
 
 Create a named query:
@@ -226,6 +232,42 @@ Response:
     "prompt_tokens": 18,
     "completion_tokens": 45,
     "total_tokens": 63
+  }
+}
+```
+
+### Query a Tool
+
+```bash
+curl -X POST http://ark-api.default.127.0.0.1.nip.io:8080/openai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tool/get_weather",
+    "messages": [
+      {"role": "user", "content": "{\"location\": \"New York\"}"}
+    ]
+  }'
+```
+
+Response:
+```json
+{
+  "id": "query-ghi789",
+  "object": "chat.completion",
+  "model": "tool/get_weather",
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "{\"temperature\": 72, \"condition\": \"partly cloudy\"}"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 15,
+    "total_tokens": 25
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Updated query documentation to include tools as a direct query target alongside agents, teams, and models
- Added tool query examples to fark CLI, OpenAI-compatible endpoints, and Ark CLI developer guide sections
- Documented that memory persists conversation history for all target types including tools

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 