### PR TITLE
chore: remove postgres-memory references from project docs

### DIFF
--- a/.claude/skills/analysis/SKILL.md
+++ b/.claude/skills/analysis/SKILL.md
@@ -34,7 +34,6 @@ The Ark repository is organized as follows:
   - Webhooks for validation
 
 - **`services/`** - Supporting services (Go, Python, TypeScript)
-  - `postgres-memory/` - Memory persistence
   - `ark-api/` - REST API
 
 - **`samples/`** - Example configurations (YAML)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,6 @@
   - Webhooks for validation and admission control
 
 - **`services/`** - Supporting services for Ark (Go, Python, TypeScript)
-  - `postgres-memory/` - Memory persistence service (Go)
   - `vnext-ui/` - vNext Next.js web interface (TypeScript/React)
   - `ark-sdk-python/` - Python SDK for Ark resources
   - `arkpy/` - Python CLI and API client


### PR DESCRIPTION
## Summary

- Remove `postgres-memory/` entry from services listing in CLAUDE.md
- Remove `postgres-memory/` entry from analysis skill project structure
- The postgres-memory service directory has already been removed; these are leftover doc references