### PR TITLE
feat: add Events and Memory menu items to sidebar navigation

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
@@ -5,11 +5,13 @@ import {
   Activity,
   AlertCircle,
   Bot,
+  Calendar,
   Check,
   ChevronsLeft,
   ChevronsRight,
   ChevronsUpDown,
   ChevronsUpDownIcon,
+  Database,
   File,
   HelpCircle,
   Home,
@@ -394,6 +396,24 @@ export function AppSidebar() {
               isNamespaceResolved={isNamespaceResolved}
               loading={loading}
             />
+
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                onClick={() => navigateToSection('events')}
+                isActive={getCurrentSection() === 'events'}>
+                <Calendar />
+                <span>Events</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                onClick={() => navigateToSection('memory')}
+                isActive={getCurrentSection() === 'memory'}>
+                <Database />
+                <span>Memory</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
 
             <SidebarMenuItem>
               <Popover open={morePopoverOpen} onOpenChange={setMorePopoverOpen}>


### PR DESCRIPTION
Added standalone Events and Memory navigation items in the sidebar above the More menu for improved visibility and direct access to these frequently used sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 