### PR TITLE
fix: restore HELM_ARGS array syntax broken by merge from main

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -90,19 +90,18 @@ fi
 echo "=== Installing ARK Controller ==="
 cd "${REPO_ROOT}/ark"
 
-# Deploy controller with impersonation enabled for E2E tests
-helm upgrade --install ark-controller ./dist/chart \
-  --namespace ark-system \
-  --create-namespace \
-  --wait --timeout=300s \
-  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller" \
-  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set controllerManager.container.image.pullPolicy=IfNotPresent \
-  --set queryEngine.enabled=true \
-  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine" \
-  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set queryEngine.container.image.pullPolicy=IfNotPresent \
-  --set rbac.enable=true \
+HELM_ARGS=(
+  --namespace ark-system
+  --create-namespace
+  --wait --timeout=300s
+  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller"
+  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}"
+  --set controllerManager.container.image.pullPolicy=IfNotPresent
+  --set queryEngine.enabled=true
+  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine"
+  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}"
+  --set queryEngine.container.image.pullPolicy=IfNotPresent
+  --set rbac.enable=true
   --set rbac.impersonation.enabled=true
 )
 


### PR DESCRIPTION
## Summary

The merge from main into this branch added `queryEngine` settings to `setup-local.sh` but broke the `HELM_ARGS=()` array syntax — the array opener was lost, leaving an orphan `)` on line 107. This caused all 6 E2E jobs to fail with `syntax error near unexpected token ')'`.