### PR TITLE
fix: Fix problem with secrets in UI tests and other improvements 

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -667,22 +667,10 @@ jobs:
             --wait \
             --timeout=5m
 
-      - name: Deploy ark-mcp
-        run: |
-          helm upgrade --install ark-mcp services/ark-mcp/chart \
-            --namespace default \
-            --create-namespace \
-            --set app.image.repository="${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}/ark-mcp" \
-            --set app.image.tag="${{ github.sha }}" \
-            --set app.image.pullPolicy="Always" \
-            --wait \
-            --timeout=5m
-
       - name: Wait for services to be ready
         run: |
           kubectl wait --for=condition=ready pod -l app=ark-api -n default --timeout=120s
           kubectl wait --for=condition=ready pod -l app=ark-dashboard -n default --timeout=120s
-          kubectl wait --for=condition=ready pod -l app=ark-mcp -n default --timeout=120s
 
       - name: Update Argo Workflows dependencies
         run: |

--- a/services/ark-dashboard/ark-dashboard/lib/services/secrets-hooks.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/secrets-hooks.ts
@@ -43,8 +43,8 @@ export const useCreateSecret = (props: UseCreateSecretProps) => {
       // Optimistically update to the new value
       queryClient.setQueryData(
         [GET_ALL_SECRETS_QUERY_KEY],
-        (old: Secret[]): Secret[] => [
-          ...old,
+        (old: Secret[] | undefined): Secret[] => [
+          ...(old ?? []),
           { id: newSecret.name, name: newSecret.name },
         ],
       );

--- a/tests/pytest/ui-tests/conftest.py
+++ b/tests/pytest/ui-tests/conftest.py
@@ -1,15 +1,16 @@
 import json
 import logging
-import os
 import pytest
 import subprocess
 import time
 import urllib.request
+from collections import defaultdict
 from pathlib import Path
 from playwright.sync_api import Browser, BrowserContext, Page, sync_playwright
 
 logger = logging.getLogger(__name__)
 
+REQUIRED_SERVICES = ['ark-dashboard', 'ark-api']
 
 def pytest_addoption(parser):
     try:
@@ -33,21 +34,23 @@ def get_ark_pods():
         return []
     
     pods_data = json.loads(result.stdout)
-    ark_pods = []
+    ark_pods = defaultdict(list)
     
     for pod in pods_data.get('items', []):
-        pod_name = pod['metadata']['name']
-        if any(name in pod_name for name in ['ark-dashboard', 'ark-api', 'ark-mcp']):
+        pod_labels = pod['metadata']['labels']
+        service = pod_labels.get('app.kubernetes.io/name') or pod_labels.get('app')
+        if service in REQUIRED_SERVICES:
             ready = False
             for condition in pod.get('status', {}).get('conditions', []):
                 if condition.get('type') == 'Ready' and condition.get('status') == 'True':
                     ready = True
                     break
-            ark_pods.append({
-                'name': pod_name,
+            ark_pods[service].append({
+                'name': pod['metadata']['name'],
                 'status': pod['status']['phase'],
                 'ready': ready
             })
+    logger.info(f"Ark pod statuses: {ark_pods}")
     
     return ark_pods
 
@@ -57,9 +60,9 @@ def is_ark_running():
     if not pods:
         return False
     
-    required_services = ['ark-dashboard', 'ark-api', 'ark-mcp']
+    required_services = REQUIRED_SERVICES
     for service in required_services:
-        service_pods = [p for p in pods if service in p['name']]
+        service_pods = pods.get(service, [])
         if not any(p['status'] == 'Running' and p['ready'] for p in service_pods):
             return False
     return True
@@ -75,27 +78,14 @@ def install_ark():
 
 def wait_for_pods_ready():
     logger.info("Waiting for ARK pods to be ready...")
-    required_services = ['ark-dashboard', 'ark-api', 'ark-mcp']
     
     for attempt in range(60):
-        pods = get_ark_pods()
-        if not pods:
-            time.sleep(5)
-            continue
-            
-        all_ready = True
-        for service in required_services:
-            service_pods = [p for p in pods if service in p['name']]
-            if not any(p['status'] == 'Running' and p['ready'] for p in service_pods):
-                all_ready = False
-                break
-        
-        if all_ready:
-            ready_pods = [p for p in pods if p['status'] == 'Running' and p['ready']]
-            pod_statuses = [f"{p['name']}: {p['status']}" for p in ready_pods]
-            logger.info(f"Attempt {attempt + 1}/60: {', '.join(pod_statuses)}")
+        logger.info(f"Attempt {attempt + 1}/60")
+        if is_ark_running():
             logger.info("All required ARK services have at least one ready pod")
             return
+        else:
+            logger.info(f"Not yet ready, trying again")
         
         time.sleep(5)
     pytest.exit("ARK pods not ready", returncode=1)
@@ -219,7 +209,6 @@ def page(context):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    logger.info(f"pytest_runtest_makereport called: {item.name} phase={call.when}")
     outcome = yield
     rep = outcome.get_result()
     

--- a/tests/pytest/ui-tests/conftest.py
+++ b/tests/pytest/ui-tests/conftest.py
@@ -214,7 +214,6 @@ def pytest_runtest_makereport(item, call):
     
     if rep.when == "call" and rep.failed:
         page = item.funcargs.get("page")
-        logger.warning(f"Page: {page}")
         if page:
             try:
                 # Ensure screenshots directory exists
@@ -226,5 +225,3 @@ def pytest_runtest_makereport(item, call):
                 logger.info(f"Screenshot saved: {screenshot_path}")
             except Exception as e:
                 logger.error(f"Failed to save screenshot: {e}")
-        else:
-            logger.warning(f"item.funcargs: {item.funcargs}")

--- a/tests/pytest/ui-tests/conftest.py
+++ b/tests/pytest/ui-tests/conftest.py
@@ -219,11 +219,13 @@ def page(context):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    logger.info(f"pytest_runtest_makereport called: {item.name} phase={call.when}")
     outcome = yield
     rep = outcome.get_result()
     
     if rep.when == "call" and rep.failed:
         page = item.funcargs.get("page")
+        logger.warning(f"Page: {page}")
         if page:
             try:
                 # Ensure screenshots directory exists
@@ -235,3 +237,5 @@ def pytest_runtest_makereport(item, call):
                 logger.info(f"Screenshot saved: {screenshot_path}")
             except Exception as e:
                 logger.error(f"Failed to save screenshot: {e}")
+        else:
+            logger.warning(f"item.funcargs: {item.funcargs}")

--- a/tests/pytest/ui-tests/pages/agents_page.py
+++ b/tests/pytest/ui-tests/pages/agents_page.py
@@ -16,7 +16,6 @@ class AgentsPage(BasePage):
     AGENT_DESCRIPTION_INPUT = "textarea[name='description'], textarea[placeholder*='description' i], input[name='description']"
     MODEL_SELECT = "select, [role='combobox'], button:has-text('Select')"
     SAVE_BUTTON = "button:has-text('Create Agent'), button:has-text('Save Changes'), button:has-text('Add Agent'), button:has-text('Create'), button:has-text('Save'), button[type='submit']"
-    SUCCESS_POPUP = "[role='alert'], [role='status'], .notification, .toast, div:has-text('success'), div:has-text('Success'), div:has-text('created'), div:has-text('Created'), div:has-text('deleted'), div:has-text('Deleted')"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
     
@@ -258,11 +257,7 @@ class AgentsPage(BasePage):
             logger.error(f"{error_banner['message']}")
             raise Exception(f"Agent creation failed: {error_banner['message']}")
         
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            popup_visible = True
-        except:
-            popup_visible = False
+        popup_visible = self._check_toast_popup()
         
         self._close_dialog_if_open()
         
@@ -303,7 +298,7 @@ class AgentsPage(BasePage):
             self.page.locator(self.CONFIRM_DELETE_BUTTON).first.click()
         
         self.wait_for_load_state("domcontentloaded")
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         deleted_from_table = not self.is_agent_in_table(agent_name, retries=0)
         
         return {

--- a/tests/pytest/ui-tests/pages/agents_page.py
+++ b/tests/pytest/ui-tests/pages/agents_page.py
@@ -325,13 +325,6 @@ class AgentsPage(BasePage):
             "deleted_from_table": False
         }
     
-    def _check_success_popup(self) -> bool:
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            return True
-        except:
-            return False
-    
     def _close_dialog_if_open(self) -> None:
         for attempt in range(3):
             try:

--- a/tests/pytest/ui-tests/pages/agents_page.py
+++ b/tests/pytest/ui-tests/pages/agents_page.py
@@ -304,7 +304,7 @@ class AgentsPage(BasePage):
         
         self.wait_for_load_state("domcontentloaded")
         popup_visible = self._check_success_popup()
-        deleted_from_table = not self.is_agent_in_table(agent_name)
+        deleted_from_table = not self.is_agent_in_table(agent_name, retries=0)
         
         return {
             "agent_name": agent_name,

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -1,6 +1,6 @@
 import logging
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, TimeoutError
 
 
 logger = logging.getLogger(__name__)
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class BasePage:
 
-    POPUP = "body > section > ol > li"
+    POPUP = "[data-sonner-toast]"
 
     def __init__(self, page: Page):
         self.page = page
@@ -16,11 +16,18 @@ class BasePage:
     def navigate(self, url: str) -> None:
         self.page.goto(url)
 
-    def _check_success_popup(self) -> bool:
-        popup_locator = self.page.locator(self.POPUP).first
-        popup_locator.wait_for(state="visible", timeout=5000)
-        logger.info(popup_locator.aria_snapshot())
-        return True
+    def _check_toast_popup(self, timeout: int = 5000) -> bool:
+        # Note: This does not confirm whether the toast shows success, only waits to see it
+        # and logs what it contains.
+        try:
+            popup_locator = self.page.locator(self.POPUP).first
+            popup_locator.wait_for(state="visible", timeout=timeout)
+            logger.info(popup_locator.inner_text())
+            return True
+        except TimeoutError:
+            # we don't necessarily want to break if we don't see the popup, but we should at least log it
+            logger.exception("Did not see expected toast")
+            return False
 
     def is_visible(self, selector: str, timeout: int = 5000) -> bool:
         try:

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -7,13 +7,21 @@ logger = logging.getLogger(__name__)
 
 
 class BasePage:
-    
+
+    POPUP = "body > section > ol > li"
+
     def __init__(self, page: Page):
         self.page = page
     
     def navigate(self, url: str) -> None:
         self.page.goto(url)
-    
+
+    def _check_success_popup(self) -> bool:
+        popup_locator = self.page.locator(self.POPUP).first
+        popup_locator.wait_for(state="visible", timeout=5000)
+        logger.info(popup_locator.aria_snapshot())
+        return True
+
     def is_visible(self, selector: str, timeout: int = 5000) -> bool:
         try:
             self.page.locator(selector).first.wait_for(state="visible", timeout=timeout)

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -51,6 +51,7 @@ class BasePage:
         try:
             self.page.locator("[data-slot='dialog-overlay'], [role='dialog']").first.wait_for(state="hidden", timeout=timeout)
         except:
+            logger.info("Modal did not close")
             self.page.keyboard.press("Escape")
             self.wait_for_element_hidden("[data-slot='dialog-overlay'], [role='dialog']")
     

--- a/tests/pytest/ui-tests/pages/models_page.py
+++ b/tests/pytest/ui-tests/pages/models_page.py
@@ -180,14 +180,7 @@ class ModelsPage(BasePage):
             "popup_visible": False,
             "deleted_from_table": False
         }
-    
-    def _check_success_popup(self) -> bool:
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            return True
-        except:
-            return False
-    
+
     def create_model_for_test(self, prefix: str, secret_name: str, secrets_page):
         model_data = self.TEST_DATA["openai"]
         

--- a/tests/pytest/ui-tests/pages/models_page.py
+++ b/tests/pytest/ui-tests/pages/models_page.py
@@ -34,8 +34,8 @@ class ModelsPage(BasePage):
     def navigate_to_models_tab(self) -> None:
         dashboard = DashboardPage(self.page)
         self.page.goto(f"{dashboard.base_url}/models")
-        self.wait_for_navigation_complete()
-        self.wait_for_element(self.ADD_MODEL_BUTTON, timeout=10000)
+        # full page has not loaded until the networkidle state, unfortunately
+        self.wait_for_load_state("networkidle")
     
     def generate_model_name(self, prefix: str = "model") -> str:
         date_str = datetime.now().strftime("%d%m%y%H%M%S")
@@ -111,18 +111,11 @@ class ModelsPage(BasePage):
             popup_visible = True
         except:
             popup_visible = False
-        
-        logger.info(f"Navigating back to models list...")
-        self.navigate_to_models_tab()
-        
+
         in_table = self.is_model_in_table(model_name)
         
-        try:
-            self.page.get_by_text(model_name, exact=True).first.wait_for(state="visible", timeout=10000)
-        except:
-            logger.info(f"Model {model_name} not found with exact match, checking if it exists in table...")
-            if not self.is_model_in_table(model_name):
-                logger.warning(f"Model {model_name} not found in table after creation")
+        if not in_table:
+            logger.warning(f"Model {model_name} not found in table after creation")
         
         is_available = self.is_model_available(model_name)
         for retry in range(5):

--- a/tests/pytest/ui-tests/pages/models_page.py
+++ b/tests/pytest/ui-tests/pages/models_page.py
@@ -18,7 +18,6 @@ class ModelsPage(BasePage):
     API_KEY_SELECT = "button:has-text('Select a secret'), [role='combobox']:has-text('Select')"
     BASE_URL_INPUT = "input[name='baseUrl'], input[placeholder*='url' i], input[type='url']"
     SAVE_BUTTON = "button:has-text('Add Model'), button:has-text('Create'), button:has-text('Save')"
-    SUCCESS_POPUP = "[role='alert'], [role='status'], .notification, .toast, div:has-text('success'), div:has-text('Success'), div:has-text('created'), div:has-text('Created'), div:has-text('deleted'), div:has-text('Deleted')"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
     
@@ -106,11 +105,7 @@ class ModelsPage(BasePage):
         
         self.wait_for_navigation_complete()
         
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            popup_visible = True
-        except:
-            popup_visible = False
+        popup_visible = self._check_toast_popup()
 
         in_table = self.is_model_in_table(model_name)
         
@@ -159,7 +154,7 @@ class ModelsPage(BasePage):
             self.page.locator(self.CONFIRM_DELETE_BUTTON).first.click()
         
         self.wait_for_navigation_complete()
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         deleted_from_table = not self.is_model_in_table(model_name)
         
         return {

--- a/tests/pytest/ui-tests/pages/secrets_page.py
+++ b/tests/pytest/ui-tests/pages/secrets_page.py
@@ -177,13 +177,6 @@ class SecretsPage(BasePage):
             "deleted_from_table": False
         }
     
-    def _check_success_popup(self) -> bool:
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            return True
-        except:
-            return False
-    
     def create_secret_for_test(self, prefix: str, env_key: str):
         self.navigate_to_secrets_tab()
         

--- a/tests/pytest/ui-tests/pages/secrets_page.py
+++ b/tests/pytest/ui-tests/pages/secrets_page.py
@@ -156,7 +156,7 @@ class SecretsPage(BasePage):
         
         self.wait_for_load_state("domcontentloaded")
         popup_visible = self._check_success_popup()
-        deleted_from_table = not self.is_secret_in_table(secret_name)
+        deleted_from_table = not self.is_secret_in_table(secret_name, retries=0)
         
         return {
             "secret_name": secret_name,

--- a/tests/pytest/ui-tests/pages/secrets_page.py
+++ b/tests/pytest/ui-tests/pages/secrets_page.py
@@ -19,7 +19,6 @@ class SecretsPage(BasePage):
     SECRET_VALUE_INPUT = "input[name='value'], textarea[name='value'], input[placeholder*='value' i], input[type='password'], textarea, input[type='text']:last-of-type"
     SAVE_BUTTON = "button:has-text('Save'), button:has-text('Create'), button:has-text('Submit'), button[type='submit']"
     SECRET_FORM = "form, [role='dialog'], [data-testid='secret-form']"
-    SUCCESS_POPUP = "[role='alert'], [role='status'], .notification, .toast, .alert-success, div:has-text('success'), div:has-text('created'), div:has-text('Success'), div:has-text('Created'), div:has-text('updated'), div:has-text('Updated'), div:has-text('deleted'), div:has-text('Deleted')"
     DELETE_ICON_TEMPLATE = "tr:has-text('{secret_name}') svg, tr:has-text('{secret_name}') button[aria-label='Delete'], tr:has-text('{secret_name}') [data-testid='delete-icon']"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
@@ -117,7 +116,7 @@ class SecretsPage(BasePage):
         save_button.wait_for(state="visible", timeout=5000)
         save_button.click(force=True)
 
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         self.wait_for_modal_close()
 
         self.navigate_to_secrets_tab()
@@ -155,7 +154,7 @@ class SecretsPage(BasePage):
             self.page.locator(self.CONFIRM_DELETE_BUTTON).first.click()
         
         self.wait_for_load_state("domcontentloaded")
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         deleted_from_table = not self.is_secret_in_table(secret_name, retries=0)
         
         return {

--- a/tests/pytest/ui-tests/pages/teams_page.py
+++ b/tests/pytest/ui-tests/pages/teams_page.py
@@ -243,14 +243,6 @@ class TeamsPage(BasePage):
             "deleted_from_table": False
         }
 
-    def _check_success_popup(self) -> bool:
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            return True
-        except PlaywrightTimeoutError:
-            logger.debug("Success popup not visible")
-            return False
-
     def get_strategy_options(self) -> list[str]:
         self.page.locator(self.ADD_TEAM_BUTTON).first.click()
         self.wait_for_load_state("domcontentloaded")

--- a/tests/pytest/ui-tests/pages/teams_page.py
+++ b/tests/pytest/ui-tests/pages/teams_page.py
@@ -222,7 +222,7 @@ class TeamsPage(BasePage):
         self.wait_for_load_state("domcontentloaded")
         popup_visible = self._check_success_popup()
         self.navigate_to_teams_tab()
-        deleted_from_table = not self.is_team_in_table(team_name)
+        deleted_from_table = not self.is_team_in_table(team_name, retries=0)
 
         return {
             "team_name": team_name,

--- a/tests/pytest/ui-tests/pages/teams_page.py
+++ b/tests/pytest/ui-tests/pages/teams_page.py
@@ -17,7 +17,6 @@ class TeamsPage(BasePage):
     MAX_TURNS_INPUT = "input[name='maxTurns'], input[placeholder*='turns' i], input[type='number'], input[name='max']"
     MEMBERS_SELECT = "button:has-text('Select'), [role='combobox']:has-text('Select'), button:has-text('Add')"
     SAVE_BUTTON = "button:has-text('Add Team'), button:has-text('Create'), button:has-text('Save'), button[type='submit']"
-    SUCCESS_POPUP = "[role='alert'], [role='status'], .notification, .toast, div:has-text('success'), div:has-text('Success'), div:has-text('created'), div:has-text('Created'), div:has-text('deleted'), div:has-text('Deleted')"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
 
@@ -109,12 +108,7 @@ class TeamsPage(BasePage):
         self.page.locator("button:has-text('Create Team')").first.click()
         self.wait_for_load_state("domcontentloaded")
 
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=10000)
-            popup_visible = True
-        except PlaywrightTimeoutError:
-            popup_visible = False
-
+        popup_visible = self._check_toast_popup()
         self.navigate_to_teams_tab()
         in_table = self.is_team_in_table(team_name)
 
@@ -166,12 +160,7 @@ class TeamsPage(BasePage):
         save_button.click(force=True)
         self.wait_for_load_state("domcontentloaded")
 
-        try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
-            popup_visible = True
-        except PlaywrightTimeoutError:
-            logger.debug("Success popup not visible")
-            popup_visible = False
+        popup_visible = self._check_toast_popup()
 
         try:
             self.page.locator("[data-slot='dialog-overlay'], [role='dialog']").first.wait_for(state="hidden", timeout=10000)
@@ -220,7 +209,7 @@ class TeamsPage(BasePage):
             btn.click(force=True)
 
         self.wait_for_load_state("domcontentloaded")
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         self.navigate_to_teams_tab()
         deleted_from_table = not self.is_team_in_table(team_name, retries=0)
 
@@ -307,14 +296,17 @@ class TeamsPage(BasePage):
         self.select_strategy_in_form("Sequential")
 
         loops_visible = self.is_loops_checkbox_visible()
-        if loops and loops_visible:
-            checkbox = self.page.locator(
-                "label:has-text('Enable loops')"
-            ).locator("xpath=preceding-sibling::input[@type='checkbox']").first
-            checkbox.dispatch_event("click")
-            self.page.locator("input[name='maxTurns'], input[type='number']").first.wait_for(
-                state="visible", timeout=8000
-            )
+        if loops:
+            if loops_visible:
+                checkbox = self.page.locator(
+                    "label:has-text('Enable loops')"
+                ).locator("xpath=preceding-sibling::input[@type='checkbox']").first
+                checkbox.dispatch_event("click")
+                self.page.locator("input[name='maxTurns'], input[type='number']").first.wait_for(
+                    state="visible", timeout=8000
+                )
+            else:
+                logger.warning("Loops checkbox not visible")
 
         max_turns_visible = self.is_max_turns_field_visible()
         if loops and max_turns_visible:
@@ -339,15 +331,7 @@ class TeamsPage(BasePage):
         create_btn.click(force=True)
         self.wait_for_load_state("domcontentloaded")
 
-        popup_visible = False
-        try:
-            popup = self.page.locator(self.SUCCESS_POPUP).first
-            popup.wait_for(state="visible", timeout=10000)
-            popup_text = popup.inner_text().lower()
-            is_error = any(w in popup_text for w in ("error", "fail", "denied", "invalid", "cannot", "only be set"))
-            popup_visible = not is_error
-        except PlaywrightTimeoutError:
-            pass
+        popup_visible = self._check_toast_popup()
 
         self.wait_for_modal_close()
         self.navigate_to_teams_tab()

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -13,7 +13,6 @@ class ToolsPage(BasePage):
 
     ADD_TOOL_BUTTON = "button:has-text('Add Tool'), button:has-text('Create Tool'), button:has-text('New Tool')"
     TOOL_NAME_INPUT = "input[name='name'], input[placeholder*='name' i], input#name, [role='dialog'] input:first-of-type"
-    POPUP = "body > section > ol > li"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
     
@@ -211,19 +210,7 @@ class ToolsPage(BasePage):
             "popup_visible": False,
             "deleted_from_table": False
         }
-    
-    def _check_success_popup(self) -> bool:
-        try:
-            popup_locator = self.page.locator(self.POPUP).first
-            popup_locator.wait_for(state="visible", timeout=5000)
-            logger.info(popup_locator.all_text_contents())
-            logger.info(popup_locator.aria_snapshot())
-            popup_locator.screenshot(path="tests/pytest/ui-tests/screenshots/tool_popup.png")
-            return True
-        except:
-            logger.exception("Error finding tool page popup")
-            return False
-    
+
     def create_tool_for_test(self, prefix: str, test_data_key: str = "get_coordinates"):
         tool_data = self.TEST_DATA[test_data_key]
         

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -199,7 +199,7 @@ class ToolsPage(BasePage):
         
         self.wait_for_navigation_complete()
         popup_visible = self._check_success_popup()
-        deleted_from_table = not self.is_tool_in_table(tool_name)
+        deleted_from_table = not self.is_tool_in_table(tool_name, retries=0)
         
         return {
             "tool_name": tool_name,

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -140,7 +140,7 @@ class ToolsPage(BasePage):
             error_text = error_banner.inner_text()
             logger.error(f"Tool creation error: {error_text}")
         
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         logger.info(f"Success popup visible: {popup_visible}")
         
         self.wait_for_modal_close()
@@ -189,7 +189,7 @@ class ToolsPage(BasePage):
             self.page.locator(self.CONFIRM_DELETE_BUTTON).first.click()
         
         self.wait_for_navigation_complete()
-        popup_visible = self._check_success_popup()
+        popup_visible = self._check_toast_popup()
         deleted_from_table = not self.is_tool_in_table(tool_name, retries=0)
         
         return {

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -13,7 +13,7 @@ class ToolsPage(BasePage):
 
     ADD_TOOL_BUTTON = "button:has-text('Add Tool'), button:has-text('Create Tool'), button:has-text('New Tool')"
     TOOL_NAME_INPUT = "input[name='name'], input[placeholder*='name' i], input#name, [role='dialog'] input:first-of-type"
-    SUCCESS_POPUP = "[role='alert'], [role='status'], .notification, .toast, div:has-text('success'), div:has-text('Success'), div:has-text('created'), div:has-text('Created')"
+    POPUP = "body > section > ol > li"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
     
@@ -214,9 +214,14 @@ class ToolsPage(BasePage):
     
     def _check_success_popup(self) -> bool:
         try:
-            self.page.locator(self.SUCCESS_POPUP).first.wait_for(state="visible", timeout=5000)
+            popup_locator = self.page.locator(self.POPUP).first
+            popup_locator.wait_for(state="visible", timeout=5000)
+            logger.info(popup_locator.all_text_contents())
+            logger.info(popup_locator.aria_snapshot())
+            popup_locator.screenshot(path="tests/pytest/ui-tests/screenshots/tool_popup.png")
             return True
         except:
+            logger.exception("Error finding tool page popup")
             return False
     
     def create_tool_for_test(self, prefix: str, test_data_key: str = "get_coordinates"):

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -47,14 +47,8 @@ class ToolsPage(BasePage):
         date_str = datetime.now().strftime("%d%m%y%H%M%S")
         rand = random.randint(100, 999)
         return f"{prefix}-{date_str}{rand}"
-    
-    def _goto_tools(self) -> None:
-        self.page.goto("http://localhost:3274/tools")
-        self.wait_for_navigation_complete()
-        self.wait_for_element(self.ADD_TOOL_BUTTON, timeout=10000)
 
     def is_tool_in_table(self, tool_name: str, retries: int = 3) -> bool:
-        self._goto_tools()
         for attempt in range(retries):
             try:
                 self.page.get_by_text(tool_name, exact=False).first.wait_for(state="visible", timeout=10000)
@@ -63,7 +57,8 @@ class ToolsPage(BasePage):
                 logger.debug(f"Tool {tool_name} not visible on attempt {attempt + 1}/{retries}: {e}")
                 if attempt < retries - 1:
                     logger.info(f"Tool {tool_name} not found, retrying ({attempt + 1}/{retries})...")
-                    self._goto_tools()
+                    self.page.reload()
+                    self.wait_for_navigation_complete()
         return False
     
     def create_http_tool_with_verification(self, tool_name: str, description: str, url: str) -> dict:
@@ -150,9 +145,6 @@ class ToolsPage(BasePage):
         logger.info(f"Success popup visible: {popup_visible}")
         
         self.wait_for_modal_close()
-        
-        logger.info(f"Navigating back to tools list...")
-        self.navigate_to_tools_tab()
         
         in_table = self.is_tool_in_table(tool_name)
         logger.info(f"Tool '{tool_name}' in table after creation: {in_table}")

--- a/tests/pytest/ui-tests/tests/test_ark_agents.py
+++ b/tests/pytest/ui-tests/tests/test_ark_agents.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from playwright.sync_api import Page
 from pages.secrets_page import SecretsPage
@@ -5,6 +6,8 @@ from pages.models_page import ModelsPage
 from pages.agents_page import AgentsPage
 from pages.tools_page import ToolsPage
 
+
+logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="class")
 def agent_test_resources():
@@ -51,9 +54,9 @@ class TestArkAgents:
         assert row_verification["description_visible"], "Agent description should be visible in table row"
         
         if row_verification["model_visible"]:
-            print(f"Model '{model_result['name']}' is visible in agent row")
+            logger.info(f"Model '{model_result['name']}' is visible in agent row")
         else:
-            print(f"Model '{model_result['name']}' not visible in agent row (may be truncated or displayed differently)")
+            logger.info(f"Model '{model_result['name']}' not visible in agent row (may be truncated or displayed differently)")
         
         agent_test_resources["agents"][prefix] = agent_result['name']
     
@@ -72,25 +75,25 @@ class TestArkAgents:
         if not result["delete_available"]:
             pytest.skip("Delete functionality not available")
         
-        print(f"Agent deleted: {agent_name}")
+        logger.info(f"Agent deleted: {agent_name}")
         if result["confirm_dialog_visible"]:
-            print(f"Confirm dialog verified")
+            logger.info(f"Confirm dialog verified")
         if result["confirm_button_visible"]:
-            print(f"Confirm button verified")
+            logger.info(f"Confirm button verified")
         
         models = ModelsPage(page)
         models.navigate_to_models_tab()
         model_name = agent_test_resources["models"].get(prefix)
         model_result = models.delete_model_with_verification(model_name)
         if model_result["delete_available"]:
-            print(f"Model deleted: {model_name}")
+            logger.info(f"Model deleted: {model_name}")
         
         secrets = SecretsPage(page)
         secrets.navigate_to_secrets_tab()
         secret_name = agent_test_resources["secrets"].get(prefix)
         secret_result = secrets.delete_secret_with_verification(secret_name)
         if secret_result["delete_available"]:
-            print(f"Secret deleted: {secret_name}")
+            logger.info(f"Secret deleted: {secret_name}")
     
     @pytest.mark.parametrize("prefix", [
         "agent-tool",
@@ -145,26 +148,26 @@ class TestArkAgents:
         if not result["delete_available"]:
             pytest.skip("Delete functionality not available")
         
-        print(f"Agent deleted: {agent_name}")
+        logger.info(f"Agent deleted: {agent_name}")
         
         tools = ToolsPage(page)
         tools.navigate_to_tools_tab()
         tool_name = agent_test_resources["tools"].get(prefix)
         tool_result = tools.delete_tool_with_verification(tool_name)
         if tool_result["delete_available"]:
-            print(f"Tool deleted: {tool_name}")
+            logger.info(f"Tool deleted: {tool_name}")
         
         models = ModelsPage(page)
         models.navigate_to_models_tab()
         model_name = agent_test_resources["models"].get(prefix)
         model_result = models.delete_model_with_verification(model_name)
         if model_result["delete_available"]:
-            print(f"Model deleted: {model_name}")
+            logger.info(f"Model deleted: {model_name}")
         
         secrets = SecretsPage(page)
         secrets.navigate_to_secrets_tab()
         secret_name = agent_test_resources["secrets"].get(prefix)
         secret_result = secrets.delete_secret_with_verification(secret_name)
         if secret_result["delete_available"]:
-            print(f"Secret deleted: {secret_name}")
+            logger.info(f"Secret deleted: {secret_name}")
 


### PR DESCRIPTION
There seems to be some kind of race condition around the secrets hook, where sometimes the value of `old` was undefined when calling useCreateSecret and this failed because it attempted to iterate on it. This error only showed up on a toast, but the toasts were also being incorrectly identified and there was no logging of error messages.

In addition
- Moves the conftest to somewhere it'll actually get used
- Removes a bunch of redundancy in setup
- Adds more logging
- Don't install unused services
- Better identification of services
- Use logger, not print
- Don't retry the check for something being in the table if we just deleted it
- Centralized toast checking and made it actually get the toast and not just whatever modals happen to be around
- Log the message on the toast so that we have a little more hope of knowing what's happening if there's an error

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 