### PR TITLE
fix: postgresql E2E reliability — server tuning, JMESPath nil-safety, and setup hardening

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -148,6 +148,16 @@ if [ "${STORAGE_BACKEND}" = "postgresql" ]; then
   done
   echo "ark.mckinsey.com API group registered"
 
+  echo "=== Waiting for APIService availability ==="
+  kubectl wait --for=condition=Available apiservice v1alpha1.ark.mckinsey.com --timeout=120s
+  kubectl wait --for=condition=Available apiservice v1prealpha1.ark.mckinsey.com --timeout=120s 2>/dev/null || true
+
+  echo "=== Warming up aggregated API server ==="
+  for i in $(seq 1 5); do
+    kubectl get agents.ark.mckinsey.com -A --request-timeout=10s &>/dev/null && break
+    sleep 2
+  done
+
   if kubectl get crd agents.ark.mckinsey.com &>/dev/null; then
     echo "ERROR: CRD agents.ark.mckinsey.com exists — controller is using etcd, not PostgreSQL aggregated API server"
     exit 1

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -103,7 +103,7 @@ func (s *Server) Start(ctx context.Context) error {
 	serverConfig.RequestTimeout = 24 * time.Hour
 	serverConfig.MinRequestTimeout = 86400
 	serverConfig.LongRunningFunc = func(r *http.Request, requestInfo *genericrequest.RequestInfo) bool {
-		return true
+		return requestInfo.Verb == "watch"
 	}
 
 	namer := apiopenapi.NewDefinitionNamer(Scheme)

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -85,9 +85,27 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
+	backend.warmPool()
 	go backend.listenForNotifications()
 
 	return backend, nil
+}
+
+func (p *PostgreSQLBackend) warmPool() {
+	var wg sync.WaitGroup
+	for range min(p.db.Stats().MaxOpenConnections, 20) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := p.db.Conn(context.Background())
+			if err != nil {
+				return
+			}
+			_ = conn.PingContext(context.Background())
+			_ = conn.Close()
+		}()
+	}
+	wg.Wait()
 }
 
 func (p *PostgreSQLBackend) initSchema() error {

--- a/tests/a2a-agent-discovery/chainsaw-test.yaml
+++ b/tests/a2a-agent-discovery/chainsaw-test.yaml
@@ -38,7 +38,7 @@ spec:
           metadata:
             name: mock-llm-echo
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1prealpha1
@@ -46,7 +46,7 @@ spec:
           metadata:
             name: mock-llm-countdown
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     # Verify agent addresses are resolved
     - assert:
         resource:

--- a/tests/a2a-blocking-task-completed/chainsaw-test.yaml
+++ b/tests/a2a-blocking-task-completed/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
           metadata:
             name: mock-llm-countdown
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     # Apply Query targeting countdown agent
     - apply:
         file: manifests/a01-query.yaml

--- a/tests/a2a-blocking-task-failed/chainsaw-test.yaml
+++ b/tests/a2a-blocking-task-failed/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
           metadata:
             name: mock-llm-countdown
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     # Apply Query targeting countdown agent with invalid input
     - apply:
         file: manifests/a01-query.yaml

--- a/tests/a2a-message-context/chainsaw-test.yaml
+++ b/tests/a2a-message-context/chainsaw-test.yaml
@@ -29,7 +29,7 @@ spec:
           metadata:
             name: mock-llm-message-counter
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     catch:
     - events: {}
     - describe:

--- a/tests/a2a-message-query/chainsaw-test.yaml
+++ b/tests/a2a-message-query/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
           metadata:
             name: mock-llm-echo
           status:
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     # Apply Query targeting echo agent
     - apply:
         file: manifests/a01-query.yaml

--- a/tests/agent-default-model/chainsaw-test.yaml
+++ b/tests/agent-default-model/chainsaw-test.yaml
@@ -61,7 +61,7 @@ spec:
             name: mock-openai
           status:
             phase: Running
-            (contains(conditions[?type == 'Ready'].status, 'True')): true
+            (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
     catch:
     - events: {}
     - describe:

--- a/tests/agent-partial-tool-invalid/chainsaw-test.yaml
+++ b/tests/agent-partial-tool-invalid/chainsaw-test.yaml
@@ -57,7 +57,7 @@ spec:
                   app.kubernetes.io/name: mock-llm
               status:
                 phase: Running
-                (contains(conditions[?type == 'Ready'].status, 'True')): true
+                (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
         - wait:
             apiVersion: ark.mckinsey.com/v1alpha1
             kind: Model

--- a/tests/agent-partial-tool/chainsaw-test.yaml
+++ b/tests/agent-partial-tool/chainsaw-test.yaml
@@ -59,7 +59,7 @@ spec:
                   app.kubernetes.io/name: mock-llm
               status:
                 phase: Running
-                (contains(conditions[?type == 'Ready'].status, 'True')): true
+                (contains(conditions[?type == 'Ready'].status || `[]`, 'True')): true
         - wait:
             apiVersion: ark.mckinsey.com/v1alpha1
             kind: Model

--- a/tests/aggregation-smoke/chainsaw-test.yaml
+++ b/tests/aggregation-smoke/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
               config:
                 openai:
                   baseUrl:
-                    value: http://localhost:9999/v1
+                    value: https://localhost:9999/v1
                   apiKey:
                     value: smoke-test-key
             MANIFEST
@@ -78,7 +78,7 @@ spec:
               config:
                 openai:
                   baseUrl:
-                    value: http://localhost:9999/v1
+                    value: https://localhost:9999/v1
                   apiKey:
                     value: smoke-test-key
             MANIFEST

--- a/tests/mcp-discovery/chainsaw-test.yaml
+++ b/tests/mcp-discovery/chainsaw-test.yaml
@@ -41,7 +41,7 @@ spec:
           metadata:
             name: mock-llm-mcp
           status:
-            (contains(conditions[?type == 'Available'].status, 'True')): true
+            (contains(conditions[?type == 'Available'].status || `[]`, 'True')): true
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
@@ -58,7 +58,7 @@ spec:
           metadata:
             name: mock-llm-mcp
           status:
-            (contains(conditions[?type == 'Discovering'].reason, 'DiscoveryComplete')): true
+            (contains(conditions[?type == 'Discovering'].reason || `[]`, 'DiscoveryComplete')): true
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1

--- a/tests/team-of-teams/chainsaw-test.yaml
+++ b/tests/team-of-teams/chainsaw-test.yaml
@@ -93,6 +93,7 @@ spec:
             - type: team
               name: synthesis-team
     - assert:
+        timeout: 2m
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
           kind: Query

--- a/tests/tool-type-deprecation-warning/chainsaw-test.yaml
+++ b/tests/tool-type-deprecation-warning/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
           metadata:
             name: mock-llm-mcp
           status:
-            (contains(conditions[?type == 'Available'].status, 'True')): true
+            (contains(conditions[?type == 'Available'].status || `[]`, 'True')): true
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1


### PR DESCRIPTION
## Summary
- Fix `LongRunningFunc` to only classify watch requests as long-running (was: all requests), preventing slow DB queries from tying up goroutines during burst load
- Pre-warm PostgreSQL connection pool (20 connections) to eliminate cold-start latency
- Add APIService availability wait and warm-up in E2E setup script
- Add JMESPath nil-safety (`|| \`[]\``) to all `contains(conditions[...])` assertions across 10 test files
- Fix aggregation-smoke URLs from http to https for HTTPS validation
- Increase team-of-teams query assert timeout to 2m for postgresql latency