### PR TITLE
fix: implement label selector filtering in PostgreSQL List and Watch

### DIFF
--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,6 +23,32 @@ import (
 )
 
 const jsonNull = "null"
+
+func parseLabelSelector(selector string) (map[string]string, error) {
+	if selector == "" {
+		return nil, nil
+	}
+	result := map[string]string{}
+	for _, part := range strings.Split(selector, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, "!=") || strings.Contains(part, " in ") || strings.Contains(part, " notin ") || strings.HasPrefix(part, "!") {
+			return nil, fmt.Errorf("unsupported label selector operator in %q, only equality (=, ==) is supported in SQL", part)
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid label selector %q", part)
+		}
+		key := strings.TrimSuffix(strings.TrimSpace(kv[0]), "=")
+		result[strings.TrimSpace(key)] = strings.TrimSpace(kv[1])
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
 
 type Config struct {
 	Host         string
@@ -365,6 +392,19 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 		argIndex++
 	}
 
+	if opts.LabelSelector != "" {
+		labelMap, err := parseLabelSelector(opts.LabelSelector)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to parse label selector: %w", err)
+		}
+		if labelMap != nil {
+			labelJSON, _ := json.Marshal(labelMap)
+			query += fmt.Sprintf(" AND labels @> $%d::jsonb", argIndex)
+			args = append(args, string(labelJSON))
+			argIndex++
+		}
+	}
+
 	if opts.Continue != "" {
 		cursor, err := strconv.ParseInt(opts.Continue, 10, 64)
 		if err == nil && cursor > 0 {
@@ -591,6 +631,11 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 	ch := make(chan watch.Event, 100)
 	key := fmt.Sprintf("%s/%s", kind, namespace)
 
+	labelFilter, err := parseLabelSelector(opts.LabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse label selector: %w", err)
+	}
+
 	w := &postgresWatcher{
 		ch:          ch,
 		outCh:       make(chan watch.Event, 100),
@@ -599,6 +644,7 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 		key:         key,
 		kind:        kind,
 		ns:          namespace,
+		labelFilter: labelFilter,
 		ctx:         ctx,
 		done:        make(chan struct{}),
 		initialList: true,
@@ -785,6 +831,7 @@ type postgresWatcher struct {
 	key         string
 	kind        string
 	ns          string
+	labelFilter map[string]string
 	ctx         context.Context
 	done        chan struct{}
 	stopped            atomic.Bool
@@ -897,9 +944,17 @@ func (w *postgresWatcher) relist() {
 		WHERE kind = $1 AND resource_version > $2`
 	args := []interface{}{w.kind, lastRV}
 
+	argIndex := 3
 	if w.ns != "" {
-		query += ` AND namespace = $3`
+		query += fmt.Sprintf(` AND namespace = $%d`, argIndex)
 		args = append(args, w.ns)
+		argIndex++
+	}
+
+	if w.labelFilter != nil {
+		labelJSON, _ := json.Marshal(w.labelFilter)
+		query += fmt.Sprintf(` AND labels @> $%d::jsonb`, argIndex)
+		args = append(args, string(labelJSON))
 	}
 
 	query += ` ORDER BY resource_version ASC`

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -150,12 +150,31 @@ func (p *PostgreSQLBackend) initSchema() error {
 	CREATE OR REPLACE FUNCTION notify_resource_change()
 	RETURNS TRIGGER AS $$
 	BEGIN
+		IF TG_OP = 'DELETE' THEN
+			PERFORM pg_notify('ark_resources', json_build_object(
+				'operation', TG_OP,
+				'kind', OLD.kind,
+				'namespace', OLD.namespace,
+				'name', OLD.name,
+				'resource_version', OLD.resource_version,
+				'uid', OLD.uid,
+				'spec', OLD.spec,
+				'status', OLD.status,
+				'labels', OLD.labels,
+				'annotations', OLD.annotations,
+				'finalizers', OLD.finalizers,
+				'owner_references', OLD.owner_references,
+				'generation', OLD.generation,
+				'created_at', OLD.created_at
+			)::text);
+			RETURN OLD;
+		END IF;
 		PERFORM pg_notify('ark_resources', json_build_object(
 			'operation', TG_OP,
-			'kind', COALESCE(NEW.kind, OLD.kind),
-			'namespace', COALESCE(NEW.namespace, OLD.namespace),
-			'name', COALESCE(NEW.name, OLD.name),
-			'resource_version', COALESCE(NEW.resource_version, OLD.resource_version)
+			'kind', NEW.kind,
+			'namespace', NEW.namespace,
+			'name', NEW.name,
+			'resource_version', NEW.resource_version
 		)::text);
 		RETURN NEW;
 	END;
@@ -171,31 +190,55 @@ func (p *PostgreSQLBackend) initSchema() error {
 }
 
 func (p *PostgreSQLBackend) listenForNotifications() {
-	listener := pq.NewListener(p.connStr, 10*time.Second, time.Minute, func(ev pq.ListenerEventType, err error) {
-		if err != nil {
-			klog.Errorf("PostgreSQL listener error: %v", err)
+	backoff := time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
 		}
-	})
 
-	if err := listener.Listen("ark_resources"); err != nil {
-		klog.Errorf("Failed to listen for notifications: %v", err)
-		return
+		listener := pq.NewListener(p.connStr, 10*time.Second, time.Minute, func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				klog.Errorf("PostgreSQL listener error: %v", err)
+			}
+		})
+
+		if err := listener.Listen("ark_resources"); err != nil {
+			_ = listener.Close()
+			klog.Errorf("Failed to listen for notifications, retrying in %v: %v", backoff, err)
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		backoff = time.Second
+		p.runListener(listener)
+		_ = listener.Close()
 	}
+}
 
-	defer func() { _ = listener.Close() }()
-
+func (p *PostgreSQLBackend) runListener(listener *pq.Listener) {
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
 		case n := <-listener.Notify:
 			if n == nil {
-				continue
+				klog.Warning("PostgreSQL listener connection lost, reconnecting")
+				return
 			}
 			p.nudgeWatchers(n.Extra)
 		case <-time.After(90 * time.Second):
 			if err := listener.Ping(); err != nil {
-				klog.Warningf("Failed to ping listener: %v", err)
+				klog.Warningf("Failed to ping listener, reconnecting: %v", err)
+				return
 			}
 		}
 	}
@@ -300,7 +343,7 @@ func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name strin
 
 	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, fmt.Errorf("not found")
+			return nil, storage.ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to scan row: %w", err)
 	}
@@ -538,7 +581,7 @@ func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name st
 
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
-		return fmt.Errorf("not found")
+		return storage.ErrNotFound
 	}
 
 	return nil
@@ -651,25 +694,36 @@ func (p *PostgreSQLBackend) sendDeleteEvent(kind, namespace string, obj runtime.
 
 func (p *PostgreSQLBackend) nudgeWatchers(payload string) {
 	var notification struct {
-		Operation       string `json:"operation"`
-		Kind            string `json:"kind"`
-		Namespace       string `json:"namespace"`
-		Name            string `json:"name"`
-		ResourceVersion int64  `json:"resource_version"`
+		Operation       string          `json:"operation"`
+		Kind            string          `json:"kind"`
+		Namespace       string          `json:"namespace"`
+		Name            string          `json:"name"`
+		ResourceVersion int64           `json:"resource_version"`
+		UID             string          `json:"uid"`
+		Spec            json.RawMessage `json:"spec"`
+		Status          json.RawMessage `json:"status"`
+		Labels          json.RawMessage `json:"labels"`
+		Annotations     json.RawMessage `json:"annotations"`
+		Finalizers      json.RawMessage `json:"finalizers"`
+		OwnerReferences json.RawMessage `json:"owner_references"`
+		Generation      int64           `json:"generation"`
+		CreatedAt       time.Time       `json:"created_at"`
 	}
 	if err := json.Unmarshal([]byte(payload), &notification); err != nil {
 		return
 	}
 
 	if notification.Operation == "DELETE" {
-		obj := p.converter.NewObject(notification.Kind)
+		obj, _ := p.reconstructObject(
+			notification.Kind, notification.Namespace, notification.Name,
+			notification.ResourceVersion, notification.Generation, notification.UID,
+			string(notification.Spec), string(notification.Status),
+			string(notification.Labels), string(notification.Annotations),
+			string(notification.Finalizers), string(notification.OwnerReferences),
+			notification.CreatedAt,
+		)
 		if obj == nil {
 			return
-		}
-		if accessor, err := meta.Accessor(obj); err == nil {
-			accessor.SetName(notification.Name)
-			accessor.SetNamespace(notification.Namespace)
-			accessor.SetResourceVersion(fmt.Sprintf("%d", notification.ResourceVersion))
 		}
 		p.sendDeleteEvent(notification.Kind, notification.Namespace, obj)
 		return
@@ -733,10 +787,11 @@ type postgresWatcher struct {
 	ns          string
 	ctx         context.Context
 	done        chan struct{}
-	stopped     atomic.Bool
-	closed      sync.Once
-	lastSeenRV  atomic.Int64
-	initialList bool
+	stopped            atomic.Bool
+	closed             sync.Once
+	lastSeenRV         atomic.Int64
+	initialList        bool
+	initialListDone    bool
 }
 
 func (w *postgresWatcher) send(event watch.Event) {
@@ -810,7 +865,10 @@ func (w *postgresWatcher) sendBookmark() {
 	}
 	if accessor, aErr := meta.Accessor(obj); aErr == nil {
 		accessor.SetResourceVersion(fmt.Sprintf("%d", rv))
-		accessor.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+		if !w.initialListDone {
+			accessor.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+			w.initialListDone = true
+		}
 	}
 	select {
 	case w.outCh <- watch.Event{Type: watch.Bookmark, Object: obj}:


### PR DESCRIPTION
## Summary

- Label selectors passed to `List()` and `Watch()` were silently ignored — the API accepted selectors but returned all resources regardless
- Equality selectors (`app=foo`, `env=prod`) are now pushed into SQL using the existing GIN index on the labels JSONB column via `labels @> $N::jsonb`
- Unsupported operators (`!=`, `in`, `notin`, `!`) return an explicit error instead of silently returning wrong results
- Watch relist queries also filter by labels, so watchers with label selectors only receive matching events

Validated with integration tests against PostgreSQL 16: `List(selector="app=web")` returns 2 of 5 resources, Watch with selector only delivers matching events, unsupported operators are rejected. All 7 existing watch tests pass.

## Related

- #1513 — double-nudge fix
- #1523 — pre-existing bug fixes (DELETE skeletons, ErrNotFound, bookmark, listener retry). This PR depends on #1523.
- #1514 — watch scalability spec (references this as bug #8)