### PR TITLE
feat: add tenant management specs for multi-namespace RBAC

### DIFF
--- a/openspec/changes/multi-namespace-rbac-samples/.openspec.yaml
+++ b/openspec/changes/multi-namespace-rbac-samples/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-26

--- a/openspec/changes/multi-namespace-rbac-samples/design.md
+++ b/openspec/changes/multi-namespace-rbac-samples/design.md
@@ -1,0 +1,118 @@
+## Context
+
+Each Ark tenant is deployed into its own Kubernetes namespace via the `ark-tenant` Helm chart. The ark-api service runs with a namespace-scoped `Role` and `RoleBinding`, giving it access only to resources in its own namespace. The API already accepts a `?namespace=X` query parameter on all resource endpoints.
+
+Currently, the ark-api chart includes an optional `rbac.clusterWide: true` toggle that creates a `ClusterRole` granting full CRUD on Ark resources across all namespaces. This is bundled inside the tenant's own chart, meaning a single misconfiguration gives a tenant cluster-wide write access. The `devspace.yaml` for local development sets this to `true` by default.
+
+The `list_namespaces()` API endpoint calls `v1.list_namespace()` (a cluster-scoped Kubernetes API) and returns a hard error when the service account lacks cluster permissions. The `create_namespace()` endpoint can create arbitrary Kubernetes namespaces — this is fine, but should be documented as requiring explicit permission.
+
+The dashboard sidebar currently shows the namespace as static text. There is no UI to switch between namespaces.
+
+Existing docs have tenant setup content split across `deploying-ark.mdx` (Setting Up Tenant Namespaces, Using the Tenant Service Account) and `authentication.mdx` (API Key Namespace Scoping). The tenant setup content should be consolidated into a dedicated page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide sample RBAC manifests in `samples/tenant-management/` for four tiers of namespace access
+- Consolidate tenant management docs into a dedicated operations guide page
+- Remove the ClusterRole from the ark-api chart so tenants can never accidentally get cluster-wide access from their own deployment
+- Make `list_namespaces()` gracefully return the context namespace when cluster permissions are unavailable
+- Extend `GET /api/v1/context` to report whether the service account can create namespaces
+- Add a namespace dropdown to the dashboard sidebar for switching between available namespaces
+
+**Non-Goals:**
+- Building a Helm chart or CLI for applying these RBAC manifests (samples are `kubectl apply` only)
+- Multi-cluster support
+- Automating RoleBinding creation based on namespace labels (convention only, documented)
+- Changing how the ark-api handles the `?namespace=X` parameter on resource endpoints (already works)
+
+## Decisions
+
+### 1. Sample manifests over a Helm chart
+
+Provide raw YAML manifests in `samples/tenant-management/` rather than a Helm chart.
+
+**Rationale:** RBAC grants are a one-shot admin operation. Raw manifests are transparent, auditable, and require no additional tooling. Operators can see exactly what permissions are being granted. A Helm chart can be added later if there's demand.
+
+**Alternative considered:** Small Helm chart with a values file listing target namespaces. Rejected because it adds complexity for what is typically a one-time operation, and obscures the actual RBAC resources being created.
+
+### 2. Four tiers of access
+
+Structure the samples as four escalating tiers rather than a single configurable manifest.
+
+| Tier | Manifest | What it grants |
+|------|----------|---------------|
+| 1 | `01-namespace-reader.yaml` | `ClusterRole` + `ClusterRoleBinding` granting only `get, list` on namespaces. Enables namespace discovery in dashboard. |
+| 2 | `02-specific-namespaces.yaml` | `RoleBinding` in each target namespace referencing the existing `ark-tenant-role` ClusterRole. Grants Ark resource access in named namespaces. |
+| 3 | `03-namespace-label-selector.yaml` | Same as tier 2 but uses namespace labels as a convention. The admin applies a RoleBinding in each labelled namespace. |
+| 4 | `04-full-admin.yaml` | `ClusterRole` + `ClusterRoleBinding` granting full Ark access across all namespaces plus namespace creation. Platform admin only. |
+
+**Rationale:** Each tier is independently applicable. An operator can apply tier 1 alone (discovery), or tier 1 + tier 2 (discovery + specific access). Clear escalation path.
+
+**Note on tier 3:** Kubernetes RBAC does not natively support label-based namespace scoping on Roles/RoleBindings. The manifest demonstrates the pattern using namespace labels as a convention — the admin applies a RoleBinding in each labelled namespace. The docs note this is a convention enforced by the operator, not by Kubernetes itself.
+
+### 3. Graceful 403 fallback in list_namespaces()
+
+Catch `ApiException` with status 403 in the `list_namespaces()` endpoint and return only the current context namespace.
+
+**Rationale:** This makes the default single-tenant experience work without any RBAC changes. The dashboard calls this endpoint to populate the namespace switcher; returning one namespace means it shows just the tenant's own namespace. When a ClusterRole is added (tier 1+), the endpoint returns whatever namespaces the service account can see.
+
+### 4. Remove ClusterRole from ark-api chart entirely
+
+Delete the `{{- if .Values.rbac.clusterWide }}` block from `rbac.yaml` and the `rbac.clusterWide` key from `values.yaml`.
+
+**Rationale:** The ark-api chart should never ship with the ability to grant itself cluster-wide permissions. Multi-namespace access is a separate admin concern. For local development on minikube, the service account inherits the cluster-admin permissions of the minikube user, so the `list_namespace()` call succeeds naturally.
+
+**Alternative considered:** Keep the toggle but default to `false`. Rejected because even having the option in the chart creates risk — it's one `--set rbac.clusterWide=true` away from a security issue.
+
+### 5. Capabilities in the context response
+
+Extend `GET /api/v1/context` to return a `capabilities` object:
+
+```json
+{
+  "namespace": "default",
+  "cluster": "minikube",
+  "read_only_mode": false,
+  "capabilities": {
+    "can_create_namespace": true
+  }
+}
+```
+
+The API checks whether the service account has `create` permission on namespaces using a Kubernetes `SelfSubjectAccessReview` (or a try/catch on a dry-run create). This is better than checking in the `list_namespaces()` endpoint because the context endpoint is already the place the dashboard goes to understand "what can I do?".
+
+**Rationale:** The dashboard needs to know whether to show the "Create Namespace" button. Rather than attempting a create and handling the error, the context response tells the dashboard up front what's available. This is a read-only permission check, not an action.
+
+### 6. Dashboard namespace dropdown
+
+Replace the static namespace text in the sidebar header (currently lines 256-273 of `app-sidebar.tsx`) with a dropdown/select that:
+
+1. On mount, calls `GET /api/v1/namespaces` to get the list of available namespaces
+2. Shows a dropdown with the current namespace selected
+3. On selection, updates `?namespace=X` via the existing `setNamespace()` from `NamespaceProvider`
+4. Shows a "Create Namespace" option at the bottom when `capabilities.can_create_namespace` is true (opens the existing `NamespaceEditor`)
+5. When only one namespace is available, still shows the dropdown but with just one option (consistent UI)
+
+The `NamespaceProvider` will be updated to actually call `namespacesService.getAll()` (the `useGetAllNamespaces` hook already exists but is unused) and populate `availableNamespaces` from the API response instead of the current hardcoded single-item array.
+
+### 7. Documentation consolidation
+
+Create a new page at `docs/content/operations-guide/tenant-namespace-management.mdx` that:
+
+- Moves the "Setting Up Tenant Namespaces" and "Using the Tenant Service Account" sections from `deploying-ark.mdx`
+- Adds the multi-namespace access tiers with a table linking to each sample manifest
+- Leaves a brief note + link in `deploying-ark.mdx` pointing to the new page
+- Does NOT move the API Key Namespace Scoping section from `authentication.mdx` (it's correctly in the auth context, but should cross-link)
+
+Add the page to `_meta.js` under the "Platform operations" separator, after "Deploying ARK".
+
+## Risks / Trade-offs
+
+**Breaking change for `rbac.clusterWide` users** → Document in release notes. Migration path: apply `04-full-admin.yaml` sample to restore equivalent permissions externally.
+
+**Tier 3 (label-based) is a convention, not enforced by Kubernetes** → Clearly document that the admin must apply RoleBindings to matching namespaces. Kubernetes RBAC doesn't auto-bind based on namespace labels. Future work could automate this with an operator.
+
+**SelfSubjectAccessReview may not be available in all clusters** → Fall back to `can_create_namespace: false` if the check fails. This is the safe default.
+
+**Local dev on non-minikube clusters** → If a developer uses a cluster where their service account doesn't have cluster-admin, `list_namespaces()` will gracefully return just their namespace. This is correct behaviour, not a bug.

--- a/openspec/changes/multi-namespace-rbac-samples/proposal.md
+++ b/openspec/changes/multi-namespace-rbac-samples/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The ark-api chart currently bundles an optional ClusterRole (`rbac.clusterWide: true`) that grants full CRUD on Ark resources across all namespaces. A misconfiguration could accidentally give a single tenant cluster-wide write access. Multi-namespace access should be an explicit, separate admin operation — never something that ships inside the tenant's own chart. We need sample manifests, documentation, and a dashboard namespace switcher so operators can grant namespace access at the right level and users can switch between namespaces they have access to.
+
+## What Changes
+
+- **Add `samples/tenant-management/` directory** with four RBAC manifest files covering escalating levels of namespace access:
+
+  | Manifest | Purpose |
+  |----------|---------|
+  | `01-namespace-reader.yaml` | Grant a tenant the ability to list namespaces (discovery only). Without this, the API/dashboard gracefully shows only the tenant's own context namespace. |
+  | `02-specific-namespaces.yaml` | Grant a tenant Ark resource access in an explicit list of additional namespaces (project switching). |
+  | `03-namespace-label-selector.yaml` | Grant a tenant access to namespaces matching a label convention (e.g., `ark.mckinsey.com/tenant: team-alpha`). New namespaces discovered when labelled and RoleBinding applied. |
+  | `04-full-admin.yaml` | Grant a tenant full cluster-wide namespace access including creation. For platform admins only. |
+
+  All four are pure RBAC manifests — no code changes, just `ClusterRole`, `Role`, `RoleBinding`, and `ClusterRoleBinding` resources.
+
+- **Add a docs page** at `docs/content/operations-guide/tenant-namespace-management.mdx` covering:
+  - Default behaviour (single namespace, no ClusterRole needed)
+  - A table linking each sample manifest with its use case
+  - When to use each tier
+  - A note that the ark-api chart itself should never be deployed with `clusterWide: true` in production
+  - Move the "Setting Up Tenant Namespaces" and "Using the Tenant Service Account" sections from `deploying-ark.mdx` into this page (leaving a cross-link in deploying-ark)
+
+- **Remove the ClusterRole from the ark-api chart** — delete the `rbac.clusterWide` toggle and all ClusterRole/ClusterRoleBinding resources from `services/ark-api/chart/templates/rbac.yaml`. Remove `clusterWide: true` from `services/ark-api/chart/values.yaml`. **BREAKING** for anyone currently setting `rbac.clusterWide: true`.
+
+- **Update `devspace.yaml`** — remove `rbac.clusterWide: true` from `services/ark-api/devspace.yaml`. On minikube the service account already inherits cluster-admin permissions, so no special chart config is needed for local dev.
+
+- **Add graceful fallback in `list_namespaces()` API** — when the service account lacks permission to list namespaces (403), return only the current context namespace instead of erroring. This means the default single-tenant experience works without any RBAC changes.
+
+- **Keep `create_namespace()` in the API** — it will naturally succeed or fail based on the service account's Kubernetes permissions. Document that it requires explicit namespace creation permission (tier 4).
+
+- **Extend `GET /api/v1/context` response** — add a `capabilities` object to the `ContextResponse` that includes `can_create_namespace: bool`. The API checks whether the service account has permission to create namespaces (via a Kubernetes SelfSubjectAccessReview or similar). This allows the dashboard to show/hide the "Create Namespace" UI based on actual permissions.
+
+- **Add namespace dropdown to the dashboard sidebar** — replace the static namespace text in the sidebar header with a dropdown that:
+  - Fetches available namespaces from `GET /api/v1/namespaces`
+  - Allows switching between namespaces (updates `?namespace=X` query param)
+  - Shows a "Create Namespace" option when `context.capabilities.can_create_namespace` is true
+  - Falls back to showing only the current namespace when only one is available
+
+## Capabilities
+
+### New Capabilities
+- `tenant-management`: Sample RBAC manifests, documentation for granting tenants escalating levels of cross-namespace access, and dashboard namespace switcher.
+
+### Modified Capabilities
+- `ark-api-rbac`: Remove ClusterRole from the ark-api Helm chart. Add graceful 403 fallback to namespace listing. Add capabilities to context response.
+
+## Impact
+
+- **ark-api chart** (`services/ark-api/chart/`): `rbac.yaml` and `values.yaml` modified. Breaking change for anyone using `rbac.clusterWide: true`.
+- **ark-api Python code** (`services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py`): `list_namespaces()` modified with 403 fallback.
+- **ark-api Python code** (`services/ark-api/ark-api/src/ark_api/models/context.py`): `ContextResponse` extended with `capabilities`.
+- **ark-api devspace** (`services/ark-api/devspace.yaml`): Remove `clusterWide` override.
+- **samples directory**: New `samples/tenant-management/` folder with four manifest files.
+- **docs**: New tenant management page in operations guide. Content moved from `deploying-ark.mdx`.
+- **Dashboard sidebar** (`services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx`): Namespace dropdown replacing static text.
+- **Dashboard provider** (`services/ark-dashboard/ark-dashboard/providers/NamespaceProvider.tsx`): Fetch available namespaces from API.

--- a/openspec/changes/multi-namespace-rbac-samples/specs/ark-api-rbac/spec.md
+++ b/openspec/changes/multi-namespace-rbac-samples/specs/ark-api-rbac/spec.md
@@ -1,0 +1,76 @@
+## MODIFIED Requirements
+
+### Requirement: ark-api chart RBAC configuration
+The ark-api Helm chart SHALL create only namespace-scoped RBAC resources (`Role` + `RoleBinding`). The chart SHALL NOT include any `ClusterRole`, `ClusterRoleBinding`, or toggle for cluster-wide permissions.
+
+The `rbac.clusterWide` key SHALL be removed from `values.yaml`. The conditional ClusterRole/ClusterRoleBinding block SHALL be removed from `templates/rbac.yaml`.
+
+#### Scenario: Default ark-api deployment
+- **WHEN** the ark-api chart is deployed with default values
+- **THEN** only a namespace-scoped `Role` and `RoleBinding` are created
+- **AND** no `ClusterRole` or `ClusterRoleBinding` exists for the ark-api service account
+
+#### Scenario: No cluster-wide toggle available
+- **WHEN** an operator sets `rbac.clusterWide: true` in values
+- **THEN** the value is ignored (key does not exist in the chart schema)
+- **AND** no cluster-scoped RBAC resources are created
+
+### Requirement: Namespace listing graceful fallback
+The `GET /api/v1/namespaces` endpoint SHALL return a list of namespaces the service account can see. When the service account lacks cluster-level permission to list namespaces, the endpoint SHALL return a list containing only the current context namespace instead of returning an error.
+
+#### Scenario: Service account with namespace list permission
+- **WHEN** the service account has a ClusterRole granting `list` on `namespaces`
+- **AND** a client calls `GET /api/v1/namespaces`
+- **THEN** the endpoint returns all namespaces the service account can list
+
+#### Scenario: Service account without namespace list permission
+- **WHEN** the service account has only namespace-scoped permissions (no ClusterRole)
+- **AND** a client calls `GET /api/v1/namespaces`
+- **THEN** the endpoint returns a list containing only the current context namespace
+- **AND** the response status is 200 (not 403)
+
+#### Scenario: Local development on minikube
+- **WHEN** the ark-api runs on minikube where the service account inherits cluster-admin
+- **AND** a client calls `GET /api/v1/namespaces`
+- **THEN** the endpoint returns all namespaces in the cluster
+
+### Requirement: Context response includes capabilities
+The `GET /api/v1/context` endpoint SHALL return a `capabilities` object in the response that includes `can_create_namespace: bool`.
+
+The API SHALL check whether the service account has Kubernetes permission to create namespaces (via SelfSubjectAccessReview or equivalent). If the check fails or is unavailable, `can_create_namespace` SHALL default to `false`.
+
+#### Scenario: Service account with namespace create permission
+- **WHEN** the service account has a ClusterRole granting `create` on `namespaces`
+- **AND** a client calls `GET /api/v1/context`
+- **THEN** the response includes `"capabilities": {"can_create_namespace": true}`
+
+#### Scenario: Service account without namespace create permission
+- **WHEN** the service account has only namespace-scoped permissions
+- **AND** a client calls `GET /api/v1/context`
+- **THEN** the response includes `"capabilities": {"can_create_namespace": false}`
+
+#### Scenario: SelfSubjectAccessReview unavailable
+- **WHEN** the SelfSubjectAccessReview API is unavailable or returns an error
+- **AND** a client calls `GET /api/v1/context`
+- **THEN** the response includes `"capabilities": {"can_create_namespace": false}`
+
+### Requirement: Namespace creation documented as permission-gated
+The `POST /api/v1/namespaces` endpoint SHALL remain in the API. It succeeds or fails based on the service account's Kubernetes permissions. Documentation SHALL note that namespace creation requires the full admin manifest (tier 4).
+
+#### Scenario: Service account with namespace create permission
+- **WHEN** the service account has a ClusterRole granting `create` on `namespaces`
+- **AND** a client calls `POST /api/v1/namespaces` with `{"name": "new-ns"}`
+- **THEN** the namespace is created and a success response is returned
+
+#### Scenario: Service account without namespace create permission
+- **WHEN** the service account has only namespace-scoped permissions
+- **AND** a client calls `POST /api/v1/namespaces` with `{"name": "new-ns"}`
+- **THEN** the Kubernetes API returns a 403 error which is passed through to the client
+
+### Requirement: devspace.yaml does not set cluster-wide RBAC
+The `services/ark-api/devspace.yaml` SHALL NOT set `rbac.clusterWide` or any cluster-scoped RBAC configuration. Local development on minikube works without explicit cluster RBAC because the minikube user has cluster-admin permissions.
+
+#### Scenario: Local development RBAC
+- **WHEN** a developer runs `devspace dev` for ark-api
+- **THEN** the deployed chart does not create any ClusterRole or ClusterRoleBinding
+- **AND** namespace listing works because minikube grants cluster-admin to the service account

--- a/openspec/changes/multi-namespace-rbac-samples/specs/multi-namespace-rbac/spec.md
+++ b/openspec/changes/multi-namespace-rbac-samples/specs/multi-namespace-rbac/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: Namespace reader sample manifest
+The repository SHALL include a sample manifest at `samples/tenant-management/01-namespace-reader.yaml` that grants a tenant service account the ability to list Kubernetes namespaces.
+
+The manifest SHALL contain:
+- A `ClusterRole` with `get` and `list` verbs on the `namespaces` resource in the core API group
+- A `ClusterRoleBinding` binding the ClusterRole to a configurable service account name and namespace
+- Comments explaining what to change (service account name, namespace)
+- A comment noting that without this manifest, the API and dashboard still work but only show the tenant's own context namespace
+
+#### Scenario: Tenant applies namespace reader
+- **WHEN** an operator applies `01-namespace-reader.yaml` with the tenant's service account details
+- **THEN** the ark-api `GET /api/v1/namespaces` endpoint returns all namespaces visible to the service account
+- **AND** the dashboard namespace dropdown shows the discovered namespaces
+
+#### Scenario: Tenant without namespace reader
+- **WHEN** no namespace reader ClusterRole is applied
+- **THEN** the ark-api `GET /api/v1/namespaces` endpoint returns only the tenant's own context namespace
+- **AND** the dashboard namespace dropdown shows only the current namespace
+
+### Requirement: Specific namespaces sample manifest
+The repository SHALL include a sample manifest at `samples/tenant-management/02-specific-namespaces.yaml` that grants a tenant service account Ark resource access in explicitly named namespaces.
+
+The manifest SHALL contain:
+- A `RoleBinding` in each target namespace referencing the existing `ark-tenant-role` ClusterRole
+- The `subjects` field referencing the tenant's service account from its home namespace
+- Comments explaining how to add or remove target namespaces
+
+#### Scenario: Tenant accesses resources in granted namespace
+- **WHEN** an operator applies `02-specific-namespaces.yaml` granting access to namespace `project-b`
+- **AND** the tenant calls `GET /api/v1/agents?namespace=project-b`
+- **THEN** the API returns agents from namespace `project-b`
+
+#### Scenario: Tenant cannot access resources in non-granted namespace
+- **WHEN** `02-specific-namespaces.yaml` grants access to `project-b` only
+- **AND** the tenant calls `GET /api/v1/agents?namespace=project-c`
+- **THEN** the API returns a 403 error
+
+### Requirement: Label-based namespace sample manifest
+The repository SHALL include a sample manifest at `samples/tenant-management/03-namespace-label-selector.yaml` that demonstrates granting access to namespaces matching a label convention.
+
+The manifest SHALL contain:
+- A `RoleBinding` template that references the existing `ark-tenant-role` ClusterRole
+- Namespace labels (e.g., `ark.mckinsey.com/tenant: team-alpha`) as the convention for grouping
+- Comments explaining that the admin applies a RoleBinding in each labelled namespace
+- A comment noting this is an operator convention, not auto-enforced by Kubernetes RBAC
+
+#### Scenario: Tenant accesses labelled namespace
+- **WHEN** an operator labels namespace `finance` with `ark.mckinsey.com/tenant: team-alpha`
+- **AND** applies the RoleBinding from `03-namespace-label-selector.yaml` in namespace `finance`
+- **THEN** the tenant service account can access Ark resources in namespace `finance`
+
+#### Scenario: New namespace added by label convention
+- **WHEN** an operator creates namespace `analytics` with label `ark.mckinsey.com/tenant: team-alpha`
+- **AND** applies the RoleBinding from the sample in namespace `analytics`
+- **AND** the namespace reader manifest (tier 1) is also applied
+- **THEN** the tenant sees `analytics` in the namespace list
+
+### Requirement: Full admin sample manifest
+The repository SHALL include a sample manifest at `samples/tenant-management/04-full-admin.yaml` that grants a tenant full cluster-wide Ark access including namespace creation.
+
+The manifest SHALL contain:
+- A `ClusterRole` granting `get`, `list`, `create` on `namespaces`
+- A `ClusterRole` granting full CRUD on all Ark CRD resources (`ark.mckinsey.com` API group) across all namespaces
+- A `ClusterRoleBinding` binding both to the tenant service account
+- Comments warning this is for platform admins only
+
+#### Scenario: Admin creates namespace via API
+- **WHEN** the full admin manifest is applied
+- **AND** the tenant calls `POST /api/v1/namespaces` with `{"name": "new-project"}`
+- **THEN** the namespace is created successfully
+
+#### Scenario: Admin lists all namespaces
+- **WHEN** the full admin manifest is applied
+- **THEN** `GET /api/v1/namespaces` returns all namespaces in the cluster
+
+### Requirement: Tenant namespace management documentation
+The documentation SHALL include a page at `docs/content/operations-guide/tenant-namespace-management.mdx` that opens with:
+
+1. A simple ASCII or Mermaid diagram showing the tenant isolation model:
+   - A cluster containing multiple isolated tenants (namespaces)
+   - A cluster administrator who manages tenants
+   - Visual separation between tenants to convey isolation
+2. A brief explanation that:
+   - Tenants are the fundamental isolation unit in Ark — each tenant is a Kubernetes namespace
+   - Tenants can represent projects, teams, or environments
+   - By default tenants are fully isolated from each other
+   - Cluster administrators manage tenants and can grant cross-namespace access via RBAC
+   - More empowered tenants (e.g., those that can see multiple namespaces) are created by the cluster administrator applying additional RBAC manifests
+
+The page SHALL then continue with:
+- Default single-namespace behaviour (no ClusterRole needed)
+- A table with columns for manifest name, description, and link to the sample file in the repository
+- When to use each tier
+- A note that the ark-api chart itself should never be deployed with cluster-wide permissions in production
+- The "Setting Up Tenant Namespaces" and "Using the Tenant Service Account" content currently in `deploying-ark.mdx`
+
+The `deploying-ark.mdx` page SHALL be updated to replace the moved sections with a brief note and link to the new tenant management page.
+
+The `_meta.js` SHALL include the new page under the "Platform operations" separator.
+
+#### Scenario: Operator reads documentation
+- **WHEN** an operator navigates to the operations guide
+- **THEN** they find a "Tenant Namespace Management" page under "Platform operations"
+- **AND** the page opens with a diagram showing isolated tenants in a cluster
+- **AND** the page contains a table linking all four sample manifests with descriptions
+
+#### Scenario: Deploying Ark page cross-links
+- **WHEN** an operator reads the deploying Ark page
+- **THEN** the tenant namespace section contains a link to the tenant management page
+- **AND** the detailed setup instructions are on the tenant management page, not duplicated
+
+### Requirement: Dashboard namespace dropdown
+The dashboard sidebar SHALL include a namespace dropdown in the header area that allows users to switch between available namespaces.
+
+The dropdown SHALL:
+- Fetch the list of available namespaces from `GET /api/v1/namespaces` on mount
+- Display the current namespace as the selected value
+- Allow the user to select a different namespace, which updates the `?namespace=X` query parameter
+- Show a "Create Namespace" option when the context API reports `capabilities.can_create_namespace` is true
+- When only one namespace is available, show the dropdown with that single option
+
+The `NamespaceProvider` SHALL be updated to fetch available namespaces from the API (using the existing `useGetAllNamespaces` hook) instead of the current hardcoded single-item array.
+
+#### Scenario: Single namespace tenant
+- **WHEN** the tenant has no namespace reader ClusterRole
+- **THEN** the dropdown shows only the current context namespace
+- **AND** no "Create Namespace" option is shown
+
+#### Scenario: Multi-namespace tenant
+- **WHEN** the tenant has a namespace reader ClusterRole and access to namespaces `default`, `project-a`, `project-b`
+- **THEN** the dropdown shows all three namespaces
+- **AND** selecting `project-a` navigates to the same page with `?namespace=project-a`
+
+#### Scenario: Admin with create permission
+- **WHEN** the context API returns `capabilities.can_create_namespace: true`
+- **THEN** the dropdown includes a "Create Namespace" option
+- **AND** clicking it opens the existing `NamespaceEditor` dialog


### PR DESCRIPTION
## Summary
- Recreated from stale PR #1400 (which has merge conflicts)
- OpenSpec proposal, design, and specs for tenant namespace management
- Covers four-tier RBAC sample manifests, removal of ClusterRole from ark-api chart, graceful 403 fallback in namespace listing, capabilities in context API, and dashboard namespace dropdown
- Specs only — no implementation yet (tasks artifact pending)

Replaces #1400