### PR TITLE
feat: add agent actions skeleton workflow

### DIFF
--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   TRIGGER_PHRASE: "@claude"
-  ALLOWED_USERS: "dwmkerr"
+  ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,StarkNDJ,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB,skokaina,paliwalvimal"
 
 permissions:
   contents: write

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   TRIGGER_PHRASE: "@claude"
-  ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,StarkNDJ,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB,skokaina,paliwalvimal"
+  ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB"
 
 permissions:
   contents: write

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -1,0 +1,123 @@
+# Agent Actions - Claude Code integration for the Ark team.
+#
+# Vendored from:
+#   - https://github.com/anthropics/claude-code-action
+#   - https://github.com/dwmkerr/agent-actions
+#
+# See: openspec/changes/2026-03-26-agent-actions/proposal.md
+#
+# Identity: Configure a GitHub App for a custom bot identity.
+# Required secrets:
+#   ANTHROPIC_API_KEY       - Anthropic API key for Claude Code
+#   AGENT_APP_ID            - GitHub App ID (optional, for custom identity)
+#   AGENT_APP_PRIVATE_KEY   - GitHub App private key PEM (optional, for custom identity)
+
+name: Agent Actions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, labeled]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: "Prompt to send to Claude Code"
+        required: true
+        type: string
+
+env:
+  TRIGGER_PHRASE: "@claude"
+  ALLOWED_USERS: "dwmkerr"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: agent-actions-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(format('{0}', env.ALLOWED_USERS), github.event.sender.login) && (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude')) ||
+          (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: vars.AGENT_APP_ID != ''
+        env:
+          APP_ID: ${{ vars.AGENT_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+        run: |
+          # Generate JWT for GitHub App authentication
+          NOW=$(date +%s)
+          IAT=$((NOW - 60))
+          EXP=$((NOW + 600))
+          HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+          PAYLOAD=$(echo -n "{\"iat\":${IAT},\"exp\":${EXP},\"iss\":\"${APP_ID}\"}" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+          SIGNING_INPUT="${HEADER}.${PAYLOAD}"
+          SIGNATURE=$(echo -n "$SIGNING_INPUT" | openssl dgst -sha256 -sign <(echo "$APP_PRIVATE_KEY") | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+          JWT="${SIGNING_INPUT}.${SIGNATURE}"
+
+          # Exchange JWT for installation token
+          INSTALLATION_ID=$(curl -s -H "Authorization: Bearer ${JWT}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/installation" | jq -r '.id')
+
+          TOKEN=$(curl -s -X POST \
+            -H "Authorization: Bearer ${JWT}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens" | jq -r '.token')
+
+          echo "::add-mask::${TOKEN}"
+          echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Determine prompt
+        id: prompt
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "text=${{ github.event.inputs.prompt }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "text=${{ github.event.comment.body }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            echo "text=${{ github.event.comment.body }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "text=${{ github.event.review.body }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "issues" ]; then
+            echo "text=${{ github.event.issue.body }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # TODO: Install and run Claude Code CLI
+      # TODO: Post response as comment on issue/PR
+      - name: Placeholder
+        run: echo "Agent Actions workflow triggered. Prompt - ${{ steps.prompt.outputs.text }}"

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -11,7 +11,7 @@
 #   AGENT_GITHUB_TOKEN      - PAT for a bot user (optional, for custom identity)
 #                             Falls back to GITHUB_TOKEN if not set.
 
-name: Agent Actions
+name: Ark Agent
 
 on:
   issue_comment:
@@ -30,7 +30,7 @@ on:
         type: string
 
 env:
-  TRIGGER_PHRASE: "@claude"
+  TRIGGER_PHRASE: "@ark"
   ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB"
 
 permissions:
@@ -49,11 +49,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         contains(format('{0}', env.ALLOWED_USERS), github.event.sender.login) && (
-          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-          (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude')) ||
-          (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@ark')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@ark')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@ark')) ||
+          (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'ark-agent')) ||
+          (github.event_name == 'issues' && contains(github.event.issue.body, '@ark'))
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -6,11 +6,10 @@
 #
 # See: openspec/changes/2026-03-26-agent-actions/proposal.md
 #
-# Identity: Configure a GitHub App for a custom bot identity.
 # Required secrets:
 #   ANTHROPIC_API_KEY       - Anthropic API key for Claude Code
-#   AGENT_APP_ID            - GitHub App ID (optional, for custom identity)
-#   AGENT_APP_PRIVATE_KEY   - GitHub App private key PEM (optional, for custom identity)
+#   AGENT_GITHUB_TOKEN      - PAT for a bot user (optional, for custom identity)
+#                             Falls back to GITHUB_TOKEN if not set.
 
 name: Agent Actions
 
@@ -61,41 +60,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        if: vars.AGENT_APP_ID != ''
-        env:
-          APP_ID: ${{ vars.AGENT_APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
-        run: |
-          # Generate JWT for GitHub App authentication
-          NOW=$(date +%s)
-          IAT=$((NOW - 60))
-          EXP=$((NOW + 600))
-          HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-          PAYLOAD=$(echo -n "{\"iat\":${IAT},\"exp\":${EXP},\"iss\":\"${APP_ID}\"}" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-          SIGNING_INPUT="${HEADER}.${PAYLOAD}"
-          SIGNATURE=$(echo -n "$SIGNING_INPUT" | openssl dgst -sha256 -sign <(echo "$APP_PRIVATE_KEY") | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-          JWT="${SIGNING_INPUT}.${SIGNATURE}"
-
-          # Exchange JWT for installation token
-          INSTALLATION_ID=$(curl -s -H "Authorization: Bearer ${JWT}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/installation" | jq -r '.id')
-
-          TOKEN=$(curl -s -X POST \
-            -H "Authorization: Bearer ${JWT}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens" | jq -r '.token')
-
-          echo "::add-mask::${TOKEN}"
-          echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ steps.app-token.outputs.token || github.token }}
+          token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/openspec/changes/2026-03-26-agent-actions/proposal.md
+++ b/openspec/changes/2026-03-26-agent-actions/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+We want the Ark team to be able to trigger Claude Code from GitHub - via `@claude` mentions on issues and PRs, on failed builds, or on specific PR types like Dependabot. This lets the team triage, suggest fixes, review code, or implement small changes directly from GitHub without needing a local dev environment.
+
+The existing `feat/agent-actions` branch has a basic workflow that calls `dwmkerr/agent-actions`, which wraps `anthropics/claude-code-action`. This won't work in practice - the Ark repo can't use external GitHub Actions. We need to vendor the workflow logic directly.
+
+## Constraint: No External Actions
+
+The Ark GitHub org does not allow referencing external actions (e.g. `uses: dwmkerr/agent-actions/...@main` or `uses: anthropics/claude-code-action@v1`). All action logic must be inlined or vendored into the repo. The source repos should be attributed in comments.
+
+## What Changes
+
+### 1. Workflow: `.github/workflows/agent-actions.yml`
+
+A self-contained workflow that vendors the logic from [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) and [`dwmkerr/agent-actions`](https://github.com/dwmkerr/agent-actions). Attribution to both sources in the workflow file header.
+
+Triggers:
+
+- `issue_comment`, `pull_request_review_comment`, `pull_request_review` - responds to `@claude` mentions
+- `issues` with `opened` and `labeled` - responds to `claude` label or `@claude` in issue body
+- `workflow_dispatch` with inputs: `prompt`, `issue_number`, `branch` - manual runs from Actions tab or `gh workflow run`
+- `workflow_run` on failed CI builds - agent can diagnose and suggest fixes
+- `pull_request` filtered to Dependabot PRs - agent can review, test, and merge dependency updates
+
+### 2. Claude Code execution
+
+The vendored workflow installs and runs Claude Code directly via `npx @anthropic-ai/claude-code` (or the equivalent CLI invocation). The key steps:
+
+1. Checkout the repo
+2. Install Claude Code CLI
+3. Parse the trigger context (issue body, comment body, or dispatch prompt)
+4. Run Claude Code with the prompt, passing `ANTHROPIC_API_KEY` from secrets
+5. Post the response as a comment on the issue/PR
+
+This is what `anthropics/claude-code-action` does under the hood. Vendoring it means copying the core logic into a composite action or shell steps within the workflow.
+
+### 3. Access control
+
+Check `github.event.sender.login` against a configurable `allowed_users` list (env var or workflow input). Reject and comment if the user isn't authorised. Based on the pattern in `dwmkerr/agent-actions/.github/workflows/claude.yml`.
+
+### 4. Ark-specific context
+
+The agent runs with the repo checked out, so `CLAUDE.md` is picked up automatically. No extra config needed for basic context.
+
+MCP servers: deferred. The agent runs in a GitHub Actions container with no cluster access, so K8s-dependent MCP servers aren't viable here. File-system and git MCP servers could work but add complexity for limited gain in v1.
+
+### 5. Badge
+
+Keep the existing badge in README.md (already on `feat/agent-actions`).
+
+## Options Considered
+
+### Option A: Vendor `anthropics/claude-code-action` logic inline (recommended)
+
+Copy the core execution logic into `.github/workflows/agent-actions.yml` as shell steps. Attribute the source in comments. Simple, no external dependencies, easy to audit.
+
+Cons: manual effort to track upstream changes.
+
+### Option B: Vendor as a local composite action
+
+Copy into `.github/actions/claude-code/action.yml` as a composite action, reference it locally with `uses: ./.github/actions/claude-code`. Cleaner separation but more files.
+
+Cons: slightly more structure to maintain.
+
+### Option C: Use `dwmkerr/agent-actions` as reusable workflow
+
+Not viable - external actions are blocked.
+
+**Recommendation: Option A for v1.** Inline shell steps are the simplest approach. If the workflow grows, refactor to Option B (local composite action).
+
+## Impact
+
+- `.github/workflows/agent-actions.yml` - rewritten (vendored logic, dispatch trigger, access control)
+- `README.md` - no change (badge already present on feat/agent-actions)
+
+## Non-goals
+
+- MCP server integration (follow-up)
+- Custom GitHub App identity (follow-up)
+- Cost tracking / token budgets (follow-up)
+- Running the agent against a live cluster

--- a/openspec/changes/2026-03-26-agent-actions/proposal.md
+++ b/openspec/changes/2026-03-26-agent-actions/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-We want the Ark team to be able to trigger Claude Code from GitHub - via `@claude` mentions on issues and PRs, on failed builds, or on specific PR types like Dependabot. This lets the team triage, suggest fixes, review code, or implement small changes directly from GitHub without needing a local dev environment.
+We want the Ark team to be able to trigger Claude Code from GitHub - via `@ark` mentions on issues and PRs, on failed builds, or on specific PR types like Dependabot. This lets the team triage, suggest fixes, review code, or implement small changes directly from GitHub without needing a local dev environment.
 
 The existing `feat/agent-actions` branch has a basic workflow that calls `dwmkerr/agent-actions`, which wraps `anthropics/claude-code-action`. This won't work in practice - the Ark repo can't use external GitHub Actions. We need to vendor the workflow logic directly.
 
@@ -10,17 +10,17 @@ The Ark GitHub org does not allow referencing external actions (e.g. `uses: dwmk
 
 ## What Changes
 
-### 1. Workflow: `.github/workflows/agent-actions.yml`
+### 1. Workflow: `.github/workflows/agent-actions.yml` ("Ark Agent")
 
 A self-contained workflow that vendors the logic from [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) and [`dwmkerr/agent-actions`](https://github.com/dwmkerr/agent-actions). Attribution to both sources in the workflow file header.
 
 Triggers:
 
-- `issue_comment`, `pull_request_review_comment`, `pull_request_review` - responds to `@claude` mentions
-- `issues` with `opened` and `labeled` - responds to `claude` label or `@claude` in issue body
-- `workflow_dispatch` with inputs: `prompt`, `issue_number`, `branch` - manual runs from Actions tab or `gh workflow run`
-- `workflow_run` on failed CI builds - agent can diagnose and suggest fixes
-- `pull_request` filtered to Dependabot PRs - agent can review, test, and merge dependency updates
+- `issue_comment`, `pull_request_review_comment`, `pull_request_review` - responds to `@ark` mentions
+- `issues` with `opened` and `labeled` - responds to `ark-agent` label or `@ark` in issue body
+- `workflow_dispatch` with inputs: `prompt` - manual runs from Actions tab or `gh workflow run`
+- `workflow_run` on failed CI builds - agent can diagnose and suggest fixes (follow-up)
+- `pull_request` filtered to Dependabot PRs - agent can review, test, and merge dependency updates (follow-up)
 
 ### 2. Claude Code execution
 
@@ -32,21 +32,28 @@ The vendored workflow installs and runs Claude Code directly via `npx @anthropic
 4. Run Claude Code with the prompt, passing `ANTHROPIC_API_KEY` from secrets
 5. Post the response as a comment on the issue/PR
 
-This is what `anthropics/claude-code-action` does under the hood. Vendoring it means copying the core logic into a composite action or shell steps within the workflow.
+This is what `anthropics/claude-code-action` does under the hood. Vendoring it means copying the core logic into shell steps within the workflow.
 
-### 3. Access control
+### 3. Identity
 
-Check `github.event.sender.login` against a configurable `allowed_users` list (env var or workflow input). Reject and comment if the user isn't authorised. Based on the pattern in `dwmkerr/agent-actions/.github/workflows/claude.yml`.
+Use `AGENT_GITHUB_TOKEN` secret - a PAT for a bot user account. All PRs, comments, and commits appear as that user. Falls back to `GITHUB_TOKEN` (github-actions[bot]) if not set.
 
-### 4. Ark-specific context
+### 4. Access control
+
+Check `github.event.sender.login` against `ALLOWED_USERS` env var. Current allowed users: `dwmkerr`, `Nab-0`, `havasik`, `skazinka`, `amanvr`, `peter-kismarczi`, `daniele-marostica`, `giorgio-acquati-mck`, `poornimanagQB`.
+
+### 5. Ark-specific context
 
 The agent runs with the repo checked out, so `CLAUDE.md` is picked up automatically. No extra config needed for basic context.
 
-MCP servers: deferred. The agent runs in a GitHub Actions container with no cluster access, so K8s-dependent MCP servers aren't viable here. File-system and git MCP servers could work but add complexity for limited gain in v1.
+MCP servers: deferred. The agent runs in a GitHub Actions container with no cluster access, so K8s-dependent MCP servers aren't viable here.
 
-### 5. Badge
+### 6. Required secrets
 
-Keep the existing badge in README.md (already on `feat/agent-actions`).
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes | Anthropic API key for Claude Code |
+| `AGENT_GITHUB_TOKEN` | No | PAT for bot user identity (falls back to `GITHUB_TOKEN`) |
 
 ## Options Considered
 
@@ -70,12 +77,11 @@ Not viable - external actions are blocked.
 
 ## Impact
 
-- `.github/workflows/agent-actions.yml` - rewritten (vendored logic, dispatch trigger, access control)
-- `README.md` - no change (badge already present on feat/agent-actions)
+- `.github/workflows/agent-actions.yml` - new workflow (vendored logic, dispatch trigger, access control)
+- `README.md` - badge update (already on feat/agent-actions)
 
 ## Non-goals
 
 - MCP server integration (follow-up)
-- Custom GitHub App identity (follow-up)
 - Cost tracking / token budgets (follow-up)
 - Running the agent against a live cluster


### PR DESCRIPTION
## Summary
- Skeleton GitHub Actions workflow for running Claude Code on issues, PRs, and manual dispatch
- Vendored inline (no external actions) with attribution to `anthropics/claude-code-action` and `dwmkerr/agent-actions`
- GitHub App token generation for custom bot identity (optional, configure `AGENT_APP_ID` and `AGENT_APP_PRIVATE_KEY`)
- Access control via `ALLOWED_USERS` env var
- OpenSpec proposal at `openspec/changes/2026-03-26-agent-actions/proposal.md`
- Placeholder execution step - needs Claude Code CLI integration next