### PR TITLE
feat: add A2A extension contracts for pluggable execution engines

### DIFF
--- a/ark/internal/controller/executionengine_controller.go
+++ b/ark/internal/controller/executionengine_controller.go
@@ -98,6 +98,19 @@ func (r *ExecutionEngineReconciler) processExecutionEngine(ctx context.Context, 
 	return ctrl.Result{}, nil
 }
 
+type agentCardResponse struct {
+	Name             string                 `json:"name"`
+	ExecutionProfile *executionProfileEntry `json:"executionProfile,omitempty"`
+}
+
+type executionProfileEntry struct {
+	ToolMode         string   `json:"toolMode,omitempty"`
+	MemoryMode       string   `json:"memoryMode,omitempty"`
+	StructuredOutput bool     `json:"structuredOutput,omitempty"`
+	Streaming        bool     `json:"streaming,omitempty"`
+	SupportedModels  []string `json:"supportedModels,omitempty"`
+}
+
 func (r *ExecutionEngineReconciler) fetchAgentCard(ctx context.Context, address, engineName string) error {
 	cardURL := fmt.Sprintf("%s/.well-known/agent-card.json", address)
 	httpClient := &http.Client{Timeout: 5 * time.Second}
@@ -113,11 +126,24 @@ func (r *ExecutionEngineReconciler) fetchAgentCard(ctx context.Context, address,
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("agent card returned status %d for %s", resp.StatusCode, engineName)
 	}
-	var card map[string]interface{}
+	var card agentCardResponse
 	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
 		return fmt.Errorf("failed to decode agent card for %s: %w", engineName, err)
 	}
-	logf.FromContext(ctx).Info("Agent Card fetched successfully", "executionEngine", engineName, "agentName", card["name"])
+	log := logf.FromContext(ctx)
+	if card.ExecutionProfile != nil {
+		log.Info("Agent Card fetched with execution profile",
+			"executionEngine", engineName,
+			"agentName", card.Name,
+			"toolMode", card.ExecutionProfile.ToolMode,
+			"memoryMode", card.ExecutionProfile.MemoryMode,
+			"streaming", card.ExecutionProfile.Streaming,
+			"structuredOutput", card.ExecutionProfile.StructuredOutput,
+			"supportedModels", card.ExecutionProfile.SupportedModels,
+		)
+	} else {
+		log.Info("Agent Card fetched (no execution profile)", "executionEngine", engineName, "agentName", card.Name)
+	}
 	return nil
 }
 

--- a/ark/internal/genai/a2a_payload_contract.go
+++ b/ark/internal/genai/a2a_payload_contract.go
@@ -14,6 +14,13 @@ const (
 	A2APayloadSchemaToolResultV1          = "https://ark.mckinsey.com/payloads/tool-result/v1"
 	A2APayloadSchemaRoleHintV1            = "https://ark.mckinsey.com/payloads/role-hint/v1"
 	A2APayloadSchemaToolRequestV1         = "https://ark.mckinsey.com/payloads/tool-request/v1"
+
+	A2AExtensionSchemaExecutionProfileV1 = "https://ark.mckinsey.com/extensions/execution-profile/v1"
+
+	A2APayloadSchemaHistoryV1           = "https://ark.mckinsey.com/payloads/history/v1"
+	A2APayloadSchemaUserInputRequestV1  = "https://ark.mckinsey.com/payloads/user-input-request/v1"
+	A2APayloadSchemaUserInputResponseV1 = "https://ark.mckinsey.com/payloads/user-input-response/v1"
+	A2APayloadSchemaAuthCallbackV1      = "https://ark.mckinsey.com/payloads/auth-callback/v1"
 )
 
 type HistoryExtensionV1 struct {
@@ -198,4 +205,83 @@ func buildToolResultV2Message(results []ToolResultEntryV2) protocol.Message {
 			Data: payload,
 		},
 	})
+}
+
+type HistoryPayloadV1 struct {
+	Schema    string             `json:"schema"`
+	Strategy  string             `json:"strategy"`
+	Messages  []protocol.Message `json:"messages,omitempty"`
+	Truncated bool               `json:"truncated"`
+	MaxWindow int                `json:"maxWindow,omitempty"`
+	MemoryRef string             `json:"memoryRef,omitempty"`
+}
+
+type UserInputRequestPayloadV1 struct {
+	Schema    string   `json:"schema"`
+	Prompt    string   `json:"prompt"`
+	InputType string   `json:"inputType"`
+	Options   []string `json:"options,omitempty"`
+	Timeout   int      `json:"timeout,omitempty"`
+}
+
+type UserInputResponsePayloadV1 struct {
+	Schema    string `json:"schema"`
+	Value     string `json:"value"`
+	Cancelled bool   `json:"cancelled"`
+}
+
+type AuthCallbackPayloadV1 struct {
+	Schema    string   `json:"schema"`
+	Reason    string   `json:"reason"`
+	Provider  string   `json:"provider"`
+	Scopes    []string `json:"scopes,omitempty"`
+	ExpiresAt string   `json:"expiresAt,omitempty"`
+}
+
+func parseUserInputRequestPayload(msg *protocol.Message) *UserInputRequestPayloadV1 {
+	if msg == nil {
+		return nil
+	}
+	for _, part := range msg.Parts {
+		dp, ok := part.(*protocol.DataPart)
+		if !ok || dp.Data == nil {
+			continue
+		}
+		data, err := json.Marshal(dp.Data)
+		if err != nil {
+			continue
+		}
+		var payload UserInputRequestPayloadV1
+		if err := json.Unmarshal(data, &payload); err != nil {
+			continue
+		}
+		if payload.Schema == A2APayloadSchemaUserInputRequestV1 {
+			return &payload
+		}
+	}
+	return nil
+}
+
+func parseAuthCallbackPayload(msg *protocol.Message) *AuthCallbackPayloadV1 {
+	if msg == nil {
+		return nil
+	}
+	for _, part := range msg.Parts {
+		dp, ok := part.(*protocol.DataPart)
+		if !ok || dp.Data == nil {
+			continue
+		}
+		data, err := json.Marshal(dp.Data)
+		if err != nil {
+			continue
+		}
+		var payload AuthCallbackPayloadV1
+		if err := json.Unmarshal(data, &payload); err != nil {
+			continue
+		}
+		if payload.Schema == A2APayloadSchemaAuthCallbackV1 {
+			return &payload
+		}
+	}
+	return nil
 }

--- a/ark/internal/genai/execution_engine.go
+++ b/ark/internal/genai/execution_engine.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +19,39 @@ import (
 )
 
 const ArkMetadataKey = "ark.mckinsey.com/execution-engine"
+
+type ExecutionProfile struct {
+	Schema           string   `json:"schema,omitempty"`
+	ToolMode         string   `json:"toolMode,omitempty"`
+	MemoryMode       string   `json:"memoryMode,omitempty"`
+	StructuredOutput bool     `json:"structuredOutput,omitempty"`
+	Streaming        bool     `json:"streaming,omitempty"`
+	SupportedModels  []string `json:"supportedModels,omitempty"`
+}
+
+func FetchExecutionProfile(ctx context.Context, address string) (*ExecutionProfile, error) {
+	cardURL := fmt.Sprintf("%s/.well-known/agent-card.json", address)
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cardURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent card request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent card fetch failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("agent card returned status %d", resp.StatusCode)
+	}
+	var card struct {
+		ExecutionProfile *ExecutionProfile `json:"executionProfile"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		return nil, fmt.Errorf("failed to decode agent card: %w", err)
+	}
+	return card.ExecutionProfile, nil
+}
 
 type ExecutionEngineMessage struct {
 	Role    string `json:"role"`
@@ -257,41 +292,55 @@ func (c *ExecutionEngineA2AClient) consumeEngineStreamWithToolCallback(ctx conte
 					contextID = result.ContextID
 				}
 
-				if result.Status.State == protocol.TaskStateInputRequired {
-					toolRequest := parseToolRequestPayload(result.Status.Message)
-					if toolRequest != nil && toolRegistry != nil {
-						toolResults, err := c.executeToolCallbacks(ctx, toolRequest, toolRegistry, eventStream, contextID, taskID)
-						if err != nil {
-							return nil, fmt.Errorf("tool callback execution failed: %w", err)
-						}
-
-						resultMsg := buildToolResultV2Message(toolResults)
-						if taskID != "" {
-							resultMsg.TaskID = &taskID
-						}
-						if contextID != "" {
-							resultMsg.ContextID = &contextID
-						}
-
-						_, err = a2aClient.SendMessage(ctx, protocol.SendMessageParams{
-							RPCID:   protocol.GenerateRPCID(),
-							Message: resultMsg,
-						})
-						if err != nil {
-							return nil, fmt.Errorf("failed to send tool results to engine: %w", err)
-						}
-
-						resumed, err := a2aClient.ResubscribeTask(ctx, protocol.TaskIDParams{
-							RPCID: protocol.GenerateRPCID(),
-							ID:    taskID,
-						})
-						if err != nil {
-							return nil, fmt.Errorf("failed to resubscribe after tool callback: %w", err)
-						}
-						currentEvents = resumed
-						continue
+			if result.Status.State == protocol.TaskStateInputRequired {
+				toolRequest := parseToolRequestPayload(result.Status.Message)
+				if toolRequest != nil && toolRegistry != nil {
+					toolResults, err := c.executeToolCallbacks(ctx, toolRequest, toolRegistry, eventStream, contextID, taskID)
+					if err != nil {
+						return nil, fmt.Errorf("tool callback execution failed: %w", err)
 					}
+
+					resultMsg := buildToolResultV2Message(toolResults)
+					if taskID != "" {
+						resultMsg.TaskID = &taskID
+					}
+					if contextID != "" {
+						resultMsg.ContextID = &contextID
+					}
+
+					_, err = a2aClient.SendMessage(ctx, protocol.SendMessageParams{
+						RPCID:   protocol.GenerateRPCID(),
+						Message: resultMsg,
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to send tool results to engine: %w", err)
+					}
+
+					resumed, err := a2aClient.ResubscribeTask(ctx, protocol.TaskIDParams{
+						RPCID: protocol.GenerateRPCID(),
+						ID:    taskID,
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to resubscribe after tool callback: %w", err)
+					}
+					currentEvents = resumed
+					continue
 				}
+
+				if userInputReq := parseUserInputRequestPayload(result.Status.Message); userInputReq != nil {
+					if err := streamA2AEvent(ctx, eventStream, result); err != nil {
+						return nil, err
+					}
+					continue
+				}
+
+				if authCallback := parseAuthCallbackPayload(result.Status.Message); authCallback != nil {
+					if err := streamA2AEvent(ctx, eventStream, result); err != nil {
+						return nil, err
+					}
+					continue
+				}
+			}
 
 				if result.Status.Message != nil {
 					if text := extractTextFromParts(result.Status.Message.Parts); text != "" {

--- a/services/ark-query-engine/internal/agentcard/card.go
+++ b/services/ark-query-engine/internal/agentcard/card.go
@@ -6,19 +6,29 @@ import (
 )
 
 type AgentCard struct {
-	Name               string       `json:"name"`
-	Description        string       `json:"description"`
-	URL                string       `json:"url"`
-	Version            string       `json:"version"`
-	Capabilities       Capabilities `json:"capabilities"`
-	DefaultInputModes  []string     `json:"defaultInputModes"`
-	DefaultOutputModes []string     `json:"defaultOutputModes"`
-	Skills             []any        `json:"skills"`
+	Name               string            `json:"name"`
+	Description        string            `json:"description"`
+	URL                string            `json:"url"`
+	Version            string            `json:"version"`
+	Capabilities       Capabilities      `json:"capabilities"`
+	DefaultInputModes  []string          `json:"defaultInputModes"`
+	DefaultOutputModes []string          `json:"defaultOutputModes"`
+	Skills             []any             `json:"skills"`
+	ExecutionProfile   *ExecutionProfile `json:"executionProfile,omitempty"`
 }
 
 type Capabilities struct {
 	Streaming         bool `json:"streaming"`
 	PushNotifications bool `json:"pushNotifications"`
+}
+
+type ExecutionProfile struct {
+	Schema           string   `json:"schema"`
+	ToolMode         string   `json:"toolMode"`
+	MemoryMode       string   `json:"memoryMode"`
+	StructuredOutput bool     `json:"structuredOutput"`
+	Streaming        bool     `json:"streaming"`
+	SupportedModels  []string `json:"supportedModels,omitempty"`
 }
 
 func NewDefaultCard(url string) *AgentCard {
@@ -34,6 +44,14 @@ func NewDefaultCard(url string) *AgentCard {
 		DefaultInputModes:  []string{"text/plain"},
 		DefaultOutputModes: []string{"text/plain"},
 		Skills:             []any{},
+		ExecutionProfile: &ExecutionProfile{
+			Schema:           "https://ark.mckinsey.com/extensions/execution-profile/v1",
+			ToolMode:         "callback",
+			MemoryMode:       "inline",
+			StructuredOutput: true,
+			Streaming:        true,
+			SupportedModels:  []string{"openai", "azure", "bedrock"},
+		},
 	}
 }
 

--- a/services/ark-query-engine/internal/agentcard/card_test.go
+++ b/services/ark-query-engine/internal/agentcard/card_test.go
@@ -21,6 +21,24 @@ func TestNewDefaultCard(t *testing.T) {
 	if card.Capabilities.PushNotifications {
 		t.Error("expected push notifications to be false")
 	}
+	if card.ExecutionProfile == nil {
+		t.Fatal("expected execution profile to be set")
+	}
+	if card.ExecutionProfile.ToolMode != "callback" {
+		t.Errorf("unexpected tool mode: %s", card.ExecutionProfile.ToolMode)
+	}
+	if card.ExecutionProfile.MemoryMode != "inline" {
+		t.Errorf("unexpected memory mode: %s", card.ExecutionProfile.MemoryMode)
+	}
+	if !card.ExecutionProfile.StructuredOutput {
+		t.Error("expected structured output to be true")
+	}
+	if !card.ExecutionProfile.Streaming {
+		t.Error("expected streaming to be true")
+	}
+	if len(card.ExecutionProfile.SupportedModels) != 3 {
+		t.Fatalf("expected 3 supported models, got %d", len(card.ExecutionProfile.SupportedModels))
+	}
 }
 
 func TestHandler(t *testing.T) {
@@ -44,5 +62,11 @@ func TestHandler(t *testing.T) {
 	}
 	if result.Name != "ark-query-engine" {
 		t.Errorf("unexpected name in response: %s", result.Name)
+	}
+	if result.ExecutionProfile == nil {
+		t.Fatal("expected execution profile in response")
+	}
+	if result.ExecutionProfile.Schema != "https://ark.mckinsey.com/extensions/execution-profile/v1" {
+		t.Errorf("unexpected execution profile schema: %s", result.ExecutionProfile.Schema)
 	}
 }

--- a/services/ark-query-engine/internal/protocol/metadata.go
+++ b/services/ark-query-engine/internal/protocol/metadata.go
@@ -30,8 +30,15 @@ type ToolDefinition struct {
 	Parameters  map[string]any `json:"parameters,omitempty"`
 }
 
+type HistoryConfig struct {
+	Strategy  string `json:"strategy,omitempty"`
+	MaxWindow int    `json:"maxWindow,omitempty"`
+	MemoryRef string `json:"memoryRef,omitempty"`
+}
+
 type EngineMetadata struct {
-	Agent   AgentConfig      `json:"agent"`
-	Tools   []ToolDefinition `json:"tools,omitempty"`
-	History []any            `json:"history,omitempty"`
+	Agent         AgentConfig      `json:"agent"`
+	Tools         []ToolDefinition `json:"tools,omitempty"`
+	History       []any            `json:"history,omitempty"`
+	HistoryConfig *HistoryConfig   `json:"historyConfig,omitempty"`
 }

--- a/services/ark-query-engine/internal/protocol/payload.go
+++ b/services/ark-query-engine/internal/protocol/payload.go
@@ -4,6 +4,13 @@ const (
 	PayloadSchemaToolRequestV1 = "https://ark.mckinsey.com/payloads/tool-request/v1"
 	PayloadSchemaToolResultV1  = "https://ark.mckinsey.com/payloads/tool-result/v1"
 	PayloadSchemaRoleHintV1    = "https://ark.mckinsey.com/payloads/role-hint/v1"
+
+	ExecutionProfileSchemaV1 = "https://ark.mckinsey.com/extensions/execution-profile/v1"
+
+	PayloadSchemaHistoryV1            = "https://ark.mckinsey.com/payloads/history/v1"
+	PayloadSchemaUserInputRequestV1   = "https://ark.mckinsey.com/payloads/user-input-request/v1"
+	PayloadSchemaUserInputResponseV1  = "https://ark.mckinsey.com/payloads/user-input-response/v1"
+	PayloadSchemaAuthCallbackV1       = "https://ark.mckinsey.com/payloads/auth-callback/v1"
 )
 
 type ToolRequestPayloadV1 struct {
@@ -32,4 +39,34 @@ type ToolResultEntry struct {
 type RoleHintPayloadV1 struct {
 	Schema string `json:"schema"`
 	Role   string `json:"role"`
+}
+
+type HistoryPayloadV1 struct {
+	Schema    string `json:"schema"`
+	Strategy  string `json:"strategy"`
+	Truncated bool   `json:"truncated"`
+	MaxWindow int    `json:"maxWindow,omitempty"`
+	MemoryRef string `json:"memoryRef,omitempty"`
+}
+
+type UserInputRequestPayloadV1 struct {
+	Schema    string   `json:"schema"`
+	Prompt    string   `json:"prompt"`
+	InputType string   `json:"inputType"`
+	Options   []string `json:"options,omitempty"`
+	Timeout   int      `json:"timeout,omitempty"`
+}
+
+type UserInputResponsePayloadV1 struct {
+	Schema    string `json:"schema"`
+	Value     string `json:"value"`
+	Cancelled bool   `json:"cancelled"`
+}
+
+type AuthCallbackPayloadV1 struct {
+	Schema    string   `json:"schema"`
+	Reason    string   `json:"reason"`
+	Provider  string   `json:"provider"`
+	Scopes    []string `json:"scopes,omitempty"`
+	ExpiresAt string   `json:"expiresAt,omitempty"`
 }

--- a/services/ark-query-engine/internal/protocol/payload_test.go
+++ b/services/ark-query-engine/internal/protocol/payload_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -34,5 +35,111 @@ func TestToolResultPayloadV1_Schema(t *testing.T) {
 	}
 	if len(payload.Results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(payload.Results))
+	}
+}
+
+func TestHistoryPayloadV1_RoundTrip(t *testing.T) {
+	payload := HistoryPayloadV1{
+		Schema:    PayloadSchemaHistoryV1,
+		Strategy:  "inline",
+		Truncated: true,
+		MaxWindow: 50,
+		MemoryRef: "memory/chat-history",
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded HistoryPayloadV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Schema != PayloadSchemaHistoryV1 {
+		t.Errorf("unexpected schema: %s", decoded.Schema)
+	}
+	if decoded.Strategy != "inline" {
+		t.Errorf("unexpected strategy: %s", decoded.Strategy)
+	}
+	if decoded.MaxWindow != 50 {
+		t.Errorf("unexpected maxWindow: %d", decoded.MaxWindow)
+	}
+}
+
+func TestUserInputRequestPayloadV1_RoundTrip(t *testing.T) {
+	payload := UserInputRequestPayloadV1{
+		Schema:    PayloadSchemaUserInputRequestV1,
+		Prompt:    "Approve this action?",
+		InputType: "confirmation",
+		Options:   []string{"yes", "no"},
+		Timeout:   30,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded UserInputRequestPayloadV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Schema != PayloadSchemaUserInputRequestV1 {
+		t.Errorf("unexpected schema: %s", decoded.Schema)
+	}
+	if decoded.Prompt != "Approve this action?" {
+		t.Errorf("unexpected prompt: %s", decoded.Prompt)
+	}
+	if len(decoded.Options) != 2 {
+		t.Fatalf("expected 2 options, got %d", len(decoded.Options))
+	}
+}
+
+func TestUserInputResponsePayloadV1_RoundTrip(t *testing.T) {
+	payload := UserInputResponsePayloadV1{
+		Schema:    PayloadSchemaUserInputResponseV1,
+		Value:     "yes",
+		Cancelled: false,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded UserInputResponsePayloadV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Value != "yes" {
+		t.Errorf("unexpected value: %s", decoded.Value)
+	}
+	if decoded.Cancelled {
+		t.Error("expected cancelled to be false")
+	}
+}
+
+func TestAuthCallbackPayloadV1_RoundTrip(t *testing.T) {
+	payload := AuthCallbackPayloadV1{
+		Schema:    PayloadSchemaAuthCallbackV1,
+		Reason:    "token_expired",
+		Provider:  "azure",
+		Scopes:    []string{"openid", "profile"},
+		ExpiresAt: "2026-03-03T12:00:00Z",
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded AuthCallbackPayloadV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Schema != PayloadSchemaAuthCallbackV1 {
+		t.Errorf("unexpected schema: %s", decoded.Schema)
+	}
+	if decoded.Reason != "token_expired" {
+		t.Errorf("unexpected reason: %s", decoded.Reason)
+	}
+	if decoded.Provider != "azure" {
+		t.Errorf("unexpected provider: %s", decoded.Provider)
+	}
+	if len(decoded.Scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(decoded.Scopes))
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2 of Pluggable Execution Engines (#1253). Resolves #1255.

- Define `execution-profile/v1` extension schema in Agent Card with toolMode, memoryMode, structuredOutput, streaming, supportedModels
- Formalize `history/v1` payload schema with strategy, truncation, memory reference
- Define `user-input/v1` request/response schemas for client-in-the-loop callbacks
- Define `auth-callback/v1` schema for auth interruption signaling
- Update controller to parse and log execution profile from Agent Card health checks
- Wire user-input and auth-callback as recognized `input-required` variants in the tool callback loop

Made with [Cursor](https://cursor.com)