### PR TITLE
fix: add RBAC permissions for ark-api to access ark-system ConfigMaps

### DIFF
--- a/services/ark-api/chart/templates/rbac.yaml
+++ b/services/ark-api/chart/templates/rbac.yaml
@@ -67,4 +67,41 @@ roleRef:
   kind: Role
   name: {{ .Values.serviceAccount.name }}-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+# Role in ark-system namespace for accessing export metadata ConfigMap
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccount.name }}-ark-system-role
+  namespace: ark-system
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+    resourceNames: ["ark-export-metadata"]
+
+---
+# RoleBinding in ark-system namespace for the service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.name }}-ark-system-binding
+  namespace: ark-system
+  annotations:
+    {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}-ark-system-role
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
Add Role and RoleBinding in ark-system namespace to allow ark-api service account to read the ark-export-metadata ConfigMap.

This fixes the permission error:
"configmaps 'ark-export-metadata' is forbidden: User 'system:serviceaccount:default:ark-api-sa' cannot get resource 'configmaps' in API group '' in the namespace 'ark-system'"

The ark-api service needs to access export history metadata stored in a ConfigMap in the ark-system namespace. The existing RBAC Role only granted permissions within the deployment namespace.

Changes:
- Add Role in ark-system namespace with get/list permissions for ark-export-metadata ConfigMap
- Add RoleBinding in ark-system namespace linking the Role to ark-api-sa service account

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 