### PR TITLE
fix: relative baseURLs did not resolve properly

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/api/client.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/api/client.test.ts
@@ -263,6 +263,31 @@ describe('APIClient', () => {
     })
   })
 
+  describe('relative baseURL', () => {
+    it('should resolve a relative baseURL against window.location.origin without throwing', async () => {
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'http://localhost:3274' },
+        writable: true,
+      })
+
+      const relativeClient = new APIClient('/api/v1/proxy/services')
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ services: [] }),
+      })
+
+      await relativeClient.get('')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:3274/api/v1/proxy/services?_t=${MOCK_TIMESTAMP}`,
+        expect.anything(),
+      )
+    })
+  })
+
   describe('APIError', () => {
     it('should create error with correct properties', () => {
       const error = new APIError('Test error', 404, { code: 'NOT_FOUND' })

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/api/client.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/api/client.test.ts
@@ -264,10 +264,11 @@ describe('APIClient', () => {
   })
 
   describe('relative baseURL', () => {
-    it('should resolve a relative baseURL against window.location.origin without throwing', async () => {
-      Object.defineProperty(window, 'location', {
+    it('should resolve a relative baseURL against globalThis.location.origin without throwing', async () => {
+      Object.defineProperty(globalThis, 'location', {
         value: { origin: 'http://localhost:3274' },
         writable: true,
+        configurable: true,
       })
 
       const relativeClient = new APIClient('/api/v1/proxy/services')

--- a/services/ark-dashboard/ark-dashboard/lib/api/client.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/client.ts
@@ -34,12 +34,10 @@ class APIClient {
     params?: Record<string, string | number | boolean>,
     method?: string,
   ): string {
-    const base =
-      this.baseURL.startsWith('http') || this.baseURL.startsWith('//')
-        ? this.baseURL
-        : typeof window !== 'undefined'
-          ? `${window.location.origin}${this.baseURL}`
-          : this.baseURL;
+    const isAbsolute = this.baseURL.startsWith('http') || this.baseURL.startsWith('//');
+    const base = isAbsolute || typeof globalThis.location === 'undefined'
+      ? this.baseURL
+      : `${globalThis.location.origin}${this.baseURL}`;
     const url = new URL(endpoint, base);
 
     if (params) {

--- a/services/ark-dashboard/ark-dashboard/lib/api/client.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/client.ts
@@ -34,7 +34,13 @@ class APIClient {
     params?: Record<string, string | number | boolean>,
     method?: string,
   ): string {
-    const url = new URL(endpoint, this.baseURL);
+    const base =
+      this.baseURL.startsWith('http') || this.baseURL.startsWith('//')
+        ? this.baseURL
+        : typeof window !== 'undefined'
+          ? `${window.location.origin}${this.baseURL}`
+          : this.baseURL;
+    const url = new URL(endpoint, base);
 
     if (params) {
       Object.entries(params).forEach(([key, value]) => {


### PR DESCRIPTION
Creating a URL object doesn't work with a relative URL, so we need to work it out explicitly using window.location.origin.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 