### PR TITLE
fix: query CI/CD workflow runs directly to resolve LAST_RUN_ID lookup

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           GITHUB_REPOSITORY="${{ github.repository }}"
-          LAST_RUN_ID=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs?branch=main&status=success&per_page=100" | jq -c '.workflow_runs[] | select(.name == "CI/CD") | .id' | head -n 1)
+          LAST_RUN_ID=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/cicd.yaml/runs?branch=main&status=success&per_page=1" | jq -c '.workflow_runs[0].id')
           
           echo "Downloading artifacts from run ID: $LAST_RUN_ID"
           gh run download "$LAST_RUN_ID" --repo "$GITHUB_REPOSITORY" --pattern "xray-scan-results-agents-at-scale-*" --dir ./artifacts

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -16,7 +16,7 @@ class BasePage:
     def navigate(self, url: str) -> None:
         self.page.goto(url)
 
-    def _check_toast_popup(self, timeout: int = 5000) -> bool:
+    def _check_toast_popup(self, timeout: int = 15000) -> bool:
         # Note: This does not confirm whether the toast shows success, only waits to see it
         # and logs what it contains.
         try:


### PR DESCRIPTION
Currently we get the last 100 runs on main and search for CI/CD runs within them, but there are now so many other kinds of workflow that this is no longer guaranteed to work. However, there appears to be an endpoint just for getting specific workflow runs directly, so we use this instead.


## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 