### PR TITLE
fix(ark-api): handle streaming timeout for named execution engines

### DIFF
--- a/ark/internal/annotations/annotations.go
+++ b/ark/internal/annotations/annotations.go
@@ -55,8 +55,9 @@ const (
 
 // Streaming annotations
 const (
-	StreamingEnabled = ARKPrefix + "streaming-enabled"
-	StreamingURL     = ARKPrefix + "streaming-url"
+	StreamingEnabled   = ARKPrefix + "streaming-enabled"
+	StreamingURL       = ARKPrefix + "streaming-url"
+	StreamingSupported = ARKPrefix + "streaming-supported"
 )
 
 // Migration annotations - used by mutating webhooks to record deprecation warnings.

--- a/docs/content/developer-guide/building-execution-engines.mdx
+++ b/docs/content/developer-guide/building-execution-engines.mdx
@@ -100,8 +100,6 @@ Queries targeting `my-agent` will be routed to your engine via A2A.
 
 ## Streaming Support
 
-By default, named execution engines do not support streaming. When the dashboard or an OpenAI-compatible client requests `stream: true`, Ark falls back to polling for the query result and returns it as a single-chunk SSE response.
-
 If your engine writes streaming chunks to the broker (via the memory event stream), opt in by adding the `streaming-supported` annotation to your `ExecutionEngine` resource:
 
 ```yaml

--- a/docs/content/developer-guide/building-execution-engines.mdx
+++ b/docs/content/developer-guide/building-execution-engines.mdx
@@ -98,6 +98,26 @@ spec:
 
 Queries targeting `my-agent` will be routed to your engine via A2A.
 
+## Streaming Support
+
+By default, named execution engines do not support streaming. When the dashboard or an OpenAI-compatible client requests `stream: true`, Ark falls back to polling for the query result and returns it as a single-chunk SSE response.
+
+If your engine writes streaming chunks to the broker (via the memory event stream), opt in by adding the `streaming-supported` annotation to your `ExecutionEngine` resource:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1prealpha1
+kind: ExecutionEngine
+metadata:
+  name: my-engine
+  annotations:
+    ark.mckinsey.com/streaming-supported: "true"
+spec:
+  address:
+    value: "http://my-engine-service:8000"
+```
+
+Without this annotation, streaming requests are handled transparently — clients still receive a valid SSE response, just without incremental chunks.
+
 ## Key Types
 
 Import from `ark_sdk.executor`:

--- a/docs/content/developer-guide/langchain-execution-engine.mdx
+++ b/docs/content/developer-guide/langchain-execution-engine.mdx
@@ -49,6 +49,12 @@ spec:
   description: "LangChain Executor - A2A server with RAG support"
 ```
 
+## Streaming
+
+The LangChain executor does not write streaming chunks to the broker. When a client requests streaming, Ark automatically falls back to polling and returns the complete response as a single-chunk SSE response. No configuration is needed — this is the default behavior for execution engines without the `ark.mckinsey.com/streaming-supported` annotation.
+
+See [Building Execution Engines](/developer-guide/building-execution-engines#streaming-support) for details.
+
 ## RAG Support
 
 Enable RAG for an agent by adding the label:

--- a/docs/content/developer-guide/langchain-execution-engine.mdx
+++ b/docs/content/developer-guide/langchain-execution-engine.mdx
@@ -49,12 +49,6 @@ spec:
   description: "LangChain Executor - A2A server with RAG support"
 ```
 
-## Streaming
-
-The LangChain executor does not write streaming chunks to the broker. When a client requests streaming, Ark automatically falls back to polling and returns the complete response as a single-chunk SSE response. No configuration is needed — this is the default behavior for execution engines without the `ark.mckinsey.com/streaming-supported` annotation.
-
-See [Building Execution Engines](/developer-guide/building-execution-engines#streaming-support) for details.
-
 ## RAG Support
 
 Enable RAG for an agent by adding the label:

--- a/openspec/changes/fix-streaming-named-engines/design.md
+++ b/openspec/changes/fix-streaming-named-engines/design.md
@@ -1,0 +1,79 @@
+# Design: Fix streaming timeout for named execution engines
+
+## Decision: Where to check
+
+ark-api (`openai.py`) makes two K8s API calls on the streaming hot path when the target is an agent with a named engine:
+
+1. `ark_client.agents.a_get(agent_name)` — get the agent, check `executionEngine`
+2. `ark_client.execution_engines.a_get(engine_name)` — get the engine, check annotation
+
+This only happens when `stream=true` AND target type is `agent` AND the agent has a named engine (not `"a2a"`). Acceptable cost.
+
+Alternative considered: propagate annotation from ExecutionEngine → Agent to avoid the second call. Rejected because the ExecutionEngine controller doesn't manage agents, and adding propagation adds complexity for minimal gain.
+
+## Decision: Annotation on ExecutionEngine CR, not Agent
+
+Streaming is a capability of the execution engine, not the agent. All agents using the same engine inherit the behavior. Consistent with how the system models capabilities.
+
+## Decision: Default to no streaming
+
+Named engines don't support streaming unless explicitly annotated. This is the safe default — the existing breakage is caused by assuming streaming works.
+
+## ark-api logic change
+
+```
+chat_completions(request):
+  ... create query ...
+
+  if not request.stream:
+    return poll_and_return()  # existing path
+
+  # NEW: check if target can produce streaming chunks
+  supports_streaming = await check_streaming_support(target, namespace)
+
+  if not supports_streaming:
+    # Poll for completion, wrap as single-chunk SSE
+    completion = await watch_query_completion(...)
+    sse_lines = create_single_chunk_sse_response(completion)
+    return StreamingResponse(iter(sse_lines), ...)
+
+  # Existing streaming proxy path
+  streaming_config = await get_streaming_config(...)
+  ...
+```
+
+```
+async def check_streaming_support(target, namespace) -> bool:
+  """Check if the target can produce streaming chunks to the broker."""
+  if target.type != "agent":
+    return True  # models, teams, tools go through completions engine
+
+  async with with_ark_client(namespace, "v1alpha1") as ark_client:
+    agent = await ark_client.agents.a_get(target.name)
+    agent_spec = agent.to_dict().get("spec", {})
+    engine_ref = agent_spec.get("executionEngine")
+
+    if not engine_ref or engine_ref.get("name") in (None, "", "a2a"):
+      return True  # completions engine handles streaming
+
+    engine_name = engine_ref["name"]
+    engine_namespace = engine_ref.get("namespace") or namespace
+
+  async with with_ark_client(engine_namespace, "v1prealpha1") as ark_client:
+    engine = await ark_client.execution_engines.a_get(engine_name)
+    engine_annotations = engine.to_dict().get("metadata", {}).get("annotations", {}) or {}
+    return engine_annotations.get("ark.mckinsey.com/streaming-supported") == "true"
+```
+
+## Streaming config check ordering
+
+Current code checks streaming config AFTER deciding to stream. The new check should happen BEFORE the streaming config check, since it's a higher-level gate:
+
+```
+stream=true?
+  → can target produce chunks? (NEW)
+    → NO: poll + single-chunk SSE
+    → YES: is streaming config available? (existing)
+      → NO: poll + single-chunk SSE (existing fallback)
+      → YES: proxy to broker (existing)
+```

--- a/openspec/changes/fix-streaming-named-engines/proposal.md
+++ b/openspec/changes/fix-streaming-named-engines/proposal.md
@@ -1,0 +1,56 @@
+# Fix streaming timeout for named execution engines
+
+## Problem
+
+When the dashboard chat sends a query to an agent with a named execution engine (e.g., `executionEngine.name: executor-langchain`), the request times out even though the underlying query succeeds.
+
+The dashboard defaults to `stream: true`. ark-api sets the `streaming-enabled` annotation on the Query CR and proxies to the broker's SSE streaming endpoint, waiting for chunks. But named execution engines bypass the completions engine entirely — the controller dispatches directly to the engine via blocking A2A. No chunks are ever written to the broker. The SSE proxy hangs until timeout.
+
+This works for `executionEngine: a2a` agents because the controller routes those through the completions engine, which creates an `eventStream` to the broker and writes the result as a single chunk even when the A2A agent doesn't support streaming natively.
+
+## Solution
+
+Add a `streaming-supported` annotation on the ExecutionEngine CR. ark-api checks this annotation before deciding whether to proxy to the broker or fall back to polling.
+
+### Flow
+
+1. ark-api receives `stream: true` request targeting an agent
+2. Fetches the Agent CR → finds `executionEngine.name` (not "a2a")
+3. Fetches the ExecutionEngine CR → checks `ark.mckinsey.com/streaming-supported` annotation
+4. If annotation is NOT `"true"` → polls via `watch_query_completion`, wraps result as single-chunk SSE response
+5. If annotation IS `"true"` → normal streaming proxy to broker
+
+### Annotation
+
+```yaml
+apiVersion: ark.mckinsey.com/v1prealpha1
+kind: ExecutionEngine
+metadata:
+  name: executor-langchain
+  annotations:
+    ark.mckinsey.com/streaming-supported: "false"  # or omit entirely — default is no streaming
+spec:
+  address:
+    value: "http://executor-langchain:8000"
+```
+
+Default behavior: no streaming support (annotation absent or `"false"`). Engines that write chunks to the broker can opt in with `"true"`.
+
+## Changes
+
+### ark-api (`services/ark-api/`)
+- `src/ark_api/api/v1/openai.py` — After query creation, when `stream=true` and target is an agent: fetch agent, check for named engine, fetch ExecutionEngine CR, check annotation. Fall back to poll + single-chunk SSE if streaming not supported.
+- `src/ark_api/constants/annotations.py` — Add `STREAMING_SUPPORTED_ANNOTATION` constant.
+
+### Ark operator (`ark/`)
+- `internal/annotations/annotations.go` — Add `StreamingSupported` constant (`ark.mckinsey.com/streaming-supported`).
+
+### Documentation (`docs/`)
+- `docs/content/developer-guide/building-execution-engines.mdx` — Document the `streaming-supported` annotation and when to set it.
+- `docs/content/developer-guide/langchain-execution-engine.mdx` — Note that the langchain engine does not support streaming by default.
+
+## Non-goals
+
+- Dashboard-side changes (no frontend awareness of engine capabilities)
+- Annotation propagation from ExecutionEngine to Agent (ark-api fetches both)
+- Race-with-timeout or other speculative streaming approaches

--- a/openspec/changes/fix-streaming-named-engines/tasks.md
+++ b/openspec/changes/fix-streaming-named-engines/tasks.md
@@ -1,36 +1,9 @@
 # Tasks
 
-## 1. Add streaming-supported annotation constant (Go)
-- File: `ark/internal/annotations/annotations.go`
-- Add `StreamingSupported = ARKPrefix + "streaming-supported"` to a new or existing annotation group
-
-## 2. Add streaming-supported annotation constant (Python)
-- File: `services/ark-api/ark-api/src/ark_api/constants/annotations.py`
-- Add `STREAMING_SUPPORTED_ANNOTATION = "ark.mckinsey.com/streaming-supported"`
-
-## 3. Add check_streaming_support helper in ark-api
-- File: `services/ark-api/ark-api/src/ark_api/api/v1/openai.py` (or a new util)
-- Fetch agent → check executionEngine → fetch ExecutionEngine CR → check annotation
-- Return bool indicating whether the target can produce streaming chunks
-
-## 4. Update chat_completions to use the helper
-- File: `services/ark-api/ark-api/src/ark_api/api/v1/openai.py`
-- After query creation, before streaming decision: call `check_streaming_support`
-- If not supported: poll + `create_single_chunk_sse_response` (reuse existing fallback logic)
-- If supported: existing streaming proxy path
-
-## 5. Add tests for the new behavior
-- File: `services/ark-api/ark-api/tests/api/test_routes.py` (or new test file)
-- Test: agent with named engine, no annotation → falls back to polling
-- Test: agent with named engine, annotation=true → streams normally
-- Test: agent with no engine / engine=a2a → streams normally
-- Test: non-agent targets → streams normally
-
-## 6. Update execution engine documentation
-- File: `docs/content/developer-guide/building-execution-engines.mdx`
-- Document the `streaming-supported` annotation
-- Explain default behavior (no streaming) and how to opt in
-
-## 7. Update langchain engine documentation
-- File: `docs/content/developer-guide/langchain-execution-engine.mdx`
-- Note that the langchain engine does not support streaming
+- [x] Add streaming-supported annotation constant (Go) — `ark/internal/annotations/annotations.go`
+- [x] Add streaming-supported annotation constant (Python) — `services/ark-api/ark-api/src/ark_api/constants/annotations.py`
+- [x] Add check_streaming_support helper in ark-api — `services/ark-api/ark-api/src/ark_api/api/v1/openai.py` or new util
+- [x] Update chat_completions to use the helper — `services/ark-api/ark-api/src/ark_api/api/v1/openai.py`
+- [x] Add tests for the new behavior — `services/ark-api/ark-api/tests/`
+- [x] Update execution engine documentation — `docs/content/developer-guide/building-execution-engines.mdx`
+- [x] Update langchain engine documentation — `docs/content/developer-guide/langchain-execution-engine.mdx`

--- a/openspec/changes/fix-streaming-named-engines/tasks.md
+++ b/openspec/changes/fix-streaming-named-engines/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## 1. Add streaming-supported annotation constant (Go)
+- File: `ark/internal/annotations/annotations.go`
+- Add `StreamingSupported = ARKPrefix + "streaming-supported"` to a new or existing annotation group
+
+## 2. Add streaming-supported annotation constant (Python)
+- File: `services/ark-api/ark-api/src/ark_api/constants/annotations.py`
+- Add `STREAMING_SUPPORTED_ANNOTATION = "ark.mckinsey.com/streaming-supported"`
+
+## 3. Add check_streaming_support helper in ark-api
+- File: `services/ark-api/ark-api/src/ark_api/api/v1/openai.py` (or a new util)
+- Fetch agent → check executionEngine → fetch ExecutionEngine CR → check annotation
+- Return bool indicating whether the target can produce streaming chunks
+
+## 4. Update chat_completions to use the helper
+- File: `services/ark-api/ark-api/src/ark_api/api/v1/openai.py`
+- After query creation, before streaming decision: call `check_streaming_support`
+- If not supported: poll + `create_single_chunk_sse_response` (reuse existing fallback logic)
+- If supported: existing streaming proxy path
+
+## 5. Add tests for the new behavior
+- File: `services/ark-api/ark-api/tests/api/test_routes.py` (or new test file)
+- Test: agent with named engine, no annotation → falls back to polling
+- Test: agent with named engine, annotation=true → streams normally
+- Test: agent with no engine / engine=a2a → streams normally
+- Test: non-agent targets → streams normally
+
+## 6. Update execution engine documentation
+- File: `docs/content/developer-guide/building-execution-engines.mdx`
+- Document the `streaming-supported` annotation
+- Explain default behavior (no streaming) and how to opt in
+
+## 7. Update langchain engine documentation
+- File: `docs/content/developer-guide/langchain-execution-engine.mdx`
+- Note that the langchain engine does not support streaming

--- a/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/openai.py
@@ -25,6 +25,7 @@ from ...utils.parse_duration import parse_duration_to_seconds
 from ...utils.query_targets import parse_model_to_query_target
 from ...utils.query_watch import watch_query_completion
 from ...utils.streaming import StreamingErrorResponse, create_single_chunk_sse_response
+from ...utils.streaming_support import check_streaming_support
 
 router = APIRouter(prefix="/openai/v1", tags=["OpenAI"])
 logger = logging.getLogger(__name__)
@@ -254,19 +255,30 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletion:
                     ark_client, query_name, model, messages, timeout_seconds
                 )
 
-            # Streaming was requested - check if streaming backend is available
-            # Define Server-Sent Events (SSE) headers for streaming responses
-            # These headers ensure the connection stays open and data is not cached
             sse_headers = {
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
             }
 
+            supports_streaming = await check_streaming_support(
+                target.type, target.name, namespace
+            )
+            if not supports_streaming:
+                logger.info(
+                    f"Target {target.type}/{target.name} does not support streaming, falling back to polling"
+                )
+                completion = await watch_query_completion(
+                    ark_client, query_name, model, messages, timeout_seconds
+                )
+                sse_lines = create_single_chunk_sse_response(completion)
+                return StreamingResponse(
+                    iter(sse_lines), media_type="text/event-stream", headers=sse_headers
+                )
+
             api = k8s_client.ApiClient()
             v1 = k8s_client.CoreV1Api(api)
             streaming_config = await get_streaming_config(v1, namespace)
 
-            # If no config or not enabled, fall back to polling
             if not streaming_config or not streaming_config.enabled:
                 logger.info("No streaming backend configured, falling back to polling")
                 completion = await watch_query_completion(

--- a/services/ark-api/ark-api/src/ark_api/constants/annotations.py
+++ b/services/ark-api/ark-api/src/ark_api/constants/annotations.py
@@ -23,4 +23,5 @@ LOCALHOST_GATEWAY_PORT_ANNOTATION = ARK_PREFIX + "localhost-gateway-port"
 
 # Streaming annotations
 STREAMING_ENABLED_ANNOTATION = ARK_PREFIX + "streaming-enabled"
+STREAMING_SUPPORTED_ANNOTATION = ARK_PREFIX + "streaming-supported"
 MEMORY_EVENT_STREAM_ENABLED_ANNOTATION = ARK_PREFIX + "memory-event-stream-enabled"

--- a/services/ark-api/ark-api/src/ark_api/utils/streaming_support.py
+++ b/services/ark-api/ark-api/src/ark_api/utils/streaming_support.py
@@ -1,0 +1,46 @@
+"""Utility to check if a query target supports streaming via the broker."""
+
+import logging
+
+from ark_sdk.client import with_ark_client
+
+from ..constants.annotations import STREAMING_SUPPORTED_ANNOTATION
+
+logger = logging.getLogger(__name__)
+
+EXECUTION_ENGINE_A2A = "a2a"
+V1_ALPHA1 = "v1alpha1"
+V1_PREALPHA1 = "v1prealpha1"
+
+
+async def check_streaming_support(target_type: str, target_name: str, namespace: str) -> bool:
+    """Check if the target can produce streaming chunks to the broker.
+
+    Returns True if the target goes through the completions engine (which handles
+    streaming), or if a named execution engine has opted in via annotation.
+    Returns False if the target uses a named execution engine without streaming support.
+    """
+    if target_type != "agent":
+        return True
+
+    try:
+        async with with_ark_client(namespace, V1_ALPHA1) as ark_client:
+            agent = await ark_client.agents.a_get(target_name)
+            agent_spec = agent.to_dict().get("spec", {})
+            engine_ref = agent_spec.get("executionEngine")
+
+            if not engine_ref or engine_ref.get("name") in (None, "", EXECUTION_ENGINE_A2A):
+                return True
+
+            engine_name = engine_ref["name"]
+            engine_namespace = engine_ref.get("namespace") or namespace
+
+        async with with_ark_client(engine_namespace, V1_PREALPHA1) as ark_client:
+            engine = await ark_client.executionengines.a_get(engine_name)
+            engine_meta = engine.to_dict().get("metadata", {})
+            engine_annotations = engine_meta.get("annotations") or {}
+            return engine_annotations.get(STREAMING_SUPPORTED_ANNOTATION) == "true"
+
+    except Exception as e:
+        logger.warning(f"Failed to check streaming support for {target_type}/{target_name}: {e}")
+        return True

--- a/services/ark-api/ark-api/tests/test_streaming_support.py
+++ b/services/ark-api/ark-api/tests/test_streaming_support.py
@@ -1,0 +1,169 @@
+"""Tests for streaming support check logic."""
+
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ["AUTH_MODE"] = "open"
+
+from ark_api.utils.streaming_support import check_streaming_support
+
+
+class TestCheckStreamingSupport(unittest.IsolatedAsyncioTestCase):
+
+    async def test_non_agent_target_returns_true(self):
+        result = await check_streaming_support("model", "gpt-4", "default")
+        self.assertTrue(result)
+
+    async def test_team_target_returns_true(self):
+        result = await check_streaming_support("team", "my-team", "default")
+        self.assertTrue(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_agent_without_execution_engine_returns_true(self, mock_with_ark_client):
+        mock_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {"spec": {}}
+        mock_client.agents.a_get = AsyncMock(return_value=mock_agent)
+        mock_with_ark_client.return_value.__aenter__.return_value = mock_client
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertTrue(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_agent_with_a2a_engine_returns_true(self, mock_with_ark_client):
+        mock_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {
+            "spec": {"executionEngine": {"name": "a2a"}}
+        }
+        mock_client.agents.a_get = AsyncMock(return_value=mock_agent)
+        mock_with_ark_client.return_value.__aenter__.return_value = mock_client
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertTrue(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_named_engine_without_annotation_returns_false(self, mock_with_ark_client):
+        mock_v1alpha1_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {
+            "spec": {"executionEngine": {"name": "executor-langchain"}}
+        }
+        mock_v1alpha1_client.agents.a_get = AsyncMock(return_value=mock_agent)
+
+        mock_prealpha1_client = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.to_dict.return_value = {
+            "metadata": {"annotations": {}}
+        }
+        mock_prealpha1_client.executionengines.a_get = AsyncMock(return_value=mock_engine)
+
+        call_count = 0
+        async def mock_ctx(namespace, version):
+            nonlocal call_count
+            call_count += 1
+            ctx = AsyncMock()
+            if call_count == 1:
+                ctx.__aenter__.return_value = mock_v1alpha1_client
+            else:
+                ctx.__aenter__.return_value = mock_prealpha1_client
+            return ctx
+
+        mock_with_ark_client.side_effect = lambda ns, v: (
+            _make_ctx(mock_v1alpha1_client) if v == "v1alpha1" else _make_ctx(mock_prealpha1_client)
+        )
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertFalse(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_named_engine_with_streaming_annotation_returns_true(self, mock_with_ark_client):
+        mock_v1alpha1_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {
+            "spec": {"executionEngine": {"name": "executor-custom"}}
+        }
+        mock_v1alpha1_client.agents.a_get = AsyncMock(return_value=mock_agent)
+
+        mock_prealpha1_client = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.to_dict.return_value = {
+            "metadata": {
+                "annotations": {"ark.mckinsey.com/streaming-supported": "true"}
+            }
+        }
+        mock_prealpha1_client.executionengines.a_get = AsyncMock(return_value=mock_engine)
+
+        mock_with_ark_client.side_effect = lambda ns, v: (
+            _make_ctx(mock_v1alpha1_client) if v == "v1alpha1" else _make_ctx(mock_prealpha1_client)
+        )
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertTrue(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_named_engine_with_null_annotations_returns_false(self, mock_with_ark_client):
+        mock_v1alpha1_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {
+            "spec": {"executionEngine": {"name": "executor-langchain"}}
+        }
+        mock_v1alpha1_client.agents.a_get = AsyncMock(return_value=mock_agent)
+
+        mock_prealpha1_client = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.to_dict.return_value = {
+            "metadata": {"annotations": None}
+        }
+        mock_prealpha1_client.executionengines.a_get = AsyncMock(return_value=mock_engine)
+
+        mock_with_ark_client.side_effect = lambda ns, v: (
+            _make_ctx(mock_v1alpha1_client) if v == "v1alpha1" else _make_ctx(mock_prealpha1_client)
+        )
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertFalse(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_agent_fetch_failure_returns_true(self, mock_with_ark_client):
+        mock_client = AsyncMock()
+        mock_client.agents.a_get = AsyncMock(side_effect=Exception("not found"))
+        mock_with_ark_client.return_value.__aenter__.return_value = mock_client
+
+        result = await check_streaming_support("agent", "missing-agent", "default")
+        self.assertTrue(result)
+
+    @patch("ark_api.utils.streaming_support.with_ark_client")
+    async def test_named_engine_with_custom_namespace(self, mock_with_ark_client):
+        mock_v1alpha1_client = AsyncMock()
+        mock_agent = MagicMock()
+        mock_agent.to_dict.return_value = {
+            "spec": {"executionEngine": {"name": "executor-custom", "namespace": "other-ns"}}
+        }
+        mock_v1alpha1_client.agents.a_get = AsyncMock(return_value=mock_agent)
+
+        mock_prealpha1_client = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.to_dict.return_value = {
+            "metadata": {"annotations": {}}
+        }
+        mock_prealpha1_client.executionengines.a_get = AsyncMock(return_value=mock_engine)
+
+        calls = []
+        mock_with_ark_client.side_effect = lambda ns, v: (
+            calls.append((ns, v)) or
+            _make_ctx(mock_v1alpha1_client) if v == "v1alpha1" else _make_ctx(mock_prealpha1_client)
+        )
+
+        result = await check_streaming_support("agent", "test-agent", "default")
+        self.assertFalse(result)
+        engine_call = [c for c in calls if c[1] == "v1prealpha1"]
+        if engine_call:
+            self.assertEqual(engine_call[0][0], "other-ns")
+
+
+def _make_ctx(client):
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = client
+    return ctx

--- a/services/ark-api/chart/templates/rbac.yaml
+++ b/services/ark-api/chart/templates/rbac.yaml
@@ -42,7 +42,7 @@ rules:
     verbs: ["get", "list"]
   # Ark resources
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["models", "agents", "queries", "teams", "tools", "workflows", "arktemplates", "mcpservers", "a2aservers", "memories", "evaluations", "evaluators", "a2atasks"]
+    resources: ["models", "agents", "queries", "teams", "tools", "workflows", "arktemplates", "mcpservers", "a2aservers", "memories", "evaluations", "evaluators", "a2atasks", "executionengines"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Argo Workflows resources
   - apiGroups: ["argoproj.io"]


### PR DESCRIPTION
## Summary

- Named execution engines bypass the completions engine, so no streaming chunks reach the broker — but ark-api was proxying to the broker's SSE endpoint anyway, causing timeouts
- Add `ark.mckinsey.com/streaming-supported` annotation on ExecutionEngine CRs to opt in to streaming
- ark-api now checks the agent's execution engine before deciding to stream: if the engine doesn't support streaming, it polls for the query result and wraps it as a single-chunk SSE response
- Default behavior is no streaming for named engines — safe fallback that fixes the timeout
- Add `executionengines` to ark-api RBAC so the service account can read ExecutionEngine CRs
- Add 9 unit tests covering all streaming support check scenarios