### PR TITLE
docs: openspec change set for dropping query input types

### DIFF
--- a/openspec/changes/drop-query-input-types/.openspec.yaml
+++ b/openspec/changes/drop-query-input-types/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/drop-query-input-types/README.md
+++ b/openspec/changes/drop-query-input-types/README.md
@@ -1,0 +1,3 @@
+# drop-query-input-types
+
+Remove the `type: messages` query input format now that the broker manages conversation history. Simplify the CRD to accept user text input only.

--- a/openspec/changes/drop-query-input-types/design.md
+++ b/openspec/changes/drop-query-input-types/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The Query CRD has two input types: `user` (string) and `messages` (OpenAI message array). The `messages` type was added before the broker provided session-based conversation history. Now that the broker is the default entry point and manages history, embedding full conversation arrays in the CRD is redundant.
+
+Dave Kerr noted: "we would fairly quickly consider dropping query input types of convo i.e. where we embed the full convo completions style — given that people get the broker by default we can just send input."
+
+Kristof confirmed: "the concept of broker and being able to send the query input as chain of messages are already redundant, we could clean this up nicely by a targeted fix that stretches across crd / controller / api / dashboard."
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove OpenAI type dependency from the Query CRD API
+- Simplify input handling to a single path (user text)
+- Provide backwards-compatible migration via webhook during deprecation
+
+**Non-Goals:**
+- Changing the broker's session management
+- Removing the ability for the completions engine to process multi-turn conversations internally (it gets history from memory/broker, not from the CRD input)
+
+## Decisions
+
+### 1. Deprecation via mutating webhook
+
+**Decision**: Add a mutating webhook that converts `type: messages` to `type: user` by extracting the first user message text. Attach a migration warning annotation.
+
+**Rationale**: Follows the established migration warning pattern used for model provider deprecation. Gives users a clear signal to update without breaking existing workflows.
+
+### 2. Remove OpenAI types from CRD
+
+**Decision**: Remove `GetInputMessages()`, `SetInputMessages()`, and the `openai-go` import from `query_types.go`.
+
+**Rationale**: The CRD API should not depend on a specific LLM provider SDK. Input is opaque `runtime.RawExtension` — only the executor needs to know the format.
+
+### 3. Phased rollout
+
+**Decision**: Phase 1 adds the deprecation webhook and warning. Phase 2 (after one release cycle) removes `messages` support entirely.
+
+**Rationale**: Avoids breaking existing deployments while giving users time to migrate.
+
+## Risks
+
+**[SDK/CLI consumers]** — External tools may rely on `type: messages`. Mitigation: SDK and CLI changes in the same release; migration docs published before enforcement.
+
+**[Direct CRD users]** — Teams creating Query CRs directly with `type: messages`. Mitigation: webhook provides automatic migration with warning.

--- a/openspec/changes/drop-query-input-types/proposal.md
+++ b/openspec/changes/drop-query-input-types/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The Query CRD supports two input types: `user` (a text string) and `messages` (an array of `openai.ChatCompletionMessageParamUnion`). The `messages` type exists to embed full conversation history in the query input — but the broker now manages conversation history via sessions. This makes `type: messages` redundant and carries costs:
+
+- The CRD's `GetInputMessages()` / `SetInputMessages()` methods import `openai-go` types, coupling the API schema to a specific provider SDK
+- Every component that reads query input must handle both formats
+- The `messages` format leaks implementation detail (OpenAI message structure) into the user-facing API
+
+## What Changes
+
+- Deprecate `type: messages` in the Query CRD with a migration warning
+- Add mutating webhook to convert `messages` input to `user` input (extract first user text) for backwards compatibility during migration
+- Remove `GetInputMessages()` / `SetInputMessages()` from QuerySpec
+- Remove OpenAI import from `api/v1alpha1/query_types.go`
+- Update controller, completions engine, API gateway, and dashboard to remove messages-type handling
+- Update SDK and CLI to stop sending `type: messages`
+
+## Non-goals
+
+- Changing how the broker manages conversation history
+- Removing the ability to pass context — users send input text, the broker attaches session history
+- Changing the wire format of A2A messages between controller and executor
+
+## Compatibility Contract
+
+- Existing `type: messages` queries continue to work during the deprecation period via the mutating webhook
+- Migration warning annotation tells users to switch to `type: user` with broker sessions
+- After deprecation period, `type: messages` returns a validation error
+
+## Impact
+
+- `ark/api/v1alpha1/query_types.go` — remove OpenAI import, remove messages helpers
+- `ark/internal/webhook/v1/query_webhook.go` — add migration webhook
+- `ark/internal/controller/query_controller.go` — simplify input handling
+- `ark/executors/completions/query_parameters.go` — remove messages branch in `GetQueryInputMessages`
+- `services/ark-sdk-python/` — update SDK to use text input only
+- `tools/ark-cli/` — update CLI input handling
+- `docs/` — update query documentation

--- a/openspec/changes/drop-query-input-types/specs/drop-query-input-types/spec.md
+++ b/openspec/changes/drop-query-input-types/specs/drop-query-input-types/spec.md
@@ -1,0 +1,22 @@
+# Drop Query Input Types
+
+## Requirements
+
+### MUST
+
+- Existing `type: messages` queries continue to work via mutating webhook during deprecation period
+- Migration warning annotation is attached when webhook converts `type: messages` to `type: user`
+- After removal, `type: messages` returns a clear validation error
+- `query_types.go` has no `openai-go` import dependency after removal phase
+- All tests pass with text-only input across controller, completions, API, SDK, and dashboard
+
+### SHOULD
+
+- Deprecation webhook follows the established migration warning pattern from model_webhook.go
+- SDK and CLI changes ship in the same release as the deprecation webhook
+- Documentation is updated before enforcement phase
+
+### MAY
+
+- Support structured input (e.g., JSON object) as a future extension to `type: user` if needed
+- Accept content-type hints in the input for non-text data

--- a/openspec/changes/drop-query-input-types/tasks.md
+++ b/openspec/changes/drop-query-input-types/tasks.md
@@ -1,0 +1,27 @@
+# Drop Query Input Types Tasks
+
+## Phase 1: Deprecation
+
+- [ ] 1.1 Add mutating webhook to convert `type: messages` to `type: user` with migration warning annotation
+- [ ] 1.2 Add validating webhook warning for `type: messages` using existing `collectMigrationWarnings` pattern
+- [ ] 1.3 Update `GetQueryInputMessages` in completions to handle the simplified input
+- [ ] 1.4 Update API gateway to stop accepting `type: messages` in new requests (return deprecation notice)
+
+## Phase 2: Removal
+
+- [ ] 2.1 Remove `GetInputMessages()` and `SetInputMessages()` from `QuerySpec`
+- [ ] 2.2 Remove `openai-go` import from `api/v1alpha1/query_types.go`
+- [ ] 2.3 Remove `QueryTypeMessages` constant
+- [ ] 2.4 Remove messages-type branch from `GetQueryInputMessages`
+
+## Phase 3: SDK and clients
+
+- [ ] 3.1 Update `ark-sdk-python` to use text input only
+- [ ] 3.2 Update `ark-cli` to use text input only
+- [ ] 3.3 Update dashboard chat to use text input only
+
+## Phase 4: Documentation
+
+- [ ] 4.1 Update query documentation to reflect text-only input
+- [ ] 4.2 Add migration guide for `type: messages` users
+- [ ] 4.3 Update samples to remove `type: messages` examples


### PR DESCRIPTION
## Summary
- Spec for removing `type: messages` query input format — the broker now manages conversation history via sessions, making embedded message arrays redundant
- Removes OpenAI type dependency from the Query CRD API
- Phased rollout: deprecation webhook first, then removal after one release cycle

Relates to #1059