### PR TITLE
feat: add agent actions workflow and badge

### DIFF
--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -1,0 +1,22 @@
+name: Agent Actions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  claude:
+    uses: dwmkerr/agent-actions/.github/workflows/claude.yml@main
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    # Uncomment to override defaults:
+    # with:
+    #   trigger_phrase: "@claude"
+    #   timeout_minutes: 30
+    #   allowed_users: "dwmkerr"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml/badge.svg" alt="Deploy"></a>
     <a href="https://www.npmjs.com/package/@agents-at-scale/ark"><img src="https://img.shields.io/npm/v/@agents-at-scale/ark.svg" alt="npm version"></a>
     <a href="https://pypi.org/project/ark-sdk/"><img src="https://img.shields.io/pypi/v/ark-sdk.svg" alt="PyPI version"></a>
+    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/agent-actions.yml"><img src="https://img.shields.io/badge/Agent_Actions-Running-blue?logo=github-actions&logoColor=white" alt="Agent Actions - Running"></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- Add caller workflow for `dwmkerr/agent-actions` to enable `@claude` agent on issues and PRs
- Add "Agent Actions - Running" badge to README