### PR TITLE
feat(completions): add protocol message adapter layer for A2A internal transport

### DIFF
--- a/ark/executors/completions/protocol_messages.go
+++ b/ark/executors/completions/protocol_messages.go
@@ -1,0 +1,171 @@
+package completions
+
+import (
+	"fmt"
+
+	"github.com/openai/openai-go"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+
+	arka2a "mckinsey.com/ark/internal/a2a"
+)
+
+const (
+	metadataAssistantName = "assistantName"
+	metadataToolCallID    = "toolCallID"
+)
+
+func ProtocolMessageFromOpenAI(msg Message) ProtocolMessage {
+	switch {
+	case msg.OfUser != nil:
+		return protocolMessageWithText(protocol.MessageRoleUser, msg.OfUser.Content.OfString.Value, nil)
+	case msg.OfAssistant != nil:
+		metadata := map[string]any{}
+		if msg.OfAssistant.Name.Value != "" {
+			metadata[metadataAssistantName] = msg.OfAssistant.Name.Value
+		}
+		return protocolMessageWithText(protocol.MessageRoleAgent, msg.OfAssistant.Content.OfString.Value, metadata)
+	case msg.OfSystem != nil:
+		return protocolMessageWithText(protocol.MessageRoleUser, msg.OfSystem.Content.OfString.Value, map[string]any{
+			"sourceRole": RoleSystem,
+		})
+	case msg.OfTool != nil:
+		metadata := map[string]any{
+			"sourceRole": RoleTool,
+		}
+		if msg.OfTool.ToolCallID != "" {
+			metadata[metadataToolCallID] = msg.OfTool.ToolCallID
+		}
+		return protocolMessageWithText(protocol.MessageRoleAgent, msg.OfTool.Content.OfString.Value, metadata)
+	case msg.OfFunction != nil:
+		return protocolMessageWithText(protocol.MessageRoleAgent, msg.OfFunction.Content.Value, map[string]any{
+			"sourceRole": "function",
+		})
+	default:
+		return protocolMessageWithText(protocol.MessageRoleUser, "", nil)
+	}
+}
+
+func ProtocolMessagesFromOpenAI(messages []Message) []ProtocolMessage {
+	result := make([]ProtocolMessage, 0, len(messages))
+	for _, msg := range messages {
+		result = append(result, ProtocolMessageFromOpenAI(msg))
+	}
+	return result
+}
+
+func OpenAIMessageFromProtocol(msg ProtocolMessage) Message {
+	text := arka2a.ExtractTextFromParts(msg.Parts)
+
+	if sourceRole, ok := metadataString(msg.Metadata, "sourceRole"); ok {
+		switch sourceRole {
+		case RoleSystem:
+			return NewSystemMessage(text)
+		case RoleTool:
+			toolCallID, _ := metadataString(msg.Metadata, metadataToolCallID)
+			if toolCallID != "" {
+				return ToolMessage(text, toolCallID)
+			}
+			return NewAssistantMessage(text)
+		case "function":
+			return NewAssistantMessage(text)
+		}
+	}
+
+	switch msg.Role {
+	case protocol.MessageRoleUser:
+		return NewUserMessage(text)
+	case protocol.MessageRoleAgent:
+		assistant := NewAssistantMessage(text)
+		if assistantName, ok := metadataString(msg.Metadata, metadataAssistantName); ok && assistantName != "" && assistant.OfAssistant != nil {
+			assistant.OfAssistant.Name = openai.String(assistantName)
+		}
+		return assistant
+	default:
+		return NewUserMessage(text)
+	}
+}
+
+func OpenAIMessagesFromProtocol(messages []ProtocolMessage) []Message {
+	result := make([]Message, 0, len(messages))
+	for _, msg := range messages {
+		result = append(result, OpenAIMessageFromProtocol(msg))
+	}
+	return result
+}
+
+func ProtocolUserMessage(content string) ProtocolMessage {
+	return protocolMessageWithText(protocol.MessageRoleUser, content, nil)
+}
+
+func ProtocolAssistantMessage(content, assistantName string) ProtocolMessage {
+	metadata := map[string]any{}
+	if assistantName != "" {
+		metadata[metadataAssistantName] = assistantName
+	}
+	return protocolMessageWithText(protocol.MessageRoleAgent, content, metadata)
+}
+
+func ProtocolSystemMessage(content string) ProtocolMessage {
+	return protocolMessageWithText(protocol.MessageRoleUser, content, map[string]any{
+		"sourceRole": RoleSystem,
+	})
+}
+
+func ProtocolToolMessage(content, toolCallID string) ProtocolMessage {
+	metadata := map[string]any{
+		"sourceRole": RoleTool,
+	}
+	if toolCallID != "" {
+		metadata[metadataToolCallID] = toolCallID
+	}
+	return protocolMessageWithText(protocol.MessageRoleAgent, content, metadata)
+}
+
+func ProtocolMessageText(msg ProtocolMessage) string {
+	return arka2a.ExtractTextFromParts(msg.Parts)
+}
+
+func ExtractLastProtocolAssistantMessageContent(messages []ProtocolMessage) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != protocol.MessageRoleAgent {
+			continue
+		}
+		if sourceRole, ok := metadataString(msg.Metadata, "sourceRole"); ok && sourceRole != "" {
+			continue
+		}
+		text := ProtocolMessageText(msg)
+		if text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func protocolMessageWithText(role protocol.MessageRole, text string, metadata map[string]any) ProtocolMessage {
+	parts := make([]protocol.Part, 0, 1)
+	if text != "" {
+		parts = append(parts, protocol.NewTextPart(text))
+	}
+	msg := protocol.NewMessage(role, parts)
+	if len(metadata) > 0 {
+		msg.Metadata = metadata
+	}
+	return msg
+}
+
+func metadataString(metadata map[string]any, key string) (string, bool) {
+	if metadata == nil {
+		return "", false
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return "", false
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed, true
+	default:
+		return fmt.Sprintf("%v", typed), true
+	}
+}

--- a/ark/executors/completions/protocol_messages_test.go
+++ b/ark/executors/completions/protocol_messages_test.go
@@ -1,0 +1,105 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+)
+
+func TestProtocolMessageFromOpenAIUser(t *testing.T) {
+	input := NewUserMessage("hello")
+	msg := ProtocolMessageFromOpenAI(input)
+
+	if msg.Role != protocol.MessageRoleUser {
+		t.Fatalf("expected user role, got %s", msg.Role)
+	}
+	if ProtocolMessageText(msg) != "hello" {
+		t.Fatalf("expected text hello, got %q", ProtocolMessageText(msg))
+	}
+}
+
+func TestOpenAIMessageFromProtocolAssistantName(t *testing.T) {
+	msg := ProtocolAssistantMessage("response", "planner")
+	converted := OpenAIMessageFromProtocol(msg)
+	if converted.OfAssistant == nil {
+		t.Fatalf("expected assistant message")
+	}
+	if converted.OfAssistant.Content.OfString.Value != "response" {
+		t.Fatalf("unexpected assistant content: %q", converted.OfAssistant.Content.OfString.Value)
+	}
+	if converted.OfAssistant.Name.Value != "planner" {
+		t.Fatalf("unexpected assistant name: %q", converted.OfAssistant.Name.Value)
+	}
+}
+
+func TestProtocolOpenAIRoundTripSystem(t *testing.T) {
+	input := NewSystemMessage("sys")
+	protocolMsg := ProtocolMessageFromOpenAI(input)
+	output := OpenAIMessageFromProtocol(protocolMsg)
+
+	if output.OfSystem == nil {
+		t.Fatalf("expected system message")
+	}
+	if output.OfSystem.Content.OfString.Value != "sys" {
+		t.Fatalf("unexpected system content: %q", output.OfSystem.Content.OfString.Value)
+	}
+}
+
+func TestProtocolOpenAIRoundTripTool(t *testing.T) {
+	input := ToolMessage("result", "call-1")
+	protocolMsg := ProtocolMessageFromOpenAI(input)
+	output := OpenAIMessageFromProtocol(protocolMsg)
+
+	if output.OfTool == nil {
+		t.Fatalf("expected tool message")
+	}
+	if output.OfTool.Content.OfString.Value != "result" {
+		t.Fatalf("unexpected tool content: %q", output.OfTool.Content.OfString.Value)
+	}
+	if output.OfTool.ToolCallID != "call-1" {
+		t.Fatalf("unexpected tool call id: %q", output.OfTool.ToolCallID)
+	}
+}
+
+func TestOpenAIMessagesFromProtocolBatch(t *testing.T) {
+	input := []ProtocolMessage{
+		ProtocolUserMessage("u"),
+		ProtocolAssistantMessage("a", ""),
+		ProtocolSystemMessage("s"),
+	}
+	out := OpenAIMessagesFromProtocol(input)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(out))
+	}
+	if out[0].OfUser == nil || out[0].OfUser.Content.OfString.Value != "u" {
+		t.Fatalf("unexpected first message")
+	}
+	if out[1].OfAssistant == nil || out[1].OfAssistant.Content.OfString.Value != "a" {
+		t.Fatalf("unexpected second message")
+	}
+	if out[2].OfSystem == nil || out[2].OfSystem.Content.OfString.Value != "s" {
+		t.Fatalf("unexpected third message")
+	}
+}
+
+func TestProtocolMessagesFromOpenAIBatch(t *testing.T) {
+	input := []Message{
+		NewUserMessage("u"),
+		NewAssistantMessage("a"),
+		Message(openai.SystemMessage("s")),
+	}
+	out := ProtocolMessagesFromOpenAI(input)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(out))
+	}
+	if out[0].Role != protocol.MessageRoleUser || ProtocolMessageText(out[0]) != "u" {
+		t.Fatalf("unexpected first protocol message")
+	}
+	if out[1].Role != protocol.MessageRoleAgent || ProtocolMessageText(out[1]) != "a" {
+		t.Fatalf("unexpected second protocol message")
+	}
+	if out[2].Role != protocol.MessageRoleUser || ProtocolMessageText(out[2]) != "s" {
+		t.Fatalf("unexpected third protocol message")
+	}
+}

--- a/openspec/changes/pr1-1244-protocol-core/.openspec.yaml
+++ b/openspec/changes/pr1-1244-protocol-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/pr1-1244-protocol-core/README.md
+++ b/openspec/changes/pr1-1244-protocol-core/README.md
@@ -1,0 +1,3 @@
+# pr1-1244-protocol-core
+
+Protocol-native adapter core for completions internal transport

--- a/openspec/changes/pr1-1244-protocol-core/design.md
+++ b/openspec/changes/pr1-1244-protocol-core/design.md
@@ -1,0 +1,18 @@
+# PR1 Protocol Core Adapters Design
+
+## Decision
+
+Keep OpenAI message unions as provider-boundary types and introduce protocol-native conversion utilities as the internal bridge.
+
+## Mapping
+
+- user -> `protocol.MessageRoleUser`
+- assistant -> `protocol.MessageRoleAgent`
+- system -> `protocol.MessageRoleUser` with `sourceRole=system` metadata
+- tool -> `protocol.MessageRoleAgent` with `sourceRole=tool` and tool call metadata
+
+## Boundaries
+
+- Model/provider interfaces remain unchanged in this PR.
+- Controller and handler interfaces remain unchanged in this PR.
+- This PR creates conversion primitives used by subsequent protocol-native slices.

--- a/openspec/changes/pr1-1244-protocol-core/proposal.md
+++ b/openspec/changes/pr1-1244-protocol-core/proposal.md
@@ -1,0 +1,19 @@
+# PR1 Protocol Core Adapters
+
+## Why
+
+Internal execution still relies on OpenAI message unions in core interfaces. We need a stable protocol-native message layer before converting agent/team and memory/streaming loops.
+
+## What Changes
+
+- Add protocol message adapter helpers in completions:
+  - OpenAI -> protocol conversion
+  - protocol -> OpenAI conversion
+  - batch conversion helpers
+  - protocol message constructors for user, assistant, system, and tool paths
+- Add focused unit coverage for adapter behavior.
+
+## Impact
+
+- `ark/executors/completions/protocol_messages.go`
+- `ark/executors/completions/protocol_messages_test.go`

--- a/openspec/changes/pr1-1244-protocol-core/specs/internal-a2a-transport/spec.md
+++ b/openspec/changes/pr1-1244-protocol-core/specs/internal-a2a-transport/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Protocol adapter foundation for completions messages
+The completions executor SHALL provide a protocol adapter layer that converts between OpenAI chat message unions and A2A protocol messages for internal transport migration.
+
+#### Scenario: Convert OpenAI message to protocol
+- **WHEN** completions receives user, assistant, system, or tool messages as OpenAI message unions
+- **THEN** the adapter produces protocol messages with equivalent role and text semantics
+
+#### Scenario: Convert protocol message to OpenAI
+- **WHEN** completions needs provider-compatible output from protocol-native internal messages
+- **THEN** the adapter produces OpenAI message unions that preserve assistant name and tool call context metadata

--- a/openspec/changes/pr1-1244-protocol-core/tasks.md
+++ b/openspec/changes/pr1-1244-protocol-core/tasks.md
@@ -1,0 +1,12 @@
+# PR1 Protocol Core Adapters Tasks
+
+## 1. Adapter foundation
+
+- [x] 1.1 Add OpenAI -> protocol message conversion helper.
+- [x] 1.2 Add protocol -> OpenAI message conversion helper.
+- [x] 1.3 Add batch conversion and protocol constructor helpers.
+
+## 2. Verification
+
+- [x] 2.1 Add unit tests for user, assistant, system, and tool mapping.
+- [x] 2.2 Run focused completions test package.


### PR DESCRIPTION
## Summary

Adds a bidirectional conversion layer between OpenAI `ChatCompletionMessageParamUnion` and A2A `protocol.Message` inside the completions executor. This is the foundation for migrating internal execution loops from OpenAI-schema messages to protocol-native messages, keeping OpenAI types only at provider/output boundaries.

**This is PR 1 of 5** in the #1244 linear migration plan. Each PR is self-contained and branches from main.

## Context

After the completions executor extraction (#1357), internal execution still threads OpenAI message unions through agent, team, memory, and streaming interfaces. The goal of #1244 is to make A2A the canonical internal transport. This PR provides the conversion primitives that subsequent slices depend on — it does not change any existing interfaces or behavior.

## What this PR adds

Two new files in `ark/executors/completions/`:

### `protocol_messages.go` — Adapter functions

| Function | Direction | Purpose |
|---|---|---|
| `ProtocolMessageFromOpenAI` | OpenAI → Protocol | Converts a single `Message` to `protocol.Message`, preserving role and metadata |
| `OpenAIMessageFromProtocol` | Protocol → OpenAI | Converts back, round-tripping system, tool, and assistant name metadata |
| `ProtocolMessagesFromOpenAI` | OpenAI → Protocol | Batch conversion |
| `OpenAIMessagesFromProtocol` | Protocol → OpenAI | Batch conversion |
| `ProtocolUserMessage` | Constructor | Creates a protocol user message from text |
| `ProtocolAssistantMessage` | Constructor | Creates a protocol agent message with optional assistant name |
| `ProtocolSystemMessage` | Constructor | Creates a protocol user message with `sourceRole=system` metadata |
| `ProtocolToolMessage` | Constructor | Creates a protocol agent message with `sourceRole=tool` and tool call ID |
| `ProtocolMessageText` | Accessor | Extracts text content from protocol message parts |
| `ExtractLastProtocolAssistantMessageContent` | Accessor | Finds last agent-role message without a sourceRole override |

### `protocol_messages_test.go` — Unit tests

- Single-message conversion (user, assistant with name, system, tool with call ID)
- Round-trip fidelity: OpenAI → Protocol → OpenAI preserves type and content for system and tool messages
- Batch conversion in both directions

## Role mapping

The A2A protocol has two roles (`user`, `agent`) vs OpenAI's four (`user`, `assistant`, `system`, `tool`). The adapter uses message metadata to preserve the distinction:

```
OpenAI role     →  Protocol role          Metadata
─────────────────────────────────────────────────────
user            →  MessageRoleUser        (none)
assistant       →  MessageRoleAgent       assistantName (if set)
system          →  MessageRoleUser        sourceRole=system
tool            →  MessageRoleAgent       sourceRole=tool, toolCallID
function        →  MessageRoleAgent       sourceRole=function
```

On the reverse path, `sourceRole` metadata is checked first to recover the original OpenAI type before falling back to role-based mapping.

## What this PR does NOT change

- No existing function signatures modified
- No interface changes to `TeamMember`, `MemoryInterface`, or `EventStreamInterface`
- No controller, handler, or provider-boundary changes
- No behavioral changes to any execution path

## OpenSpec

Tracked as `pr1-1244-protocol-core` — proposal, design, specs, and tasks are in `openspec/changes/pr1-1244-protocol-core/`.

## How to review

1. Read `protocol_messages.go` top-to-bottom — it is a self-contained ~170-line file with no external side effects
2. Check the role mapping table above against the switch statements in `ProtocolMessageFromOpenAI` and `OpenAIMessageFromProtocol`
3. Verify round-trip tests in `protocol_messages_test.go` cover the metadata paths
4. Confirm no other files are modified (this PR is additive-only)

## PR sequence

| PR | Scope | Status |
|---|---|---|
| **PR1** (this) | Protocol core adapters | Draft |
| PR2 | Agent/team/selector protocol-native loops | Pending |
| PR3 | Memory and streaming alignment | Pending |
| PR4 | Controller/handler boundary cleanup | Pending |
| PR5 | Targeted hardening and final gate | Pending |

Made with [Cursor](https://cursor.com)