### PR TITLE
feat(devspace): add routes-forward command for background port-forwarding

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -56,6 +56,17 @@ vars:
 commands:
   routes:
     ./services/localhost-gateway/scripts/show-routes.sh
+  routes-forward: |-
+    kill $(lsof -ti :8080) 2>/dev/null || true
+    echo "Starting port-forward on localhost:8080..."
+    nohup kubectl port-forward -n ark-system service/localhost-gateway-nginx 8080:80 > /dev/null 2>&1 &
+    sleep 1
+    PID=$(lsof -ti :8080)
+    if [ -n "$PID" ]; then
+      echo "Port-forward running in background (PID: $PID)"
+    else
+      echo "Failed to start port-forward. Is the gateway deployed?"
+    fi
 
 profiles:
   - name: enable-cert-manager


### PR DESCRIPTION
## Summary

- Add `devspace run routes-forward` command to port-forward the localhost gateway on port 8080
- Automatically kills any existing process on port 8080 before starting
- Runs kubectl port-forward in the background using nohup so the terminal stays usable
- Verifies the port-forward started successfully and reports the PID
- Complements the existing `routes` command which only displays available routes