### PR TITLE
chore: Move selector prompt to advanced settings

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as z from 'zod';
 
 import { SelectorSection } from '@/components/forms/team-form/sections/selector-section';
@@ -35,10 +35,10 @@ function Wrapper({
   disabled = false,
   initialSelectorPrompt = 'test prompt',
 }: {
-  strategy?: string;
-  unavailableAgents?: string[];
-  disabled?: boolean;
-  initialSelectorPrompt?: string;
+  readonly strategy?: string;
+  readonly unavailableAgents?: string[];
+  readonly disabled?: boolean;
+  readonly initialSelectorPrompt?: string;
 }) {
   const form = useForm({
     resolver: zodResolver(schema),
@@ -189,7 +189,9 @@ describe('SelectorSection', () => {
         'Enter the selector prompt...',
       );
       expect(textarea).toHaveValue(MOCK_DEFAULT_PROMPT);
-      expect(MOCK_DEFAULT_PROMPT).toBe('This is the mocked default prompt for testing');
+      expect(MOCK_DEFAULT_PROMPT).toBe(
+        'This is the mocked default prompt for testing',
+      );
     });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
@@ -2,12 +2,18 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod';
 
 import { SelectorSection } from '@/components/forms/team-form/sections/selector-section';
 import { Form } from '@/components/ui/form';
 import type { Agent } from '@/lib/services';
+
+vi.mock('@/components/forms/team-form/use-team-form', () => ({
+  DEFAULT_SELECTOR_PROMPT: 'This is the mocked default prompt for testing',
+}));
+
+const MOCK_DEFAULT_PROMPT = 'This is the mocked default prompt for testing';
 
 const schema = z.object({
   name: z.string(),
@@ -27,10 +33,12 @@ function Wrapper({
   strategy = 'selector',
   unavailableAgents = [] as string[],
   disabled = false,
+  initialSelectorPrompt = 'test prompt',
 }: {
   strategy?: string;
   unavailableAgents?: string[];
   disabled?: boolean;
+  initialSelectorPrompt?: string;
 }) {
   const form = useForm({
     resolver: zodResolver(schema),
@@ -40,7 +48,7 @@ function Wrapper({
       strategy,
       maxTurns: '',
       selectorAgent: '',
-      selectorPrompt: 'test prompt',
+      selectorPrompt: initialSelectorPrompt,
     },
   });
 
@@ -72,15 +80,23 @@ describe('SelectorSection', () => {
     expect(screen.getByText('Selector Agent')).toBeInTheDocument();
   });
 
-  it('should render selector prompt textarea', () => {
+  it('should render selector prompt textarea in advanced settings', async () => {
+    const user = userEvent.setup();
     render(<Wrapper />);
+
+    await user.click(screen.getByText('Advanced Settings'));
+
     expect(
       screen.getByPlaceholderText('Enter the selector prompt...'),
     ).toBeInTheDocument();
   });
 
-  it('should show character count when prompt has content', () => {
+  it('should show character count when prompt has content', async () => {
+    const user = userEvent.setup();
     render(<Wrapper />);
+
+    await user.click(screen.getByText('Advanced Settings'));
+
     expect(screen.getByText('11 characters')).toBeInTheDocument();
   });
 
@@ -95,9 +111,85 @@ describe('SelectorSection', () => {
     const user = userEvent.setup();
     render(<Wrapper />);
 
+    await user.click(screen.getByText('Advanced Settings'));
+
     expect(screen.getByText('Expand')).toBeInTheDocument();
     await user.click(screen.getByText('Expand'));
     expect(screen.getByText('Collapse')).toBeInTheDocument();
     expect(screen.getByText('1 lines')).toBeInTheDocument();
+  });
+
+  describe('Reset to Default Prompt button', () => {
+    it('should render reset button in advanced settings', async () => {
+      const user = userEvent.setup();
+      render(<Wrapper />);
+
+      await user.click(screen.getByText('Advanced Settings'));
+
+      expect(
+        screen.getByRole('button', { name: /Reset to Default Prompt/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('should reset prompt to mocked default value when clicked', async () => {
+      const user = userEvent.setup();
+      render(<Wrapper initialSelectorPrompt="custom prompt value" />);
+
+      await user.click(screen.getByText('Advanced Settings'));
+
+      const textarea = screen.getByPlaceholderText(
+        'Enter the selector prompt...',
+      );
+      expect(textarea).toHaveValue('custom prompt value');
+
+      const resetButton = screen.getByRole('button', {
+        name: /Reset to Default Prompt/i,
+      });
+      await user.click(resetButton);
+
+      expect(textarea).toHaveValue(MOCK_DEFAULT_PROMPT);
+    });
+
+    it('should be disabled when form is disabled', async () => {
+      const user = userEvent.setup();
+      render(<Wrapper disabled={true} />);
+
+      await user.click(screen.getByText('Advanced Settings'));
+
+      const resetButton = screen.getByRole('button', {
+        name: /Reset to Default Prompt/i,
+      });
+      expect(resetButton).toBeDisabled();
+    });
+
+    it('should be enabled when form is not disabled', async () => {
+      const user = userEvent.setup();
+      render(<Wrapper disabled={false} />);
+
+      await user.click(screen.getByText('Advanced Settings'));
+
+      const resetButton = screen.getByRole('button', {
+        name: /Reset to Default Prompt/i,
+      });
+      expect(resetButton).toBeEnabled();
+    });
+
+    it('should use the exact mocked constant value', async () => {
+      const user = userEvent.setup();
+      render(<Wrapper initialSelectorPrompt="" />);
+
+      await user.click(screen.getByText('Advanced Settings'));
+
+      const resetButton = screen.getByRole('button', {
+        name: /Reset to Default Prompt/i,
+      });
+      await user.click(resetButton);
+
+      const textarea = screen.getByPlaceholderText(
+        'Enter the selector prompt...',
+      );
+      expect(textarea).toHaveValue(MOCK_DEFAULT_PROMPT);
+      expect(MOCK_DEFAULT_PROMPT).toBe('This is the mocked default prompt for testing');
+    });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
@@ -1,8 +1,13 @@
-import { Maximize2, Minimize2, Zap } from 'lucide-react';
+import { ChevronDown, ChevronRight, Maximize2, Minimize2, Settings2, Zap } from 'lucide-react';
 import { useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   FormControl,
   FormField,
@@ -37,6 +42,7 @@ export function SelectorSection({
   disabled,
 }: Readonly<SelectorSectionProps>) {
   const [isPromptExpanded, setIsPromptExpanded] = useState(false);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const selectedStrategy = form.watch('strategy');
 
   if (selectedStrategy !== 'selector') {
@@ -101,64 +107,79 @@ export function SelectorSection({
         )}
       />
 
-      <FormField
-        control={form.control}
-        name="selectorPrompt"
-        render={({ field }) => (
-          <FormItem>
-            <div className="flex items-center justify-between">
-              <FormLabel>Selector Prompt</FormLabel>
-              <div className="flex items-center gap-2">
-                {field.value && field.value.length > 0 && (
-                  <span className="text-muted-foreground text-xs">
-                    {field.value.length} characters
-                  </span>
+      <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+        <CollapsibleTrigger className="flex w-full items-center justify-start gap-2 px-0 hover:bg-transparent">
+          {isAdvancedOpen ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+          <Settings2 className="h-4 w-4 text-muted-foreground" />
+          <span className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+            Advanced Settings
+          </span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-4 pt-4" style={{ marginLeft: 0 }}>
+          <FormField
+            control={form.control}
+            name="selectorPrompt"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Selector Prompt</FormLabel>
+                  <div className="flex items-center gap-2">
+                    {field.value && field.value.length > 0 && (
+                      <span className="text-muted-foreground text-xs">
+                        {field.value.length} characters
+                      </span>
+                    )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setIsPromptExpanded(!isPromptExpanded)}
+                      className="h-8 px-2">
+                      {isPromptExpanded ? (
+                        <>
+                          <Minimize2 className="mr-1 h-4 w-4" />
+                          Collapse
+                        </>
+                      ) : (
+                        <>
+                          <Maximize2 className="mr-1 h-4 w-4" />
+                          Expand
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+                <FormControl>
+                  <Textarea
+                    placeholder="Enter the selector prompt..."
+                    disabled={disabled}
+                    className={`resize-none transition-all duration-200 ${
+                      isPromptExpanded
+                        ? 'max-h-[500px] min-h-[400px] overflow-y-auto'
+                        : 'max-h-[150px] min-h-[100px]'
+                    }`}
+                    style={{
+                      whiteSpace: 'pre-wrap',
+                      wordWrap: 'break-word',
+                    }}
+                    {...field}
+                  />
+                </FormControl>
+                {isPromptExpanded && field.value && field.value.length > 0 && (
+                  <div className="text-muted-foreground text-xs">
+                    {field.value.split('\n').length} lines
+                  </div>
                 )}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsPromptExpanded(!isPromptExpanded)}
-                  className="h-8 px-2">
-                  {isPromptExpanded ? (
-                    <>
-                      <Minimize2 className="mr-1 h-4 w-4" />
-                      Collapse
-                    </>
-                  ) : (
-                    <>
-                      <Maximize2 className="mr-1 h-4 w-4" />
-                      Expand
-                    </>
-                  )}
-                </Button>
-              </div>
-            </div>
-            <FormControl>
-              <Textarea
-                placeholder="Enter the selector prompt..."
-                disabled={disabled}
-                className={`resize-none transition-all duration-200 ${
-                  isPromptExpanded
-                    ? 'max-h-[500px] min-h-[400px] overflow-y-auto'
-                    : 'max-h-[150px] min-h-[100px]'
-                }`}
-                style={{
-                  whiteSpace: 'pre-wrap',
-                  wordWrap: 'break-word',
-                }}
-                {...field}
-              />
-            </FormControl>
-            {isPromptExpanded && field.value && field.value.length > 0 && (
-              <div className="text-muted-foreground text-xs">
-                {field.value.split('\n').length} lines
-              </div>
+                <FormMessage />
+              </FormItem>
             )}
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+          />
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
@@ -1,7 +1,8 @@
-import { ChevronDown, ChevronRight, Maximize2, Minimize2, RotateCcw, Settings2, Zap } from 'lucide-react';
+import { AlertCircle, ChevronDown, ChevronRight, Maximize2, Minimize2, RotateCcw, Settings2, Zap } from 'lucide-react';
 import { useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   Collapsible,
@@ -175,6 +176,13 @@ export function SelectorSection({
                   </div>
                 )}
                 <FormMessage />
+                <Alert variant="warning" className="mt-2">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    Changing the prompt will affect team turn order and can worsen performance.
+                    Use the reset button to restore the default prompt.
+                  </AlertDescription>
+                </Alert>
                 <Button
                   type="button"
                   variant="outline"

--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Maximize2, Minimize2, Settings2, Zap } from 'lucide-react';
+import { ChevronDown, ChevronRight, Maximize2, Minimize2, RotateCcw, Settings2, Zap } from 'lucide-react';
 import { useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -26,7 +26,7 @@ import { Textarea } from '@/components/ui/textarea';
 import type { Agent } from '@/lib/services';
 import { cn } from '@/lib/utils';
 
-import type { TeamFormValues } from '../use-team-form';
+import { DEFAULT_SELECTOR_PROMPT, type TeamFormValues } from '../use-team-form';
 
 interface SelectorSectionProps {
   form: UseFormReturn<TeamFormValues>;
@@ -175,6 +175,16 @@ export function SelectorSection({
                   </div>
                 )}
                 <FormMessage />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => form.setValue('selectorPrompt', DEFAULT_SELECTOR_PROMPT, { shouldDirty: true })}
+                  disabled={disabled}
+                  className="mt-2">
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  Reset to Default Prompt
+                </Button>
               </FormItem>
             )}
           />


### PR DESCRIPTION
Adds an advanced settings dropdown to the selector team setup and puts the selector prompt in there, along with a warning and a reset button so users can restore their prompt to a working state.

Implements #1194 


https://github.com/user-attachments/assets/dba56a77-11d7-4c95-aaed-8441db8c60db



## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 