### PR TITLE
feat: add Tools menu item with Wrench icon after MCPs in sidebar

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Settings,
   Sun,
   Workflow,
+  Wrench,
   Zap,
 } from 'lucide-react';
 import Image from 'next/image';
@@ -356,6 +357,15 @@ export function AppSidebar() {
                 isActive={getCurrentSection() === 'mcp'}>
                 <Server />
                 <span>MCPs</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                onClick={() => navigateToSection('tools')}
+                isActive={getCurrentSection() === 'tools'}>
+                <Wrench />
+                <span>Tools</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
 


### PR DESCRIPTION
- Added Tools navigation item between MCPs and Models
- Imported and used Wrench icon from lucide-react
- Routes to /tools page when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 