### PR TITLE
fix: correct QB logo height to match SVG intrinsic dimensions

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/app-sidebar.tsx
@@ -250,7 +250,7 @@ export function AppSidebar() {
                     }
                     alt="QB Logo"
                     width={32}
-                    height={32}
+                    height={28}
                   />
                 </div>
                 <div className="flex flex-col gap-0.5 leading-none">


### PR DESCRIPTION
The SVG is 32x28 but the Image component was set to 32x32, distorting the logo and triggering a Next.js aspect ratio warning. The difference isn't particularly visible, but it means less noise in the console so that we are more likely to see important warnings.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 