### PR TITLE
fix: restore Add Secret button for non-empty secrets list

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/sections/secrets-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/secrets-section.tsx
@@ -196,6 +196,13 @@ export const SecretsSection = forwardRef<
   return (
     <>
       <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex-1" />
+          <Button onClick={handleOpenAddEditor} variant="default">
+            <Plus className="h-4 w-4 mr-2" />
+            Add Secret
+          </Button>
+        </div>
         <main className="mt-3 flex-1 overflow-auto">
           <div className="flex flex-row flex-wrap gap-2 pb-6">
             {secrets.map(secret => (


### PR DESCRIPTION
The Add Secret button was missing when there were existing secrets in the list. Added the button to the SecretsSection component so it appears even when secrets already exist, not just in the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 