### PR TITLE
feat(ark-cli): add executor marketplace component type

### DIFF
--- a/tools/ark-cli/src/commands/completion/index.ts
+++ b/tools/ark-cli/src/commands/completion/index.ts
@@ -94,12 +94,12 @@ _ark_completion() {
           return 0
           ;;
         install)
-          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah"
+          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah marketplace/executors/langchain marketplace/executors/claude-agent-sdk"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
         uninstall)
-          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah"
+          opts="marketplace/services/phoenix marketplace/services/langfuse marketplace/agents/noah marketplace/executors/langchain marketplace/executors/claude-agent-sdk"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
@@ -251,12 +251,16 @@ _ark() {
         install)
           _values 'services to install' \\
             'marketplace/services/phoenix[Phoenix observability platform]' \\
-            'marketplace/services/langfuse[Langfuse LLM analytics]'
+            'marketplace/services/langfuse[Langfuse LLM analytics]' \\
+            'marketplace/executors/langchain[LangChain execution engine]' \\
+            'marketplace/executors/claude-agent-sdk[Claude Agent SDK executor]'
           ;;
         uninstall)
           _values 'services to uninstall' \\
             'marketplace/services/phoenix[Phoenix observability platform]' \\
-            'marketplace/services/langfuse[Langfuse LLM analytics]'
+            'marketplace/services/langfuse[Langfuse LLM analytics]' \\
+            'marketplace/executors/langchain[LangChain execution engine]' \\
+            'marketplace/executors/claude-agent-sdk[Claude Agent SDK executor]'
           ;;
         chat)
           # Get available targets dynamically

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -32,11 +32,13 @@ const mockIsMarketplaceService = vi.fn();
 const mockGetMarketplaceItem = vi.fn();
 const mockGetAllMarketplaceServices = vi.fn();
 const mockGetAllMarketplaceAgents = vi.fn();
+const mockGetAllMarketplaceExecutors = vi.fn();
 vi.mock('../../marketplaceServices.js', () => ({
   isMarketplaceService: mockIsMarketplaceService,
   getMarketplaceItem: mockGetMarketplaceItem,
   getAllMarketplaceServices: mockGetAllMarketplaceServices,
   getAllMarketplaceAgents: mockGetAllMarketplaceAgents,
+  getAllMarketplaceExecutors: mockGetAllMarketplaceExecutors,
 }));
 
 const mockOutput = {
@@ -245,6 +247,7 @@ describe('install command', () => {
       phoenix: {name: 'phoenix'},
     });
     mockGetAllMarketplaceAgents.mockResolvedValue(null);
+    mockGetAllMarketplaceExecutors.mockResolvedValue(null);
 
     const command = createInstallCommand(mockConfig);
 

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -16,6 +16,7 @@ import {
   getMarketplaceItem,
   getAllMarketplaceServices,
   getAllMarketplaceAgents,
+  getAllMarketplaceExecutors,
 } from '../../marketplaceServices.js';
 import {printNextSteps} from '../../lib/nextSteps.js';
 import ora from 'ora';
@@ -140,7 +141,13 @@ export async function installArk(
             output.info(`  marketplace/agents/${name}`);
           }
         }
-        if (!marketplaceServices && !marketplaceAgents) {
+        const marketplaceExecutors = await getAllMarketplaceExecutors();
+        if (marketplaceExecutors) {
+          for (const name of Object.keys(marketplaceExecutors)) {
+            output.info(`  marketplace/executors/${name}`);
+          }
+        }
+        if (!marketplaceServices && !marketplaceAgents && !marketplaceExecutors) {
           output.warning('Marketplace unavailable');
         }
         process.exit(1);

--- a/tools/ark-cli/src/commands/marketplace/index.spec.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.spec.ts
@@ -8,6 +8,8 @@ const mockGetAllMarketplaceServices =
   vi.fn<() => Promise<ServiceCollection | null>>();
 const mockGetAllMarketplaceAgents =
   vi.fn<() => Promise<ServiceCollection | null>>();
+const mockGetAllMarketplaceExecutors =
+  vi.fn<() => Promise<ServiceCollection | null>>();
 const mockFetchMarketplaceManifest =
   vi.fn<() => Promise<AnthropicMarketplaceManifest | null>>();
 const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -15,6 +17,7 @@ const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 vi.mock('../../marketplaceServices.js', () => ({
   getAllMarketplaceServices: mockGetAllMarketplaceServices,
   getAllMarketplaceAgents: mockGetAllMarketplaceAgents,
+  getAllMarketplaceExecutors: mockGetAllMarketplaceExecutors,
 }));
 
 vi.mock('../../lib/marketplaceFetcher.js', () => ({
@@ -85,6 +88,7 @@ describe('marketplace command', () => {
 
     mockGetAllMarketplaceServices.mockResolvedValue(mockServices);
     mockGetAllMarketplaceAgents.mockResolvedValue(mockAgents);
+    mockGetAllMarketplaceExecutors.mockResolvedValue(null);
     mockFetchMarketplaceManifest.mockResolvedValue(mockManifest);
 
     const command = createMarketplaceCommand({} as ArkConfig);
@@ -98,6 +102,7 @@ describe('marketplace command', () => {
   it('shows unavailable message when marketplace unavailable', async () => {
     mockGetAllMarketplaceServices.mockResolvedValue(null);
     mockGetAllMarketplaceAgents.mockResolvedValue(null);
+    mockGetAllMarketplaceExecutors.mockResolvedValue(null);
     mockFetchMarketplaceManifest.mockResolvedValue(null);
 
     const command = createMarketplaceCommand({} as ArkConfig);

--- a/tools/ark-cli/src/commands/marketplace/index.ts
+++ b/tools/ark-cli/src/commands/marketplace/index.ts
@@ -8,6 +8,7 @@ import {
 import {
   getAllMarketplaceServices,
   getAllMarketplaceAgents,
+  getAllMarketplaceExecutors,
 } from '../../marketplaceServices.js';
 import {fetchMarketplaceManifest} from '../../lib/marketplaceFetcher.js';
 
@@ -32,9 +33,10 @@ Registry: ${chalk.cyan(registry.replace('oci://', ''))}
       'after',
       `
 ${chalk.cyan('Examples:')}
-  ${chalk.yellow('ark marketplace list')}                        # List available services and agents
+  ${chalk.yellow('ark marketplace list')}                        # List available marketplace items
   ${chalk.yellow('ark install marketplace/services/phoenix')}    # Install Phoenix service
   ${chalk.yellow('ark install marketplace/agents/noah')}         # Install Noah agent
+  ${chalk.yellow('ark install marketplace/executors/langchain')} # Install LangChain executor
   ${chalk.yellow('ark uninstall marketplace/services/phoenix')}  # Uninstall Phoenix
 `
     );
@@ -43,10 +45,11 @@ ${chalk.cyan('Examples:')}
   const list = new Command('list');
   list
     .alias('ls')
-    .description('List available marketplace services and agents')
+    .description('List available marketplace items')
     .action(async () => {
       const services = await getAllMarketplaceServices();
       const agents = await getAllMarketplaceAgents();
+      const executors = await getAllMarketplaceExecutors();
       const manifest = await fetchMarketplaceManifest();
 
       console.log(chalk.blue('\n🏪 ARK Marketplace\n'));
@@ -99,6 +102,25 @@ ${chalk.cyan('Examples:')}
             `${icon} ${chalk.green(agentName)} ${chalk.gray(agentDesc)}`
           );
           const namespaceInfo = `namespace: ${agent.namespace || 'default'}`;
+          console.log(`   ${chalk.dim(namespaceInfo)}`);
+          console.log();
+        }
+      }
+
+      if (executors && Object.keys(executors).length > 0) {
+        console.log(chalk.bold('Executors:'));
+        console.log(
+          chalk.gray('Install with: ark install marketplace/executors/<name>\n')
+        );
+
+        for (const [key, executor] of Object.entries(executors)) {
+          const icon = '⚙️';
+          const executorName = `marketplace/executors/${key.padEnd(12)}`;
+          const executorDesc = executor.description;
+          console.log(
+            `${icon} ${chalk.green(executorName)} ${chalk.gray(executorDesc)}`
+          );
+          const namespaceInfo = `namespace: ${executor.namespace || 'default'}`;
           console.log(`   ${chalk.dim(namespaceInfo)}`);
           console.log();
         }

--- a/tools/ark-cli/src/commands/uninstall/index.spec.ts
+++ b/tools/ark-cli/src/commands/uninstall/index.spec.ts
@@ -27,11 +27,13 @@ const mockIsMarketplaceService = vi.fn();
 const mockGetMarketplaceItem = vi.fn();
 const mockGetAllMarketplaceServices = vi.fn();
 const mockGetAllMarketplaceAgents = vi.fn();
+const mockGetAllMarketplaceExecutors = vi.fn();
 vi.mock('../../marketplaceServices.js', () => ({
   isMarketplaceService: mockIsMarketplaceService,
   getMarketplaceItem: mockGetMarketplaceItem,
   getAllMarketplaceServices: mockGetAllMarketplaceServices,
   getAllMarketplaceAgents: mockGetAllMarketplaceAgents,
+  getAllMarketplaceExecutors: mockGetAllMarketplaceExecutors,
 }));
 
 const mockOutput = {
@@ -225,6 +227,7 @@ describe('uninstall command', () => {
       phoenix: {name: 'phoenix'},
     });
     mockGetAllMarketplaceAgents.mockResolvedValue(null);
+    mockGetAllMarketplaceExecutors.mockResolvedValue(null);
 
     const command = createUninstallCommand(mockConfig);
 

--- a/tools/ark-cli/src/commands/uninstall/index.ts
+++ b/tools/ark-cli/src/commands/uninstall/index.ts
@@ -11,6 +11,7 @@ import {
   getMarketplaceItem,
   getAllMarketplaceServices,
   getAllMarketplaceAgents,
+  getAllMarketplaceExecutors,
 } from '../../marketplaceServices.js';
 
 async function uninstallService(service: ArkService, verbose: boolean = false) {
@@ -62,7 +63,13 @@ async function uninstallArk(
             output.info(`  marketplace/agents/${name}`);
           }
         }
-        if (!marketplaceServices && !marketplaceAgents) {
+        const marketplaceExecutors = await getAllMarketplaceExecutors();
+        if (marketplaceExecutors) {
+          for (const name of Object.keys(marketplaceExecutors)) {
+            output.info(`  marketplace/executors/${name}`);
+          }
+        }
+        if (!marketplaceServices && !marketplaceAgents && !marketplaceExecutors) {
           output.warning('Marketplace unavailable');
         }
         process.exit(1);

--- a/tools/ark-cli/src/lib/marketplaceFetcher.spec.ts
+++ b/tools/ark-cli/src/lib/marketplaceFetcher.spec.ts
@@ -35,6 +35,7 @@ const {
   fetchMarketplaceManifest,
   mapMarketplaceItemToArkService,
   getMarketplaceServicesFromManifest,
+  getMarketplaceExecutorsFromManifest,
 } = await import('./marketplaceFetcher.js');
 
 describe('marketplaceFetcher', () => {
@@ -281,6 +282,88 @@ describe('marketplaceFetcher', () => {
       });
 
       const result = await getMarketplaceServicesFromManifest();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getMarketplaceExecutorsFromManifest', () => {
+    it('converts executor items to service collection', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [
+          {
+            name: 'langchain',
+            description: 'LangChain executor',
+            type: 'executor',
+            ark: {
+              chartPath: 'oci://registry/langchain',
+              namespace: 'langchain-ns',
+            },
+          },
+          {
+            name: 'claude-agent-sdk',
+            description: 'Claude Agent SDK executor',
+            type: 'executor',
+            ark: {
+              chartPath: 'oci://registry/claude-agent-sdk',
+              namespace: 'claude-ns',
+            },
+          },
+          {
+            name: 'phoenix',
+            description: 'Phoenix service',
+            type: 'service',
+            ark: {
+              chartPath: 'oci://registry/phoenix',
+            },
+          },
+        ],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await getMarketplaceExecutorsFromManifest();
+
+      expect(result).not.toBeNull();
+      expect(result?.['langchain']).toBeDefined();
+      expect(result?.['claude-agent-sdk']).toBeDefined();
+      expect(result?.['phoenix']).toBeUndefined();
+      expect(result?.['langchain']?.description).toBe('LangChain executor');
+    });
+
+    it('returns null when no executor items exist', async () => {
+      const mockManifest: AnthropicMarketplaceManifest = {
+        version: '1.0.0',
+        marketplace: 'ARK Marketplace',
+        items: [
+          {
+            name: 'phoenix',
+            description: 'Phoenix service',
+            type: 'service',
+            ark: {
+              chartPath: 'oci://registry/phoenix',
+            },
+          },
+        ],
+      };
+
+      mockAxiosGet.mockResolvedValue({
+        data: mockManifest,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await getMarketplaceExecutorsFromManifest();
 
       expect(result).toBeNull();
     });

--- a/tools/ark-cli/src/lib/marketplaceFetcher.ts
+++ b/tools/ark-cli/src/lib/marketplaceFetcher.ts
@@ -100,3 +100,23 @@ export async function getMarketplaceAgentsFromManifest(): Promise<ServiceCollect
 
   return Object.keys(agents).length > 0 ? agents : null;
 }
+
+export async function getMarketplaceExecutorsFromManifest(): Promise<ServiceCollection | null> {
+  const manifest = await fetchMarketplaceManifest();
+  if (!manifest || !manifest.items) {
+    return null;
+  }
+
+  const executors: ServiceCollection = {};
+  for (const item of manifest.items) {
+    if (item.ark && item.type === 'executor') {
+      const executorName = item.name
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/^-+|-+$/g, '');
+      executors[executorName] = mapMarketplaceItemToArkService(item);
+    }
+  }
+
+  return Object.keys(executors).length > 0 ? executors : null;
+}

--- a/tools/ark-cli/src/marketplaceServices.spec.ts
+++ b/tools/ark-cli/src/marketplaceServices.spec.ts
@@ -6,16 +6,19 @@ const mockGetMarketplaceServicesFromManifest =
   vi.fn<() => Promise<ServiceCollection | null>>();
 const mockGetMarketplaceAgentsFromManifest =
   vi.fn<() => Promise<ServiceCollection | null>>();
+const mockGetMarketplaceExecutorsFromManifest =
+  vi.fn<() => Promise<ServiceCollection | null>>();
 const mockFetchMarketplaceManifest =
   vi.fn<() => Promise<AnthropicMarketplaceManifest | null>>();
 
 vi.mock('./lib/marketplaceFetcher.js', () => ({
   getMarketplaceServicesFromManifest: mockGetMarketplaceServicesFromManifest,
   getMarketplaceAgentsFromManifest: mockGetMarketplaceAgentsFromManifest,
+  getMarketplaceExecutorsFromManifest: mockGetMarketplaceExecutorsFromManifest,
   fetchMarketplaceManifest: mockFetchMarketplaceManifest,
 }));
 
-const {getAllMarketplaceServices, getMarketplaceItem} = await import(
+const {getAllMarketplaceServices, getAllMarketplaceExecutors, getMarketplaceItem} = await import(
   './marketplaceServices.js'
 );
 
@@ -23,6 +26,7 @@ describe('marketplaceServices', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetMarketplaceServicesFromManifest.mockClear();
+    mockGetMarketplaceExecutorsFromManifest.mockClear();
   });
 
   describe('getAllMarketplaceServices', () => {
@@ -50,6 +54,36 @@ describe('marketplaceServices', () => {
       mockGetMarketplaceServicesFromManifest.mockResolvedValue(null);
 
       const result = await getAllMarketplaceServices();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllMarketplaceExecutors', () => {
+    it('returns manifest executors when available', async () => {
+      const mockExecutors = {
+        'langchain': {
+          name: 'langchain',
+          helmReleaseName: 'langchain',
+          description: 'LangChain executor',
+          enabled: true,
+          category: 'marketplace',
+          namespace: 'langchain-ns',
+        },
+      };
+
+      mockGetMarketplaceExecutorsFromManifest.mockResolvedValue(mockExecutors);
+
+      const result = await getAllMarketplaceExecutors();
+
+      expect(result).toEqual(mockExecutors);
+      expect(mockGetMarketplaceExecutorsFromManifest).toHaveBeenCalled();
+    });
+
+    it('returns null when manifest unavailable', async () => {
+      mockGetMarketplaceExecutorsFromManifest.mockResolvedValue(null);
+
+      const result = await getAllMarketplaceExecutors();
 
       expect(result).toBeNull();
     });
@@ -99,6 +133,34 @@ describe('marketplaceServices', () => {
       mockGetMarketplaceServicesFromManifest.mockResolvedValue(null);
 
       const result = await getMarketplaceItem('marketplace/services/phoenix');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns executor by path from manifest', async () => {
+      const mockExecutors = {
+        'langchain': {
+          name: 'langchain',
+          helmReleaseName: 'langchain',
+          description: 'LangChain executor',
+          enabled: true,
+          category: 'marketplace',
+        },
+      };
+
+      mockGetMarketplaceExecutorsFromManifest.mockResolvedValue(mockExecutors);
+
+      const result = await getMarketplaceItem(
+        'marketplace/executors/langchain'
+      );
+
+      expect(result).toEqual(mockExecutors['langchain']);
+    });
+
+    it('returns null when executor marketplace unavailable', async () => {
+      mockGetMarketplaceExecutorsFromManifest.mockResolvedValue(null);
+
+      const result = await getMarketplaceItem('marketplace/executors/langchain');
 
       expect(result).toBeNull();
     });

--- a/tools/ark-cli/src/marketplaceServices.ts
+++ b/tools/ark-cli/src/marketplaceServices.ts
@@ -10,6 +10,7 @@ import type {ArkService, ServiceCollection} from './types/arkService.js';
 import {
   getMarketplaceServicesFromManifest,
   getMarketplaceAgentsFromManifest,
+  getMarketplaceExecutorsFromManifest,
 } from './lib/marketplaceFetcher.js';
 
 /**
@@ -29,7 +30,15 @@ export async function getAllMarketplaceAgents(): Promise<ServiceCollection | nul
 }
 
 /**
- * Get a marketplace item by path (supports both services and agents)
+ * Get all marketplace executors, fetching from marketplace.json
+ * Returns null if marketplace is unavailable
+ */
+export async function getAllMarketplaceExecutors(): Promise<ServiceCollection | null> {
+  return await getMarketplaceExecutorsFromManifest();
+}
+
+/**
+ * Get a marketplace item by path (supports services, agents, and executors)
  * Returns null if marketplace is unavailable
  */
 export async function getMarketplaceItem(
@@ -51,12 +60,21 @@ export async function getMarketplaceItem(
     }
     return agents[name];
   }
+  if (path.startsWith('marketplace/executors/')) {
+    const name = path.replace(/^marketplace\/executors\//, '');
+    const executors = await getAllMarketplaceExecutors();
+    if (!executors) {
+      return null;
+    }
+    return executors[name];
+  }
   return undefined;
 }
 
 export function isMarketplaceService(name: string): boolean {
   return (
     name.startsWith('marketplace/services/') ||
-    name.startsWith('marketplace/agents/')
+    name.startsWith('marketplace/agents/') ||
+    name.startsWith('marketplace/executors/')
   );
 }

--- a/tools/ark-cli/src/types/marketplace.ts
+++ b/tools/ark-cli/src/types/marketplace.ts
@@ -2,7 +2,7 @@ export interface AnthropicMarketplaceItem {
   name: string;
   displayName?: string;
   description: string;
-  type?: 'service' | 'agent';
+  type?: 'service' | 'agent' | 'executor';
   version?: string;
   author?: string;
   homepage?: string;


### PR DESCRIPTION
## Summary

- Add `executor` as a new marketplace component type in the ark CLI, matching the recently introduced executor category in agents-at-scale-marketplace
- Support `marketplace/executors/<name>` paths for install, uninstall, and item lookup
- Display executors in `ark marketplace list` alongside services and agents
- Add bash and zsh shell completions for the LangChain and Claude Agent SDK executors
- Update all related tests with executor mocks and new test cases

## Test plan

- [x] Run `ark marketplace list` and verify executors section appears
- [x] Run `ark install marketplace/executors/langchain` and verify it resolves correctly
- [x] Run `ark uninstall marketplace/executors/langchain` and verify it resolves correctly
- [x] Verify `ark install marketplace/executors/<TAB>` completes executor names
- [x] Run `npm test` in ark-cli — all 458 tests pass