### PR TITLE
fix(ci): update Go version in CI workflows to match go.mod 1.25.8

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -185,7 +185,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -1035,7 +1035,7 @@ jobs:
       - name: Setup Go for coverage tools
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
 
       - name: Install Python coverage tools
         run: |
@@ -1250,7 +1250,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-coverage.outputs.found == 'false'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
           cache-dependency-path: ark/go.sum
 


### PR DESCRIPTION
## Summary

- Update `go-version` from 1.24.13 to 1.25.8 in `cicd.yaml` and `sonar_scan.yaml`
- Aligns CI Go toolchain with the go.mod requirement introduced by the Go 1.25.8 CVE fix
- Fixes coverage compilation failures caused by `go tool version` mismatch between the auto-downloaded 1.25.8 toolchain and the CI-installed 1.24.13
- Affects all 5 `setup-go` steps across both workflow files