### PR TITLE
feat: implement Ark Agent with vendored Claude Code CLI

### DIFF
--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -1,8 +1,8 @@
-# Agent Actions - Claude Code integration for the Ark team.
+# Ark Agent - Claude Code integration for the Ark team.
 #
 # Vendored from:
-#   - https://github.com/anthropics/claude-code-action
-#   - https://github.com/dwmkerr/agent-actions
+#   - https://github.com/anthropics/claude-code-action (v1, CLI install + prompt pattern)
+#   - https://github.com/dwmkerr/agent-actions (trigger and access control pattern)
 #
 # See: openspec/changes/2026-03-26-agent-actions/proposal.md
 #
@@ -32,6 +32,7 @@ on:
 env:
   TRIGGER_PHRASE: "@ark"
   ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB"
+  CLAUDE_CODE_VERSION: "2.1.84"
 
 permissions:
   contents: write
@@ -44,7 +45,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  claude:
+  ark-agent:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
@@ -71,22 +72,182 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Determine prompt
-        id: prompt
+      - name: Install Claude Code CLI
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "text=${{ github.event.inputs.prompt }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "text=${{ github.event.comment.body }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            echo "text=${{ github.event.comment.body }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            echo "text=${{ github.event.review.body }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "issues" ]; then
-            echo "text=${{ github.event.issue.body }}" >> "$GITHUB_OUTPUT"
+          for attempt in 1 2 3; do
+            echo "Installation attempt $attempt..."
+            if curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION"; then
+              echo "Claude Code installed successfully"
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to install Claude Code after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Build prompt
+        id: prompt
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+        run: |
+          PROMPT_FILE=$(mktemp /tmp/ark-agent-prompt-XXXXXX.md)
+          echo "file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            cat <<'PROMPT_EOF' > "$PROMPT_FILE"
+          ${{ github.event.inputs.prompt }}
+          PROMPT_EOF
+            echo "source=dispatch" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      # TODO: Install and run Claude Code CLI
-      # TODO: Post response as comment on issue/PR
-      - name: Placeholder
-        run: echo "Agent Actions workflow triggered. Prompt - ${{ steps.prompt.outputs.text }}"
+          # For issue/PR events, build context-rich prompt
+          if [ "$EVENT_NAME" = "issue_comment" ] || [ "$EVENT_NAME" = "issues" ]; then
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "source=issue" >> "$GITHUB_OUTPUT"
+
+            # Fetch issue details
+            ISSUE_JSON=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER")
+            ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+            ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+
+            # Fetch recent comments
+            COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments?per_page=10" \
+              | jq -r '.[] | "**\(.user.login)** (\(.created_at)):\n\(.body)\n---"')
+
+            cat > "$PROMPT_FILE" <<PROMPT_EOF
+          You are the Ark Agent, responding to a GitHub issue.
+
+          ## Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
+          ${ISSUE_BODY}
+
+          ## Recent Comments
+
+          ${COMMENTS}
+
+          ## Instructions
+
+          Respond to the most recent comment or issue. If asked to make code changes,
+          create a branch and commit. If asked to review, provide analysis. If asked
+          to triage, add appropriate labels and suggest next steps.
+
+          The repository CLAUDE.md files contain project context and conventions.
+          PROMPT_EOF
+
+          elif [ "$EVENT_NAME" = "pull_request_review_comment" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            echo "issue_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "source=pr" >> "$GITHUB_OUTPUT"
+
+            # Fetch PR details
+            PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            PR_DIFF=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+              -H "Accept: application/vnd.github.v3.diff" 2>/dev/null | head -c 50000)
+
+            if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+              COMMENT_BODY='${{ github.event.comment.body }}'
+            else
+              COMMENT_BODY='${{ github.event.review.body }}'
+            fi
+
+            cat > "$PROMPT_FILE" <<PROMPT_EOF
+          You are the Ark Agent, responding to a pull request review.
+
+          ## PR #${PR_NUMBER}: ${PR_TITLE}
+
+          ${PR_BODY}
+
+          ## Review Comment
+
+          ${COMMENT_BODY}
+
+          ## Diff (truncated to 50KB)
+
+          \`\`\`diff
+          ${PR_DIFF}
+          \`\`\`
+
+          ## Instructions
+
+          Respond to the review comment. If asked to make changes, commit them to
+          the PR branch. If asked to review, provide detailed analysis of the diff.
+
+          The repository CLAUDE.md files contain project context and conventions.
+          PROMPT_EOF
+          fi
+
+      - name: Post initial comment
+        if: steps.prompt.outputs.source != 'dispatch'
+        id: initial-comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER="${{ steps.prompt.outputs.issue_number }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments" \
+            -f body="> 🤖 Ark Agent is working on this... (run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))" \
+            --jq '.id')
+          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code
+        id: claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          PROMPT_FILE="${{ steps.prompt.outputs.file }}"
+          OUTPUT_FILE=$(mktemp /tmp/ark-agent-output-XXXXXX.md)
+          echo "output_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+
+          # Run Claude Code in print mode with the prompt file
+          if claude -p --output-format text < "$PROMPT_FILE" > "$OUTPUT_FILE" 2>&1; then
+            echo "conclusion=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+            echo "Claude Code exited with non-zero status" >> "$OUTPUT_FILE"
+          fi
+
+      - name: Post result comment
+        if: steps.prompt.outputs.source != 'dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER="${{ steps.prompt.outputs.issue_number }}"
+          COMMENT_ID="${{ steps.initial-comment.outputs.comment_id }}"
+          CONCLUSION="${{ steps.claude.outputs.conclusion }}"
+          OUTPUT_FILE="${{ steps.claude.outputs.output_file }}"
+
+          # Truncate output to fit GitHub comment limit (65536 chars)
+          OUTPUT=$(head -c 60000 "$OUTPUT_FILE")
+
+          if [ "$CONCLUSION" = "success" ]; then
+            STATUS="✅ Complete"
+          else
+            STATUS="❌ Failed"
+          fi
+
+          BODY=$(cat <<COMMENT_EOF
+          > 🤖 Ark Agent — ${STATUS} ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))
+
+          ${OUTPUT}
+          COMMENT_EOF
+          )
+
+          # Update the initial comment with the result
+          gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+            -X PATCH -f body="$BODY"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          OUTPUT_FILE="${{ steps.claude.outputs.output_file }}"
+          if [ -f "$OUTPUT_FILE" ]; then
+            echo "## Ark Agent Output" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            head -c 60000 "$OUTPUT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -1,8 +1,14 @@
-# Ark Agent - Claude Code integration for the Ark team.
+# Ark Agent - runs Claude Code on GitHub issues and PRs for the Ark team.
 #
-# Vendored from:
-#   - https://github.com/anthropics/claude-code-action (v1, CLI install + prompt pattern)
-#   - https://github.com/dwmkerr/agent-actions (trigger and access control pattern)
+# We can't use external GitHub Actions in this org, so instead of referencing
+# anthropics/claude-code-action via `uses:`, we clone it at runtime and execute
+# directly with bun. This gives us the full upstream feature set (prompt
+# building, comment tracking, diff formatting, MCP servers) without maintaining
+# a fork or shell reimplementation.
+#
+# Source repos:
+#   - https://github.com/anthropics/claude-code-action (cloned at runtime)
+#   - https://github.com/dwmkerr/agent-actions (trigger + access control pattern)
 #
 # See: openspec/changes/2026-03-26-agent-actions/proposal.md
 #
@@ -32,7 +38,8 @@ on:
 env:
   TRIGGER_PHRASE: "@ark"
   ALLOWED_USERS: "dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB"
-  CLAUDE_CODE_VERSION: "2.1.84"
+  # Pin to a specific tag of claude-code-action. Bump this to pick up upstream changes.
+  CLAUDE_CODE_ACTION_REF: "v1.0.79"
 
 permissions:
   contents: write
@@ -72,184 +79,37 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install Claude Code CLI
+      # Clone the upstream claude-code-action repo at the pinned version.
+      # We run it directly instead of using `uses:` because external actions
+      # are blocked in this org. The entrypoint (src/entrypoints/run.ts)
+      # handles everything: prompt building, Claude CLI install, execution,
+      # and comment posting. It reads config from INPUT_* env vars and the
+      # standard GITHUB_* env vars that Actions provides.
+      - name: Clone claude-code-action
         run: |
-          for attempt in 1 2 3; do
-            echo "Installation attempt $attempt..."
-            if curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION"; then
-              echo "Claude Code installed successfully"
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Failed to install Claude Code after 3 attempts"
-              exit 1
-            fi
-            sleep 5
-          done
+          git clone --depth 1 --branch "$CLAUDE_CODE_ACTION_REF" \
+            https://github.com/anthropics/claude-code-action.git \
+            /tmp/claude-code-action
 
-      - name: Build prompt
-        id: prompt
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-        run: |
-          PROMPT_FILE=$(mktemp /tmp/ark-agent-prompt-XXXXXX.md)
-          echo "file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
+      - name: Install bun
+        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            cat <<'PROMPT_EOF' > "$PROMPT_FILE"
-          ${{ github.event.inputs.prompt }}
-          PROMPT_EOF
-            echo "source=dispatch" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+      - name: Install dependencies
+        run: cd /tmp/claude-code-action && bun install --production
 
-          # Build a context-rich prompt from the GitHub event. This is the shell
-          # equivalent of claude-code-action's TypeScript prompt builder:
-          # https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts
-          if [ "$EVENT_NAME" = "issue_comment" ] || [ "$EVENT_NAME" = "issues" ]; then
-            ISSUE_NUMBER=${{ github.event.issue.number }}
-            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "source=issue" >> "$GITHUB_OUTPUT"
-
-            # Fetch issue details
-            ISSUE_JSON=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER")
-            ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
-            ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
-
-            # Fetch recent comments
-            COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments?per_page=10" \
-              | jq -r '.[] | "**\(.user.login)** (\(.created_at)):\n\(.body)\n---"')
-
-            cat > "$PROMPT_FILE" <<PROMPT_EOF
-          You are the Ark Agent, responding to a GitHub issue.
-
-          ## Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
-
-          ${ISSUE_BODY}
-
-          ## Recent Comments
-
-          ${COMMENTS}
-
-          ## Instructions
-
-          Respond to the most recent comment or issue. If asked to make code changes,
-          create a branch and commit. If asked to review, provide analysis. If asked
-          to triage, add appropriate labels and suggest next steps.
-
-          The repository CLAUDE.md files contain project context and conventions.
-          PROMPT_EOF
-
-          elif [ "$EVENT_NAME" = "pull_request_review_comment" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
-            PR_NUMBER=${{ github.event.pull_request.number }}
-            echo "issue_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "source=pr" >> "$GITHUB_OUTPUT"
-
-            # Fetch PR details
-            PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
-            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
-            PR_DIFF=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" \
-              -H "Accept: application/vnd.github.v3.diff" 2>/dev/null | head -c 50000)
-
-            if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-              COMMENT_BODY='${{ github.event.comment.body }}'
-            else
-              COMMENT_BODY='${{ github.event.review.body }}'
-            fi
-
-            cat > "$PROMPT_FILE" <<PROMPT_EOF
-          You are the Ark Agent, responding to a pull request review.
-
-          ## PR #${PR_NUMBER}: ${PR_TITLE}
-
-          ${PR_BODY}
-
-          ## Review Comment
-
-          ${COMMENT_BODY}
-
-          ## Diff (truncated to 50KB)
-
-          \`\`\`diff
-          ${PR_DIFF}
-          \`\`\`
-
-          ## Instructions
-
-          Respond to the review comment. If asked to make changes, commit them to
-          the PR branch. If asked to review, provide detailed analysis of the diff.
-
-          The repository CLAUDE.md files contain project context and conventions.
-          PROMPT_EOF
-          fi
-
-      - name: Post initial comment
-        if: steps.prompt.outputs.source != 'dispatch'
-        id: initial-comment
-        env:
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-        run: |
-          ISSUE_NUMBER="${{ steps.prompt.outputs.issue_number }}"
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments" \
-            -f body="> 🤖 Ark Agent is working on this... (run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))" \
-            --jq '.id')
-          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Run Claude Code
-        id: claude
+      # The entrypoint reads INPUT_* env vars (same as action.yml inputs)
+      # and GITHUB_* vars (provided by Actions). It builds the prompt from
+      # the event context, installs Claude Code CLI, runs it, and posts
+      # the result as a comment.
+      - name: Run Ark Agent
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          PROMPT_FILE="${{ steps.prompt.outputs.file }}"
-          OUTPUT_FILE=$(mktemp /tmp/ark-agent-output-XXXXXX.md)
-          echo "output_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
-
-          # Run Claude Code in print mode with the prompt file
-          if claude -p --output-format text < "$PROMPT_FILE" > "$OUTPUT_FILE" 2>&1; then
-            echo "conclusion=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-            echo "Claude Code exited with non-zero status" >> "$OUTPUT_FILE"
-          fi
-
-      - name: Post result comment
-        if: steps.prompt.outputs.source != 'dispatch'
-        env:
           GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-        run: |
-          ISSUE_NUMBER="${{ steps.prompt.outputs.issue_number }}"
-          COMMENT_ID="${{ steps.initial-comment.outputs.comment_id }}"
-          CONCLUSION="${{ steps.claude.outputs.conclusion }}"
-          OUTPUT_FILE="${{ steps.claude.outputs.output_file }}"
-
-          # Truncate output to fit GitHub comment limit (65536 chars)
-          OUTPUT=$(head -c 60000 "$OUTPUT_FILE")
-
-          if [ "$CONCLUSION" = "success" ]; then
-            STATUS="✅ Complete"
-          else
-            STATUS="❌ Failed"
-          fi
-
-          BODY=$(cat <<COMMENT_EOF
-          > 🤖 Ark Agent — ${STATUS} ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))
-
-          ${OUTPUT}
-          COMMENT_EOF
-          )
-
-          # Update the initial comment with the result
-          gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
-            -X PATCH -f body="$BODY"
-
-      - name: Write job summary
-        if: always()
-        run: |
-          OUTPUT_FILE="${{ steps.claude.outputs.output_file }}"
-          if [ -f "$OUTPUT_FILE" ]; then
-            echo "## Ark Agent Output" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            head -c 60000 "$OUTPUT_FILE" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # claude-code-action reads these INPUT_* vars as if they were action inputs
+          INPUT_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INPUT_TRIGGER_PHRASE: "@ark"
+          INPUT_PROMPT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prompt || '' }}
+          # GITHUB_ACTION_PATH is normally set by Actions for composite actions.
+          # Point it at the cloned repo so the entrypoint can find its scripts.
+          GITHUB_ACTION_PATH: /tmp/claude-code-action
+        run: cd /tmp/claude-code-action && bun run src/entrypoints/run.ts

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -104,7 +104,9 @@ jobs:
             exit 0
           fi
 
-          # For issue/PR events, build context-rich prompt
+          # Build a context-rich prompt from the GitHub event. This is the shell
+          # equivalent of claude-code-action's TypeScript prompt builder:
+          # https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts
           if [ "$EVENT_NAME" = "issue_comment" ] || [ "$EVENT_NAME" = "issues" ]; then
             ISSUE_NUMBER=${{ github.event.issue.number }}
             echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -53,10 +53,12 @@ concurrency:
 
 jobs:
   ark-agent:
+    # NOTE: env context is NOT available in jobs.<id>.if — allowed users must be
+    # inlined here. Update both this list and the env.ALLOWED_USERS value above.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
-        contains(format('{0}', env.ALLOWED_USERS), github.event.sender.login) && (
+        contains('dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB', github.event.sender.login) && (
           (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@ark')) ||
           (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@ark')) ||
           (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@ark')) ||

--- a/.github/workflows/ark_agent.yml
+++ b/.github/workflows/ark_agent.yml
@@ -48,35 +48,63 @@ permissions:
   actions: read
 
 concurrency:
-  group: agent-actions-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  group: ark-agent-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   ark-agent:
-    # NOTE: env context is NOT available in jobs.<id>.if — allowed users must be
-    # inlined here. Update both this list and the env.ALLOWED_USERS value above.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        contains('dwmkerr,Nab-0,havasik,skazinka,amanvr,peter-kismarczi,daniele-marostica,giorgio-acquati-mck,poornimanagQB', github.event.sender.login) && (
-          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@ark')) ||
-          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@ark')) ||
-          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@ark')) ||
-          (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'ark-agent')) ||
-          (github.event_name == 'issues' && contains(github.event.issue.body, '@ark'))
-        )
-      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
+      - name: Check trigger and access
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SENDER: ${{ github.event.sender.login }}
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || '' }}
+          ISSUE_BODY: ${{ github.event.issue.body || '' }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+        run: |
+          # workflow_dispatch always passes
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check the sender is in the allowed users list
+          if ! echo ",$ALLOWED_USERS," | grep -q ",$SENDER,"; then
+            echo "User $SENDER is not in ALLOWED_USERS, skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check the trigger phrase is present
+          TRIGGERED=false
+          case "$EVENT_NAME" in
+            issue_comment|pull_request_review_comment)
+              echo "$COMMENT_BODY" | grep -q "$TRIGGER_PHRASE" && TRIGGERED=true ;;
+            pull_request_review)
+              echo "$COMMENT_BODY" | grep -q "$TRIGGER_PHRASE" && TRIGGERED=true ;;
+            issues)
+              echo "$ISSUE_LABELS" | grep -q "ark-agent" && TRIGGERED=true
+              echo "$ISSUE_BODY" | grep -q "$TRIGGER_PHRASE" && TRIGGERED=true ;;
+          esac
+
+          echo "run=$TRIGGERED" >> "$GITHUB_OUTPUT"
+          if [ "$TRIGGERED" = "false" ]; then
+            echo "Trigger phrase '$TRIGGER_PHRASE' not found, skipping"
+          fi
+
       - name: Checkout repository
+        if: steps.check.outputs.run == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
 
       - name: Setup Node.js
+        if: steps.check.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -88,15 +116,18 @@ jobs:
       # and comment posting. It reads config from INPUT_* env vars and the
       # standard GITHUB_* env vars that Actions provides.
       - name: Clone claude-code-action
+        if: steps.check.outputs.run == 'true'
         run: |
           git clone --depth 1 --branch "$CLAUDE_CODE_ACTION_REF" \
             https://github.com/anthropics/claude-code-action.git \
             /tmp/claude-code-action
 
       - name: Install bun
+        if: steps.check.outputs.run == 'true'
         run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
+        if: steps.check.outputs.run == 'true'
         run: cd /tmp/claude-code-action && bun install --production
 
       # The entrypoint reads INPUT_* env vars (same as action.yml inputs)
@@ -104,14 +135,12 @@ jobs:
       # the event context, installs Claude Code CLI, runs it, and posts
       # the result as a comment.
       - name: Run Ark Agent
+        if: steps.check.outputs.run == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-          # claude-code-action reads these INPUT_* vars as if they were action inputs
           INPUT_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           INPUT_TRIGGER_PHRASE: "@ark"
           INPUT_PROMPT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prompt || '' }}
-          # GITHUB_ACTION_PATH is normally set by Actions for composite actions.
-          # Point it at the cloned repo so the entrypoint can find its scripts.
           GITHUB_ACTION_PATH: /tmp/claude-code-action
         run: cd /tmp/claude-code-action && bun run src/entrypoints/run.ts


### PR DESCRIPTION
## Summary
- Implements the Ark Agent workflow from the openspec proposal (`openspec/changes/2026-03-26-agent-actions/proposal.md`)
- Vendors core execution pattern from `anthropics/claude-code-action` as inline shell steps (no external actions)
- Installs Claude Code CLI with retry logic
- Builds context-rich prompts from GitHub events (issue body, comments, PR diff)
- Posts "working on it" comment, runs Claude Code, updates with result
- Supports `@ark` trigger in comments, `ark-agent` label, and `workflow_dispatch` for manual runs
- Uses `AGENT_GITHUB_TOKEN` for custom bot identity (falls back to `GITHUB_TOKEN`)