### PR TITLE
fix(ark-sdk): add overlay tests to CI and fix 14 test failures

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -345,6 +345,9 @@ jobs:
       - name: Build libraries
         run: make libs-build-all
 
+      - name: Test libraries
+        run: make libs-test-all
+
       - name: Upload library artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/config.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/config.py
@@ -1,24 +1,21 @@
 """Authentication configuration for ARK SDK."""
 
-from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 
 
 class AuthConfig(BaseSettings):
     """Configuration for authentication."""
-    
-    # JWT settings
+
+    model_config = SettingsConfigDict(env_prefix="ARK_", case_sensitive=False)
+
     jwt_algorithm: str = "RS256"
-    
-    # Authentication settings
-    issuer: Optional[str] = Field(None, env="OIDC_ISSUER_URL")
-    audience: Optional[str] = Field(None, env="OIDC_APPLICATION_ID")
+    issuer: Optional[str] = None
+    audience: Optional[str] = None
     jwks_url: Optional[str] = None
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # Convert empty strings to None
         if self.issuer == "":
             self.issuer = None
         if self.audience == "":

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/exceptions.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/exceptions.py
@@ -5,7 +5,10 @@ from fastapi import HTTPException
 
 class AuthenticationError(Exception):
     """Base exception for authentication errors."""
-    pass
+
+    def __init__(self, message=None, details=None):
+        super().__init__(message)
+        self.details = details
 
 
 class TokenValidationError(AuthenticationError):

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
@@ -88,7 +88,7 @@ class TokenValidator:
             logger.error(f"Failed to get signing key: {e}")
             raise TokenValidationError(f"Failed to get signing key: {e}")
     
-    async def validate_token(self, token: str) -> Dict[str, Any]:
+    def validate_token(self, token: str) -> Dict[str, Any]:
         """
         Validate a JWT token.
 

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
@@ -78,8 +78,9 @@ class TestExtractQueryRef(unittest.TestCase):
 
 
 class TestResolveQuery(unittest.IsolatedAsyncioTestCase):
+    @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)
     @patch("ark_sdk.client.with_ark_client")
-    async def test_resolves_agent_target(self, mock_with_client):
+    async def test_resolves_agent_target(self, mock_with_client, mock_init_k8s):
         mock_ark = AsyncMock()
 
         mock_query = MagicMock()
@@ -113,8 +114,9 @@ class TestResolveQuery(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.userInput.role, "user")
         self.assertEqual(request.userInput.content, "hello")
 
+    @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)
     @patch("ark_sdk.client.with_ark_client")
-    async def test_raises_on_non_agent_target(self, mock_with_client):
+    async def test_raises_on_non_agent_target(self, mock_with_client, mock_init_k8s):
         mock_ark = AsyncMock()
 
         mock_query = MagicMock()
@@ -202,8 +204,9 @@ class TestResolveValueSource(unittest.IsolatedAsyncioTestCase):
 
 
 class TestResolveModelWithSecrets(unittest.IsolatedAsyncioTestCase):
+    @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)
     @patch("ark_sdk.client.with_ark_client")
-    async def test_resolves_model_with_api_key(self, mock_with_client):
+    async def test_resolves_model_with_api_key(self, mock_with_client, mock_init_k8s):
         mock_ark = AsyncMock()
 
         mock_query = MagicMock()

--- a/services/ark-api/ark-api/src/ark_api/auth/middleware.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/middleware.py
@@ -134,7 +134,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 else:
                     # Validate JWT token using ark_sdk validator
                     validator = TokenValidator()
-                    await validator.validate_token(token)
+                    validator.validate_token(token)
                     auth_success = True
                     logger.debug("JWT authentication successful")
                     


### PR DESCRIPTION
## Summary

- Add `make libs-test-all` step to the `build-libs` CI job so ark-sdk overlay tests run on every PR
- Fix `AuthConfig` to use `ARK_` env prefix with case-insensitive loading via pydantic-settings `SettingsConfigDict`
- Add `details` keyword argument support to `AuthenticationError` base exception
- Make `TokenValidator.validate_token` synchronous — it never used `await` internally, causing all validator tests to fail with unawaited coroutine errors
- Update ark-api auth middleware to call `validate_token` without `await` to match the corrected signature
- Mock `init_k8s` in query extension tests so they don't require a kubeconfig in CI

Closes #1378