### PR TITLE
docs: add Deploy GCP, SonarQube, and Codecov badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml/badge.svg" alt="CI/CD"></a>
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml/badge.svg" alt="Deploy"></a>
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml/badge.svg" alt="Deploy GCP"></a>
-    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml/badge.svg" alt="SonarQube Scan"></a>
     <a href="https://codecov.io/gh/mckinsey/agents-at-scale-ark"><img src="https://codecov.io/gh/mckinsey/agents-at-scale-ark/branch/main/graph/badge.svg" alt="Coverage"></a>
+    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml/badge.svg" alt="SonarQube Scan"></a>
     <a href="https://www.npmjs.com/package/@agents-at-scale/ark"><img src="https://img.shields.io/npm/v/@agents-at-scale/ark.svg" alt="npm version"></a>
     <a href="https://pypi.org/project/ark-sdk/"><img src="https://img.shields.io/pypi/v/ark-sdk.svg" alt="PyPI version"></a>
   </p>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@
   <p align="center">
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml/badge.svg" alt="CI/CD"></a>
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml/badge.svg" alt="Deploy"></a>
+    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml/badge.svg" alt="Deploy GCP"></a>
+    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml/badge.svg" alt="SonarQube Scan"></a>
+    <a href="https://codecov.io/gh/mckinsey/agents-at-scale-ark"><img src="https://codecov.io/gh/mckinsey/agents-at-scale-ark/branch/main/graph/badge.svg" alt="Coverage"></a>
     <a href="https://www.npmjs.com/package/@agents-at-scale/ark"><img src="https://img.shields.io/npm/v/@agents-at-scale/ark.svg" alt="npm version"></a>
     <a href="https://pypi.org/project/ark-sdk/"><img src="https://img.shields.io/pypi/v/ark-sdk.svg" alt="PyPI version"></a>
-    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/agent-actions.yml"><img src="https://img.shields.io/badge/Agent_Actions-Running-green?logo=github-actions&logoColor=white" alt="Agent Actions - Running"></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- Add Deploy GCP, SonarQube Scan, and Codecov coverage badges
- Remove Agent Actions badge (workflow was deleted in #1322)