### PR TITLE
feat: add Events section to Settings sidebar above Memory

### DIFF
--- a/services/ark-dashboard/ark-dashboard/atoms/settings-modal.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/settings-modal.ts
@@ -5,6 +5,7 @@ export const settingsModalOpenAtom = atom<boolean>(false);
 export type SettingPage =
   | 'a2a-servers'
   | 'ark-services'
+  | 'events'
   | 'memory'
   | 'service-api-keys'
   | 'secrets'

--- a/services/ark-dashboard/ark-dashboard/components/settings-modal/settings-content.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings-modal/settings-content.tsx
@@ -5,6 +5,7 @@ import { Suspense, useMemo } from 'react';
 import type { SettingPage } from '@/atoms/settings-modal';
 import { MemorySection } from '@/components/sections';
 import { A2AServersSection } from '@/components/sections/a2a-servers-section';
+import { EventsSection } from '@/components/sections/events-section';
 import { SecretsSection } from '@/components/sections/secrets-section';
 import { useNamespace } from '@/providers/NamespaceProvider';
 
@@ -33,6 +34,10 @@ export function SettingsContent({ activePage }: SettingsContentProps) {
       'ark-services': {
         title: 'Ark Services',
         component: <ArkServicesSettings />,
+      },
+      events: {
+        title: 'Events',
+        component: <EventsSection page={1} limit={10} />,
       },
       memory: {
         title: 'Memory',

--- a/services/ark-dashboard/ark-dashboard/components/settings-modal/settings-types.ts
+++ b/services/ark-dashboard/ark-dashboard/components/settings-modal/settings-types.ts
@@ -1,4 +1,4 @@
-import { Database, Key, Lock, Server, Zap } from 'lucide-react';
+import { Calendar, Database, Key, Lock, Server, Zap } from 'lucide-react';
 
 import type { SettingPage } from '@/atoms/settings-modal';
 
@@ -28,6 +28,11 @@ export const settingsSections: SettingsSection[] = [
         key: 'ark-services',
         label: 'Ark Services',
         icon: Server,
+      },
+      {
+        key: 'events',
+        label: 'Events',
+        icon: Calendar,
       },
       {
         key: 'memory',


### PR DESCRIPTION
Added Events section in the Settings modal sidebar positioned above Memory section. The Events section displays query logs with pagination support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 