### PR TITLE
fix: postgresql watch initial events and aggregation-smoke model spec

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -90,19 +90,18 @@ fi
 echo "=== Installing ARK Controller ==="
 cd "${REPO_ROOT}/ark"
 
-# Deploy controller with impersonation enabled for E2E tests
-helm upgrade --install ark-controller ./dist/chart \
-  --namespace ark-system \
-  --create-namespace \
-  --wait --timeout=300s \
-  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller" \
-  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set controllerManager.container.image.pullPolicy=IfNotPresent \
-  --set queryEngine.enabled=true \
-  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine" \
-  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set queryEngine.container.image.pullPolicy=IfNotPresent \
-  --set rbac.enable=true \
+HELM_ARGS=(
+  --namespace ark-system
+  --create-namespace
+  --wait --timeout=300s
+  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller"
+  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}"
+  --set controllerManager.container.image.pullPolicy=IfNotPresent
+  --set queryEngine.enabled=true
+  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine"
+  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}"
+  --set queryEngine.container.image.pullPolicy=IfNotPresent
+  --set rbac.enable=true
   --set rbac.impersonation.enabled=true
 )
 

--- a/ark/internal/queryengine/handler_test.go
+++ b/ark/internal/queryengine/handler_test.go
@@ -14,8 +14,8 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
-	"mckinsey.com/ark/internal/genai"
 	eventingnoop "mckinsey.com/ark/internal/eventing/noop"
+	"mckinsey.com/ark/internal/genai"
 	telemetrynoop "mckinsey.com/ark/internal/telemetry/noop"
 )
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -530,6 +530,16 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 	p.watchers[key] = append(p.watchers[key], ch)
 	p.mu.Unlock()
 
+	existing, _, err := p.List(ctx, kind, namespace, storage.ListOptions{
+		LabelSelector: opts.LabelSelector,
+		FieldSelector: opts.FieldSelector,
+	})
+	if err == nil {
+		for _, obj := range existing {
+			ch <- watch.Event{Type: watch.Added, Object: obj}
+		}
+	}
+
 	w := &postgresWatcher{
 		ch:      ch,
 		backend: p,

--- a/tests/aggregation-smoke/chainsaw-test.yaml
+++ b/tests/aggregation-smoke/chainsaw-test.yaml
@@ -34,9 +34,15 @@ spec:
             metadata:
               name: smoke-test-model
             spec:
-              type: none
+              provider: openai
               model:
                 value: smoke-test
+              config:
+                openai:
+                  baseUrl:
+                    value: http://localhost:9999/v1
+                  apiKey:
+                    value: smoke-test-key
             MANIFEST
             echo "OK Model created"
 
@@ -66,9 +72,15 @@ spec:
             metadata:
               name: smoke-test-watch
             spec:
-              type: none
+              provider: openai
               model:
                 value: watch-test
+              config:
+                openai:
+                  baseUrl:
+                    value: http://localhost:9999/v1
+                  apiKey:
+                    value: smoke-test-key
             MANIFEST
 
             sleep 3


### PR DESCRIPTION
## Summary
- Watch() now sends existing objects as ADDED events before the bookmark, fixing kubectl wait timeouts with sendInitialEvents=true
- Updated aggregation-smoke model specs from `type: none` to `provider: openai` with dummy config (validation now requires a provider)