### PR TITLE
feat(ark): decouple controller input path from completions engine

### DIFF
--- a/ark/executors/completions/query_parameters.go
+++ b/ark/executors/completions/query_parameters.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"mckinsey.com/ark/internal/common"
+	"mckinsey.com/ark/internal/resolution"
 )
 
 func ResolveQueryInput(ctx context.Context, k8sClient client.Client, namespace, input string, parameters []arkv1alpha1.Parameter) (string, error) {
@@ -58,41 +57,15 @@ func resolveQueryValueFrom(ctx context.Context, k8sClient client.Client, namespa
 
 func resolveValueFrom(ctx context.Context, k8sClient client.Client, namespace string, valueFrom *arkv1alpha1.ValueFromSource) (string, error) {
 	if valueFrom.ConfigMapKeyRef != nil {
-		return resolveConfigMapKeyRef(ctx, k8sClient, namespace, valueFrom.ConfigMapKeyRef)
+		return resolution.ResolveFromConfigMap(ctx, k8sClient, valueFrom.ConfigMapKeyRef, namespace)
 	}
 	if valueFrom.SecretKeyRef != nil {
-		return resolveSecretKeyRef(ctx, k8sClient, namespace, valueFrom.SecretKeyRef)
+		return resolution.ResolveFromSecret(ctx, k8sClient, valueFrom.SecretKeyRef, namespace)
 	}
 	if valueFrom.QueryParameterRef != nil {
 		return resolveQueryParameterRef(ctx, valueFrom.QueryParameterRef)
 	}
 	return "", fmt.Errorf("no supported valueFrom source specified")
-}
-
-func resolveConfigMapKeyRef(ctx context.Context, k8sClient client.Client, namespace string, ref *corev1.ConfigMapKeySelector) (string, error) {
-	configMap := &corev1.ConfigMap{}
-	key := types.NamespacedName{Name: ref.Name, Namespace: namespace}
-	if err := k8sClient.Get(ctx, key, configMap); err != nil {
-		return "", fmt.Errorf("failed to get ConfigMap %s: %w", ref.Name, err)
-	}
-	value, exists := configMap.Data[ref.Key]
-	if !exists {
-		return "", fmt.Errorf("key %s not found in ConfigMap %s", ref.Key, ref.Name)
-	}
-	return value, nil
-}
-
-func resolveSecretKeyRef(ctx context.Context, k8sClient client.Client, namespace string, ref *corev1.SecretKeySelector) (string, error) {
-	secret := &corev1.Secret{}
-	key := types.NamespacedName{Name: ref.Name, Namespace: namespace}
-	if err := k8sClient.Get(ctx, key, secret); err != nil {
-		return "", fmt.Errorf("failed to get Secret %s: %w", ref.Name, err)
-	}
-	value, exists := secret.Data[ref.Key]
-	if !exists {
-		return "", fmt.Errorf("key %s not found in Secret %s", ref.Key, ref.Name)
-	}
-	return string(value), nil
 }
 
 func resolveQueryParameterRef(ctx context.Context, ref *arkv1alpha1.QueryParameterReference) (string, error) {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -27,6 +27,7 @@ import (
 	completions "mckinsey.com/ark/executors/completions"
 	arka2a "mckinsey.com/ark/internal/a2a"
 	eventingconfig "mckinsey.com/ark/internal/eventing/config"
+	"mckinsey.com/ark/internal/resolution"
 	"mckinsey.com/ark/internal/telemetry"
 	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
 	otelimpl "mckinsey.com/ark/internal/telemetry/otel"
@@ -375,11 +376,11 @@ func (r *QueryReconciler) sendQueryA2A(ctx context.Context, address string, quer
 }
 
 func extractUserInput(ctx context.Context, query arkv1alpha1.Query, k8sClient client.Client) string {
-	inputMessages, err := completions.GetQueryInputMessages(ctx, query, k8sClient)
+	text, err := resolution.ResolveQueryInputText(ctx, query, k8sClient)
 	if err != nil {
 		return ""
 	}
-	return completions.ExtractUserMessageContent(inputMessages)
+	return text
 }
 
 func serializeMessages(messages []completions.Message) string {

--- a/ark/internal/resolution/query_input.go
+++ b/ark/internal/resolution/query_input.go
@@ -1,0 +1,147 @@
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/common"
+)
+
+func ResolveQueryInputText(ctx context.Context, query arkv1alpha1.Query, k8sClient client.Client) (string, error) {
+	queryType := query.Spec.Type
+	if queryType == "" {
+		queryType = arkv1alpha1.QueryTypeUser
+	}
+
+	switch queryType {
+	case arkv1alpha1.QueryTypeUser:
+		return resolveUserTypeInput(ctx, query, k8sClient)
+	case arkv1alpha1.QueryTypeMessages:
+		return ExtractFirstUserText(query.Spec.Input.Raw)
+	default:
+		return "", fmt.Errorf("unknown query input type: %s", queryType)
+	}
+}
+
+func resolveUserTypeInput(ctx context.Context, query arkv1alpha1.Query, k8sClient client.Client) (string, error) {
+	inputString, err := query.Spec.GetInputString()
+	if err != nil {
+		return "", fmt.Errorf("failed to get input string: %w", err)
+	}
+
+	return ResolveQueryInput(ctx, k8sClient, query.Namespace, inputString, query.Spec.Parameters)
+}
+
+func ResolveQueryInput(ctx context.Context, k8sClient client.Client, namespace, input string, parameters []arkv1alpha1.Parameter) (string, error) {
+	if len(parameters) == 0 {
+		return input, nil
+	}
+
+	templateData, err := ResolveParameters(ctx, k8sClient, namespace, parameters)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve parameters: %w", err)
+	}
+
+	resolved, err := common.ResolveTemplate(input, toAnyMap(templateData))
+	if err != nil {
+		return "", fmt.Errorf("template resolution failed: %w", err)
+	}
+	return resolved, nil
+}
+
+func ResolveParameters(ctx context.Context, k8sClient client.Client, namespace string, parameters []arkv1alpha1.Parameter) (map[string]string, error) {
+	templateData := make(map[string]string)
+
+	for _, param := range parameters {
+		if param.Value != "" {
+			templateData[param.Name] = param.Value
+			continue
+		}
+
+		if param.ValueFrom == nil {
+			return nil, fmt.Errorf("parameter %s must specify either value or valueFrom", param.Name)
+		}
+
+		value, err := resolveParameterValueFrom(ctx, k8sClient, namespace, param.ValueFrom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve parameter %s: %w", param.Name, err)
+		}
+		templateData[param.Name] = value
+	}
+
+	return templateData, nil
+}
+
+func resolveParameterValueFrom(ctx context.Context, k8sClient client.Client, namespace string, valueFrom *arkv1alpha1.ValueFromSource) (string, error) {
+	if valueFrom.ConfigMapKeyRef != nil {
+		return ResolveFromConfigMap(ctx, k8sClient, valueFrom.ConfigMapKeyRef, namespace)
+	}
+	if valueFrom.SecretKeyRef != nil {
+		return ResolveFromSecret(ctx, k8sClient, valueFrom.SecretKeyRef, namespace)
+	}
+	return "", fmt.Errorf("no supported valueFrom source specified")
+}
+
+func ExtractFirstUserText(raw []byte) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+
+	var messages []json.RawMessage
+	if err := json.Unmarshal(raw, &messages); err != nil {
+		return "", fmt.Errorf("failed to parse messages array: %w", err)
+	}
+
+	for _, msgRaw := range messages {
+		text, ok := extractUserTextFromMessage(msgRaw)
+		if ok {
+			return text, nil
+		}
+	}
+
+	return "", nil
+}
+
+func extractUserTextFromMessage(raw json.RawMessage) (string, bool) {
+	var msg struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return "", false
+	}
+	if msg.Role != "user" {
+		return "", false
+	}
+
+	var contentStr string
+	if err := json.Unmarshal(msg.Content, &contentStr); err == nil && contentStr != "" {
+		return contentStr, true
+	}
+
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(msg.Content, &parts); err == nil {
+		for _, p := range parts {
+			if p.Type == "text" && p.Text != "" {
+				return p.Text, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func toAnyMap(m map[string]string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/ark/internal/resolution/query_input.go
+++ b/ark/internal/resolution/query_input.go
@@ -111,7 +111,7 @@ func extractUserTextFromMessage(raw json.RawMessage) (string, bool) {
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
 	}
-	if err := json.Unmarshal(raw, &msg); err != nil {
+	if json.Unmarshal(raw, &msg) != nil {
 		return "", false
 	}
 	if msg.Role != "user" {
@@ -119,7 +119,7 @@ func extractUserTextFromMessage(raw json.RawMessage) (string, bool) {
 	}
 
 	var contentStr string
-	if err := json.Unmarshal(msg.Content, &contentStr); err == nil && contentStr != "" {
+	if json.Unmarshal(msg.Content, &contentStr) == nil && contentStr != "" {
 		return contentStr, true
 	}
 
@@ -127,7 +127,7 @@ func extractUserTextFromMessage(raw json.RawMessage) (string, bool) {
 		Type string `json:"type"`
 		Text string `json:"text"`
 	}
-	if err := json.Unmarshal(msg.Content, &parts); err == nil {
+	if json.Unmarshal(msg.Content, &parts) == nil {
 		for _, p := range parts {
 			if p.Type == "text" && p.Text != "" {
 				return p.Text, true

--- a/ark/internal/resolution/query_input_test.go
+++ b/ark/internal/resolution/query_input_test.go
@@ -1,0 +1,291 @@
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestResolveQueryInputText(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   arkv1alpha1.Query
+		objects []client.Object
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "type=user with plain input",
+			query: makeQuery("user", jsonStr("hello world"), nil),
+			want:  "hello world",
+		},
+		{
+			name:  "type empty defaults to user",
+			query: makeQuery("", jsonStr("default user"), nil),
+			want:  "default user",
+		},
+		{
+			name: "type=user with parameter substitution",
+			query: makeQuery("user", jsonStr("hello {{.name}}"), []arkv1alpha1.Parameter{
+				{Name: "name", Value: "Alice"},
+			}),
+			want: "hello Alice",
+		},
+		{
+			name: "type=user with configmap parameter",
+			query: makeQuery("user", jsonStr("key={{.apiKey}}"), []arkv1alpha1.Parameter{
+				{Name: "apiKey", ValueFrom: &arkv1alpha1.ValueFromSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"},
+						Key:                  "key",
+					},
+				}},
+			}),
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default"},
+					Data:       map[string]string{"key": "cm-value"},
+				},
+			},
+			want: "key=cm-value",
+		},
+		{
+			name: "type=user with secret parameter",
+			query: makeQuery("user", jsonStr("token={{.secret}}"), []arkv1alpha1.Parameter{
+				{Name: "secret", ValueFrom: &arkv1alpha1.ValueFromSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+						Key:                  "token",
+					},
+				}},
+			}),
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+					Data:       map[string][]byte{"token": []byte("s3cret")},
+				},
+			},
+			want: "token=s3cret",
+		},
+		{
+			name:  "type=messages extracts first user text (string content)",
+			query: makeQuery("messages", messagesJSON([]msg{{Role: "system", Content: "sys"}, {Role: "user", Content: "the question"}}), nil),
+			want:  "the question",
+		},
+		{
+			name:  "type=messages skips non-user messages",
+			query: makeQuery("messages", messagesJSON([]msg{{Role: "assistant", Content: "hi"}, {Role: "user", Content: "found it"}}), nil),
+			want:  "found it",
+		},
+		{
+			name:  "type=messages empty array",
+			query: makeQuery("messages", json.RawMessage(`[]`), nil),
+			want:  "",
+		},
+		{
+			name:    "malformed input returns error",
+			query:   makeQuery("user", json.RawMessage(`{bad json`), nil),
+			wantErr: true,
+		},
+		{
+			name:  "type=messages with no user message",
+			query: makeQuery("messages", messagesJSON([]msg{{Role: "assistant", Content: "only me"}}), nil),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := setupTestClient(tt.objects)
+			got, err := ResolveQueryInputText(context.Background(), tt.query, fakeClient)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractFirstUserText(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "string content",
+			raw:  []byte(`[{"role":"user","content":"hello"}]`),
+			want: "hello",
+		},
+		{
+			name: "array content parts",
+			raw:  []byte(`[{"role":"user","content":[{"type":"text","text":"from parts"}]}]`),
+			want: "from parts",
+		},
+		{
+			name: "skips non-user",
+			raw:  []byte(`[{"role":"system","content":"sys"},{"role":"user","content":"found"}]`),
+			want: "found",
+		},
+		{
+			name: "empty array",
+			raw:  []byte(`[]`),
+			want: "",
+		},
+		{
+			name: "nil input",
+			raw:  nil,
+			want: "",
+		},
+		{
+			name: "no user message",
+			raw:  []byte(`[{"role":"assistant","content":"only assistant"}]`),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractFirstUserText(tt.raw)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveParameters(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  []arkv1alpha1.Parameter
+		objects []client.Object
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "inline values",
+			params: []arkv1alpha1.Parameter{
+				{Name: "a", Value: "1"},
+				{Name: "b", Value: "2"},
+			},
+			want: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name: "configmap value",
+			params: []arkv1alpha1.Parameter{
+				{Name: "key", ValueFrom: &arkv1alpha1.ValueFromSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "cm"},
+						Key:                  "k",
+					},
+				}},
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "default"},
+					Data:       map[string]string{"k": "v"},
+				},
+			},
+			want: map[string]string{"key": "v"},
+		},
+		{
+			name: "missing valueFrom errors",
+			params: []arkv1alpha1.Parameter{
+				{Name: "bad"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported valueFrom source errors",
+			params: []arkv1alpha1.Parameter{
+				{Name: "qp", ValueFrom: &arkv1alpha1.ValueFromSource{
+					QueryParameterRef: &arkv1alpha1.QueryParameterReference{Name: "x"},
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := setupTestClient(tt.objects)
+			got, err := ResolveParameters(context.Background(), fakeClient, "default", tt.params)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveQueryInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		params []arkv1alpha1.Parameter
+		want   string
+	}{
+		{
+			name:  "no parameters returns input unchanged",
+			input: "plain text",
+			want:  "plain text",
+		},
+		{
+			name:  "template substitution",
+			input: "Hello {{.who}}!",
+			params: []arkv1alpha1.Parameter{
+				{Name: "who", Value: "World"},
+			},
+			want: "Hello World!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := setupTestClient(nil)
+			got, err := ResolveQueryInput(context.Background(), fakeClient, "default", tt.input, tt.params)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type msg struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+func messagesJSON(msgs []msg) json.RawMessage {
+	b, _ := json.Marshal(msgs)
+	return b
+}
+
+func jsonStr(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+func makeQuery(queryType string, input json.RawMessage, params []arkv1alpha1.Parameter) arkv1alpha1.Query {
+	return arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-query",
+			Namespace: "default",
+		},
+		Spec: arkv1alpha1.QuerySpec{
+			Type:       queryType,
+			Input:      runtime.RawExtension{Raw: input},
+			Parameters: params,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce engine-agnostic query input resolver at `ark/internal/resolution/query_input.go` with support for `type=user` (template/parameter resolution) and `type=messages` (generic JSON extraction of first user text)
- Controller `extractUserInput` now calls `resolution.ResolveQueryInputText` instead of `completions.GetQueryInputMessages` + `completions.ExtractUserMessageContent`
- Completions `query_parameters.go` delegates ConfigMap/Secret resolution to shared resolver helpers while retaining completions-specific `QueryParameterRef` handling
- 22 new unit tests covering user input, messages input, parameter resolution (inline, ConfigMap, Secret), malformed input fallback, and content part formats

This is the first step in the G1 (controller boundary independence) gate from #1059. The controller input path no longer depends on any execution-engine-specific types.

Relates to #1059

Made with [Cursor](https://cursor.com)