### PR TITLE
feat: add Claude overnight automation workflow

### DIFF
--- a/.github/workflows/agent-actions.yaml
+++ b/.github/workflows/agent-actions.yaml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - dependabot
+          - triage-prs
         required: true
 
 permissions:
@@ -37,4 +38,30 @@ jobs:
             Skip any PRs that modify .github/workflows/ files (these need manual
             merge due to GitHub token scope requirements) and note them in the PR
             description.
+          claude_args: "--dangerously-skip-permissions --max-turns 30"
+
+  triage-prs:
+    if: inputs.task == 'triage-prs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
+          prompt: |
+            List all open PRs in this repo using gh pr list. For each PR, check
+            the diff with gh pr diff. If the PR touches RBAC, security, auth,
+            permissions, roles, or secrets (look for changes to RBAC manifests,
+            auth middleware, token handling, secret references, ClusterRole,
+            Role, RoleBinding, ServiceAccount permissions, or security policies),
+            add a comment on the PR:
+
+            "@dwmkerr FYI please assess for security"
+
+            Only comment once per PR — check existing comments first with
+            gh pr view --comments to avoid duplicates. Skip Dependabot PRs.
           claude_args: "--dangerously-skip-permissions --max-turns 30"

--- a/.github/workflows/agent-actions.yaml
+++ b/.github/workflows/agent-actions.yaml
@@ -1,15 +1,14 @@
-name: Claude Overnight Automation
+name: Agent Actions
 
 on:
-  schedule:
-    # Run at 2 AM UTC daily (overnight for most team timezones)
-    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       task:
-        description: "Task to run (e.g. 'dependabot', 'all')"
-        required: false
-        default: "all"
+        description: "Task to run"
+        type: choice
+        options:
+          - dependabot
+        required: true
 
 permissions:
   contents: write
@@ -18,10 +17,7 @@ permissions:
 
 jobs:
   consolidate-dependabot:
-    if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (inputs.task == 'dependabot' || inputs.task == 'all'))
+    if: inputs.task == 'dependabot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,8 +26,8 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          anthropic_api_key: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
           prompt: |
             Use the /dependabot skill to consolidate all open Dependabot PRs
             into a single integration/dependabot branch and create a consolidated

--- a/.github/workflows/agent-actions.yaml
+++ b/.github/workflows/agent-actions.yaml
@@ -20,16 +20,20 @@ jobs:
   consolidate-dependabot:
     if: inputs.task == 'dependabot'
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
+      GH_TOKEN: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
-          prompt: |
+      - name: Install Claude CLI
+        run: curl -fsSL https://claude.ai/install.sh | sh
+
+      - name: Consolidate Dependabot PRs
+        run: |
+          claude --dangerously-skip-permissions --max-turns 30 -p "
             Use the /dependabot skill to consolidate all open Dependabot PRs
             into a single integration/dependabot branch and create a consolidated
             PR into main. If an integration/dependabot branch and PR already exist,
@@ -38,21 +42,25 @@ jobs:
             Skip any PRs that modify .github/workflows/ files (these need manual
             merge due to GitHub token scope requirements) and note them in the PR
             description.
-          claude_args: "--dangerously-skip-permissions --max-turns 30"
+          "
 
   triage-prs:
     if: inputs.task == 'triage-prs'
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
+      GH_TOKEN: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.AGENT_ACTIONS_ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.AGENT_ACTIONS_GH_TOKEN }}
-          prompt: |
+      - name: Install Claude CLI
+        run: curl -fsSL https://claude.ai/install.sh | sh
+
+      - name: Triage PRs for security
+        run: |
+          claude --dangerously-skip-permissions --max-turns 30 -p "
             List all open PRs in this repo using gh pr list. For each PR, check
             the diff with gh pr diff. If the PR touches RBAC, security, auth,
             permissions, roles, or secrets (look for changes to RBAC manifests,
@@ -60,8 +68,8 @@ jobs:
             Role, RoleBinding, ServiceAccount permissions, or security policies),
             add a comment on the PR:
 
-            "@dwmkerr FYI please assess for security"
+            @dwmkerr FYI please assess for security
 
             Only comment once per PR — check existing comments first with
             gh pr view --comments to avoid duplicates. Skip Dependabot PRs.
-          claude_args: "--dangerously-skip-permissions --max-turns 30"
+          "

--- a/.github/workflows/claude-overnight.yaml
+++ b/.github/workflows/claude-overnight.yaml
@@ -1,0 +1,44 @@
+name: Claude Overnight Automation
+
+on:
+  schedule:
+    # Run at 2 AM UTC daily (overnight for most team timezones)
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task to run (e.g. 'dependabot', 'all')"
+        required: false
+        default: "all"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  consolidate-dependabot:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+       (inputs.task == 'dependabot' || inputs.task == 'all'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          prompt: |
+            Use the /dependabot skill to consolidate all open Dependabot PRs
+            into a single integration/dependabot branch and create a consolidated
+            PR into main. If an integration/dependabot branch and PR already exist,
+            merge any new Dependabot PRs into it and update the PR description.
+
+            Skip any PRs that modify .github/workflows/ files (these need manual
+            merge due to GitHub token scope requirements) and note them in the PR
+            description.
+          claude_args: "--dangerously-skip-permissions --max-turns 30"


### PR DESCRIPTION
## Summary

- Adds a scheduled GitHub Action that runs Claude CLI overnight to automate repo maintenance
- First automated task: consolidate Dependabot PRs using the `/dependabot` skill
- Can be triggered manually via `workflow_dispatch` for on-demand runs

### How it works

Uses [claude-code-action](https://github.com/anthropics/claude-code-action) which installs the Claude CLI and runs it with `--dangerously-skip-permissions`. The action:

1. Checks out the repo
2. Runs Claude with a prompt that invokes the `/dependabot` skill
3. Claude creates an `integration/dependabot` branch, retargets all open Dependabot PRs, merges them, and opens a consolidated PR

### Secrets required

| Secret | Purpose |
|--------|---------|
| `ANTHROPIC_API_KEY` | Claude API authentication |
| `CLAUDE_GH_TOKEN` | GitHub token with `repo` + `workflow` scopes for merging PRs and pushing branches |

### Extensibility

The workflow uses a `task` input so additional overnight jobs can be added later (e.g. stale branch cleanup, changelog generation). The `if` condition pattern makes it easy to add new jobs that run on `all` or a specific task name.

### Open questions

- Should we use a GitHub App token instead of a PAT for `CLAUDE_GH_TOKEN`?
- What's the right `--max-turns` limit? Started with 30 since dependabot consolidation can require many tool calls
- Should failures notify a Slack channel?