### PR TITLE
fix: Add browser console and network error logging to UI tests

### DIFF
--- a/tests/pytest/ui-tests/conftest.py
+++ b/tests/pytest/ui-tests/conftest.py
@@ -25,6 +25,10 @@ def pytest_addoption(parser):
         parser.addoption("--skip-install", action="store_true", default=False)
     except ValueError:
         pass
+    try:
+        parser.addoption("--log-browser-console", action="store_true", default=False)
+    except ValueError:
+        pass
 
 
 def get_ark_pods():
@@ -201,9 +205,34 @@ def context(browser, request):
 
 
 @pytest.fixture(scope="function")
-def page(context):
+def page(context, request):
     page = context.new_page()
+
+    console_messages = []
+
+    def handle_console(msg):
+        if msg.type in ("error", "warning"):
+            console_messages.append({"type": msg.type, "text": msg.text})
+
+    def handle_response(response):
+        if response.status >= 400:
+            try:
+                body = response.text()
+            except Exception:
+                body = "<unreadable>"
+            logger.warning(f"HTTP {response.status} {response.request.method} {response.url}: {body[:500]}")
+
+    page.on("console", handle_console)
+    page.on("response", handle_response)
+    page._test_console_messages = console_messages
+
     yield page
+
+    if console_messages and request.config.getoption("--log-browser-console"):
+        logger.info("Browser console errors during test:")
+        for message in console_messages:
+            logger.info(f"\t{message}")
+
     page.close()
 
 

--- a/tests/pytest/ui-tests/conftest.py
+++ b/tests/pytest/ui-tests/conftest.py
@@ -168,6 +168,13 @@ def ark_setup(request, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def screenshots_dir() -> Path:
+    path = Path("screenshots")
+    path.mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture(scope="session")
 def playwright():
     with sync_playwright() as p:
         yield p
@@ -205,8 +212,9 @@ def context(browser, request):
 
 
 @pytest.fixture(scope="function")
-def page(context, request):
+def page(context, request, screenshots_dir):
     page = context.new_page()
+    page._screenshots_dir = screenshots_dir
 
     console_messages = []
 
@@ -243,12 +251,9 @@ def pytest_runtest_makereport(item, call):
     
     if rep.when == "call" and rep.failed:
         page = item.funcargs.get("page")
-        if page:
+        screenshots_dir = item.funcargs.get("screenshots_dir")
+        if page and screenshots_dir:
             try:
-                # Ensure screenshots directory exists
-                screenshots_dir = Path("screenshots")
-                screenshots_dir.mkdir(exist_ok=True)
-                
                 screenshot_path = screenshots_dir / f"{item.name}.png"
                 page.screenshot(path=str(screenshot_path))
                 logger.info(f"Screenshot saved: {screenshot_path}")

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Page, TimeoutError
 
@@ -24,16 +25,19 @@ class BasePage:
             popup_locator.wait_for(state="visible", timeout=timeout)
             logger.info(popup_locator.inner_text())
             return True
-        except TimeoutError:
+        except Exception:
             logger.exception("Did not see expected toast")
-            self._capture_failure_debug("toast_not_visible")
+            page_name = urlsplit(self.page.url).path.replace("/", "_")
+            self._capture_failure_debug(f"toast_not_visible{page_name}")
             return False
 
     def _capture_failure_debug(self, label: str = "failure") -> None:
         try:
-            screenshot_path = f"/tmp/{label}.png"
-            self.page.screenshot(path=screenshot_path, full_page=True)
-            logger.info(f"Screenshot saved: {screenshot_path}")
+            screenshots_dir = getattr(self.page, "_screenshots_dir", None)
+            if screenshots_dir:
+                screenshot_path = screenshots_dir / f"{label}.png"
+                self.page.screenshot(path=screenshot_path, full_page=True)
+                logger.info(f"Screenshot saved: {screenshot_path}")
         except Exception as e:
             logger.warning(f"Screenshot failed: {e}")
 

--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -25,9 +25,33 @@ class BasePage:
             logger.info(popup_locator.inner_text())
             return True
         except TimeoutError:
-            # we don't necessarily want to break if we don't see the popup, but we should at least log it
             logger.exception("Did not see expected toast")
+            self._capture_failure_debug("toast_not_visible")
             return False
+
+    def _capture_failure_debug(self, label: str = "failure") -> None:
+        try:
+            screenshot_path = f"/tmp/{label}.png"
+            self.page.screenshot(path=screenshot_path, full_page=True)
+            logger.info(f"Screenshot saved: {screenshot_path}")
+        except Exception as e:
+            logger.warning(f"Screenshot failed: {e}")
+
+        console_messages = getattr(self.page, "_test_console_messages", [])
+        if console_messages:
+            logger.error(f"Browser console errors: {console_messages}")
+
+        try:
+            dialog = self.page.locator("[role='dialog'], [data-slot='dialog-content']").first
+            if dialog.is_visible(timeout=1000):
+                logger.info(f"Dialog still open. Content: {dialog.inner_text()}")
+                field_errors = self.page.locator("[role='dialog'] [role='alert'], [role='dialog'] .error, [role='dialog'] [aria-invalid='true']").all_inner_texts()
+                if field_errors:
+                    logger.error(f"Field validation errors in dialog: {field_errors}")
+            else:
+                logger.info("Dialog is closed")
+        except Exception as e:
+            logger.warning(f"Could not inspect dialog: {e}")
 
     def is_visible(self, selector: str, timeout: int = 5000) -> bool:
         try:


### PR DESCRIPTION
When tool creation fails intermittently, the only signal was that the toast popup didn't appear. This adds three additional debug signals:

- Network responses: any 4xx/5xx from the API is logged immediately with method, URL, and response body (truncated to 500 chars)
- Browser console errors/warnings: collected throughout the test via Playwright's console event listener, logged at teardown when --log-browser-console is passed
- Dialog state: when the toast doesn't appear, logs whether the dialog is still open and any field-level validation errors inside it
- Screenshot: full-page screenshot saved to /tmp/toast_not_visible_{page}.png on toast timeout

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 