### PR TITLE
feat: post failure comment when Ark Agent crashes

### DIFF
--- a/.github/workflows/ark_agent.yml
+++ b/.github/workflows/ark_agent.yml
@@ -156,3 +156,15 @@ jobs:
           GITHUB_ACTION_PATH: /tmp/claude-code-action
         run: cd /tmp/claude-code-action && bun run src/entrypoints/run.ts
 
+      # Post a comment on failure so the user knows something went wrong
+      - name: Post failure comment
+        if: failure() && steps.check.outputs.run == 'true' && github.event_name != 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh api "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments" \
+              -f body="> ❌ Ark Agent failed. [View logs](${RUN_URL})"
+          fi

--- a/.github/workflows/ark_agent.yml
+++ b/.github/workflows/ark_agent.yml
@@ -154,7 +154,7 @@ jobs:
           INPUT_TRIGGER_PHRASE: "@ark"
           INPUT_PROMPT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prompt || '' }}
           GITHUB_ACTION_PATH: /tmp/claude-code-action
-        run: cd /tmp/claude-code-action && bun run src/entrypoints/run.ts
+        run: bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
       # Post a comment on failure so the user knows something went wrong
       - name: Post failure comment


### PR DESCRIPTION
## Summary
- Adds a failure comment step that posts to the issue/PR when the agent crashes
- Previous test failed because the PR branch was deleted from remote — the upstream entrypoint tries to git fetch the branch for diffs and fails if it no longer exists
- Test on a PR with an active branch