### PR TITLE
feat(completions): adopt standard K8s port convention for completions service

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -130,7 +130,7 @@ func parseFlags() struct {
 	flag.BoolVar(&cfg.enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
-	flag.StringVar(&cfg.completionsAddr, "completions-addr", "http://ark-completions.ark-system:9090",
+	flag.StringVar(&cfg.completionsAddr, "completions-addr", "http://ark-completions.ark-system",
 		"Address of the completions engine for A2A communication")
 
 	zapOpts := zap.Options{Development: false}

--- a/ark/devspace.yaml
+++ b/ark/devspace.yaml
@@ -69,7 +69,7 @@ deployments:
               - "--leader-elect"
               - "--metrics-bind-address=:8443"
               - "--health-probe-bind-address=:8081"
-              - "--completions-addr=http://ark-completions.ark-system:9090"
+              - "--completions-addr=http://ark-completions.ark-system"
             resources:
               limits:
                 memory: "4096Mi"
@@ -116,7 +116,7 @@ dev:
       - |
         cd /app
         mkdir -p internal/apiserver/crds && cp config/crd/bases/*.yaml internal/apiserver/crds/
-        GOTOOLCHAIN=auto go run cmd/main.go --leader-elect=false --completions-addr=http://ark-completions.ark-system:9090
+        GOTOOLCHAIN=auto go run cmd/main.go --leader-elect=false --completions-addr=http://ark-completions.ark-system
     namespace: ark-system
     logs:
       lastLines: 50
@@ -190,4 +190,4 @@ profiles:
             ARK_POSTGRES_PASSWORD=arkdev123 \
             ARK_POSTGRES_SSL_MODE=disable \
             ARK_APISERVER_PORT=6443 \
-            go run cmd/main.go --leader-elect=false --completions-addr=http://ark-completions.ark-system:9090
+            go run cmd/main.go --leader-elect=false --completions-addr=http://ark-completions.ark-system

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -48,7 +48,7 @@ controllerManager:
   serviceAccountName: ark-controller
 
 completions:
-  addr: "http://ark-completions.ark-system:9090" # NOSONAR - cluster-internal service communication
+  addr: "http://ark-completions.ark-system" # NOSONAR - cluster-internal service communication
 
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:

--- a/ark/executors/completions/chart/templates/deployment.yaml
+++ b/ark/executors/completions/chart/templates/deployment.yaml
@@ -24,9 +24,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--addr=:{{ .Values.port }}"
+            - "--addr=:{{ .Values.targetPort }}"
           ports:
-            - containerPort: {{ .Values.port }}
+            - containerPort: {{ .Values.targetPort }}
               protocol: TCP
           env:
           - name: OTEL_SERVICE_NAME
@@ -47,14 +47,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.port }}
+              port: {{ .Values.targetPort }}
             initialDelaySeconds: 10
             periodSeconds: 20
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.port }}
+              port: {{ .Values.targetPort }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5

--- a/ark/executors/completions/chart/templates/service.yaml
+++ b/ark/executors/completions/chart/templates/service.yaml
@@ -10,4 +10,4 @@ spec:
     app: ark-completions
   ports:
     - port: {{ .Values.port }}
-      targetPort: {{ .Values.port }}
+      targetPort: {{ .Values.targetPort }}

--- a/ark/executors/completions/chart/values.yaml
+++ b/ark/executors/completions/chart/values.yaml
@@ -3,7 +3,8 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
-port: 9090
+port: 80
+targetPort: 9090
 
 serviceAccountName: ark-controller
 

--- a/docs/content/developer-guide/local-development.mdx
+++ b/docs/content/developer-guide/local-development.mdx
@@ -70,7 +70,7 @@ Switching between storage backends is destructive. Resources created with etcd (
 
 The completions engine runs as a standalone pod. This allows independent code sync and restart — changing engine code only restarts the engine, not the controller.
 
-DevSpace deploys the engine using the chart at `executors/completions/chart/`. The controller connects via `--completions-addr=http://ark-completions.ark-system:9090`.
+DevSpace deploys the engine using the chart at `executors/completions/chart/`. The controller connects via `--completions-addr=http://ark-completions.ark-system`.
 
 ```bash
 # Both controller and completions engine start with devspace dev

--- a/docs/content/developer-guide/services/ark-completions.mdx
+++ b/docs/content/developer-guide/services/ark-completions.mdx
@@ -15,7 +15,7 @@ The controller delegates query execution to the completions engine via A2A `Send
 Kubernetes Cluster (ark-system namespace)
 ┌─────────────────────┐    K8s Service     ┌─────────────────────────┐
 │  Controller Pod      │    (A2A)           │  Completions Pod         │
-│  (reconciler)        │──────────────────►│  (ark-completions:9090)  │
+│  (reconciler)        │──────────────────►│  (ark-completions:80)    │
 │       │              │◄──────────────────│       │                  │
 │  - watch CRs         │                    │  - agent loop            │
 │  - resolve target    │                    │  - team orchestration    │
@@ -37,7 +37,8 @@ image:
   repository: ghcr.io/mckinsey/agents-at-scale-ark/ark-completions
   pullPolicy: IfNotPresent
   tag: ""
-port: 9090
+port: 80
+targetPort: 9090
 resources:
   limits:
     cpu: 500m
@@ -52,7 +53,7 @@ Helm chart location: `ark/executors/completions/chart/`
 
 ### Controller Flag
 
-The controller connects to the engine via the `--completions-addr` flag (default: `http://ark-completions.ark-system:9090`).
+The controller connects to the engine via the `--completions-addr` flag (default: `http://ark-completions.ark-system`).
 
 ## Source Code
 
@@ -67,7 +68,7 @@ cd ark
 devspace dev
 ```
 
-DevSpace deploys the engine using the chart at `ark/executors/completions/chart/`. The controller's `--completions-addr` is set to `http://ark-completions.ark-system:9090`.
+DevSpace deploys the engine using the chart at `ark/executors/completions/chart/`. The controller's `--completions-addr` is set to `http://ark-completions.ark-system`.
 
 Changes to engine code restart only the engine pod. Changes to controller code restart only the controller pod.
 


### PR DESCRIPTION
## Summary

- Expose completions service port as 80 (was 9090) with targetPort 9090, matching the ark-api pattern
- Add separate `targetPort` value in Helm chart so consumers connect on well-known port 80
- Update `--completions-addr` default to `http://ark-completions.ark-system` (implicit port 80)
- Update devspace.yaml, controller Helm values, and documentation to reflect the new convention

Closes #1364