### PR TITLE
fix: skip known bots in Ark Agent to avoid wasting runners

### DIFF
--- a/.github/workflows/ark_agent.yml
+++ b/.github/workflows/ark_agent.yml
@@ -67,6 +67,16 @@ concurrency:
 
 jobs:
   ark-agent:
+    # Skip known bots to avoid wasting a runner on every automated comment
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.sender.login != 'dependabot[bot]' &&
+        github.event.sender.login != 'mckinsey-sq[bot]' &&
+        github.event.sender.login != 'aas-ark-bot[bot]' &&
+        github.event.sender.login != 'github-actions[bot]' &&
+        github.event.sender.login != 'allcontributors[bot]'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary
- Skip dependabot, mckinsey-sq, aas-ark-bot, github-actions, and allcontributors bots at job level before a runner is allocated
- Previously every bot comment spun up a runner for ~6s just to reject it