### PR TITLE
fix: postgresql watch bookmarks and aggregation-smoke test

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -549,7 +549,11 @@ jobs:
         run: |
           cd tests
           mkdir -p /tmp/chainsaw-report
-          chainsaw test --config .chainsaw.yaml --selector '!evaluated,!llm'
+          if [ "${{ matrix.storage-backend }}" = "etcd" ]; then
+            chainsaw test --config .chainsaw.yaml --selector '!evaluated,!llm,!postgresql'
+          else
+            chainsaw test --config .chainsaw.yaml --selector '!evaluated,!llm'
+          fi
 
       - uses: ./.github/actions/collect-coverage-e2e
         with:

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -530,12 +530,16 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 	p.watchers[key] = append(p.watchers[key], ch)
 	p.mu.Unlock()
 
-	return &postgresWatcher{
+	w := &postgresWatcher{
 		ch:      ch,
 		backend: p,
 		key:     key,
+		kind:    kind,
 		ctx:     ctx,
-	}, nil
+		done:    make(chan struct{}),
+	}
+	go w.sendBookmarks()
+	return w, nil
 }
 
 func (p *PostgreSQLBackend) GetResourceVersion(ctx context.Context, kind, namespace, name string) (int64, error) {
@@ -635,18 +639,70 @@ func (p *PostgreSQLBackend) removeWatcher(key string, ch chan watch.Event) {
 	}
 }
 
+func (p *PostgreSQLBackend) getMaxResourceVersion() (int64, error) {
+	var rv sql.NullInt64
+	err := p.db.QueryRowContext(p.ctx, `SELECT MAX(resource_version) FROM resources`).Scan(&rv)
+	if err != nil {
+		return 0, err
+	}
+	if !rv.Valid {
+		return 0, nil
+	}
+	return rv.Int64, nil
+}
+
 type postgresWatcher struct {
 	ch      chan watch.Event
 	backend *PostgreSQLBackend
 	key     string
+	kind    string
 	ctx     context.Context
+	done    chan struct{}
 }
 
 func (w *postgresWatcher) Stop() {
 	w.backend.removeWatcher(w.key, w.ch)
+	close(w.done)
 	close(w.ch)
 }
 
 func (w *postgresWatcher) ResultChan() <-chan watch.Event {
 	return w.ch
+}
+
+func (w *postgresWatcher) sendBookmarks() {
+	w.sendBookmark()
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-w.ctx.Done():
+			return
+		case <-ticker.C:
+			w.sendBookmark()
+		}
+	}
+}
+
+func (w *postgresWatcher) sendBookmark() {
+	rv, err := w.backend.getMaxResourceVersion()
+	if err != nil {
+		return
+	}
+	obj := w.backend.converter.NewObject(w.kind)
+	if obj == nil {
+		return
+	}
+	if accessor, aErr := meta.Accessor(obj); aErr == nil {
+		accessor.SetResourceVersion(fmt.Sprintf("%d", rv))
+		accessor.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+	}
+	select {
+	case w.ch <- watch.Event{Type: watch.Bookmark, Object: obj}:
+	default:
+	}
 }

--- a/tests/aggregation-smoke/chainsaw-test.yaml
+++ b/tests/aggregation-smoke/chainsaw-test.yaml
@@ -2,20 +2,22 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: aggregation-smoke
+  labels:
+    postgresql: "true"
 spec:
   steps:
     - name: api-discovery
       try:
       - script:
           content: |
-            set -euo pipefail
+            set -eu
             echo "Checking ark.mckinsey.com/v1alpha1 API resources..."
             RESOURCES=$(kubectl api-resources --api-group=ark.mckinsey.com -o name)
             for kind in agents models queries teams; do
               if echo "$RESOURCES" | grep -q "^${kind}\."; then
-                echo "✓ ${kind} discovered"
+                echo "OK ${kind} discovered"
               else
-                echo "✗ ${kind} not found in API discovery"
+                echo "FAIL ${kind} not found in API discovery"
                 exit 1
               fi
             done
@@ -25,7 +27,7 @@ spec:
       try:
       - script:
           content: |
-            set -euo pipefail
+            set -eu
             cat <<'MANIFEST' | kubectl apply -n $NAMESPACE -f -
             apiVersion: ark.mckinsey.com/v1alpha1
             kind: Model
@@ -36,14 +38,14 @@ spec:
               model:
                 value: smoke-test
             MANIFEST
-            echo "✓ Model created"
+            echo "OK Model created"
 
             MODEL=$(kubectl get model smoke-test-model -n $NAMESPACE -o jsonpath='{.metadata.name}')
             if [ "$MODEL" != "smoke-test-model" ]; then
-              echo "✗ Model read-back failed: got '$MODEL'"
+              echo "FAIL Model read-back failed: got '$MODEL'"
               exit 1
             fi
-            echo "✓ Model read-back succeeded"
+            echo "OK Model read-back succeeded"
           env:
           - name: NAMESPACE
             value: ($namespace)
@@ -53,7 +55,7 @@ spec:
       try:
       - script:
           content: |
-            set -euo pipefail
+            set -eu
             kubectl get models -n $NAMESPACE --watch-only --timeout=5 &
             WATCH_PID=$!
             sleep 2
@@ -72,7 +74,7 @@ spec:
             sleep 3
             kill $WATCH_PID 2>/dev/null || true
             wait $WATCH_PID 2>/dev/null || true
-            echo "✓ Watch routing operational"
+            echo "OK Watch routing operational"
           env:
           - name: NAMESPACE
             value: ($namespace)


### PR DESCRIPTION
## Summary

Fixes for PR #1287 — makes E2E tests pass on both etcd and postgresql backends.

- **PostgreSQL watch bookmarks**: the storage backend never sent `watch.Bookmark` events, causing controller informers and `kubectl wait` to timeout. Adds immediate + periodic (30s) bookmark delivery
- **aggregation-smoke shell fix**: `set -euo pipefail` fails under `/bin/sh` (chainsaw default). Changed to `set -eu`
- **aggregation-smoke label**: added `postgresql: "true"` label so it only runs on the postgresql matrix, skipped on etcd via selector `!postgresql`