### PR TITLE
feat(ark): controller response path independence (G1 response-side)

### DIFF
--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -262,17 +262,35 @@ func (h *Handler) buildA2AResponse(ctx context.Context, state *executionState, r
 		h.telemetry.QueryRecorder().RecordTokenUsage(state.querySpan, tokenSummary.PromptTokens, tokenSummary.CompletionTokens, tokenSummary.TotalTokens)
 	}
 
-	responseMeta := buildResponseMeta(state, execResult, responseMessages, tokenSummary)
+	extensionPayload := arka2a.ExecutionResponsePayload{
+		ConversationId: state.conversationId,
+	}
+	if tokenSummary.TotalTokens > 0 {
+		extensionPayload.TokenUsage = &arka2a.ResponseTokenUsage{
+			PromptTokens:     tokenSummary.PromptTokens,
+			CompletionTokens: tokenSummary.CompletionTokens,
+			TotalTokens:      tokenSummary.TotalTokens,
+		}
+	}
+
+	serializedMessages := serializeResponseMessages(responseMessages)
+	if serializedMessages != "" {
+		extensionPayload.Messages = json.RawMessage(serializedMessages)
+	}
+
+	protocolMessages := openAIToProtocolResponseMessages(responseMessages)
+	if protoBytes, err := json.Marshal(protocolMessages); err == nil && len(protocolMessages) > 0 {
+		extensionPayload.ResponseMessagesV1 = protoBytes
+	}
+
+	legacyMeta := buildResponseMeta(state, execResult, responseMessages, tokenSummary)
 
 	responseMessage := protocol.NewMessage(
 		protocol.MessageRoleAgent,
 		[]protocol.Part{protocol.NewTextPart(responseContent)},
 	)
-	if len(responseMeta) > 0 {
-		responseMessage.Metadata = map[string]any{
-			arka2a.QueryExtensionMetadataKey: responseMeta,
-		}
-	}
+	arka2a.SetExecutionContextExtension(&responseMessage, extensionPayload)
+	arka2a.SetMetadata(&responseMessage, arka2a.QueryExtensionMetadataKey, legacyMeta)
 
 	state.finalizeStream(ctx, responseMessages)
 
@@ -500,11 +518,7 @@ func firstItemName[T any, PT interface {
 
 // Query extension spec: ark/api/extensions/query/v1/
 func extractArkMetadata(message protocol.Message) (*arkMetadata, error) {
-	if message.Metadata == nil {
-		return nil, fmt.Errorf("message has no metadata")
-	}
-
-	refData, ok := message.Metadata[arka2a.QueryExtensionMetadataKey]
+	refData, ok := arka2a.GetMetadata(message, arka2a.QueryExtensionMetadataKey)
 	if !ok {
 		return nil, fmt.Errorf("message metadata missing %s key", arka2a.QueryExtensionMetadataKey)
 	}
@@ -558,4 +572,92 @@ func serializeResponseMessages(messages []Message) string {
 		return ""
 	}
 	return string(data)
+}
+
+func openAIToProtocolResponseMessages(messages []Message) []protocol.Message {
+	var result []protocol.Message
+	for _, msg := range messages {
+		switch {
+		case msg.OfAssistant != nil:
+			result = append(result, convertAssistantMessage(msg.OfAssistant))
+		case msg.OfUser != nil:
+			pm := protocol.NewMessage(protocol.MessageRoleUser, []protocol.Part{
+				protocol.NewTextPart(msg.OfUser.Content.OfString.Value),
+			})
+			result = append(result, pm)
+		case msg.OfTool != nil:
+			result = append(result, convertToolMessage(msg.OfTool))
+		case msg.OfSystem != nil:
+			result = append(result, convertSystemMessage(msg.OfSystem))
+		case msg.OfFunction != nil:
+			result = append(result, convertFunctionMessage(msg.OfFunction))
+		}
+	}
+	return result
+}
+
+func convertAssistantMessage(m *openai.ChatCompletionAssistantMessageParam) protocol.Message {
+	parts := make([]protocol.Part, 0, 1+len(m.ToolCalls))
+	if content := m.Content.OfString.Value; content != "" {
+		parts = append(parts, protocol.NewTextPart(content))
+	}
+	for _, tc := range m.ToolCalls {
+		parts = append(parts, protocol.DataPart{
+			Kind: "data",
+			Data: map[string]any{
+				"type": "tool_call",
+				"id":   tc.ID,
+				"function": map[string]any{
+					"name":      tc.Function.Name,
+					"arguments": tc.Function.Arguments,
+				},
+			},
+			Metadata: map[string]any{"mediaType": "application/json"},
+		})
+	}
+	if len(parts) == 0 {
+		parts = append(parts, protocol.NewTextPart(""))
+	}
+	return protocol.NewMessage(protocol.MessageRoleAgent, parts)
+}
+
+func convertToolMessage(m *openai.ChatCompletionToolMessageParam) protocol.Message {
+	return protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+		protocol.DataPart{
+			Kind: "data",
+			Data: map[string]any{
+				"type":         "tool_result",
+				"tool_call_id": m.ToolCallID,
+				"content":      m.Content.OfString.Value,
+			},
+			Metadata: map[string]any{"mediaType": "application/json"},
+		},
+	})
+}
+
+func convertSystemMessage(m *openai.ChatCompletionSystemMessageParam) protocol.Message {
+	return protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+		protocol.DataPart{
+			Kind: "data",
+			Data: map[string]any{
+				"type":    "system",
+				"content": m.Content.OfString.Value,
+			},
+			Metadata: map[string]any{"mediaType": "application/json"},
+		},
+	})
+}
+
+func convertFunctionMessage(m *openai.ChatCompletionFunctionMessageParam) protocol.Message { //nolint:staticcheck
+	return protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+		protocol.DataPart{
+			Kind: "data",
+			Data: map[string]any{
+				"type":    "function_result",
+				"name":    m.Name,
+				"content": m.Content.Value,
+			},
+			Metadata: map[string]any{"mediaType": "application/json"},
+		},
+	})
 }

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -549,6 +550,128 @@ func TestResolveSelectorResourceTypes(t *testing.T) {
 		target, err := h.resolveSelector(context.Background(), query)
 		require.NoError(t, err)
 		assert.Equal(t, "agent", target.Type)
+	})
+}
+
+func TestOpenAIToProtocolResponseMessages(t *testing.T) {
+	t.Run("assistant text-only", func(t *testing.T) {
+		msgs := []Message{NewAssistantMessage("hello")}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+		assert.Equal(t, protocol.MessageRoleAgent, result[0].Role)
+		assert.Equal(t, "hello", arka2a.ExtractTextFromParts(result[0].Parts))
+		assert.Empty(t, arka2a.ExtractDataParts(result[0].Parts))
+	})
+
+	t.Run("user message", func(t *testing.T) {
+		msgs := []Message{NewUserMessage("question")}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+		assert.Equal(t, protocol.MessageRoleUser, result[0].Role)
+		assert.Equal(t, "question", arka2a.ExtractTextFromParts(result[0].Parts))
+	})
+
+	t.Run("system message preserved as DataPart", func(t *testing.T) {
+		msgs := []Message{NewSystemMessage("you are helpful")}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+		assert.Equal(t, protocol.MessageRoleAgent, result[0].Role)
+		dps := arka2a.ExtractDataParts(result[0].Parts)
+		require.Len(t, dps, 1)
+		assert.Equal(t, "system", arka2a.DataPartType(dps[0]))
+		assert.Equal(t, "you are helpful", arka2a.DataPartField(dps[0], "content"))
+	})
+
+	t.Run("tool result preserved as DataPart", func(t *testing.T) {
+		msgs := []Message{ToolMessage("72°F sunny", "call-123")}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+		assert.Equal(t, protocol.MessageRoleAgent, result[0].Role)
+		dps := arka2a.ExtractDataParts(result[0].Parts)
+		require.Len(t, dps, 1)
+		assert.Equal(t, "tool_result", arka2a.DataPartType(dps[0]))
+		assert.Equal(t, "call-123", arka2a.DataPartField(dps[0], "tool_call_id"))
+		assert.Equal(t, "72°F sunny", arka2a.DataPartField(dps[0], "content"))
+	})
+
+	t.Run("assistant with tool calls produces TextPart + DataParts", func(t *testing.T) {
+		assistant := openai.ChatCompletionAssistantMessageParam{
+			Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+				OfString: openai.Opt("I'll check the weather"),
+			},
+			ToolCalls: []openai.ChatCompletionMessageToolCallParam{
+				{
+					ID: "tc-1",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name:      "weather_api",
+						Arguments: `{"city":"NYC"}`,
+					},
+				},
+			},
+		}
+		msgs := []Message{{OfAssistant: &assistant}}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+
+		text := arka2a.ExtractTextFromParts(result[0].Parts)
+		assert.Equal(t, "I'll check the weather", text)
+
+		dps := arka2a.ExtractDataParts(result[0].Parts)
+		require.Len(t, dps, 1)
+		assert.Equal(t, "tool_call", arka2a.DataPartType(dps[0]))
+		assert.Equal(t, "tc-1", arka2a.DataPartField(dps[0], "id"))
+
+		fn := arka2a.DataPartMap(dps[0], "function")
+		require.NotNil(t, fn)
+		assert.Equal(t, "weather_api", fn["name"])
+		assert.Equal(t, `{"city":"NYC"}`, fn["arguments"])
+	})
+
+	t.Run("function result preserved as DataPart", func(t *testing.T) {
+		fn := openai.ChatCompletionFunctionMessageParam{ //nolint:staticcheck
+			Name:    "my_func",
+			Content: openai.Opt("result data"),
+		}
+		msgs := []Message{{OfFunction: &fn}}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 1)
+		dps := arka2a.ExtractDataParts(result[0].Parts)
+		require.Len(t, dps, 1)
+		assert.Equal(t, "function_result", arka2a.DataPartType(dps[0]))
+		assert.Equal(t, "my_func", arka2a.DataPartField(dps[0], "name"))
+		assert.Equal(t, "result data", arka2a.DataPartField(dps[0], "content"))
+	})
+
+	t.Run("mixed message sequence preserves all types", func(t *testing.T) {
+		assistant := openai.ChatCompletionAssistantMessageParam{
+			Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+				OfString: openai.Opt("Let me look that up"),
+			},
+			ToolCalls: []openai.ChatCompletionMessageToolCallParam{
+				{
+					ID: "tc-abc",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name:      "search",
+						Arguments: `{"q":"test"}`,
+					},
+				},
+			},
+		}
+		msgs := []Message{
+			NewSystemMessage("system prompt"),
+			NewUserMessage("question"),
+			{OfAssistant: &assistant},
+			ToolMessage("search result", "tc-abc"),
+			NewAssistantMessage("Here is the answer"),
+		}
+		result := openAIToProtocolResponseMessages(msgs)
+		require.Len(t, result, 5)
+
+		assert.Equal(t, "system", arka2a.DataPartType(arka2a.ExtractDataParts(result[0].Parts)[0]))
+		assert.Equal(t, protocol.MessageRoleUser, result[1].Role)
+		assert.Equal(t, "tool_call", arka2a.DataPartType(arka2a.ExtractDataParts(result[2].Parts)[0]))
+		assert.Equal(t, "tool_result", arka2a.DataPartType(arka2a.ExtractDataParts(result[3].Parts)[0]))
+		assert.Equal(t, "Here is the answer", arka2a.ExtractTextFromParts(result[4].Parts))
 	})
 }
 

--- a/ark/internal/a2a/a2a_types.go
+++ b/ark/internal/a2a/a2a_types.go
@@ -3,10 +3,17 @@
 package a2a
 
 import (
+	"encoding/json"
+
 	"trpc.group/trpc-go/trpc-a2a-go/server"
 )
 
 const ExecutionEngineA2A = "a2a"
+
+const (
+	ExecutionContextExtensionURI = "ark.mckinsey.com/extensions/execution-context/v1"
+	ExecutionTraceExtensionURI   = "ark.mckinsey.com/extensions/execution-trace/v1"
+)
 
 const (
 	TaskStateSubmitted     = "submitted"
@@ -18,6 +25,19 @@ const (
 	TaskStateRejected      = "rejected"
 	TaskStateAuthRequired  = "auth-required"
 )
+
+type ExecutionResponsePayload struct {
+	TokenUsage         *ResponseTokenUsage `json:"tokenUsage,omitempty"`
+	ConversationId     string              `json:"conversationId,omitempty"`
+	Messages           any                 `json:"messages,omitempty"`
+	ResponseMessagesV1 json.RawMessage     `json:"responseMessagesV1,omitempty"`
+}
+
+type ResponseTokenUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
 
 type (
 	A2AAgentCard = server.AgentCard

--- a/ark/internal/a2a/extensions.go
+++ b/ark/internal/a2a/extensions.go
@@ -1,0 +1,133 @@
+/* Copyright 2025. McKinsey & Company */
+
+package a2a
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+)
+
+func SetExtension(m *protocol.Message, uri string, payload any) {
+	if m.Metadata == nil {
+		m.Metadata = map[string]any{}
+	}
+	m.Metadata[uri] = payload
+
+	if m.Extensions == nil {
+		m.Extensions = []string{uri}
+		return
+	}
+	for _, existing := range m.Extensions {
+		if existing == uri {
+			return
+		}
+	}
+	m.Extensions = append(m.Extensions, uri)
+}
+
+func SetMetadata(m *protocol.Message, key string, value any) {
+	if m.Metadata == nil {
+		m.Metadata = map[string]any{}
+	}
+	m.Metadata[key] = value
+}
+
+func GetExtension(m protocol.Message, uri string) (any, bool) {
+	if m.Metadata == nil {
+		return nil, false
+	}
+	v, ok := m.Metadata[uri]
+	return v, ok
+}
+
+func GetExtensionAs[T any](m protocol.Message, uri string) (T, error) {
+	var zero T
+	raw, ok := GetExtension(m, uri)
+	if !ok {
+		return zero, fmt.Errorf("extension %s not found in message metadata", uri)
+	}
+
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return zero, fmt.Errorf("failed to marshal extension %s: %w", uri, err)
+	}
+
+	var result T
+	if err := json.Unmarshal(b, &result); err != nil {
+		return zero, fmt.Errorf("failed to unmarshal extension %s: %w", uri, err)
+	}
+	return result, nil
+}
+
+func HasExtension(m protocol.Message, uri string) bool {
+	for _, ext := range m.Extensions {
+		if ext == uri {
+			return true
+		}
+	}
+	return false
+}
+
+func GetMetadata(m protocol.Message, key string) (any, bool) {
+	if m.Metadata == nil {
+		return nil, false
+	}
+	v, ok := m.Metadata[key]
+	return v, ok
+}
+
+func SetExecutionContextExtension(m *protocol.Message, payload ExecutionResponsePayload) {
+	SetExtension(m, ExecutionContextExtensionURI, payload)
+}
+
+func GetExecutionContextExtension(m protocol.Message) (*ExecutionResponsePayload, error) {
+	result, err := GetExtensionAs[ExecutionResponsePayload](m, ExecutionContextExtensionURI)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func ExtractDataParts(parts []protocol.Part) []protocol.DataPart {
+	var result []protocol.DataPart
+	for _, part := range parts {
+		switch dp := part.(type) {
+		case protocol.DataPart:
+			result = append(result, dp)
+		case *protocol.DataPart:
+			if dp != nil {
+				result = append(result, *dp)
+			}
+		}
+	}
+	return result
+}
+
+func DataPartType(dp protocol.DataPart) string {
+	m, ok := dp.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	t, _ := m["type"].(string)
+	return t
+}
+
+func DataPartField(dp protocol.DataPart, key string) string {
+	m, ok := dp.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}
+
+func DataPartMap(dp protocol.DataPart, key string) map[string]any {
+	m, ok := dp.Data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	sub, _ := m[key].(map[string]any)
+	return sub
+}

--- a/ark/internal/a2a/extensions_test.go
+++ b/ark/internal/a2a/extensions_test.go
@@ -1,0 +1,345 @@
+/* Copyright 2025. McKinsey & Company */
+
+package a2a
+
+import (
+	"encoding/json"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+)
+
+func TestSetExtension(t *testing.T) {
+	t.Run("adds URI to Extensions and payload to Metadata", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext/v1", map[string]string{"key": "val"})
+
+		if len(m.Extensions) != 1 || m.Extensions[0] != "https://example.com/ext/v1" {
+			t.Fatalf("expected Extensions=[https://example.com/ext/v1], got %v", m.Extensions)
+		}
+		if m.Metadata["https://example.com/ext/v1"] == nil {
+			t.Fatal("expected payload in Metadata")
+		}
+	})
+
+	t.Run("deduplicates on repeated calls with same URI", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext/v1", "first")
+		SetExtension(&m, "https://example.com/ext/v1", "second")
+
+		if len(m.Extensions) != 1 {
+			t.Fatalf("expected 1 extension entry, got %d", len(m.Extensions))
+		}
+		if m.Metadata["https://example.com/ext/v1"] != "second" {
+			t.Fatalf("expected payload to be updated to 'second', got %v", m.Metadata["https://example.com/ext/v1"])
+		}
+	})
+
+	t.Run("supports multiple distinct extensions", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext-a/v1", "a")
+		SetExtension(&m, "https://example.com/ext-b/v1", "b")
+
+		if len(m.Extensions) != 2 {
+			t.Fatalf("expected 2 extension entries, got %d", len(m.Extensions))
+		}
+		if m.Metadata["https://example.com/ext-a/v1"] != "a" {
+			t.Fatal("missing ext-a payload")
+		}
+		if m.Metadata["https://example.com/ext-b/v1"] != "b" {
+			t.Fatal("missing ext-b payload")
+		}
+	})
+}
+
+func TestSetMetadata(t *testing.T) {
+	t.Run("sets Metadata without modifying Extensions", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetMetadata(&m, "ark.mckinsey.com/execution-engine", map[string]string{"legacy": "true"})
+
+		if len(m.Extensions) != 0 {
+			t.Fatalf("expected empty Extensions, got %v", m.Extensions)
+		}
+		if m.Metadata["ark.mckinsey.com/execution-engine"] == nil {
+			t.Fatal("expected payload in Metadata")
+		}
+	})
+
+	t.Run("initializes nil Metadata", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		m.Metadata = nil
+		SetMetadata(&m, "key", "value")
+
+		if m.Metadata["key"] != "value" {
+			t.Fatal("expected Metadata to be initialized and set")
+		}
+	})
+}
+
+func TestGetExtension(t *testing.T) {
+	t.Run("returns payload for existing extension", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext/v1", "payload")
+
+		val, ok := GetExtension(m, "https://example.com/ext/v1")
+		if !ok || val != "payload" {
+			t.Fatalf("expected (payload, true), got (%v, %v)", val, ok)
+		}
+	})
+
+	t.Run("returns false for missing extension", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+
+		_, ok := GetExtension(m, "https://example.com/missing")
+		if ok {
+			t.Fatal("expected false for missing extension")
+		}
+	})
+
+	t.Run("returns false for nil Metadata", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		m.Metadata = nil
+
+		_, ok := GetExtension(m, "anything")
+		if ok {
+			t.Fatal("expected false for nil Metadata")
+		}
+	})
+}
+
+func TestGetExtensionAs(t *testing.T) {
+	t.Run("round-trips typed payload", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		original := ExecutionResponsePayload{
+			ConversationId: "conv-123",
+			TokenUsage: &ResponseTokenUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			},
+		}
+		SetExtension(&m, ExecutionContextExtensionURI, original)
+
+		result, err := GetExtensionAs[ExecutionResponsePayload](m, ExecutionContextExtensionURI)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.ConversationId != "conv-123" {
+			t.Fatalf("expected conv-123, got %s", result.ConversationId)
+		}
+		if result.TokenUsage == nil || result.TokenUsage.TotalTokens != 150 {
+			t.Fatalf("token usage mismatch: %+v", result.TokenUsage)
+		}
+	})
+
+	t.Run("handles map[string]any from JSON deserialization", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		m.Metadata = map[string]any{
+			ExecutionContextExtensionURI: map[string]any{
+				"conversationId": "conv-456",
+				"tokenUsage": map[string]any{
+					"prompt_tokens":     float64(200),
+					"completion_tokens": float64(100),
+					"total_tokens":      float64(300),
+				},
+			},
+		}
+		m.Extensions = []string{ExecutionContextExtensionURI}
+
+		result, err := GetExtensionAs[ExecutionResponsePayload](m, ExecutionContextExtensionURI)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.ConversationId != "conv-456" {
+			t.Fatalf("expected conv-456, got %s", result.ConversationId)
+		}
+		if result.TokenUsage.TotalTokens != 300 {
+			t.Fatalf("expected 300 total tokens, got %d", result.TokenUsage.TotalTokens)
+		}
+	})
+
+	t.Run("returns error for missing extension", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+
+		_, err := GetExtensionAs[ExecutionResponsePayload](m, "missing")
+		if err == nil {
+			t.Fatal("expected error for missing extension")
+		}
+	})
+}
+
+func TestHasExtension(t *testing.T) {
+	t.Run("returns true for declared extension", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext/v1", "payload")
+
+		if !HasExtension(m, "https://example.com/ext/v1") {
+			t.Fatal("expected HasExtension to return true")
+		}
+	})
+
+	t.Run("returns false for bare metadata key", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetMetadata(&m, QueryExtensionMetadataKey, "legacy")
+
+		if HasExtension(m, QueryExtensionMetadataKey) {
+			t.Fatal("bare metadata key must not appear in Extensions")
+		}
+	})
+
+	t.Run("returns false for undeclared URI", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+
+		if HasExtension(m, "https://example.com/ext/v1") {
+			t.Fatal("expected false for undeclared URI")
+		}
+	})
+}
+
+func TestGetMetadata(t *testing.T) {
+	t.Run("reads extension URI keys", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExtension(&m, "https://example.com/ext/v1", "ext-data")
+
+		val, ok := GetMetadata(m, "https://example.com/ext/v1")
+		if !ok || val != "ext-data" {
+			t.Fatalf("expected ext-data, got %v", val)
+		}
+	})
+
+	t.Run("reads non-extension keys", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetMetadata(&m, "custom-key", "custom-val")
+
+		val, ok := GetMetadata(m, "custom-key")
+		if !ok || val != "custom-val" {
+			t.Fatalf("expected custom-val, got %v", val)
+		}
+	})
+}
+
+func TestSetExecutionContextExtension(t *testing.T) {
+	m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+	payload := ExecutionResponsePayload{
+		ConversationId: "conv-typed",
+		TokenUsage: &ResponseTokenUsage{
+			PromptTokens:     10,
+			CompletionTokens: 20,
+			TotalTokens:      30,
+		},
+	}
+	SetExecutionContextExtension(&m, payload)
+
+	if !HasExtension(m, ExecutionContextExtensionURI) {
+		t.Fatal("expected ExecutionContextExtensionURI in Extensions")
+	}
+
+	raw, ok := GetExtension(m, ExecutionContextExtensionURI)
+	if !ok {
+		t.Fatal("expected payload in Metadata")
+	}
+
+	b, _ := json.Marshal(raw)
+	var roundTripped ExecutionResponsePayload
+	_ = json.Unmarshal(b, &roundTripped)
+	if roundTripped.ConversationId != "conv-typed" {
+		t.Fatalf("expected conv-typed, got %s", roundTripped.ConversationId)
+	}
+}
+
+func TestGetExecutionContextExtension(t *testing.T) {
+	t.Run("extracts typed payload", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+		SetExecutionContextExtension(&m, ExecutionResponsePayload{
+			ConversationId: "conv-get",
+		})
+
+		result, err := GetExecutionContextExtension(m)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.ConversationId != "conv-get" {
+			t.Fatalf("expected conv-get, got %s", result.ConversationId)
+		}
+	})
+
+	t.Run("returns error when extension missing", func(t *testing.T) {
+		m := protocol.NewMessage(protocol.MessageRoleAgent, nil)
+
+		_, err := GetExecutionContextExtension(m)
+		if err == nil {
+			t.Fatal("expected error for missing extension")
+		}
+	})
+}
+
+func TestExtractDataParts(t *testing.T) {
+	t.Run("extracts DataParts from mixed parts", func(t *testing.T) {
+		parts := []protocol.Part{
+			protocol.NewTextPart("hello"),
+			protocol.DataPart{Kind: "data", Data: map[string]any{"type": "tool_call"}},
+			protocol.NewTextPart("world"),
+			protocol.DataPart{Kind: "data", Data: map[string]any{"type": "tool_result"}},
+		}
+		dps := ExtractDataParts(parts)
+		if len(dps) != 2 {
+			t.Fatalf("expected 2 DataParts, got %d", len(dps))
+		}
+	})
+
+	t.Run("returns nil for text-only parts", func(t *testing.T) {
+		parts := []protocol.Part{
+			protocol.NewTextPart("hello"),
+		}
+		dps := ExtractDataParts(parts)
+		if dps != nil {
+			t.Fatalf("expected nil, got %v", dps)
+		}
+	})
+
+	t.Run("handles pointer DataParts", func(t *testing.T) {
+		dp := &protocol.DataPart{Kind: "data", Data: map[string]any{"type": "system"}}
+		parts := []protocol.Part{dp}
+		dps := ExtractDataParts(parts)
+		if len(dps) != 1 {
+			t.Fatalf("expected 1 DataPart, got %d", len(dps))
+		}
+	})
+}
+
+func TestDataPartType(t *testing.T) {
+	dp := protocol.DataPart{Data: map[string]any{"type": "tool_call", "id": "tc-1"}}
+	if DataPartType(dp) != "tool_call" {
+		t.Fatalf("expected tool_call, got %s", DataPartType(dp))
+	}
+}
+
+func TestDataPartField(t *testing.T) {
+	dp := protocol.DataPart{Data: map[string]any{"type": "tool_result", "tool_call_id": "tc-1", "content": "result"}}
+	if DataPartField(dp, "tool_call_id") != "tc-1" {
+		t.Fatalf("expected tc-1, got %s", DataPartField(dp, "tool_call_id"))
+	}
+	if DataPartField(dp, "content") != "result" {
+		t.Fatalf("expected result, got %s", DataPartField(dp, "content"))
+	}
+	if DataPartField(dp, "missing") != "" {
+		t.Fatal("expected empty string for missing key")
+	}
+}
+
+func TestDataPartMap(t *testing.T) {
+	dp := protocol.DataPart{Data: map[string]any{
+		"type":     "tool_call",
+		"function": map[string]any{"name": "weather", "arguments": `{"city":"NYC"}`},
+	}}
+	fn := DataPartMap(dp, "function")
+	if fn == nil {
+		t.Fatal("expected non-nil function map")
+	}
+	if fn["name"] != "weather" {
+		t.Fatalf("expected weather, got %v", fn["name"])
+	}
+	if DataPartMap(dp, "missing") != nil {
+		t.Fatal("expected nil for missing key")
+	}
+}

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -353,8 +353,7 @@ func (r *QueryReconciler) sendQueryA2A(ctx context.Context, address string, quer
 
 	rawJSON := engineMeta.MessagesRaw
 	if rawJSON == "" {
-		responseMessages := []completions.Message{completions.NewAssistantMessage(responseText)}
-		rawJSON = serializeMessages(responseMessages)
+		rawJSON = buildFallbackRaw(responseText)
 	}
 
 	response := &arkv1alpha1.Response{
@@ -382,27 +381,13 @@ func extractUserInput(ctx context.Context, query arkv1alpha1.Query, k8sClient cl
 	return completions.ExtractUserMessageContent(inputMessages)
 }
 
-func serializeMessages(messages []completions.Message) string {
-	var actualMessages []interface{}
-	for _, msg := range messages {
-		switch {
-		case msg.OfAssistant != nil:
-			actualMessages = append(actualMessages, msg.OfAssistant)
-		case msg.OfUser != nil:
-			actualMessages = append(actualMessages, msg.OfUser)
-		case msg.OfSystem != nil:
-			actualMessages = append(actualMessages, msg.OfSystem)
-		case msg.OfTool != nil:
-			actualMessages = append(actualMessages, msg.OfTool)
-		case msg.OfFunction != nil:
-			actualMessages = append(actualMessages, msg.OfFunction)
-		}
-	}
-	rawBytes, err := json.Marshal(actualMessages)
+func buildFallbackRaw(content string) string {
+	msg := map[string]string{"role": "assistant", "content": content}
+	b, err := json.Marshal([]map[string]string{msg})
 	if err != nil {
 		return "[]"
 	}
-	return string(rawBytes)
+	return string(b)
 }
 
 func extractA2AResponseText(result *protocol.MessageResult) (string, error) {
@@ -509,141 +494,13 @@ func metadataToMap(data any) map[string]any {
 }
 
 func extractResponseMessages(arkMap map[string]any) (raw string, protocolNative bool) {
-	if v1Raw, ok := arkMap["responseMessagesV1"]; ok {
-		rawBytes := toRawBytes(v1Raw)
-		if rawJSON := protocolMessagesToRawJSON(rawBytes); rawJSON != "" {
-			return rawJSON, true
-		}
-	}
+	_, hasProtocol := arkMap["responseMessagesV1"]
 	if messagesRaw, ok := arkMap["messages"]; ok {
 		if rawBytes, err := json.Marshal(messagesRaw); err == nil {
-			return string(rawBytes), false
+			return string(rawBytes), hasProtocol
 		}
 	}
-	return "", false
-}
-
-func toRawBytes(v any) []byte {
-	switch typed := v.(type) {
-	case string:
-		return []byte(typed)
-	case json.RawMessage:
-		return typed
-	default:
-		if b, err := json.Marshal(typed); err == nil {
-			return b
-		}
-		return nil
-	}
-}
-
-func protocolMessagesToRawJSON(data []byte) string {
-	if len(data) == 0 {
-		return ""
-	}
-	var protoMsgs []protocol.Message
-	if err := json.Unmarshal(data, &protoMsgs); err != nil {
-		return ""
-	}
-	if len(protoMsgs) == 0 {
-		return ""
-	}
-
-	converted := make([]any, 0, len(protoMsgs))
-	for _, pm := range protoMsgs {
-		converted = append(converted, protocolMessageToRawCompat(pm))
-	}
-	if len(converted) == 0 {
-		return ""
-	}
-
-	rawBytes, err := json.Marshal(converted)
-	if err != nil {
-		return ""
-	}
-	return string(rawBytes)
-}
-
-func protocolMessageToRawCompat(pm protocol.Message) any {
-	dataParts := arka2a.ExtractDataParts(pm.Parts)
-	if len(dataParts) == 0 {
-		return textOnlyCompat(pm)
-	}
-
-	dpType := arka2a.DataPartType(dataParts[0])
-	switch dpType {
-	case "tool_result":
-		return toolResultCompat(dataParts[0])
-	case "system":
-		return systemCompat(dataParts[0])
-	case "function_result":
-		return functionResultCompat(dataParts[0])
-	default:
-		return assistantWithToolCallsCompat(pm, dataParts)
-	}
-}
-
-func textOnlyCompat(pm protocol.Message) map[string]any {
-	role := "assistant"
-	if pm.Role == protocol.MessageRoleUser {
-		role = "user"
-	}
-	return map[string]any{
-		"role":    role,
-		"content": arka2a.ExtractTextFromParts(pm.Parts),
-	}
-}
-
-func assistantWithToolCallsCompat(pm protocol.Message, dataParts []protocol.DataPart) map[string]any {
-	msg := map[string]any{
-		"role":    "assistant",
-		"content": arka2a.ExtractTextFromParts(pm.Parts),
-	}
-	toolCalls := make([]map[string]any, 0, len(dataParts))
-	for _, dp := range dataParts {
-		if arka2a.DataPartType(dp) != "tool_call" {
-			continue
-		}
-		tc := map[string]any{
-			"id":   arka2a.DataPartField(dp, "id"),
-			"type": "function",
-			"function": map[string]any{
-				"name":      arka2a.DataPartField(arka2a.ExtractDataParts([]protocol.Part{dp})[0], ""),
-				"arguments": "",
-			},
-		}
-		if fn := arka2a.DataPartMap(dp, "function"); fn != nil {
-			tc["function"] = fn
-		}
-		toolCalls = append(toolCalls, tc)
-	}
-	if len(toolCalls) > 0 {
-		msg["tool_calls"] = toolCalls
-	}
-	return msg
-}
-
-func toolResultCompat(dp protocol.DataPart) map[string]any {
-	return map[string]any{
-		"role":         "tool",
-		"tool_call_id": arka2a.DataPartField(dp, "tool_call_id"),
-		"content":      arka2a.DataPartField(dp, "content"),
-	}
-}
-
-func systemCompat(dp protocol.DataPart) map[string]any {
-	return map[string]any{
-		"role":    "system",
-		"content": arka2a.DataPartField(dp, "content"),
-	}
-}
-
-func functionResultCompat(dp protocol.DataPart) map[string]any {
-	return map[string]any{
-		"role":    "function",
-		"name":    arka2a.DataPartField(dp, "name"),
-		"content": arka2a.DataPartField(dp, "content"),
-	}
+	return "", hasProtocol
 }
 
 func extractA2AMeta(arkMap map[string]any, responseMeta *engineResponseMeta) {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -435,6 +435,7 @@ type engineResponseMeta struct {
 	MessagesRaw    string
 	A2AContextID   string
 	A2ATaskID      string
+	ProtocolNative bool
 }
 
 func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMeta {
@@ -443,22 +444,8 @@ func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMet
 		return responseMeta
 	}
 
-	var msgMeta map[string]any
-	if msg, ok := result.Result.(*protocol.Message); ok {
-		msgMeta = msg.Metadata
-	}
-
-	if msgMeta == nil {
-		return responseMeta
-	}
-
-	arkData, ok := msgMeta[arka2a.QueryExtensionMetadataKey]
-	if !ok {
-		return responseMeta
-	}
-
-	arkMap, ok := arkData.(map[string]any)
-	if !ok {
+	arkMap := extractArkPayloadMap(result)
+	if arkMap == nil {
 		return responseMeta
 	}
 
@@ -466,16 +453,181 @@ func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMet
 		responseMeta.ConversationId = convId
 	}
 
-	if messagesRaw, ok := arkMap["messages"]; ok {
-		if rawBytes, err := json.Marshal(messagesRaw); err == nil {
-			responseMeta.MessagesRaw = string(rawBytes)
-		}
-	}
+	raw, protocolNative := extractResponseMessages(arkMap)
+	responseMeta.MessagesRaw = raw
+	responseMeta.ProtocolNative = protocolNative
 
 	extractA2AMeta(arkMap, &responseMeta)
 	extractTokenUsage(arkMap, &responseMeta)
 
 	return responseMeta
+}
+
+func extractArkPayloadMap(result *protocol.MessageResult) map[string]any {
+	msg, ok := result.Result.(*protocol.Message)
+	if !ok || msg.Metadata == nil {
+		return nil
+	}
+
+	arkData, ok := msg.Metadata[arka2a.ExecutionContextExtensionURI]
+	if !ok {
+		arkData, ok = msg.Metadata[arka2a.QueryExtensionMetadataKey]
+	}
+	if !ok {
+		return nil
+	}
+
+	arkMap, ok := arkData.(map[string]any)
+	if ok {
+		return arkMap
+	}
+
+	rawBytes, err := json.Marshal(arkData)
+	if err != nil {
+		return nil
+	}
+	if json.Unmarshal(rawBytes, &arkMap) != nil {
+		return nil
+	}
+	return arkMap
+}
+
+func extractResponseMessages(arkMap map[string]any) (raw string, protocolNative bool) {
+	if v1Raw, ok := arkMap["responseMessagesV1"]; ok {
+		rawBytes := toRawBytes(v1Raw)
+		if rawJSON := protocolMessagesToRawJSON(rawBytes); rawJSON != "" {
+			return rawJSON, true
+		}
+	}
+	if messagesRaw, ok := arkMap["messages"]; ok {
+		if rawBytes, err := json.Marshal(messagesRaw); err == nil {
+			return string(rawBytes), false
+		}
+	}
+	return "", false
+}
+
+func toRawBytes(v any) []byte {
+	switch typed := v.(type) {
+	case string:
+		return []byte(typed)
+	case json.RawMessage:
+		return typed
+	default:
+		if b, err := json.Marshal(typed); err == nil {
+			return b
+		}
+		return nil
+	}
+}
+
+func protocolMessagesToRawJSON(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var protoMsgs []protocol.Message
+	if err := json.Unmarshal(data, &protoMsgs); err != nil {
+		return ""
+	}
+	if len(protoMsgs) == 0 {
+		return ""
+	}
+
+	converted := make([]any, 0, len(protoMsgs))
+	for _, pm := range protoMsgs {
+		converted = append(converted, protocolMessageToRawCompat(pm))
+	}
+	if len(converted) == 0 {
+		return ""
+	}
+
+	rawBytes, err := json.Marshal(converted)
+	if err != nil {
+		return ""
+	}
+	return string(rawBytes)
+}
+
+func protocolMessageToRawCompat(pm protocol.Message) any {
+	dataParts := arka2a.ExtractDataParts(pm.Parts)
+	if len(dataParts) == 0 {
+		return textOnlyCompat(pm)
+	}
+
+	dpType := arka2a.DataPartType(dataParts[0])
+	switch dpType {
+	case "tool_result":
+		return toolResultCompat(dataParts[0])
+	case "system":
+		return systemCompat(dataParts[0])
+	case "function_result":
+		return functionResultCompat(dataParts[0])
+	default:
+		return assistantWithToolCallsCompat(pm, dataParts)
+	}
+}
+
+func textOnlyCompat(pm protocol.Message) map[string]any {
+	role := "assistant"
+	if pm.Role == protocol.MessageRoleUser {
+		role = "user"
+	}
+	return map[string]any{
+		"role":    role,
+		"content": arka2a.ExtractTextFromParts(pm.Parts),
+	}
+}
+
+func assistantWithToolCallsCompat(pm protocol.Message, dataParts []protocol.DataPart) map[string]any {
+	msg := map[string]any{
+		"role":    "assistant",
+		"content": arka2a.ExtractTextFromParts(pm.Parts),
+	}
+	toolCalls := make([]map[string]any, 0, len(dataParts))
+	for _, dp := range dataParts {
+		if arka2a.DataPartType(dp) != "tool_call" {
+			continue
+		}
+		tc := map[string]any{
+			"id":   arka2a.DataPartField(dp, "id"),
+			"type": "function",
+			"function": map[string]any{
+				"name":      arka2a.DataPartField(arka2a.ExtractDataParts([]protocol.Part{dp})[0], ""),
+				"arguments": "",
+			},
+		}
+		if fn := arka2a.DataPartMap(dp, "function"); fn != nil {
+			tc["function"] = fn
+		}
+		toolCalls = append(toolCalls, tc)
+	}
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
+	}
+	return msg
+}
+
+func toolResultCompat(dp protocol.DataPart) map[string]any {
+	return map[string]any{
+		"role":         "tool",
+		"tool_call_id": arka2a.DataPartField(dp, "tool_call_id"),
+		"content":      arka2a.DataPartField(dp, "content"),
+	}
+}
+
+func systemCompat(dp protocol.DataPart) map[string]any {
+	return map[string]any{
+		"role":    "system",
+		"content": arka2a.DataPartField(dp, "content"),
+	}
+}
+
+func functionResultCompat(dp protocol.DataPart) map[string]any {
+	return map[string]any{
+		"role":    "function",
+		"name":    arka2a.DataPartField(dp, "name"),
+		"content": arka2a.DataPartField(dp, "content"),
+	}
 }
 
 func extractA2AMeta(arkMap map[string]any, responseMeta *engineResponseMeta) {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -469,27 +469,43 @@ func extractArkPayloadMap(result *protocol.MessageResult) map[string]any {
 		return nil
 	}
 
-	arkData, ok := msg.Metadata[arka2a.ExecutionContextExtensionURI]
-	if !ok {
-		arkData, ok = msg.Metadata[arka2a.QueryExtensionMetadataKey]
+	merged := map[string]any{}
+
+	if legacyData, ok := msg.Metadata[arka2a.QueryExtensionMetadataKey]; ok {
+		if m := metadataToMap(legacyData); m != nil {
+			for k, v := range m {
+				merged[k] = v
+			}
+		}
 	}
-	if !ok {
+
+	if extData, ok := msg.Metadata[arka2a.ExecutionContextExtensionURI]; ok {
+		if m := metadataToMap(extData); m != nil {
+			for k, v := range m {
+				merged[k] = v
+			}
+		}
+	}
+
+	if len(merged) == 0 {
 		return nil
 	}
+	return merged
+}
 
-	arkMap, ok := arkData.(map[string]any)
-	if ok {
-		return arkMap
+func metadataToMap(data any) map[string]any {
+	if m, ok := data.(map[string]any); ok {
+		return m
 	}
-
-	rawBytes, err := json.Marshal(arkData)
+	rawBytes, err := json.Marshal(data)
 	if err != nil {
 		return nil
 	}
-	if json.Unmarshal(rawBytes, &arkMap) != nil {
+	var m map[string]any
+	if json.Unmarshal(rawBytes, &m) != nil {
 		return nil
 	}
-	return arkMap
+	return m
 }
 
 func extractResponseMessages(arkMap map[string]any) (raw string, protocolNative bool) {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -266,6 +266,42 @@ var _ = Describe("extractEngineResponseMeta", func() {
 			Expect(meta.ProtocolNative).To(BeTrue())
 		})
 
+		It("should merge a2a metadata from legacy key when extension key is primary", func() {
+			protoMsgs := []protocol.Message{
+				protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+					protocol.NewTextPart("answer"),
+				}),
+			}
+			protoBytes, err := json.Marshal(protoMsgs)
+			Expect(err).NotTo(HaveOccurred())
+
+			responseMsg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.NewTextPart("hello"),
+			})
+			responseMsg.Metadata = map[string]any{
+				arka2a.QueryExtensionMetadataKey: map[string]any{
+					"conversationId": "conv-legacy",
+					"a2a": map[string]any{
+						"contextId": "ctx-abc",
+						"taskId":    "task-xyz",
+					},
+					"messages": json.RawMessage(`[{"role":"assistant","content":"legacy"}]`),
+				},
+				arka2a.ExecutionContextExtensionURI: map[string]any{
+					"conversationId":     "conv-ext",
+					"responseMessagesV1": json.RawMessage(protoBytes),
+				},
+			}
+
+			result := &protocol.MessageResult{Result: &responseMsg}
+			meta := extractEngineResponseMeta(result)
+
+			Expect(meta.ConversationId).To(Equal("conv-ext"))
+			Expect(meta.A2AContextID).To(Equal("ctx-abc"))
+			Expect(meta.A2ATaskID).To(Equal("task-xyz"))
+			Expect(meta.ProtocolNative).To(BeTrue())
+		})
+
 		It("should fall back to legacy messages when responseMessagesV1 is absent", func() {
 			responseMsg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
 				protocol.NewTextPart("hello"),

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openai/openai-go"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
-	completions "mckinsey.com/ark/executors/completions"
 	arka2a "mckinsey.com/ark/internal/a2a"
 )
 
@@ -211,34 +209,30 @@ var _ = Describe("Query Controller", func() {
 	})
 })
 
-var _ = Describe("Query Controller Message Serialization", func() {
-	Context("When serializing messages", func() {
-		It("should serialize all message types correctly", func() {
-			messages := []completions.Message{
-				completions.Message(openai.AssistantMessage("hello")),
-				completions.Message(openai.UserMessage("hi")),
-				completions.Message(openai.SystemMessage("sys")),
-				completions.Message(openai.ToolMessage("tool-content", "tool-1")),
-			}
+var _ = Describe("buildFallbackRaw", func() {
+	It("should produce valid JSON with assistant role", func() {
+		raw := buildFallbackRaw("hello world")
+		Expect(raw).To(ContainSubstring(`"role":"assistant"`))
+		Expect(raw).To(ContainSubstring(`"content":"hello world"`))
 
-			jsonStr := serializeMessages(messages)
-			Expect(jsonStr).To(ContainSubstring("assistant"))
-			Expect(jsonStr).To(ContainSubstring("user"))
-			Expect(jsonStr).To(ContainSubstring("system"))
-			Expect(jsonStr).To(ContainSubstring("tool"))
-		})
+		var parsed []map[string]string
+		Expect(json.Unmarshal([]byte(raw), &parsed)).To(Succeed())
+		Expect(parsed).To(HaveLen(1))
+		Expect(parsed[0]["role"]).To(Equal("assistant"))
+		Expect(parsed[0]["content"]).To(Equal("hello world"))
+	})
 
-		It("should return empty array for unknown message types", func() {
-			messages := []completions.Message{{}}
-			jsonStr := serializeMessages(messages)
-			Expect(jsonStr).To(Equal("null"))
-		})
+	It("should handle empty content", func() {
+		raw := buildFallbackRaw("")
+		var parsed []map[string]string
+		Expect(json.Unmarshal([]byte(raw), &parsed)).To(Succeed())
+		Expect(parsed[0]["content"]).To(Equal(""))
 	})
 })
 
 var _ = Describe("extractEngineResponseMeta", func() {
 	Context("protocol-first extraction precedence", func() {
-		It("should prefer responseMessagesV1 when both fields are present", func() {
+		It("should pass through legacy messages and track protocol presence", func() {
 			protoMsgs := []protocol.Message{
 				protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
 					protocol.NewTextPart("protocol answer"),
@@ -262,11 +256,11 @@ var _ = Describe("extractEngineResponseMeta", func() {
 			meta := extractEngineResponseMeta(result)
 
 			Expect(meta.ConversationId).To(Equal("conv-123"))
-			Expect(meta.MessagesRaw).To(ContainSubstring("protocol answer"))
+			Expect(meta.MessagesRaw).To(ContainSubstring("legacy msg"))
 			Expect(meta.ProtocolNative).To(BeTrue())
 		})
 
-		It("should merge a2a metadata from legacy key when extension key is primary", func() {
+		It("should merge a2a metadata from legacy key and pass through legacy messages", func() {
 			protoMsgs := []protocol.Message{
 				protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
 					protocol.NewTextPart("answer"),
@@ -299,6 +293,7 @@ var _ = Describe("extractEngineResponseMeta", func() {
 			Expect(meta.ConversationId).To(Equal("conv-ext"))
 			Expect(meta.A2AContextID).To(Equal("ctx-abc"))
 			Expect(meta.A2ATaskID).To(Equal("task-xyz"))
+			Expect(meta.MessagesRaw).To(ContainSubstring("legacy"))
 			Expect(meta.ProtocolNative).To(BeTrue())
 		})
 
@@ -324,62 +319,6 @@ var _ = Describe("extractEngineResponseMeta", func() {
 		It("should handle nil result gracefully", func() {
 			meta := extractEngineResponseMeta(nil)
 			Expect(meta.MessagesRaw).To(BeEmpty())
-		})
-	})
-
-	Context("protocolMessagesToRawJSON with DataParts", func() {
-		It("should reconstruct tool calls from DataParts", func() {
-			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
-				protocol.NewTextPart("checking weather"),
-				protocol.DataPart{
-					Kind: "data",
-					Data: map[string]any{
-						"type": "tool_call",
-						"id":   "tc-1",
-						"function": map[string]any{
-							"name":      "weather_api",
-							"arguments": `{"city":"NYC"}`,
-						},
-					},
-				},
-			})
-			data, _ := json.Marshal([]protocol.Message{msg})
-			rawJSON := protocolMessagesToRawJSON(data)
-			Expect(rawJSON).To(ContainSubstring("tool_calls"))
-			Expect(rawJSON).To(ContainSubstring("weather_api"))
-		})
-
-		It("should reconstruct tool results from DataParts", func() {
-			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
-				protocol.DataPart{
-					Kind: "data",
-					Data: map[string]any{
-						"type":         "tool_result",
-						"tool_call_id": "tc-1",
-						"content":      "72F sunny",
-					},
-				},
-			})
-			data, _ := json.Marshal([]protocol.Message{msg})
-			rawJSON := protocolMessagesToRawJSON(data)
-			Expect(rawJSON).To(ContainSubstring(`"role":"tool"`))
-			Expect(rawJSON).To(ContainSubstring("tc-1"))
-		})
-
-		It("should reconstruct system messages from DataParts", func() {
-			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
-				protocol.DataPart{
-					Kind: "data",
-					Data: map[string]any{
-						"type":    "system",
-						"content": "you are helpful",
-					},
-				},
-			})
-			data, _ := json.Marshal([]protocol.Message{msg})
-			rawJSON := protocolMessagesToRawJSON(data)
-			Expect(rawJSON).To(ContainSubstring(`"role":"system"`))
-			Expect(rawJSON).To(ContainSubstring("you are helpful"))
 		})
 	})
 })

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,11 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	completions "mckinsey.com/ark/executors/completions"
+	arka2a "mckinsey.com/ark/internal/a2a"
 )
 
 var _ = Describe("Query Controller", func() {
@@ -229,6 +232,118 @@ var _ = Describe("Query Controller Message Serialization", func() {
 			messages := []completions.Message{{}}
 			jsonStr := serializeMessages(messages)
 			Expect(jsonStr).To(Equal("null"))
+		})
+	})
+})
+
+var _ = Describe("extractEngineResponseMeta", func() {
+	Context("protocol-first extraction precedence", func() {
+		It("should prefer responseMessagesV1 when both fields are present", func() {
+			protoMsgs := []protocol.Message{
+				protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+					protocol.NewTextPart("protocol answer"),
+				}),
+			}
+			protoBytes, err := json.Marshal(protoMsgs)
+			Expect(err).NotTo(HaveOccurred())
+
+			responseMsg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.NewTextPart("hello"),
+			})
+			responseMsg.Metadata = map[string]any{
+				arka2a.ExecutionContextExtensionURI: map[string]any{
+					"conversationId":     "conv-123",
+					"responseMessagesV1": json.RawMessage(protoBytes),
+					"messages":           json.RawMessage(`[{"role":"assistant","content":"legacy msg"}]`),
+				},
+			}
+
+			result := &protocol.MessageResult{Result: &responseMsg}
+			meta := extractEngineResponseMeta(result)
+
+			Expect(meta.ConversationId).To(Equal("conv-123"))
+			Expect(meta.MessagesRaw).To(ContainSubstring("protocol answer"))
+			Expect(meta.ProtocolNative).To(BeTrue())
+		})
+
+		It("should fall back to legacy messages when responseMessagesV1 is absent", func() {
+			responseMsg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.NewTextPart("hello"),
+			})
+			responseMsg.Metadata = map[string]any{
+				arka2a.QueryExtensionMetadataKey: map[string]any{
+					"conversationId": "conv-456",
+					"messages":       json.RawMessage(`[{"role":"assistant","content":"legacy msg"}]`),
+				},
+			}
+
+			result := &protocol.MessageResult{Result: &responseMsg}
+			meta := extractEngineResponseMeta(result)
+
+			Expect(meta.ConversationId).To(Equal("conv-456"))
+			Expect(meta.MessagesRaw).To(ContainSubstring("legacy msg"))
+			Expect(meta.ProtocolNative).To(BeFalse())
+		})
+
+		It("should handle nil result gracefully", func() {
+			meta := extractEngineResponseMeta(nil)
+			Expect(meta.MessagesRaw).To(BeEmpty())
+		})
+	})
+
+	Context("protocolMessagesToRawJSON with DataParts", func() {
+		It("should reconstruct tool calls from DataParts", func() {
+			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.NewTextPart("checking weather"),
+				protocol.DataPart{
+					Kind: "data",
+					Data: map[string]any{
+						"type": "tool_call",
+						"id":   "tc-1",
+						"function": map[string]any{
+							"name":      "weather_api",
+							"arguments": `{"city":"NYC"}`,
+						},
+					},
+				},
+			})
+			data, _ := json.Marshal([]protocol.Message{msg})
+			rawJSON := protocolMessagesToRawJSON(data)
+			Expect(rawJSON).To(ContainSubstring("tool_calls"))
+			Expect(rawJSON).To(ContainSubstring("weather_api"))
+		})
+
+		It("should reconstruct tool results from DataParts", func() {
+			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.DataPart{
+					Kind: "data",
+					Data: map[string]any{
+						"type":         "tool_result",
+						"tool_call_id": "tc-1",
+						"content":      "72F sunny",
+					},
+				},
+			})
+			data, _ := json.Marshal([]protocol.Message{msg})
+			rawJSON := protocolMessagesToRawJSON(data)
+			Expect(rawJSON).To(ContainSubstring(`"role":"tool"`))
+			Expect(rawJSON).To(ContainSubstring("tc-1"))
+		})
+
+		It("should reconstruct system messages from DataParts", func() {
+			msg := protocol.NewMessage(protocol.MessageRoleAgent, []protocol.Part{
+				protocol.DataPart{
+					Kind: "data",
+					Data: map[string]any{
+						"type":    "system",
+						"content": "you are helpful",
+					},
+				},
+			})
+			data, _ := json.Marshal([]protocol.Message{msg})
+			rawJSON := protocolMessagesToRawJSON(data)
+			Expect(rawJSON).To(ContainSubstring(`"role":"system"`))
+			Expect(rawJSON).To(ContainSubstring("you are helpful"))
 		})
 	})
 })

--- a/openspec/changes/pra-1244-boundary-contract/.openspec.yaml
+++ b/openspec/changes/pra-1244-boundary-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/pra-1244-boundary-contract/README.md
+++ b/openspec/changes/pra-1244-boundary-contract/README.md
@@ -1,0 +1,3 @@
+# pra-1244-boundary-contract
+
+Generic multi-extension support and full-fidelity protocol-native response contract at the handler/controller A2A boundary. Implements DataPart-based conversion preserving tool calls, system messages, and function results through the A2A protocol layer. Controller prefers protocol-native path for `response.raw`. Follows A2A Protocol Specification v1.0 Section 4.6.2.

--- a/openspec/changes/pra-1244-boundary-contract/design.md
+++ b/openspec/changes/pra-1244-boundary-contract/design.md
@@ -107,24 +107,13 @@ func DataPartMap(dp protocol.DataPart, key string) map[string]any
 
 ## Controller Extraction Path
 
-`extractEngineResponseMeta()` protocol-first precedence:
+`extractEngineResponseMeta()` with controller response path independence:
 
-1. `arka2a.GetExtension(msg, ExecutionContextExtensionURI)` as primary, falls back to `arka2a.GetMetadata(msg, ArkMetadataKey)`.
-2. Within the metadata map, prefer `responseMessagesV1` -- if present, unmarshal as `[]protocol.Message` and convert to `response.raw` compatible JSON via `protocolMessagesToRawJSON`.
-3. If `responseMessagesV1` is absent, fall back to legacy `messages` field.
-4. If neither is present, caller constructs a single assistant message from response text.
+1. `extractArkPayloadMap` merges metadata from `QueryExtensionMetadataKey` (base) and `ExecutionContextExtensionURI` (overlay). Extension key values take precedence for overlapping fields.
+2. `extractResponseMessages` passes through `messages` (executor-produced legacy JSON) as opaque bytes for `response.raw`. No parsing, no reconstruction. Tracks `responseMessagesV1` presence via `ProtocolNative` flag.
+3. If no `messages` field exists, `buildFallbackRaw` constructs minimal `[{"role":"assistant","content":"..."}]` without importing OpenAI types.
 
-## Protocol-to-Raw Conversion
-
-`protocolMessagesToRawJSON()` reconstructs full OpenAI-compatible JSON from DataParts:
-
-| DataPart type | Reconstructed JSON |
-|---|---|
-| (text only, no DataParts) | `{"role":"assistant\|user","content":"..."}` |
-| `tool_call` | `{"role":"assistant","content":"...","tool_calls":[{"id":"...","type":"function","function":{"name":"...","arguments":"..."}}]}` |
-| `tool_result` | `{"role":"tool","tool_call_id":"...","content":"..."}` |
-| `system` | `{"role":"system","content":"..."}` |
-| `function_result` | `{"role":"function","name":"...","content":"..."}` |
+The controller does NOT contain `protocolMessagesToRawJSON` or any OpenAI reconstruction logic. The executor owns the boundary where OpenAI types exist and produces both formats (`messages` for legacy consumers, `responseMessagesV1` for A2A-native consumers).
 
 ## Wire Format Example
 

--- a/openspec/changes/pra-1244-boundary-contract/design.md
+++ b/openspec/changes/pra-1244-boundary-contract/design.md
@@ -1,0 +1,152 @@
+# PR-A Boundary Contract Design
+
+## Decision
+
+Introduce a generic multi-extension API following A2A Protocol Specification v1.0 (Section 4.6.2) and a versioned protocol-native response field at the handler/controller boundary while maintaining backward compatibility with legacy OpenAI-shaped metadata. The controller uses three-tier extraction precedence to support mixed-engine environments.
+
+## A2A Spec Alignment
+
+- **Section 4.1.4 (Message)**: `extensions` is an array of URI strings declaring which extensions "are present or contributed to this Message". `metadata` is a key-value map where extension URIs serve as keys and strongly-typed payloads as values.
+- **Section 4.6.2 (Extension Points)**: Messages carry extension data via `extensions` (URI declaration) + `metadata[extensionURI]` (payload).
+- **Section 4.6.3 (Extension Versioning)**: Extensions SHOULD include version info in their URI. A new URI MUST be created for breaking changes.
+
+**Critical distinction**: Only spec-compliant A2A extensions belong in `Message.extensions`. The legacy `ArkMetadataKey` (`ark.mckinsey.com/execution-engine`) is NOT an extension -- it is bare metadata that predates the extension pattern. It is set via `SetMetadata` (metadata only) and MUST NOT appear in `Message.extensions`.
+
+## Generic Extension Helpers
+
+New file `ark/internal/a2a/extensions.go` with:
+
+```go
+func SetExtension(m *protocol.Message, uri string, payload any)
+func SetMetadata(m *protocol.Message, key string, value any)
+func GetExtension(m protocol.Message, uri string) (any, bool)
+func GetExtensionAs[T any](m protocol.Message, uri string) (T, error)
+func HasExtension(m protocol.Message, uri string) bool
+func GetMetadata(m protocol.Message, key string) (any, bool)
+```
+
+`SetExtension` follows the spec: adds URI to `m.Extensions` (deduped) AND sets `m.Metadata[uri] = payload`.
+`SetMetadata` sets only `m.Metadata[key]` without touching `m.Extensions` -- for non-extension metadata like the legacy `ArkMetadataKey`.
+
+Typed convenience wrappers for known Ark extensions:
+
+```go
+func SetExecutionContextExtension(m *protocol.Message, payload ExecutionResponsePayload)
+func GetExecutionContextExtension(m protocol.Message) (*ExecutionResponsePayload, error)
+```
+
+## Types
+
+Add to `ark/internal/a2a/a2a_types.go`:
+
+```go
+const (
+    ExecutionContextExtensionURI = "ark.mckinsey.com/extensions/execution-context/v1"
+    ExecutionTraceExtensionURI   = "ark.mckinsey.com/extensions/execution-trace/v1"
+)
+
+type ExecutionResponsePayload struct {
+    TokenUsage         *ResponseTokenUsage `json:"tokenUsage,omitempty"`
+    ConversationId     string              `json:"conversationId,omitempty"`
+    Messages           any                 `json:"messages,omitempty"`
+    ResponseMessagesV1 json.RawMessage     `json:"responseMessagesV1,omitempty"`
+}
+
+type ResponseTokenUsage struct {
+    PromptTokens     int64 `json:"prompt_tokens"`
+    CompletionTokens int64 `json:"completion_tokens"`
+    TotalTokens      int64 `json:"total_tokens"`
+}
+```
+
+`ResponseMessagesV1` contains `json.Marshal([]protocol.Message)` -- the protocol-native message sequence. `Messages` retains the legacy OpenAI-shaped JSON for backward compatibility.
+
+## Handler Response Path
+
+`buildA2AResponse()` uses the extension helpers:
+
+1. Build `ExecutionResponsePayload` with both `responseMessagesV1` (protocol-native) and `messages` (legacy).
+2. Call `arka2a.SetExecutionContextExtension(responseMsg, extensionPayload)` -- adds URI to `extensions` + payload to `metadata`.
+3. Call `arka2a.SetMetadata(responseMsg, arka2a.ArkMetadataKey, legacyMeta)` -- legacy metadata only, NOT added to `extensions`.
+
+## Handler Extraction Path
+
+`extractArkMetadata()` uses:
+1. `arka2a.GetExtension(msg, ExecutionContextExtensionURI)` as primary lookup.
+2. Falls back to `arka2a.GetMetadata(msg, ArkMetadataKey)` for legacy messages.
+
+## Controller Request Path
+
+`executeViaEngine()` uses:
+1. `arka2a.SetExtension(msg, ExecutionContextExtensionURI, arkMetadata)` for the spec-compliant extension.
+2. `arka2a.SetMetadata(msg, ArkMetadataKey, arkMetadata)` for legacy backward compat.
+
+## DataPart Helpers
+
+New helpers in `ark/internal/a2a/extensions.go` for consuming structured protocol data:
+
+```go
+func ExtractDataParts(parts []protocol.Part) []protocol.DataPart
+func DataPartType(dp protocol.DataPart) string
+func DataPartField(dp protocol.DataPart, key string) string
+func DataPartMap(dp protocol.DataPart, key string) map[string]any
+```
+
+## Full-Fidelity Protocol Conversion
+
+`openAIToProtocolResponseMessages()` maps each OpenAI message to a `protocol.Message` with DataParts:
+
+| OpenAI type | Protocol representation |
+|---|---|
+| `OfAssistant` (text only) | `role: agent`, `TextPart` |
+| `OfAssistant` (with tool calls) | `role: agent`, `TextPart` + `DataPart` per call (`{type:tool_call, id, function:{name, arguments}}`) |
+| `OfUser` | `role: user`, `TextPart` |
+| `OfTool` | `role: agent`, `DataPart{type:tool_result, tool_call_id, content}` |
+| `OfSystem` | `role: agent`, `DataPart{type:system, content}` |
+| `OfFunction` | `role: agent`, `DataPart{type:function_result, name, content}` |
+
+## Controller Extraction Path
+
+`extractEngineResponseMeta()` protocol-first precedence:
+
+1. `arka2a.GetExtension(msg, ExecutionContextExtensionURI)` as primary, falls back to `arka2a.GetMetadata(msg, ArkMetadataKey)`.
+2. Within the metadata map, prefer `responseMessagesV1` -- if present, unmarshal as `[]protocol.Message` and convert to `response.raw` compatible JSON via `protocolMessagesToRawJSON`.
+3. If `responseMessagesV1` is absent, fall back to legacy `messages` field.
+4. If neither is present, caller constructs a single assistant message from response text.
+
+## Protocol-to-Raw Conversion
+
+`protocolMessagesToRawJSON()` reconstructs full OpenAI-compatible JSON from DataParts:
+
+| DataPart type | Reconstructed JSON |
+|---|---|
+| (text only, no DataParts) | `{"role":"assistant\|user","content":"..."}` |
+| `tool_call` | `{"role":"assistant","content":"...","tool_calls":[{"id":"...","type":"function","function":{"name":"...","arguments":"..."}}]}` |
+| `tool_result` | `{"role":"tool","tool_call_id":"...","content":"..."}` |
+| `system` | `{"role":"system","content":"..."}` |
+| `function_result` | `{"role":"function","name":"...","content":"..."}` |
+
+## Wire Format Example
+
+Per A2A spec Section 4.6.2:
+
+```json
+{
+  "role": "ROLE_AGENT",
+  "parts": [{"text": "..."}],
+  "extensions": ["ark.mckinsey.com/extensions/execution-context/v1"],
+  "metadata": {
+    "ark.mckinsey.com/extensions/execution-context/v1": { "tokenUsage": {...}, "responseMessagesV1": [...] },
+    "ark.mckinsey.com/execution-engine": { "conversationId": "...", "messages": [...] }
+  }
+}
+```
+
+Only the first key appears in `extensions`. The second is plain metadata, never declared in `extensions`.
+
+## Compatibility
+
+- Legacy engines that only write `ArkMetadataKey` continue to work via `GetMetadata` fallback.
+- Dashboard parsing of `response.raw` is unchanged -- the controller produces the same output shape.
+- New engines can write `responseMessagesV1` without needing OpenAI union knowledge.
+- Third-party extensions use the same `SetExtension`/`GetExtension` API with their own URIs.

--- a/openspec/changes/pra-1244-boundary-contract/proposal.md
+++ b/openspec/changes/pra-1244-boundary-contract/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The handler/controller boundary serializes response messages as OpenAI-shaped JSON in A2A metadata. Non-OpenAI execution engines must emulate OpenAI union shape to participate, blocking mixed-engine execution. The `ArkMetadataKey` is used without `Message.Extensions`, violating A2A extension semantics (Section 4.6.2). Extension handling is hardcoded inline with no reusable API, preventing Ark from supporting multiple extensions (its own or third-party).
+
+## What Changes
+
+- Add generic multi-extension helpers (`SetExtension`, `SetMetadata`, `GetExtension`, `GetExtensionAs[T]`, `HasExtension`, `GetMetadata`) in `ark/internal/a2a/extensions.go` implementing A2A spec Section 4.6.2.
+- Add DataPart extraction helpers (`ExtractDataParts`, `DataPartType`, `DataPartField`, `DataPartMap`) for consuming structured protocol data.
+- Add typed wrappers (`SetExecutionContextExtension`, `GetExecutionContextExtension`) for Ark's execution-context extension.
+- Add `ExecutionContextExtensionURI` and `ExecutionTraceExtensionURI` constants with versioned URIs per spec Section 4.6.3.
+- Add `ExecutionResponsePayload` and `ResponseTokenUsage` types.
+- Refactor handler `buildA2AResponse()` to use `SetExecutionContextExtension` for the spec-compliant extension and `SetMetadata` for legacy `ArkMetadataKey`.
+- Refactor handler `extractArkMetadata()` to use `GetExtension` with `GetMetadata` fallback.
+- Rewrite handler `openAIToProtocolResponseMessages()` to produce full-fidelity `protocol.Message` with DataParts for tool calls, tool results, system messages, and function messages.
+- Refactor controller `executeViaEngine()` to use `SetExtension` and `SetMetadata`.
+- Refactor controller `extractEngineResponseMeta()` to use `GetExtension` with `GetMetadata` fallback, protocol-first extraction precedence.
+- Rewrite controller `protocolMessagesToRawJSON()` to reconstruct OpenAI-compatible JSON from DataParts with correct roles (`system`, `tool`, `function`, `assistant`) and tool call structure.
+- Controller `extractResponseMessages()` prefers `responseMessagesV1` (protocol-first), falls back to legacy `messages`.
+- Handler populates protocol-native `responseMessagesV1` alongside legacy `messages`. Controller reads protocol path as source of truth.
+
+## Capabilities
+
+### New Capabilities
+- `a2a-multi-extension-support`: Generic, spec-compliant extension API enabling Ark to support many A2A extensions (its own and third-party) via `SetExtension`/`GetExtension`.
+- `a2a-boundary-contract`: Full-fidelity protocol-native response payload at the handler/controller A2A boundary. DataParts preserve tool call structure, system messages, and function results. Controller generates `response.raw` from protocol path.
+- `a2a-datapart-helpers`: Reusable helpers for extracting and inspecting DataParts from protocol messages.
+
+### Modified Capabilities
+
+## Impact
+
+- `ark/internal/a2a/extensions.go` (new)
+- `ark/internal/a2a/extensions_test.go` (new)
+- `ark/internal/a2a/a2a_types.go`
+- `ark/executors/completions/handler.go`
+- `ark/internal/controller/query_controller.go`
+- `ark/internal/controller/query_controller_test.go`

--- a/openspec/changes/pra-1244-boundary-contract/proposal.md
+++ b/openspec/changes/pra-1244-boundary-contract/proposal.md
@@ -13,16 +13,17 @@ The handler/controller boundary serializes response messages as OpenAI-shaped JS
 - Refactor handler `extractArkMetadata()` to use `GetExtension` with `GetMetadata` fallback.
 - Rewrite handler `openAIToProtocolResponseMessages()` to produce full-fidelity `protocol.Message` with DataParts for tool calls, tool results, system messages, and function messages.
 - Refactor controller `executeViaEngine()` to use `SetExtension` and `SetMetadata`.
-- Refactor controller `extractEngineResponseMeta()` to use `GetExtension` with `GetMetadata` fallback, protocol-first extraction precedence.
-- Rewrite controller `protocolMessagesToRawJSON()` to reconstruct OpenAI-compatible JSON from DataParts with correct roles (`system`, `tool`, `function`, `assistant`) and tool call structure.
-- Controller `extractResponseMessages()` prefers `responseMessagesV1` (protocol-first), falls back to legacy `messages`.
-- Handler populates protocol-native `responseMessagesV1` alongside legacy `messages`. Controller reads protocol path as source of truth.
+- Refactor controller `extractEngineResponseMeta()` with `extractArkPayloadMap` merging both metadata keys (legacy base, extension overlay).
+- Remove `protocolMessagesToRawJSON()` and all OpenAI compat helpers from controller — reconstruction was wrong-direction coupling.
+- Controller `extractResponseMessages()` passes through executor-produced `messages` as opaque bytes for `response.raw`, tracks `responseMessagesV1` presence via `ProtocolNative` flag.
+- Replace `serializeMessages` with `buildFallbackRaw` — no `completions.Message` type dependency on response path.
+- Handler populates protocol-native `responseMessagesV1` alongside legacy `messages`. Controller passes through legacy path opaquely.
 
 ## Capabilities
 
 ### New Capabilities
 - `a2a-multi-extension-support`: Generic, spec-compliant extension API enabling Ark to support many A2A extensions (its own and third-party) via `SetExtension`/`GetExtension`.
-- `a2a-boundary-contract`: Full-fidelity protocol-native response payload at the handler/controller A2A boundary. DataParts preserve tool call structure, system messages, and function results. Controller generates `response.raw` from protocol path.
+- `a2a-boundary-contract`: Full-fidelity protocol-native response payload at the handler/controller A2A boundary. DataParts preserve tool call structure, system messages, and function results. Controller passes through executor-produced content for `response.raw` with zero OpenAI coupling.
 - `a2a-datapart-helpers`: Reusable helpers for extracting and inspecting DataParts from protocol messages.
 
 ### Modified Capabilities

--- a/openspec/changes/pra-1244-boundary-contract/specs/a2a-boundary-contract/spec.md
+++ b/openspec/changes/pra-1244-boundary-contract/specs/a2a-boundary-contract/spec.md
@@ -66,35 +66,24 @@ Ark SHALL provide reusable helpers for consuming DataParts from protocol message
 - **WHEN** `DataPartType(dp)` is called on a DataPart with `data.type = "tool_call"`
 - **THEN** it SHALL return `"tool_call"`
 
-### Requirement: Protocol-first extraction precedence in controller
-The controller SHALL extract response metadata preferring `responseMessagesV1` first, legacy `messages` second, assistant-text fallback third.
+### Requirement: Controller response path independence
+The controller SHALL have zero OpenAI reconstruction logic on the response path. `response.raw` receives executor-produced content as opaque bytes.
 
-#### Scenario: Controller prefers protocol-native responseMessagesV1
-- **WHEN** the response metadata contains both `responseMessagesV1` and legacy `messages`
-- **THEN** the controller SHALL use `responseMessagesV1` to derive `response.raw`
+#### Scenario: Controller passes through legacy messages for response.raw
+- **WHEN** the response metadata contains a `messages` field (executor-produced legacy JSON)
+- **THEN** the controller SHALL pass through the `messages` content as opaque bytes to `response.raw` without parsing or reconstructing it
 
-#### Scenario: Controller falls back to legacy messages
-- **WHEN** the response metadata does not contain `responseMessagesV1` but contains a legacy `messages` field
-- **THEN** the controller SHALL use the legacy `messages` field for `response.raw`
+#### Scenario: Controller tracks protocol presence without conversion
+- **WHEN** the response metadata contains `responseMessagesV1`
+- **THEN** the controller SHALL set `ProtocolNative = true` but SHALL NOT convert `responseMessagesV1` to a different format
 
-#### Scenario: Controller falls back to assistant text
+#### Scenario: Controller falls back to minimal assistant message
 - **WHEN** the response metadata contains neither `responseMessagesV1` nor legacy `messages`
-- **THEN** the controller SHALL construct a single-element assistant message array from the response text for `response.raw`
+- **THEN** the controller SHALL construct a single-element assistant message array from the response text using `buildFallbackRaw` (no OpenAI type dependency)
 
-### Requirement: Full-fidelity protocol-to-raw reconstruction
-The controller SHALL reconstruct OpenAI-compatible JSON from protocol messages by mapping DataParts back to their original role and structure.
-
-#### Scenario: Tool call DataParts reconstruct to assistant with tool_calls
-- **WHEN** a protocol message contains `DataPart` with `data.type = "tool_call"`
-- **THEN** `response.raw` SHALL contain `{"role":"assistant","tool_calls":[...]}`
-
-#### Scenario: Tool result DataParts reconstruct to tool role
-- **WHEN** a protocol message contains `DataPart` with `data.type = "tool_result"`
-- **THEN** `response.raw` SHALL contain `{"role":"tool","tool_call_id":"...","content":"..."}`
-
-#### Scenario: System DataParts reconstruct to system role
-- **WHEN** a protocol message contains `DataPart` with `data.type = "system"`
-- **THEN** `response.raw` SHALL contain `{"role":"system","content":"..."}`
+#### Scenario: Controller does not import OpenAI types for response path
+- **WHEN** the controller processes A2A response messages
+- **THEN** the controller SHALL NOT use `completions.Message`, `completions.NewAssistantMessage`, or any OpenAI type constructors for the response serialization path
 
 ### Requirement: Extension URI declaration on outbound controller messages
 The controller SHALL use `SetExtension` to declare `ExecutionContextExtensionURI` on all outbound messages to execution engines, and `SetMetadata` for legacy `ArkMetadataKey`.

--- a/openspec/changes/pra-1244-boundary-contract/specs/a2a-boundary-contract/spec.md
+++ b/openspec/changes/pra-1244-boundary-contract/specs/a2a-boundary-contract/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Generic multi-extension API per A2A spec Section 4.6.2
+Ark SHALL provide a generic, composable API for setting and reading A2A extensions on protocol messages, following the pattern defined in A2A Protocol Specification v1.0 Section 4.6.2.
+
+#### Scenario: SetExtension adds URI to extensions and payload to metadata
+- **WHEN** `SetExtension(msg, uri, payload)` is called
+- **THEN** the URI SHALL appear in `msg.Extensions` (deduplicated)
+- **AND** the payload SHALL be set in `msg.Metadata[uri]`
+
+#### Scenario: SetExtension deduplicates on repeated calls
+- **WHEN** `SetExtension` is called twice with the same URI but different payloads
+- **THEN** `msg.Extensions` SHALL contain the URI exactly once
+- **AND** the payload SHALL be updated to the latest value
+
+#### Scenario: SetMetadata does not add to extensions
+- **WHEN** `SetMetadata(msg, key, value)` is called with a non-extension key
+- **THEN** the key SHALL appear in `msg.Metadata`
+- **AND** the key SHALL NOT appear in `msg.Extensions`
+
+#### Scenario: HasExtension distinguishes declared extensions from bare metadata
+- **WHEN** a URI was added via `SetExtension`
+- **THEN** `HasExtension(msg, uri)` SHALL return true
+- **WHEN** a key was added via `SetMetadata` only
+- **THEN** `HasExtension(msg, key)` SHALL return false
+
+### Requirement: Protocol-native response field in execution-context payload
+The handler SHALL write a versioned protocol-native response field (`responseMessagesV1`) containing `[]protocol.Message` JSON into the `ExecutionContextExtensionURI` metadata of the A2A response message.
+
+#### Scenario: Handler populates responseMessagesV1 alongside legacy messages
+- **WHEN** the handler builds an A2A response after successful execution
+- **THEN** the response message metadata under `ExecutionContextExtensionURI` SHALL contain both `responseMessagesV1` (protocol-native `[]protocol.Message` JSON) and `messages` (legacy OpenAI-shaped JSON)
+
+#### Scenario: Handler uses SetExecutionContextExtension for spec-compliant extension
+- **WHEN** the handler builds an A2A response message
+- **THEN** `SetExecutionContextExtension` SHALL be used to add the extension URI to `Message.extensions` and the payload to `Message.metadata`
+- **AND** `SetMetadata` SHALL be used for the legacy `ArkMetadataKey` (NOT added to `Message.extensions`)
+
+### Requirement: Full-fidelity protocol conversion using DataParts
+The handler SHALL convert OpenAI message types to protocol messages with DataParts that preserve all structured execution data.
+
+#### Scenario: Tool calls preserved as DataParts
+- **WHEN** an assistant message contains tool calls
+- **THEN** each tool call SHALL be represented as a `DataPart` with `data.type = "tool_call"`, `data.id`, and `data.function` containing name and arguments
+
+#### Scenario: Tool results preserved as DataParts
+- **WHEN** a tool message is converted
+- **THEN** it SHALL be represented as a `DataPart` with `data.type = "tool_result"`, `data.tool_call_id`, and `data.content`
+
+#### Scenario: System messages preserved as DataParts
+- **WHEN** a system message is converted
+- **THEN** it SHALL be represented as a `DataPart` with `data.type = "system"` and `data.content` (NOT silently dropped)
+
+#### Scenario: Function results preserved as DataParts
+- **WHEN** a function message is converted
+- **THEN** it SHALL be represented as a `DataPart` with `data.type = "function_result"`, `data.name`, and `data.content`
+
+### Requirement: DataPart extraction helpers
+Ark SHALL provide reusable helpers for consuming DataParts from protocol messages.
+
+#### Scenario: ExtractDataParts filters mixed parts
+- **WHEN** `ExtractDataParts(parts)` is called on a slice containing both TextParts and DataParts
+- **THEN** only the DataParts SHALL be returned
+
+#### Scenario: DataPartType reads the type field
+- **WHEN** `DataPartType(dp)` is called on a DataPart with `data.type = "tool_call"`
+- **THEN** it SHALL return `"tool_call"`
+
+### Requirement: Protocol-first extraction precedence in controller
+The controller SHALL extract response metadata preferring `responseMessagesV1` first, legacy `messages` second, assistant-text fallback third.
+
+#### Scenario: Controller prefers protocol-native responseMessagesV1
+- **WHEN** the response metadata contains both `responseMessagesV1` and legacy `messages`
+- **THEN** the controller SHALL use `responseMessagesV1` to derive `response.raw`
+
+#### Scenario: Controller falls back to legacy messages
+- **WHEN** the response metadata does not contain `responseMessagesV1` but contains a legacy `messages` field
+- **THEN** the controller SHALL use the legacy `messages` field for `response.raw`
+
+#### Scenario: Controller falls back to assistant text
+- **WHEN** the response metadata contains neither `responseMessagesV1` nor legacy `messages`
+- **THEN** the controller SHALL construct a single-element assistant message array from the response text for `response.raw`
+
+### Requirement: Full-fidelity protocol-to-raw reconstruction
+The controller SHALL reconstruct OpenAI-compatible JSON from protocol messages by mapping DataParts back to their original role and structure.
+
+#### Scenario: Tool call DataParts reconstruct to assistant with tool_calls
+- **WHEN** a protocol message contains `DataPart` with `data.type = "tool_call"`
+- **THEN** `response.raw` SHALL contain `{"role":"assistant","tool_calls":[...]}`
+
+#### Scenario: Tool result DataParts reconstruct to tool role
+- **WHEN** a protocol message contains `DataPart` with `data.type = "tool_result"`
+- **THEN** `response.raw` SHALL contain `{"role":"tool","tool_call_id":"...","content":"..."}`
+
+#### Scenario: System DataParts reconstruct to system role
+- **WHEN** a protocol message contains `DataPart` with `data.type = "system"`
+- **THEN** `response.raw` SHALL contain `{"role":"system","content":"..."}`
+
+### Requirement: Extension URI declaration on outbound controller messages
+The controller SHALL use `SetExtension` to declare `ExecutionContextExtensionURI` on all outbound messages to execution engines, and `SetMetadata` for legacy `ArkMetadataKey`.
+
+#### Scenario: Controller sets extensions on engine request
+- **WHEN** the controller constructs an A2A message to send to the execution engine
+- **THEN** `SetExtension` SHALL add `ExecutionContextExtensionURI` to `Message.extensions` and the payload to `Message.metadata`
+- **AND** `SetMetadata` SHALL add `ArkMetadataKey` to `Message.metadata` only (NOT to `Message.extensions`)
+
+### Requirement: Backward-compatible metadata extraction
+The handler and controller SHALL use `GetExtension` to read from `ExecutionContextExtensionURI` first, falling back to `GetMetadata` for `ArkMetadataKey`.
+
+#### Scenario: Handler extracts from extension URI key
+- **WHEN** the inbound message metadata contains `ExecutionContextExtensionURI`
+- **THEN** `GetExtension(msg, ExecutionContextExtensionURI)` SHALL return the payload
+
+#### Scenario: Handler falls back to legacy ArkMetadataKey
+- **WHEN** the inbound message metadata does not contain `ExecutionContextExtensionURI` but contains `ArkMetadataKey`
+- **THEN** `GetMetadata(msg, ArkMetadataKey)` SHALL return the legacy payload
+
+#### Scenario: Controller extracts from extension URI key
+- **WHEN** the response message metadata contains `ExecutionContextExtensionURI`
+- **THEN** `GetExtension(msg, ExecutionContextExtensionURI)` SHALL return the response payload
+
+#### Scenario: Controller falls back to legacy ArkMetadataKey
+- **WHEN** the response message metadata does not contain `ExecutionContextExtensionURI` but contains `ArkMetadataKey`
+- **THEN** `GetMetadata(msg, ArkMetadataKey)` SHALL return the legacy payload

--- a/openspec/changes/pra-1244-boundary-contract/tasks.md
+++ b/openspec/changes/pra-1244-boundary-contract/tasks.md
@@ -1,0 +1,66 @@
+# PR-A Boundary Contract Tasks
+
+## 1. Generic extension helpers
+
+- [x] 1.1 Create `ark/internal/a2a/extensions.go` with `SetExtension`, `SetMetadata`, `GetExtension`, `GetExtensionAs[T]`, `HasExtension`, `GetMetadata`.
+- [x] 1.2 Add typed wrappers `SetExecutionContextExtension` and `GetExecutionContextExtension`.
+- [x] 1.3 Create `ark/internal/a2a/extensions_test.go` with unit tests for all generic and typed helpers.
+
+## 2. DataPart helpers
+
+- [x] 2.1 Add `ExtractDataParts(parts)` to extract DataParts from mixed Part slices.
+- [x] 2.2 Add `DataPartType(dp)`, `DataPartField(dp, key)`, `DataPartMap(dp, key)` for inspecting DataPart payloads.
+- [x] 2.3 Unit tests for all DataPart helpers.
+
+## 3. Extension types and constants
+
+- [x] 3.1 Add `ExecutionContextExtensionURI` constant to `ark/internal/a2a/a2a_types.go`.
+- [x] 3.2 Add `ExecutionTraceExtensionURI` constant.
+- [x] 3.3 Add `ExecutionResponsePayload` struct with `ResponseMessagesV1 json.RawMessage` field.
+- [x] 3.4 Add `ResponseTokenUsage` struct.
+
+## 4. Handler response path
+
+- [x] 4.1 Refactor `buildA2AResponse()` to use `SetExecutionContextExtension` for spec-compliant extension.
+- [x] 4.2 Refactor `buildA2AResponse()` to use `SetMetadata` for legacy `ArkMetadataKey` (not added to `extensions`).
+- [x] 4.3 Serialize `[]protocol.Message` into `responseMessagesV1` under `ExecutionContextExtensionURI` metadata key.
+- [x] 4.4 Keep legacy `ArkMetadataKey` metadata with OpenAI-shaped `messages` for backward compatibility.
+
+## 5. Full-fidelity protocol conversion
+
+- [x] 5.1 Rewrite `openAIToProtocolResponseMessages()` to use DataParts for tool calls (`tool_call` type with ID, function name, arguments).
+- [x] 5.2 Map `OfTool` messages to DataParts with `tool_result` type preserving `tool_call_id`.
+- [x] 5.3 Map `OfSystem` messages to DataParts with `system` type (no longer dropped).
+- [x] 5.4 Map `OfFunction` messages to DataParts with `function_result` type preserving function name.
+- [x] 5.5 Unit tests for all message type conversions including mixed sequences.
+
+## 6. Handler extraction path
+
+- [x] 6.1 Refactor `extractArkMetadata()` to use `GetExtension(msg, ExecutionContextExtensionURI)` first, fall back to `GetMetadata(msg, ArkMetadataKey)`.
+
+## 7. Controller request path
+
+- [x] 7.1 Refactor `executeViaEngine()` to use `SetExtension(msg, ExecutionContextExtensionURI, arkMetadata)`.
+- [x] 7.2 Refactor `executeViaEngine()` to use `SetMetadata(msg, ArkMetadataKey, arkMetadata)` for legacy compat.
+
+## 8. Controller extraction path (protocol-first)
+
+- [x] 8.1 Refactor `extractEngineResponseMeta()` to use `GetExtension` with `GetMetadata` fallback.
+- [x] 8.2 Flip `extractResponseMessages()` to prefer `responseMessagesV1` (protocol-first), fall back to legacy `messages`.
+- [x] 8.3 Rewrite `protocolMessagesToRawJSON()` to reconstruct OpenAI-compatible JSON from DataParts:
+  - `tool_call` DataParts → `{"role":"assistant","tool_calls":[...]}`
+  - `tool_result` DataParts → `{"role":"tool","tool_call_id":"...","content":"..."}`
+  - `system` DataParts → `{"role":"system","content":"..."}`
+  - `function_result` DataParts → `{"role":"function","name":"...","content":"..."}`
+  - Text-only messages → `{"role":"assistant|user","content":"..."}`
+
+## 9. Verification
+
+- [x] 9.1 Unit tests for extension helpers covering dedup, metadata-only writes, typed round-trips, and `HasExtension` distinction.
+- [x] 9.2 Unit tests for DataPart helpers covering extraction, type inspection, field access, map access.
+- [x] 9.3 Unit tests for `openAIToProtocolResponseMessages()` covering all message types and mixed sequences.
+- [x] 9.4 Unit tests for `extractEngineResponseMeta()` covering protocol-first precedence.
+- [x] 9.5 Unit tests for `protocolMessagesToRawJSON()` covering DataPart reconstruction for all types.
+- [x] 9.6 Compile `ark/internal/a2a`, `ark/executors/completions`, and `ark/internal/controller` packages.
+- [x] 9.7 Run existing controller and completions tests to verify no regressions.
+- [x] 9.8 Zero lint issues (`make lint`).

--- a/openspec/changes/pra-1244-boundary-contract/tasks.md
+++ b/openspec/changes/pra-1244-boundary-contract/tasks.md
@@ -43,24 +43,21 @@
 - [x] 7.1 Refactor `executeViaEngine()` to use `SetExtension(msg, ExecutionContextExtensionURI, arkMetadata)`.
 - [x] 7.2 Refactor `executeViaEngine()` to use `SetMetadata(msg, ArkMetadataKey, arkMetadata)` for legacy compat.
 
-## 8. Controller extraction path (protocol-first)
+## 8. Controller response path independence
 
-- [x] 8.1 Refactor `extractEngineResponseMeta()` to use `GetExtension` with `GetMetadata` fallback.
-- [x] 8.2 Flip `extractResponseMessages()` to prefer `responseMessagesV1` (protocol-first), fall back to legacy `messages`.
-- [x] 8.3 Rewrite `protocolMessagesToRawJSON()` to reconstruct OpenAI-compatible JSON from DataParts:
-  - `tool_call` DataParts → `{"role":"assistant","tool_calls":[...]}`
-  - `tool_result` DataParts → `{"role":"tool","tool_call_id":"...","content":"..."}`
-  - `system` DataParts → `{"role":"system","content":"..."}`
-  - `function_result` DataParts → `{"role":"function","name":"...","content":"..."}`
-  - Text-only messages → `{"role":"assistant|user","content":"..."}`
+- [x] 8.1 Refactor `extractEngineResponseMeta()` with `extractArkPayloadMap` merging both metadata keys.
+- [x] 8.2 Rewrite `extractResponseMessages()` to pass through `messages` as opaque bytes for `response.raw`, track `responseMessagesV1` presence via `ProtocolNative` flag.
+- [x] 8.3 Remove `protocolMessagesToRawJSON()` and all 6 compat helpers from controller — reconstruction was wrong-direction coupling.
+- [x] 8.4 Replace `serializeMessages` with `buildFallbackRaw` — no `completions.Message` type dependency.
+- [x] 8.5 Remove `openai` and `completions` imports from controller test serialization tests.
 
 ## 9. Verification
 
 - [x] 9.1 Unit tests for extension helpers covering dedup, metadata-only writes, typed round-trips, and `HasExtension` distinction.
 - [x] 9.2 Unit tests for DataPart helpers covering extraction, type inspection, field access, map access.
 - [x] 9.3 Unit tests for `openAIToProtocolResponseMessages()` covering all message types and mixed sequences.
-- [x] 9.4 Unit tests for `extractEngineResponseMeta()` covering protocol-first precedence.
-- [x] 9.5 Unit tests for `protocolMessagesToRawJSON()` covering DataPart reconstruction for all types.
+- [x] 9.4 Unit tests for `extractEngineResponseMeta()` covering pass-through behavior, metadata merge, and protocol presence tracking.
+- [x] 9.5 Unit tests for `buildFallbackRaw()` covering valid JSON output without OpenAI types.
 - [x] 9.6 Compile `ark/internal/a2a`, `ark/executors/completions`, and `ark/internal/controller` packages.
 - [x] 9.7 Run existing controller and completions tests to verify no regressions.
 - [x] 9.8 Zero lint issues (`make lint`).


### PR DESCRIPTION
## Summary

- Replace `serializeMessages` (completions-typed) with `buildFallbackRaw` (engine-agnostic) in the controller response path
- Controller passes through executor-produced `messages` as opaque bytes for `response.raw` and tracks `responseMessagesV1` presence without converting it
- Remove `protocolMessagesToRawJSON` and all OpenAI reconstruction helpers from controller (~110 lines deleted)
- Add generic multi-extension API (`SetExtension`/`GetExtension`/`SetMetadata`/`GetMetadata`/`HasExtension`) following A2A Protocol Specification v1.0 Section 4.6.2
- Add full-fidelity `openAIToProtocolResponseMessages` at the executor boundary using DataParts for tool calls, tool results, system messages, and function messages
- Add `ExecutionContextExtensionURI` and `ExecutionTraceExtensionURI` with typed `ExecutionResponsePayload`
- Add DataPart extraction helpers (`ExtractDataParts`, `DataPartType`, `DataPartField`, `DataPartMap`)
- Backward-compatible metadata merge: controller reads from both `QueryExtensionMetadataKey` (base) and `ExecutionContextExtensionURI` (overlay)

This PR satisfies the **G1 response-side** gate from the architecture-first roadmap in #1059. It is independently mergeable and non-breaking — existing response contracts are preserved while the controller no longer reconstructs or switches on OpenAI message shapes.

Relates to #1059

Made with [Cursor](https://cursor.com)