### PR TITLE
fix: resolve race condition and password escaping in River query workers

### DIFF
--- a/ark/internal/apiserver/admission.go
+++ b/ark/internal/apiserver/admission.go
@@ -65,7 +65,6 @@ func (s *QueryAdmissionStorage) Create(ctx context.Context, obj runtime.Object, 
 		return result, nil
 	}
 
-	// print logs always
 	klog.Infof("Creating query %s/%s", accessor.GetNamespace(), accessor.GetName())
 
 	_, insertErr := s.riverClient.Insert(ctx, queryworker.QueryJobArgs{

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -84,11 +84,16 @@ func (r *QueryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
-	if result, err := r.handleFinalizer(ctx, &obj); result != nil {
-		return *result, err
+	if !r.QueryWorkersEnabled {
+		if result, err := r.handleFinalizer(ctx, &obj); result != nil {
+			return *result, err
+		}
 	}
 
 	if len(obj.Status.Conditions) == 0 {
+		if r.QueryWorkersEnabled {
+			return ctrl.Result{}, nil
+		}
 		r.setConditionCompleted(&obj, metav1.ConditionFalse, "QueryNotStarted", "The query has not been started yet")
 		return ctrl.Result{}, r.Status().Update(ctx, &obj)
 	}

--- a/ark/internal/queryworker/setup.go
+++ b/ark/internal/queryworker/setup.go
@@ -3,6 +3,8 @@ package queryworker
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -70,7 +72,14 @@ func buildConnString() string {
 	pass := os.Getenv("ARK_POSTGRES_PASSWORD")
 	sslMode := envOrDefault("ARK_POSTGRES_SSL_MODE", "disable")
 
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", user, pass, host, port, db, sslMode)
+	u := &url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, pass),
+		Host:     net.JoinHostPort(host, port),
+		Path:     db,
+		RawQuery: "sslmode=" + sslMode,
+	}
+	return u.String()
 }
 
 func envOrDefault(key, fallback string) string {


### PR DESCRIPTION
## Summary

Fixes two bugs found during E2E testing of #1167:

- **Race condition between reconciler and River worker**: When a query is created, the reconciler fires and adds a finalizer (`handleFinalizer`) + sets the `QueryNotStarted` condition, bumping `resourceVersion` each time. The River worker fires simultaneously and fails with `resource version mismatch` when trying to `updateStatus(running)`. Fix: skip both finalizer handling and condition init when `QueryWorkersEnabled=true` — River manages the full query lifecycle, and the finalizer only cancels `sync.Map` operations which River doesn't use.

- **Password escaping in `buildConnString`**: `fmt.Sprintf("postgres://%s:%s@...")` breaks when the password contains `/`, `#`, or `@` because `url.Parse` treats these as URL structural characters. Fix: build the connection string using `url.URL` struct with `url.UserPassword()` for proper RFC 3986 percent-encoding.

- Remove leftover `// print logs always` debug comment in `admission.go`.

### Validated with E2E tests

- Kind cluster with PostgreSQL backend, mock-llm, API aggregation (v1alpha1 + v1prealpha1)
- Single query: `phase: done`, River job completed on attempt 1
- 5 concurrent queries: all `phase: done`, all River jobs completed on attempt 1
- 0 `resource version mismatch` errors in controller logs