### PR TITLE
feat(ark): propose River job queue for query execution in PostgreSQL mode

### DIFF
--- a/openspec/changes/river-query-workers/.openspec.yaml
+++ b/openspec/changes/river-query-workers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-05

--- a/openspec/changes/river-query-workers/design.md
+++ b/openspec/changes/river-query-workers/design.md
@@ -1,0 +1,120 @@
+## Context
+
+In PostgreSQL mode (`ARK_STORAGE_BACKEND != etcd`), Ark runs an embedded aggregated API server (`ark/internal/apiserver/server.go`) that stores all resources in a PostgreSQL `resources` table. The query reconciler watches Query CRs via controller-runtime's `client.Client` (pointed at the embedded API server), spawns a goroutine per query tracked in a `sync.Map`, and updates status via the Kubernetes client. LISTEN/NOTIFY on the `resources` table drives watch events.
+
+The current approach has limitations: goroutines are lost on crash (queries stuck in `running`), `sync.Map` only prevents duplicates within a single process, there's no backpressure or retry, and in-flight state is opaque.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Durable query execution that survives process restarts
+- Exclusive locking via PostgreSQL advisory locks (replacing `sync.Map`)
+- Automatic retry with backoff for transient failures (LLM timeouts, rate limits)
+- Configurable worker concurrency with backpressure
+- Queryable job state for operator debugging
+- Zero changes to the Query CRD API surface
+- Shared execution logic between etcd mode (reconciler) and PostgreSQL mode (River worker)
+
+**Non-Goals:**
+- Separate worker pods / horizontal scaling (future evolution)
+- Changes to the etcd code path
+- New query phases (e.g. "retrying")
+- Migration of other resource types to River
+
+## Decisions
+
+### 1. River as the job queue library
+
+**Choice:** Use `github.com/riverqueue/river` for PostgreSQL-native job queuing.
+
+**Why River over alternatives:**
+- Go-native, uses `pgx` (Ark already depends on PostgreSQL)
+- Advisory lock-based exclusive locking via `SELECT ... FOR UPDATE SKIP LOCKED`
+- Built-in retry with configurable backoff
+- Periodic job support (for TTL cleanup)
+- In-process client — no separate broker infrastructure
+- Active maintenance, well-documented
+
+**Alternatives considered:**
+- Raw goroutines with `pg_advisory_lock`: More control but reinvents retry, backoff, observability
+- Temporal/other workflow engines: Too heavy for this use case, adds infrastructure dependency
+- Redis-based queues (Asynq): Adds Redis dependency when PostgreSQL is already present
+
+### 2. Job enqueue at the storage layer (transactional)
+
+**Choice:** Enqueue a River job in the same database transaction as the Query resource INSERT in `postgresql.go`.
+
+**Why:** Atomicity — the query and its execution job either both exist or neither does. No window where a query exists but its job was lost.
+
+**Implementation:** The `PostgreSQLBackend.Create()` method detects `kind == "Query"` and enqueues a River job in the same transaction. This requires converting the single `ExecContext` call to a transaction.
+
+**Alternative considered:** A thin reconciler that watches for new queries and enqueues — adds latency and a failure window between query creation and job enqueue.
+
+### 3. Workers write status directly to PostgreSQL
+
+**Choice:** Workers update the `resources` table directly using SQL (not through the Kubernetes API server).
+
+**Why:**
+- Avoids network round-trip back to the embedded API server
+- The existing LISTEN/NOTIFY trigger on the `resources` table still fires, so watchers are notified
+- Workers must bump `resource_version` atomically to maintain optimistic concurrency
+
+**Trade-off:** Bypasses admission/validation on status updates. Acceptable because status writes are internal (not user-facing) and the current reconciler also writes status without re-validation.
+
+### 4. In-process River client (same binary)
+
+**Choice:** River client runs as goroutines within the existing Ark controller process, started as a manager runnable alongside the embedded API server.
+
+**Why:** Minimal deployment change. Same binary, same process, same `client.Client` for resolving Agent/Model/Team/Tool CRDs. Gets durability and locking benefits without operational complexity.
+
+**Future path:** Workers can be extracted to separate pods later by running the same binary with a `--mode=worker` flag and sharing the PostgreSQL connection.
+
+### 5. Export execution function from controller package
+
+**Choice:** Export `ExecuteQuery` (currently `executeQueryAsync`) from the controller package. Both the reconciler (etcd mode) and River worker (PostgreSQL mode) call it.
+
+**Why:** Single source of truth for query execution logic. The function already has all the right dependencies via the `QueryReconciler` struct — the worker can construct one with the same fields.
+
+**What changes:** The function signature becomes exported. Status update calls within it need to be abstracted or handled by the caller. The worker will construct a `QueryReconciler` value (not registering it as a controller) purely to access the execution method.
+
+### 6. Disable query reconciler in PostgreSQL mode
+
+**Choice:** Skip registering the `QueryReconciler` with the controller manager when `ARK_STORAGE_BACKEND` is not etcd.
+
+**Implementation:** `setupControllers()` in `main.go` checks the environment variable and omits the Query controller from the registration list. All other controllers remain unchanged.
+
+### 7. Error classification for retry
+
+**Choice:** Classify errors as retryable or permanent. River retries transient errors; permanent errors immediately cancel the job and set `phase: error`.
+
+**Retryable:** LLM provider timeouts, HTTP 429/502/503, transient network errors, memory service temporarily unavailable.
+
+**Permanent:** Target not found (Agent/Model/Team/Tool doesn't exist), validation errors, auth/RBAC failures, malformed input.
+
+**Implementation:** A helper function `IsRetryable(error) bool` checks error types and HTTP status codes. The River worker returns the error for retry or calls `river.JobCancel` for permanent failures.
+
+### 8. TTL cleanup as River periodic job
+
+**Choice:** Replace reconciler-based TTL expiry with a River periodic job that runs on a configurable interval (default: every 10 minutes).
+
+**Implementation:** The periodic job queries `SELECT FROM resources WHERE kind='Query' AND created_at + ttl < NOW()` and deletes expired queries. This is more efficient than the current approach where every reconcile checks TTL.
+
+### 9. Cancellation via spec.cancel check
+
+**Choice:** Workers check `spec.cancel` on the Query resource periodically during execution rather than relying on a separate watcher.
+
+**Implementation:** Between major execution steps (after resolving target, before/after LLM call), the worker re-reads the Query from PostgreSQL and checks `spec.cancel`. If true, it cancels the execution context and returns. River's built-in cancellation propagates through the context.
+
+## Risks / Trade-offs
+
+**[Risk] River schema migration** → River requires its own tables (`river_job`, `river_leader`, etc.). These must be created during `initSchema()`. River provides migration helpers. Low risk since it's additive.
+
+**[Risk] Direct PG status writes bypass optimistic concurrency** → Workers write status without checking `resource_version` from the API server's perspective. Mitigated by: only one worker processes a query at a time (exclusive lock), and workers read-then-write with their own `resource_version` check.
+
+**[Risk] `database/sql` vs `pgx` pool** → The current PostgreSQL backend uses `database/sql` with `lib/pq`. River requires `pgx`. This means either migrating the backend to `pgx` or maintaining two connection pools. Recommendation: use a separate `pgx` pool for River, migrate the backend later.
+
+**[Risk] Execution function coupling** → Exporting `executeQueryAsync` ties the worker to the controller package. If the function's dependencies change, the worker must adapt. Mitigated by: the worker constructs a `QueryReconciler` value directly, so it automatically picks up dependency changes.
+
+**[Trade-off] Two connection pools** → Short-term cost of maintaining `database/sql` (existing backend) and `pgxpool` (River). Acceptable as a transitional state.
+
+**[Trade-off] Query reconciler still exists** → The reconciler code remains for etcd mode. Two code paths for query execution until etcd mode is deprecated or also migrated.

--- a/openspec/changes/river-query-workers/proposal.md
+++ b/openspec/changes/river-query-workers/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+In PostgreSQL mode, query execution relies on the Kubernetes reconciler pattern: a single controller watches Query CRs, spawns goroutines tracked in a `sync.Map`, and loses all in-flight work on crash. This is fragile — queries stuck in `phase: running` after a crash have no recovery path. The `sync.Map` only prevents duplicates within a single process, provides no backpressure, and is opaque to operators. Since PostgreSQL is already the storage backend in this mode, we can use River (a Go-native PostgreSQL job queue) to get durable execution, exclusive locking, automatic retries, and configurable concurrency — all within the same process.
+
+## What Changes
+
+- Enqueue a River job transactionally when a Query resource is created in the PostgreSQL storage layer (same INSERT transaction)
+- In-process River workers (goroutines managed by River client) dequeue and execute queries using the existing exported execution logic from the controller package
+- Workers write query status directly to PostgreSQL (with `resource_version` bump to trigger LISTEN/NOTIFY for watchers)
+- Disable the query reconciler when running in PostgreSQL mode
+- Replace `sync.Map` duplicate prevention with River's exclusive locking (PG advisory locks via `SELECT ... FOR UPDATE SKIP LOCKED`)
+- Classify execution errors as retryable (LLM timeouts, rate limits, transient network) vs permanent (invalid target, auth failure) — River retries transient errors with backoff, permanent errors set `phase: error` immediately
+- Replace TTL expiry logic with a River periodic job
+- Handle cancellation by having workers check `spec.cancel` during execution
+- Export the query execution function from the controller package so both the reconciler (etcd mode) and River worker (PostgreSQL mode) can call it
+- The etcd/reconciler code path remains unchanged
+
+## Capabilities
+
+### New Capabilities
+- `river-job-queue`: River client setup, worker registration, job enqueue integration with PostgreSQL storage layer
+- `query-worker`: River worker that dequeues query jobs, executes via shared logic, writes status directly to PostgreSQL
+- `query-ttl-cleanup`: River periodic job replacing reconciler-based TTL expiry
+- `error-classification`: Retryable vs permanent error classification for River retry semantics
+
+### Modified Capabilities
+
+## Impact
+
+- **Code**: `ark/internal/storage/postgresql/postgresql.go` (job enqueue on Query CREATE), `ark/internal/controller/query_controller.go` (export execution function, disable in PG mode), `ark/cmd/main.go` (start River client conditionally), new `ark/internal/worker/` package
+- **Dependencies**: New Go dependency on `github.com/riverqueue/river` and `github.com/riverqueue/river/riverdriver/riverpgxv5`
+- **Database**: River migration tables (`river_job`, `river_leader`, etc.) added to PostgreSQL
+- **APIs**: No changes to Query CRD spec/status — phases remain `pending/running/done/error/canceled`
+- **Deployment**: No topology change — workers run in-process in the same binary

--- a/openspec/changes/river-query-workers/specs/error-classification/spec.md
+++ b/openspec/changes/river-query-workers/specs/error-classification/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Transient errors trigger retry
+The system SHALL classify certain execution errors as transient and allow River to retry them with backoff.
+
+#### Scenario: LLM provider timeout
+- **WHEN** query execution fails with a context deadline exceeded or timeout error from the LLM provider
+- **THEN** the worker returns the error to River (triggering retry)
+- **AND** the query `phase` remains "running"
+
+#### Scenario: HTTP 429 rate limit
+- **WHEN** query execution fails with an HTTP 429 response
+- **THEN** the worker returns the error to River (triggering retry)
+
+#### Scenario: HTTP 502/503 transient server error
+- **WHEN** query execution fails with an HTTP 502 or 503 response
+- **THEN** the worker returns the error to River (triggering retry)
+
+#### Scenario: Memory service temporarily unavailable
+- **WHEN** query execution fails because the memory service is unreachable
+- **THEN** the worker returns the error to River (triggering retry)
+
+### Requirement: Permanent errors cancel the job
+The system SHALL classify certain execution errors as permanent and immediately cancel the River job.
+
+#### Scenario: Target resource not found
+- **WHEN** query execution fails because the target Agent/Model/Team/Tool does not exist
+- **THEN** the worker cancels the River job
+- **AND** the worker writes `phase: error` with the error message to the Query status
+
+#### Scenario: Validation or input error
+- **WHEN** query execution fails due to malformed input or validation failure
+- **THEN** the worker cancels the River job
+- **AND** the worker writes `phase: error` to the Query status
+
+#### Scenario: Auth/RBAC failure
+- **WHEN** query execution fails due to insufficient permissions (impersonation failure, forbidden)
+- **THEN** the worker cancels the River job
+- **AND** the worker writes `phase: error` to the Query status
+
+### Requirement: Max retry attempts
+The system SHALL set a maximum number of retry attempts for transient errors.
+
+#### Scenario: Retries exhausted
+- **WHEN** a query has been retried the maximum number of times (default: 5)
+- **AND** it still fails with a transient error
+- **THEN** River discards the job
+- **AND** the worker writes `phase: error` to the Query status with the last error message

--- a/openspec/changes/river-query-workers/specs/query-ttl-cleanup/spec.md
+++ b/openspec/changes/river-query-workers/specs/query-ttl-cleanup/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Periodic TTL cleanup job
+The system SHALL run a River periodic job that deletes Query resources whose TTL has expired.
+
+#### Scenario: Expired queries are deleted
+- **WHEN** the TTL cleanup periodic job runs
+- **THEN** it queries the `resources` table for Query resources where `created_at + spec.ttl < NOW()`
+- **AND** deletes each expired query from the `resources` table
+- **AND** the DELETE trigger fires LISTEN/NOTIFY for each deletion
+
+#### Scenario: Queries without TTL use default expiry
+- **WHEN** a Query resource has no `spec.ttl` set (nil or omitted)
+- **THEN** the cleanup job uses a default TTL of 1 hour (matching the current reconciler default)
+
+#### Scenario: Cleanup job runs periodically
+- **WHEN** the River client is started
+- **THEN** a periodic job for TTL cleanup is registered with a default interval of 10 minutes
+
+#### Scenario: Running queries are not deleted
+- **WHEN** a Query resource has expired TTL but its `status.phase` is "running"
+- **THEN** the cleanup job skips it (to avoid deleting actively executing queries)

--- a/openspec/changes/river-query-workers/specs/query-worker/spec.md
+++ b/openspec/changes/river-query-workers/specs/query-worker/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: River worker executes queries
+The system SHALL implement a River worker that dequeues `query_execute` jobs and executes them using the exported execution logic from the controller package.
+
+#### Scenario: Successful query execution
+- **WHEN** a `query_execute` job is dequeued by a worker
+- **THEN** the worker reads the Query resource from the PostgreSQL `resources` table using the namespace and name from the job args
+- **AND** the worker calls the exported execution function from the controller package
+- **AND** on success, the worker writes `phase: done`, response, token usage, and duration to the Query's status directly in PostgreSQL
+- **AND** `resource_version` is incremented atomically on status write
+- **AND** the LISTEN/NOTIFY trigger fires, notifying watchers
+
+#### Scenario: Query not found
+- **WHEN** a `query_execute` job is dequeued but the Query resource no longer exists in the `resources` table
+- **THEN** the worker cancels the job (no retry)
+
+### Requirement: Worker sets initial status before execution
+The system SHALL transition the query to `phase: running` with appropriate conditions before beginning execution.
+
+#### Scenario: Status set to running
+- **WHEN** a worker begins processing a `query_execute` job
+- **THEN** the worker writes `phase: running` and condition `QueryCompleted=False, reason=QueryRunning` to the Query status in PostgreSQL
+- **AND** `resource_version` is incremented
+
+### Requirement: Exclusive locking prevents duplicate execution
+The system SHALL use River's exclusive locking to ensure only one worker processes a given query at a time.
+
+#### Scenario: Duplicate job prevented
+- **WHEN** a `query_execute` job exists for namespace/name "default/my-query"
+- **AND** another `query_execute` job is enqueued for the same namespace/name
+- **THEN** the duplicate job is not created (River unique constraint)
+
+#### Scenario: Concurrent dequeue prevented
+- **WHEN** worker A is processing a `query_execute` job
+- **AND** worker B attempts to dequeue the same job
+- **THEN** worker B skips the job (`SELECT ... FOR UPDATE SKIP LOCKED`)
+
+### Requirement: Worker handles cancellation
+The system SHALL check for query cancellation during execution.
+
+#### Scenario: Query cancelled during execution
+- **WHEN** a worker is executing a query
+- **AND** the Query resource's `spec.cancel` field is set to `true`
+- **THEN** the worker detects the cancellation (by re-reading the Query between execution steps)
+- **AND** the worker cancels the execution context
+- **AND** the worker writes `phase: canceled` to the Query status
+- **AND** the River job is marked as cancelled
+
+### Requirement: Worker constructs QueryReconciler for execution
+The system SHALL construct a `QueryReconciler` value with the required dependencies (Client, Scheme, Telemetry, Eventing) to call the exported execution function.
+
+#### Scenario: Worker has access to shared dependencies
+- **WHEN** the River worker is initialized
+- **THEN** it holds references to the same `client.Client`, `runtime.Scheme`, telemetry provider, and eventing provider used by the controller manager
+- **AND** these are injected during River client setup

--- a/openspec/changes/river-query-workers/specs/river-job-queue/spec.md
+++ b/openspec/changes/river-query-workers/specs/river-job-queue/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: River client initialization
+The system SHALL initialize a River client with a `pgxpool.Pool` connection when the storage backend is PostgreSQL. The River client SHALL be added to the controller manager as a runnable and started alongside the embedded API server.
+
+#### Scenario: River client starts in PostgreSQL mode
+- **WHEN** `ARK_STORAGE_BACKEND` is set to a value other than "" or "etcd"
+- **THEN** a River client is created with a `pgxpool.Pool` using the same PostgreSQL connection parameters as the embedded API server
+- **AND** the River client is added to the manager via `mgr.Add()`
+- **AND** River's migration tables (`river_job`, `river_leader`, etc.) are created if they don't exist
+
+#### Scenario: River client does not start in etcd mode
+- **WHEN** `ARK_STORAGE_BACKEND` is "" or "etcd"
+- **THEN** no River client is created
+- **AND** the query reconciler operates as before
+
+### Requirement: Transactional job enqueue on Query CREATE
+The system SHALL enqueue a River job in the same database transaction as the Query resource INSERT when the storage backend is PostgreSQL.
+
+#### Scenario: Query creation enqueues execution job
+- **WHEN** a Query resource is created via the embedded API server
+- **THEN** a River job of type `query_execute` is inserted in the same transaction as the resource INSERT
+- **AND** the job args contain the query's namespace and name
+- **AND** the job has a unique constraint on (namespace, name) to prevent duplicate jobs
+
+#### Scenario: Failed job enqueue rolls back query creation
+- **WHEN** a Query resource INSERT succeeds but the River job INSERT fails
+- **THEN** the entire transaction is rolled back
+- **AND** the Query resource is not persisted
+
+### Requirement: Configurable worker concurrency
+The system SHALL support configuring the maximum number of concurrent River workers.
+
+#### Scenario: Default worker concurrency
+- **WHEN** no worker concurrency is configured
+- **THEN** River starts with a default of 10 workers
+
+#### Scenario: Custom worker concurrency via environment variable
+- **WHEN** `ARK_QUERY_WORKERS` is set to a positive integer
+- **THEN** River starts with that number of max workers
+
+### Requirement: Query reconciler disabled in PostgreSQL mode
+The system SHALL skip registration of the `QueryReconciler` controller when the storage backend is PostgreSQL.
+
+#### Scenario: Query reconciler not registered
+- **WHEN** `ARK_STORAGE_BACKEND` is set to a value other than "" or "etcd"
+- **THEN** the `QueryReconciler` is not added to the controller manager
+- **AND** all other reconcilers (Agent, Model, Team, etc.) are registered normally

--- a/openspec/changes/river-query-workers/tasks.md
+++ b/openspec/changes/river-query-workers/tasks.md
@@ -1,0 +1,43 @@
+## 1. Dependencies and River Setup
+
+- [ ] 1.1 Add `github.com/riverqueue/river`, `github.com/riverqueue/river/riverdriver/riverpgxv5`, and `github.com/jackc/pgx/v5` to `ark/go.mod`
+- [ ] 1.2 Create `ark/internal/worker/client.go` — River client initialization: create `pgxpool.Pool` from PostgreSQL config, run River migrations, configure worker count from `ARK_QUERY_WORKERS` env var (default 10), return a `river.Client` and a manager-compatible runnable
+- [ ] 1.3 Wire River client startup in `ark/cmd/main.go` — in `setupEmbeddedApiserver()`, create the River client and add it to the manager via `mgr.Add()`; pass shared dependencies (client.Client, Scheme, telemetry, eventing providers)
+
+## 2. Export Execution Logic
+
+- [ ] 2.1 Export the query execution function in `ark/internal/controller/query_controller.go` — rename `executeQueryAsync` to `ExecuteQueryAsync` (or extract an exported wrapper) so the worker package can call it
+- [ ] 2.2 Verify the exported function works with a `QueryReconciler` value constructed outside the controller manager (no `SetupWithManager` call needed)
+
+## 3. Transactional Job Enqueue
+
+- [ ] 3.1 Modify `ark/internal/storage/postgresql/postgresql.go` — refactor `Create()` to use a transaction; when `kind == "Query"`, enqueue a `query_execute` River job with `{namespace, name}` args and a unique constraint on (namespace, name) within the same transaction
+- [ ] 3.2 Pass the River client (or a job insert interface) to `PostgreSQLBackend` so it can enqueue jobs — update `New()` constructor and `apiserver/server.go` wiring
+
+## 4. Query Worker Implementation
+
+- [ ] 4.1 Create `ark/internal/worker/query_execute.go` — define `QueryExecuteArgs` struct (namespace, name) and `QueryExecuteWorker` implementing `river.Worker[QueryExecuteArgs]`
+- [ ] 4.2 Implement the `Work()` method: read Query from `resources` table, set status to `running`, construct `QueryReconciler` value, call exported execution function, write final status (done/error/canceled) directly to PostgreSQL with `resource_version` bump
+- [ ] 4.3 Add cancellation checking — between major execution steps, re-read the Query from PostgreSQL and check `spec.cancel`; if true, cancel context and write `phase: canceled`
+
+## 5. Error Classification
+
+- [ ] 5.1 Create `ark/internal/worker/errors.go` — implement `IsRetryable(error) bool` that checks for transient patterns: context deadline exceeded, HTTP 429/502/503, connection refused, memory service unavailable
+- [ ] 5.2 Wire error classification in `QueryExecuteWorker.Work()` — return error for retryable failures (River retries), return `river.JobCancel` for permanent failures (target not found, auth failure, validation error)
+- [ ] 5.3 Set `MaxAttempts: 5` on the `query_execute` job type; on final attempt failure, write `phase: error` to the Query status
+
+## 6. TTL Cleanup
+
+- [ ] 6.1 Create `ark/internal/worker/query_cleanup.go` — implement a River periodic job that runs every 10 minutes, queries for expired queries (`created_at + ttl < NOW()` and `phase != 'running'`), and deletes them from the `resources` table
+- [ ] 6.2 Register the periodic job in the River client setup
+
+## 7. Disable Query Reconciler in PG Mode
+
+- [ ] 7.1 Modify `setupControllers()` in `ark/cmd/main.go` — skip `QueryReconciler` registration when `ARK_STORAGE_BACKEND` is not "" or "etcd"
+
+## 8. Testing
+
+- [ ] 8.1 Unit test `IsRetryable()` with transient and permanent error cases
+- [ ] 8.2 Unit test `QueryExecuteWorker.Work()` with mocked PostgreSQL backend and execution function — verify status transitions, retry behavior, and cancellation
+- [ ] 8.3 Integration test: verify transactional enqueue — Query CREATE results in both a resource row and a River job row
+- [ ] 8.4 Integration test: verify end-to-end flow — Query CREATE → job dequeue → execution → status update with correct phase and response


### PR DESCRIPTION
## Summary

- Propose replacing the query reconciler with River job queue workers when running in PostgreSQL mode
- Design transactional job enqueue in the same DB transaction as Query CREATE for atomicity
- Specify exclusive locking via PG advisory locks to replace the fragile sync.Map pattern
- Define error classification (retryable vs permanent) with automatic retry and backoff
- Add specs for worker execution, TTL cleanup periodic job, and configurable concurrency
- Break implementation into 19 tasks across 8 groups ready for `/opsx:apply`

## Test plan

- [ ] Review proposal for correctness against current query reconciler behavior
- [ ] Verify design decisions align with existing PostgreSQL storage backend patterns
- [ ] Confirm task ordering respects implementation dependencies