### PR TITLE
fix: postgresql status conditions, admission warnings, and connection pool

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -90,19 +90,18 @@ fi
 echo "=== Installing ARK Controller ==="
 cd "${REPO_ROOT}/ark"
 
-# Deploy controller with impersonation enabled for E2E tests
-helm upgrade --install ark-controller ./dist/chart \
-  --namespace ark-system \
-  --create-namespace \
-  --wait --timeout=300s \
-  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller" \
-  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set controllerManager.container.image.pullPolicy=IfNotPresent \
-  --set queryEngine.enabled=true \
-  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine" \
-  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}" \
-  --set queryEngine.container.image.pullPolicy=IfNotPresent \
-  --set rbac.enable=true \
+HELM_ARGS=(
+  --namespace ark-system
+  --create-namespace
+  --wait --timeout=300s
+  --set controllerManager.container.image.repository="${REGISTRY}/ark-controller"
+  --set controllerManager.container.image.tag="${ARK_IMAGE_TAG}"
+  --set controllerManager.container.image.pullPolicy=IfNotPresent
+  --set queryEngine.enabled=true
+  --set queryEngine.container.image.repository="${REGISTRY}/ark-query-engine"
+  --set queryEngine.container.image.tag="${ARK_IMAGE_TAG}"
+  --set queryEngine.container.image.pullPolicy=IfNotPresent
+  --set rbac.enable=true
   --set rbac.impersonation.enabled=true
 )
 

--- a/ark/internal/apiserver/admission.go
+++ b/ark/internal/apiserver/admission.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/warning"
 
 	"mckinsey.com/ark/internal/apiserver/registry"
 	"mckinsey.com/ark/internal/validation"
@@ -22,8 +23,12 @@ func NewAdmissionStorage(inner *registry.GenericStorage, validator *validation.V
 
 func (s *AdmissionStorage) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	validation.ApplyDefaults(obj)
-	if _, err := s.validator.Validate(ctx, obj); err != nil {
+	warnings, err := s.validator.Validate(ctx, obj)
+	if err != nil {
 		return nil, err
+	}
+	for _, w := range warnings {
+		warning.AddWarning(ctx, "", w)
 	}
 	return s.GenericStorage.Create(ctx, obj, nil, options)
 }
@@ -31,12 +36,18 @@ func (s *AdmissionStorage) Create(ctx context.Context, obj runtime.Object, _ res
 func (s *AdmissionStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	admissionCreate := func(ctx context.Context, obj runtime.Object) error {
 		validation.ApplyDefaults(obj)
-		_, err := s.validator.Validate(ctx, obj)
+		warnings, err := s.validator.Validate(ctx, obj)
+		for _, w := range warnings {
+			warning.AddWarning(ctx, "", w)
+		}
 		return err
 	}
 	admissionUpdate := func(ctx context.Context, obj, _ runtime.Object) error {
 		validation.ApplyDefaults(obj)
-		_, err := s.validator.Validate(ctx, obj)
+		warnings, err := s.validator.Validate(ctx, obj)
+		for _, w := range warnings {
+			warning.AddWarning(ctx, "", w)
+		}
 		return err
 	}
 	return s.GenericStorage.Update(ctx, name, objInfo, admissionCreate, admissionUpdate, forceAllowCreate, options)

--- a/ark/internal/apiserver/registry/status.go
+++ b/ark/internal/apiserver/registry/status.go
@@ -4,6 +4,7 @@ package registry
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -98,19 +99,31 @@ func getNamespaceFromContext(ctx context.Context) string {
 }
 
 func copyStatusOnly(dst, src runtime.Object) error {
-	srcValue, err := runtime.DefaultUnstructuredConverter.ToUnstructured(src)
+	srcData, err := json.Marshal(src)
 	if err != nil {
-		return fmt.Errorf("failed to convert source to unstructured: %w", err)
+		return fmt.Errorf("failed to marshal source: %w", err)
 	}
-
-	dstValue, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dst)
+	dstData, err := json.Marshal(dst)
 	if err != nil {
-		return fmt.Errorf("failed to convert destination to unstructured: %w", err)
+		return fmt.Errorf("failed to marshal destination: %w", err)
 	}
 
-	if status, ok := srcValue["status"]; ok {
-		dstValue["status"] = status
+	var srcMap map[string]json.RawMessage
+	var dstMap map[string]json.RawMessage
+	if err := json.Unmarshal(srcData, &srcMap); err != nil {
+		return fmt.Errorf("failed to parse source: %w", err)
+	}
+	if err := json.Unmarshal(dstData, &dstMap); err != nil {
+		return fmt.Errorf("failed to parse destination: %w", err)
 	}
 
-	return runtime.DefaultUnstructuredConverter.FromUnstructured(dstValue, dst)
+	if status, ok := srcMap["status"]; ok {
+		dstMap["status"] = status
+	}
+
+	merged, err := json.Marshal(dstMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal merged: %w", err)
+	}
+	return json.Unmarshal(merged, dst)
 }

--- a/ark/internal/queryengine/handler_test.go
+++ b/ark/internal/queryengine/handler_test.go
@@ -14,8 +14,8 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
-	"mckinsey.com/ark/internal/genai"
 	eventingnoop "mckinsey.com/ark/internal/eventing/noop"
+	"mckinsey.com/ark/internal/genai"
 	telemetrynoop "mckinsey.com/ark/internal/telemetry/noop"
 )
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -59,8 +59,8 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	db.SetMaxOpenConns(50)
-	db.SetMaxIdleConns(25)
+	db.SetMaxOpenConns(200)
+	db.SetMaxIdleConns(50)
 	db.SetConnMaxLifetime(30 * time.Minute)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -530,6 +530,16 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 	p.watchers[key] = append(p.watchers[key], ch)
 	p.mu.Unlock()
 
+	existing, _, err := p.List(ctx, kind, namespace, storage.ListOptions{
+		LabelSelector: opts.LabelSelector,
+		FieldSelector: opts.FieldSelector,
+	})
+	if err == nil {
+		for _, obj := range existing {
+			ch <- watch.Event{Type: watch.Added, Object: obj}
+		}
+	}
+
 	w := &postgresWatcher{
 		ch:      ch,
 		backend: p,

--- a/tests/aggregation-smoke/chainsaw-test.yaml
+++ b/tests/aggregation-smoke/chainsaw-test.yaml
@@ -34,9 +34,15 @@ spec:
             metadata:
               name: smoke-test-model
             spec:
-              type: none
+              provider: openai
               model:
                 value: smoke-test
+              config:
+                openai:
+                  baseUrl:
+                    value: http://localhost:9999/v1
+                  apiKey:
+                    value: smoke-test-key
             MANIFEST
             echo "OK Model created"
 
@@ -66,9 +72,15 @@ spec:
             metadata:
               name: smoke-test-watch
             spec:
-              type: none
+              provider: openai
               model:
                 value: watch-test
+              config:
+                openai:
+                  baseUrl:
+                    value: http://localhost:9999/v1
+                  apiKey:
+                    value: smoke-test-key
             MANIFEST
 
             sleep 3


### PR DESCRIPTION
## Summary
- **Status conditions fix**: `copyStatusOnly` now uses JSON marshal/unmarshal instead of `runtime.DefaultUnstructuredConverter`. The unstructured round-trip was losing typed arrays like `[]metav1.Condition`, causing status conditions to be nil when read back — this broke 6 tests (a2a-*, ark-mcp-discovery, tool-type-deprecation-warning)
- **Admission warnings**: `AdmissionStorage` now surfaces validation warnings via `warning.AddWarning(ctx)` instead of discarding them with `_`. Migration deprecation warnings now reach kubectl output through the aggregated API server path
- **Connection pool**: Increased from 50/25 to 200/50 max open/idle connections to prevent 503 "server unable to handle request" under parallel E2E load (model-token-usage, agent-structured-output)