### PR TITLE
feat(selector): implement select-next-conversant tool for selector agents

### DIFF
--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -196,7 +196,7 @@ func (a *Agent) executeLocally(ctx context.Context, userInput Message, history [
 
 		if err := a.executeToolCalls(ctx, choice.Message.ToolCalls, &agentMessages, &newMessages); err != nil {
 			logger := logf.FromContext(ctx)
-			if !IsTerminateTeam(err) {
+			if !IsTerminateTeam(err) && !IsSelectNextConversant(err) {
 				logger.Error(err, "Tool execution failed", "agent", a.FullName())
 			}
 			return newMessages, err

--- a/ark/executors/completions/team_selector.go
+++ b/ark/executors/completions/team_selector.go
@@ -17,11 +17,10 @@ import (
 
 const defaultSelectorPrompt = `You are in a role play game. The following roles are available:
 {{.Roles}}.
-Read the following conversation. Then select the next role from {{.Participants}} to play. Only return the role.
+Read the following conversation and select the next role from {{.Participants}} to play.
+Use the select-next-conversant tool to select the next role, or use the terminate tool to end the conversation.
 
-{{.History}}
-
-Read the above conversation. Then select the next role from {{.Participants}} to play. Only return the role.`
+{{.History}}`
 
 type SelectorTemplateData struct {
 	Roles        string
@@ -70,8 +69,7 @@ func buildRoles(members []TeamMember) string {
 	return strings.Join(roles, ", ")
 }
 
-func (t *Team) loadSelectorAgent(ctx context.Context) (SelectorAgentInterface, error) {
-	// Check for override selector agent first (used in tests)
+func (t *Team) loadSelectorAgent(ctx context.Context, candidateMembers []TeamMember) (SelectorAgentInterface, error) {
 	if t.mockSelectorAgent != nil {
 		return t.mockSelectorAgent, nil
 	}
@@ -93,11 +91,29 @@ func (t *Team) loadSelectorAgent(ctx context.Context) (SelectorAgentInterface, e
 		return nil, fmt.Errorf("failed to create selector agent: %w", err)
 	}
 
+	if agent.Tools != nil {
+		_ = agent.Tools.Close()
+	}
+
+	candidateNames := make([]string, 0, len(candidateMembers))
+	for _, m := range candidateMembers {
+		candidateNames = append(candidateNames, m.GetName())
+	}
+
+	selectorTools := NewToolRegistry(nil, t.telemetry.ToolRecorder(), t.eventing.ToolRecorder())
+	selectorTools.RegisterTool(GetTerminateTool(), &TerminateExecutor{})
+	selectorTools.RegisterTool(GetSelectNextConversantTool(candidateNames), &SelectNextConversantExecutor{})
+	agent.Tools = selectorTools
+
 	return agent, nil
 }
 
-//nolint:gocognit // Complex function handling selector agent logic, but cohesive responsibilities
 func (t *Team) selectMember(ctx context.Context, messages []Message, tmpl *template.Template, participantsList, rolesList string, candidateMembers []TeamMember) (TeamMember, error) {
+	membersToSearch := t.Members
+	if candidateMembers != nil {
+		membersToSearch = candidateMembers
+	}
+
 	history := buildHistory(messages)
 	data := SelectorTemplateData{
 		Roles:        rolesList,
@@ -110,54 +126,31 @@ func (t *Team) selectMember(ctx context.Context, messages []Message, tmpl *templ
 		return nil, err
 	}
 
-	selectorAgent, err := t.loadSelectorAgent(ctx)
+	selectorAgent, err := t.loadSelectorAgent(ctx, membersToSearch)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := selectorAgent.Execute(ctx, NewUserMessage("Select the next participant to respond."), []Message{NewSystemMessage(buf.String())}, nil, nil)
-	if err != nil {
-		if IsTerminateTeam(err) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("selector agent call failed: %w", err)
-	}
+	_, err = selectorAgent.Execute(ctx, NewUserMessage("Select the next participant to respond."), []Message{NewSystemMessage(buf.String())}, nil, nil)
 
-	if len(result.Messages) == 0 {
-		return nil, fmt.Errorf("selector agent returned no messages")
-	}
-
-	var selectedName string
-	lastMsg := result.Messages[len(result.Messages)-1]
-	if lastMsg.OfAssistant != nil && lastMsg.OfAssistant.Content.OfString.Value != "" {
-		selectedName = strings.TrimSpace(lastMsg.OfAssistant.Content.OfString.Value)
+	var selectErr *SelectNextConversantResult
+	switch {
+	case errors.As(err, &selectErr):
 		logger := logf.FromContext(ctx)
-		logger.Info("Selector chose", "selectedName", selectedName)
-
-	} else {
-		return nil, fmt.Errorf("selector agent returned invalid response")
-	}
-
-	// Use candidateMembers if provided, otherwise use all team members
-	membersToSearch := t.Members
-	if candidateMembers != nil {
-		membersToSearch = candidateMembers
-	}
-
-	// Find selected member
-	for _, member := range membersToSearch {
-		if member.GetName() == selectedName {
-			return member, nil
+		logger.Info("Selector chose", "selectedName", selectErr.Conversant)
+		for _, member := range membersToSearch {
+			if member.GetName() == selectErr.Conversant {
+				return member, nil
+			}
 		}
-	}
-
-	if len(membersToSearch) > 0 {
-		// This error will allow us to message to the user that the selector's response doesn't match an agent
-		err := &InvalidAgentError{SelectedName: selectedName}
+		return nil, &InvalidAgentError{SelectedName: selectErr.Conversant}
+	case IsTerminateTeam(err):
 		return nil, err
+	case err != nil:
+		return nil, fmt.Errorf("selector agent call failed: %w", err)
+	default:
+		return nil, fmt.Errorf("selector agent did not call a tool")
 	}
-
-	return nil, fmt.Errorf("no members available")
 }
 
 // determineNextMember routes to the appropriate selection logic based on whether graph constraints exist.

--- a/ark/executors/completions/team_selector_mocks_test.go
+++ b/ark/executors/completions/team_selector_mocks_test.go
@@ -47,11 +47,7 @@ func (m *mockSelectorAgent) Execute(ctx context.Context, userInput Message, hist
 	if m.returnEmpty {
 		return &ExecutionResult{Messages: []Message{}}, nil
 	}
-	return &ExecutionResult{
-		Messages: []Message{
-			NewAssistantMessage(m.returnName),
-		},
-	}, nil
+	return &ExecutionResult{Messages: []Message{}}, &SelectNextConversantResult{Conversant: m.returnName}
 }
 
 func (m *mockSelectorAgent) FullName() string {

--- a/ark/executors/completions/team_selector_test.go
+++ b/ark/executors/completions/team_selector_test.go
@@ -792,7 +792,7 @@ func TestSelectMember_WithInvalidAgent(t *testing.T) {
 	assert.Nil(t, member)
 }
 
-func TestSelectMember_ReturnsErrorOnNoMessages(t *testing.T) {
+func TestSelectMember_ReturnsErrorWhenNoToolCalled(t *testing.T) {
 	members := []TeamMember{
 		&mockTeamMember{name: "agent1"},
 	}
@@ -810,7 +810,7 @@ func TestSelectMember_ReturnsErrorOnNoMessages(t *testing.T) {
 	_, err = team.selectMember(ctx, []Message{}, tmpl, "agent1", "roles", nil)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "selector agent returned no messages")
+	assert.Contains(t, err.Error(), "selector agent did not call a tool")
 }
 
 func TestLoadSelectorAgent_WithMock(t *testing.T) {
@@ -820,7 +820,7 @@ func TestLoadSelectorAgent_WithMock(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	agent, err := team.loadSelectorAgent(ctx)
+	agent, err := team.loadSelectorAgent(ctx, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, agent)
@@ -833,7 +833,7 @@ func TestLoadSelectorAgent_RequiresSelectorSpec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err := team.loadSelectorAgent(ctx)
+	_, err := team.loadSelectorAgent(ctx, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "selector agent must be specified")

--- a/ark/executors/completions/tools.go
+++ b/ark/executors/completions/tools.go
@@ -3,6 +3,7 @@ package completions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -367,6 +368,56 @@ func GetTerminateTool() ToolDefinition {
 				},
 			},
 			"required": []string{"response"},
+		},
+	}
+}
+
+type SelectNextConversantResult struct {
+	Conversant string
+}
+
+func (s *SelectNextConversantResult) Error() string {
+	return fmt.Sprintf("selected conversant: %s", s.Conversant)
+}
+
+func IsSelectNextConversant(err error) bool {
+	if err == nil {
+		return false
+	}
+	var selectErr *SelectNextConversantResult
+	return errors.As(err, &selectErr)
+}
+
+type SelectNextConversantExecutor struct{}
+
+func (s *SelectNextConversantExecutor) Execute(_ context.Context, call ToolCall) (ToolResult, error) {
+	var arguments map[string]any
+	if err := json.Unmarshal([]byte(call.Function.Arguments), &arguments); err != nil {
+		logf.Log.Info("Error parsing tool arguments", "ToolCall", call)
+		arguments = make(map[string]any)
+	}
+	if conversant, exists := arguments["conversant"]; exists {
+		if name, ok := conversant.(string); ok {
+			return ToolResult{ID: call.ID, Name: call.Function.Name, Content: name}, &SelectNextConversantResult{Conversant: name}
+		}
+	}
+	return ToolResult{ID: call.ID, Name: call.Function.Name, Content: ""}, fmt.Errorf("no conversant specified")
+}
+
+func GetSelectNextConversantTool(candidateNames []string) ToolDefinition {
+	return ToolDefinition{
+		Name:        "select-next-conversant",
+		Description: "Select the next conversant to speak in the conversation",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"conversant": map[string]any{
+					"type":        "string",
+					"description": "The name of the next conversant to select",
+					"enum":        candidateNames,
+				},
+			},
+			"required": []string{"conversant"},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Implements [#1375](https://github.com/mckinsey/agents-at-scale-ark/issues/1375).

- **New `select-next-conversant` tool**: the selector agent uses this tool to pick the next conversant. The tool schema lists valid candidates as an `enum`, giving the LLM a structured contract rather than relying on free-text output.
- **Tool injection on load**: `loadSelectorAgent` now closes the agent's original tool registry and replaces it with exactly two tools — `terminate` and `select-next-conversant` — regardless of what the agent CRD declares.
- **Prompt update**: `defaultSelectorPrompt` now instructs the selector to call one of the two tools instead of returning a plain name.
- **Result extraction via error**: `SelectNextConversantResult` is a sentinel error type (mirrors `TerminateTeam`) that carries the selected name out of the agent execution loop. `selectMember` catches it and resolves the member, falling back to `InvalidAgentError` if the name doesn't match any candidate.
- **Logging fix**: `SelectNextConversantResult` is suppressed from error logging in `agent.go`, same as `TerminateTeam`.