### PR TITLE
fix: evaluation parameter validation accepts valueFrom references

### DIFF
--- a/ark/internal/validation/evaluation.go
+++ b/ark/internal/validation/evaluation.go
@@ -105,7 +105,7 @@ func validateEvaluatorParameters(evaluation *arkv1alpha1.Evaluation) error {
 		if param.Name == "" {
 			return fmt.Errorf("evaluator parameter[%d]: name cannot be empty", i)
 		}
-		if param.Value == "" {
+		if param.Value == "" && param.ValueFrom == nil {
 			return fmt.Errorf("evaluator parameter[%d]: value cannot be empty", i)
 		}
 	}


### PR DESCRIPTION
## Summary
- `validateEvaluatorParameters` rejected parameters with `valueFrom` references because it only checked `Value == ""` without considering `ValueFrom`
- All other validators in the codebase already check `Value == "" && ValueFrom == nil`
- This caused all 7 evaluated E2E tests to fail on postgresql while passing on etcd

Reproduced locally: same Evaluation manifest rejected with `evaluator parameter[3]: value cannot be empty` before fix, accepted after.