### PR TITLE
fix: set NODE_ENV=production in ark-broker container

### DIFF
--- a/services/ark-broker/ark-broker/Dockerfile
+++ b/services/ark-broker/ark-broker/Dockerfile
@@ -11,6 +11,7 @@ RUN npm run build
 
 FROM node:25.4.0-alpine AS runner
 WORKDIR /app
+ENV NODE_ENV=production
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs


### PR DESCRIPTION
Without NODE_ENV set, swagger-jsdoc globs for ./src/**/*.ts which doesn't exist in the production image, causing a crash on startup when deployed via Helm without DevSpace.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 