### PR TITLE
test(ark): add #1244 repro baseline assertions

### DIFF
--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -192,3 +192,107 @@ func TestExtractTextFromTaskStatus(t *testing.T) {
 		assert.Equal(t, "", extractTextFromTaskStatus(task))
 	})
 }
+
+func TestConsumeA2AStreamEventsEmitsIncrementalChunks(t *testing.T) {
+	ctx := context.Background()
+	events := make(chan protocol.StreamingMessageEvent, 3)
+	stream := &mockEventStream{}
+
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskStatusUpdateEvent{
+			TaskID:    "task-1",
+			ContextID: "ctx-1",
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(arka2a.TaskStateWorking),
+				Message: &protocol.Message{
+					Parts: []protocol.Part{protocol.NewTextPart("first")},
+				},
+			},
+		},
+	}
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskArtifactUpdateEvent{
+			TaskID: "task-1",
+			Artifact: protocol.Artifact{
+				Parts: []protocol.Part{protocol.NewTextPart("second")},
+			},
+		},
+	}
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.TaskStatusUpdateEvent{
+			TaskID:    "task-1",
+			ContextID: "ctx-1",
+			Final:     true,
+			Status: protocol.TaskStatus{
+				State: protocol.TaskState(arka2a.TaskStateCompleted),
+				Message: &protocol.Message{
+					Parts: []protocol.Part{protocol.NewTextPart("third")},
+				},
+			},
+		},
+	}
+
+	result, err := consumeA2AStreamEvents(ctx, nil, events, stream, "model-1", "comp-1", "agent", "default", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "second", result.A2AResponse.Content)
+	require.Len(t, stream.chunks, 3)
+	assert.Equal(t, "first", extractChunkContent(t, stream.chunks[0]))
+	assert.Equal(t, "second", extractChunkContent(t, stream.chunks[1]))
+	assert.Equal(t, "third", extractChunkContent(t, stream.chunks[2]))
+}
+
+func TestConsumeA2AStreamEventsWrapsOpenAIEnvelopeAndArkMetadata(t *testing.T) {
+	ctx := WithQueryContext(context.Background(), "query-1", "session-1", "query-name")
+	ctx = WithExecutionMetadata(ctx, map[string]interface{}{
+		"target": "team/my-team",
+		"team":   "my-team",
+		"agent":  "research-agent",
+	})
+
+	events := make(chan protocol.StreamingMessageEvent, 1)
+	stream := &mockEventStream{}
+
+	events <- protocol.StreamingMessageEvent{
+		Result: &protocol.Message{
+			Role:  protocol.MessageRoleAgent,
+			Parts: []protocol.Part{protocol.NewTextPart("hello")},
+		},
+	}
+	close(events)
+
+	_, err := consumeA2AStreamEvents(ctx, nil, events, stream, "model-1", "comp-1", "research-agent", "default", "", nil)
+	require.NoError(t, err)
+	require.Len(t, stream.chunks, 1)
+
+	chunkWithMeta, ok := stream.chunks[0].(ChunkWithMetadata)
+	require.True(t, ok)
+	require.NotNil(t, chunkWithMeta.ChatCompletionChunk)
+	require.Len(t, chunkWithMeta.Choices, 1)
+	assert.Equal(t, "hello", chunkWithMeta.Choices[0].Delta.Content)
+	require.NotNil(t, chunkWithMeta.Ark)
+	assert.Equal(t, "query-1", chunkWithMeta.Ark.Query)
+	assert.Equal(t, "session-1", chunkWithMeta.Ark.Session)
+	assert.Equal(t, "team/my-team", chunkWithMeta.Ark.Target)
+	assert.Equal(t, "my-team", chunkWithMeta.Ark.Team)
+	assert.Equal(t, "research-agent", chunkWithMeta.Ark.Agent)
+	assert.Equal(t, "model-1", chunkWithMeta.Ark.Model)
+}
+
+func extractChunkContent(t *testing.T, chunk interface{}) string {
+	t.Helper()
+
+	switch c := chunk.(type) {
+	case ChunkWithMetadata:
+		require.NotNil(t, c.ChatCompletionChunk)
+		require.NotEmpty(t, c.Choices)
+		return c.Choices[0].Delta.Content
+	case *ChunkWithMetadata:
+		require.NotNil(t, c)
+		require.NotNil(t, c.ChatCompletionChunk)
+		require.NotEmpty(t, c.Choices)
+		return c.Choices[0].Delta.Content
+	default:
+		t.Fatalf("unexpected chunk type %T", chunk)
+		return ""
+	}
+}

--- a/ark/executors/completions/team_repro_test.go
+++ b/ark/executors/completions/team_repro_test.go
@@ -1,0 +1,134 @@
+package completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/eventing"
+)
+
+type recordingTeamMember struct {
+	name        string
+	description string
+	response    []Message
+	seenHistory []Message
+}
+
+func (m *recordingTeamMember) Execute(_ context.Context, _ Message, history []Message, _ MemoryInterface, _ EventStreamInterface) (*ExecutionResult, error) {
+	m.seenHistory = append([]Message{}, history...)
+	return &ExecutionResult{Messages: append([]Message{}, m.response...)}, nil
+}
+
+func (m *recordingTeamMember) GetName() string {
+	return m.name
+}
+
+func (m *recordingTeamMember) GetType() string {
+	return MemberTypeAgent
+}
+
+func (m *recordingTeamMember) GetDescription() string {
+	return m.description
+}
+
+type noopEventingTeamRecorder struct{}
+
+func (noopEventingTeamRecorder) InitializeQueryContext(ctx context.Context, _ *arkv1alpha1.Query) context.Context {
+	return ctx
+}
+
+func (noopEventingTeamRecorder) Start(ctx context.Context, _ string, _ string, _ map[string]string) context.Context {
+	return ctx
+}
+
+func (noopEventingTeamRecorder) Complete(_ context.Context, _ string, _ string, _ map[string]string) {}
+
+func (noopEventingTeamRecorder) Fail(_ context.Context, _ string, _ string, _ error, _ map[string]string) {}
+
+func (noopEventingTeamRecorder) StartTokenCollection(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (noopEventingTeamRecorder) AddTokens(_ context.Context, _ int64, _ int64, _ int64) {}
+
+func (noopEventingTeamRecorder) AddTokenUsage(_ context.Context, _ arkv1alpha1.TokenUsage) {}
+
+func (noopEventingTeamRecorder) AddCompletionUsage(_ context.Context, _ openai.CompletionUsage) {}
+
+func (noopEventingTeamRecorder) GetTokenSummary(_ context.Context) arkv1alpha1.TokenUsage {
+	return arkv1alpha1.TokenUsage{}
+}
+
+var _ eventing.TeamRecorder = (*noopEventingTeamRecorder)(nil)
+
+func TestExecuteMemberAndAccumulatePassesFullHistoryToNextMember(t *testing.T) {
+	team := &Team{
+		Name:           "test-team",
+		Strategy:       "sequential",
+		eventingRecorder: noopEventingTeamRecorder{},
+	}
+
+	memberOne := &recordingTeamMember{
+		name:     "member-one",
+		response: []Message{NewAssistantMessage("first reply")},
+	}
+	memberTwo := &recordingTeamMember{
+		name:     "member-two",
+		response: []Message{NewAssistantMessage("second reply")},
+	}
+
+	messages := []Message{NewUserMessage("question")}
+	newMessages := []Message{}
+
+	err := team.executeMemberAndAccumulate(context.Background(), memberOne, NewUserMessage("question"), &messages, &newMessages, 0)
+	require.NoError(t, err)
+
+	err = team.executeMemberAndAccumulate(context.Background(), memberTwo, NewUserMessage("question"), &messages, &newMessages, 1)
+	require.NoError(t, err)
+
+	require.Len(t, memberTwo.seenHistory, 2)
+	assert.Equal(t, "question", memberTwo.seenHistory[0].OfUser.Content.OfString.Value)
+	assert.Equal(t, "first reply", memberTwo.seenHistory[1].OfAssistant.Content.OfString.Value)
+	assert.Equal(t, "member-one", memberTwo.seenHistory[1].OfAssistant.Name.Value)
+}
+
+func TestExecuteMemberAndAccumulatePreservesHistoryOrderAcrossTurns(t *testing.T) {
+	team := &Team{
+		Name:           "test-team",
+		Strategy:       "sequential",
+		eventingRecorder: noopEventingTeamRecorder{},
+	}
+
+	memberOne := &recordingTeamMember{
+		name: "member-one",
+		response: []Message{
+			NewAssistantMessage("step one"),
+			NewAssistantMessage("step two"),
+		},
+	}
+	memberTwo := &recordingTeamMember{
+		name:     "member-two",
+		response: []Message{NewAssistantMessage("final")},
+	}
+
+	messages := []Message{NewUserMessage("root input")}
+	newMessages := []Message{}
+
+	err := team.executeMemberAndAccumulate(context.Background(), memberOne, NewUserMessage("root input"), &messages, &newMessages, 0)
+	require.NoError(t, err)
+
+	err = team.executeMemberAndAccumulate(context.Background(), memberTwo, NewUserMessage("root input"), &messages, &newMessages, 1)
+	require.NoError(t, err)
+
+	require.Len(t, memberTwo.seenHistory, 3)
+	assert.Equal(t, "root input", memberTwo.seenHistory[0].OfUser.Content.OfString.Value)
+	assert.Equal(t, "step one", memberTwo.seenHistory[1].OfAssistant.Content.OfString.Value)
+	assert.Equal(t, "step two", memberTwo.seenHistory[2].OfAssistant.Content.OfString.Value)
+	assert.Equal(t, "member-one", memberTwo.seenHistory[1].OfAssistant.Name.Value)
+	assert.Equal(t, "member-one", memberTwo.seenHistory[2].OfAssistant.Name.Value)
+}

--- a/ark/executors/completions/team_selector_test.go
+++ b/ark/executors/completions/team_selector_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -395,6 +396,21 @@ func TestBuildHistory(t *testing.T) {
 				NewUserMessage("Follow-up"),
 			},
 			want: "# user:\nQuestion?\n\n# :\nAnswer\n\n# user:\nFollow-up\n",
+		},
+		{
+			name: "assistant names preserved in history",
+			messages: func() []Message {
+				researchReply := NewAssistantMessage("Research result")
+				researchReply.OfAssistant.Name = openai.String("researcher")
+				analysisReply := NewAssistantMessage("Analysis result")
+				analysisReply.OfAssistant.Name = openai.String("analyst")
+				return []Message{
+					NewUserMessage("Explain renewable energy benefits"),
+					researchReply,
+					analysisReply,
+				}
+			}(),
+			want: "# user:\nExplain renewable energy benefits\n\n# researcher:\nResearch result\n\n# analyst:\nAnalysis result\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- add test-only repro assertions for streaming chunk sequence and metadata envelope in completions A2A stream consumption
- add team history handoff/order assertions and named assistant history coverage to establish the baseline before P1 behavior fixes
- keep runtime behavior unchanged in this draft slice

Made with [Cursor](https://cursor.com)