### PR TITLE
fix: PostgreSQL soft-delete — resolve 8KB pg_notify limit for cross-replica watch events

### DIFF
--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -35,7 +35,7 @@ func parseLabelSelector(selector string) (map[string]string, error) {
 			continue
 		}
 		if strings.Contains(part, "!=") || strings.Contains(part, " in ") || strings.Contains(part, " notin ") || strings.HasPrefix(part, "!") {
-			return nil, fmt.Errorf("unsupported label selector operator in %q, only equality (=, ==) is supported in SQL", part)
+			return nil, fmt.Errorf("unsupported label selector operator in %q, only equality (=, ==) is supported", part)
 		}
 		kv := strings.SplitN(part, "=", 2)
 		if len(kv) != 2 {
@@ -125,6 +125,7 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 	backend.warmPool()
 	go backend.listenForNotifications()
 	go backend.refreshBookmarkLoop()
+	go backend.cleanupLoop()
 
 	return backend, nil
 }
@@ -163,41 +164,24 @@ func (p *PostgreSQLBackend) initSchema() error {
 		finalizers JSONB DEFAULT '[]',
 		created_at TIMESTAMPTZ DEFAULT NOW(),
 		updated_at TIMESTAMPTZ DEFAULT NOW(),
-		deleted_at TIMESTAMPTZ,
-		UNIQUE(kind, namespace, name)
+		deleted_at TIMESTAMPTZ
 	);
 	ALTER TABLE resources ADD COLUMN IF NOT EXISTS finalizers JSONB DEFAULT '[]';
 	ALTER TABLE resources ADD COLUMN IF NOT EXISTS owner_references JSONB DEFAULT '[]';
+
+	ALTER TABLE resources DROP CONSTRAINT IF EXISTS resources_kind_namespace_name_key;
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_unique_active ON resources(kind, namespace, name) WHERE deleted_at IS NULL;
 
 	CREATE INDEX IF NOT EXISTS idx_resources_kind_namespace ON resources(kind, namespace);
 	CREATE INDEX IF NOT EXISTS idx_resources_kind_namespace_name ON resources(kind, namespace, name);
 	CREATE INDEX IF NOT EXISTS idx_resources_labels ON resources USING GIN(labels);
 	CREATE INDEX IF NOT EXISTS idx_resources_lookup ON resources(kind, namespace, name, resource_version);
+	CREATE INDEX IF NOT EXISTS idx_resources_deleted ON resources(deleted_at) WHERE deleted_at IS NOT NULL;
 
 	CREATE OR REPLACE FUNCTION notify_resource_change()
 	RETURNS TRIGGER AS $$
 	BEGIN
-		IF TG_OP = 'DELETE' THEN
-			PERFORM pg_notify('ark_resources', json_build_object(
-				'operation', TG_OP,
-				'kind', OLD.kind,
-				'namespace', OLD.namespace,
-				'name', OLD.name,
-				'resource_version', OLD.resource_version,
-				'uid', OLD.uid,
-				'spec', OLD.spec,
-				'status', OLD.status,
-				'labels', OLD.labels,
-				'annotations', OLD.annotations,
-				'finalizers', OLD.finalizers,
-				'owner_references', OLD.owner_references,
-				'generation', OLD.generation,
-				'created_at', OLD.created_at
-			)::text);
-			RETURN OLD;
-		END IF;
 		PERFORM pg_notify('ark_resources', json_build_object(
-			'operation', TG_OP,
 			'kind', NEW.kind,
 			'namespace', NEW.namespace,
 			'name', NEW.name,
@@ -209,7 +193,7 @@ func (p *PostgreSQLBackend) initSchema() error {
 
 	DROP TRIGGER IF EXISTS resource_change_trigger ON resources;
 	CREATE TRIGGER resource_change_trigger
-	AFTER INSERT OR UPDATE OR DELETE ON resources
+	AFTER INSERT OR UPDATE ON resources
 	FOR EACH ROW EXECUTE FUNCTION notify_resource_change();
 	`
 	_, err := p.db.Exec(schema)
@@ -295,6 +279,19 @@ func (p *PostgreSQLBackend) refreshCachedRV() {
 	p.cachedRV.Store(rv)
 }
 
+func (p *PostgreSQLBackend) cleanupLoop() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			_, _ = p.db.ExecContext(p.ctx, `DELETE FROM resources WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - INTERVAL '5 minutes'`)
+		}
+	}
+}
+
 func (p *PostgreSQLBackend) Create(ctx context.Context, kind, namespace, name string, obj runtime.Object) error {
 	data, err := p.converter.Encode(obj)
 	if err != nil {
@@ -361,7 +358,7 @@ func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name strin
 	row := p.db.QueryRowContext(ctx, `
 		SELECT resource_version, generation, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, updated_at
 		FROM resources
-		WHERE kind = $1 AND namespace = $2 AND name = $3	`, kind, namespace, name)
+		WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL`, kind, namespace, name)
 
 	var rv, generation int64
 	var uid string
@@ -382,7 +379,7 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 	query := `
 		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at
 		FROM resources
-		WHERE kind = $1	`
+		WHERE kind = $1 AND deleted_at IS NULL`
 	args := []interface{}{kind}
 	argIndex := 2
 
@@ -527,7 +524,7 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 			SET spec = $1::jsonb, status = $2::jsonb, labels = $3::jsonb, annotations = $4::jsonb,
 			    finalizers = $5::jsonb, owner_references = $6::jsonb,
 			    generation = generation + 1, resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
-			WHERE kind = $7 AND namespace = $8 AND name = $9 AND resource_version = $10
+			WHERE kind = $7 AND namespace = $8 AND name = $9 AND resource_version = $10 AND deleted_at IS NULL
 			RETURNING resource_version, generation, uid, created_at
 		)
 		SELECT resource_version, generation, uid, created_at, true FROM upd
@@ -587,7 +584,7 @@ func (p *PostgreSQLBackend) UpdateStatus(ctx context.Context, kind, namespace, n
 		WITH upd AS (
 			UPDATE resources
 			SET status = $1::jsonb, resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
-			WHERE kind = $2 AND namespace = $3 AND name = $4 AND resource_version = $5
+			WHERE kind = $2 AND namespace = $3 AND name = $4 AND resource_version = $5 AND deleted_at IS NULL
 			RETURNING resource_version
 		)
 		SELECT resource_version, true FROM upd
@@ -612,8 +609,9 @@ func (p *PostgreSQLBackend) UpdateStatus(ctx context.Context, kind, namespace, n
 
 func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name string) error {
 	result, err := p.db.ExecContext(ctx, `
-		DELETE FROM resources
-		WHERE kind = $1 AND namespace = $2 AND name = $3
+		UPDATE resources
+		SET deleted_at = NOW(), resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
+		WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL
 	`, kind, namespace, name)
 	if err != nil {
 		return fmt.Errorf("failed to delete resource: %w", err)
@@ -621,14 +619,13 @@ func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name st
 
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
-		return fmt.Errorf("not found")
+		return storage.ErrNotFound
 	}
 
 	return nil
 }
 
 func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, opts storage.WatchOptions) (watch.Interface, error) {
-	ch := make(chan watch.Event, 100)
 	key := fmt.Sprintf("%s/%s", kind, namespace)
 
 	labelFilter, err := parseLabelSelector(opts.LabelSelector)
@@ -637,7 +634,6 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 	}
 
 	w := &postgresWatcher{
-		ch:          ch,
 		outCh:       make(chan watch.Event, 100),
 		nudgeCh:     make(chan struct{}, 1),
 		backend:     p,
@@ -663,7 +659,7 @@ func (p *PostgreSQLBackend) GetResourceVersion(ctx context.Context, kind, namesp
 	var rv int64
 	err := p.db.QueryRowContext(ctx, `
 		SELECT resource_version FROM resources
-		WHERE kind = $1 AND namespace = $2 AND name = $3	`, kind, namespace, name).Scan(&rv)
+		WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL`, kind, namespace, name).Scan(&rv)
 	return rv, err
 }
 
@@ -720,63 +716,12 @@ func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, 
 	return p.converter.Decode(kind, data)
 }
 
-func (p *PostgreSQLBackend) sendDeleteEvent(kind, namespace string, obj runtime.Object) {
-	key := fmt.Sprintf("%s/%s", kind, namespace)
-	allKey := fmt.Sprintf("%s/", kind)
-
-	p.mu.RLock()
-	watchers := make([]*postgresWatcher, 0, len(p.watchers[key])+len(p.watchers[allKey]))
-	watchers = append(watchers, p.watchers[key]...)
-	if namespace != "" {
-		watchers = append(watchers, p.watchers[allKey]...)
-	}
-	p.mu.RUnlock()
-
-	event := watch.Event{Type: watch.Deleted, Object: obj}
-	for _, w := range watchers {
-		w.send(event)
-	}
-}
-
 func (p *PostgreSQLBackend) nudgeWatchers(payload string) {
 	var notification struct {
-		Operation       string          `json:"operation"`
-		Kind            string          `json:"kind"`
-		Namespace       string          `json:"namespace"`
-		Name            string          `json:"name"`
-		ResourceVersion int64           `json:"resource_version"`
-		UID             string          `json:"uid"`
-		Spec            json.RawMessage `json:"spec"`
-		Status          json.RawMessage `json:"status"`
-		Labels          json.RawMessage `json:"labels"`
-		Annotations     json.RawMessage `json:"annotations"`
-		Finalizers      json.RawMessage `json:"finalizers"`
-		OwnerReferences json.RawMessage `json:"owner_references"`
-		Generation      int64           `json:"generation"`
-		CreatedAt       time.Time       `json:"created_at"`
+		Kind      string `json:"kind"`
+		Namespace string `json:"namespace"`
 	}
 	if err := json.Unmarshal([]byte(payload), &notification); err != nil {
-		return
-	}
-
-	if notification.Operation == "DELETE" {
-		obj, _ := p.reconstructObject(
-			notification.Kind, notification.Namespace, notification.Name,
-			notification.ResourceVersion, notification.Generation, notification.UID,
-			string(notification.Spec), string(notification.Status),
-			string(notification.Labels), string(notification.Annotations),
-			string(notification.Finalizers), string(notification.OwnerReferences),
-			notification.CreatedAt,
-		)
-		if obj == nil {
-			return
-		}
-		if accessor, err := meta.Accessor(obj); err == nil {
-			accessor.SetName(notification.Name)
-			accessor.SetNamespace(notification.Namespace)
-			accessor.SetResourceVersion(fmt.Sprintf("%d", notification.ResourceVersion))
-		}
-		p.sendDeleteEvent(notification.Kind, notification.Namespace, obj)
 		return
 	}
 
@@ -824,36 +769,21 @@ func (p *PostgreSQLBackend) getMaxResourceVersion() (int64, error) {
 	return rv.Int64, nil
 }
 
-// postgresWatcher implements watch.Interface with panic-safe channel ownership.
-// The run() goroutine is the sole owner of outCh — only run() closes it on exit.
-// send() writes to the internal ch (never closed by Stop), and run() forwards
-// from ch to outCh. This eliminates all send-on-closed-channel races.
 type postgresWatcher struct {
-	ch          chan watch.Event
-	outCh       chan watch.Event
-	nudgeCh     chan struct{}
-	backend     *PostgreSQLBackend
-	key         string
-	kind        string
-	ns          string
-	labelFilter map[string]string
-	ctx         context.Context
-	done        chan struct{}
-	stopped            atomic.Bool
-	closed             sync.Once
-	lastSeenRV         atomic.Int64
-	initialList        bool
-	initialListDone    bool
-}
-
-func (w *postgresWatcher) send(event watch.Event) {
-	if w.stopped.Load() {
-		return
-	}
-	select {
-	case w.ch <- event:
-	default:
-	}
+	outCh           chan watch.Event
+	nudgeCh         chan struct{}
+	backend         *PostgreSQLBackend
+	key             string
+	kind            string
+	ns              string
+	labelFilter     map[string]string
+	ctx             context.Context
+	done            chan struct{}
+	stopped         atomic.Bool
+	closed          sync.Once
+	lastSeenRV      atomic.Int64
+	initialList     bool
+	initialListDone bool
 }
 
 func (w *postgresWatcher) Stop() {
@@ -888,14 +818,6 @@ func (w *postgresWatcher) run() {
 			return
 		case <-w.ctx.Done():
 			return
-		case ev := <-w.ch:
-			select {
-			case w.outCh <- ev:
-			case <-w.done:
-				return
-			case <-w.ctx.Done():
-				return
-			}
 		case <-bookmarkTicker.C:
 			w.sendBookmark()
 		case <-relistTicker.C:
@@ -908,6 +830,9 @@ func (w *postgresWatcher) run() {
 
 func (w *postgresWatcher) sendBookmark() {
 	rv := w.backend.cachedRV.Load()
+	if lastSeen := w.lastSeenRV.Load(); lastSeen > rv {
+		rv = lastSeen
+	}
 	if rv == 0 {
 		return
 	}
@@ -944,12 +869,12 @@ func (w *postgresWatcher) relist() {
 	lastRV := w.lastSeenRV.Load()
 
 	query := `
-		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at
+		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deleted_at
 		FROM resources
 		WHERE kind = $1 AND resource_version > $2`
 	args := []interface{}{w.kind, lastRV}
-
 	argIndex := 3
+
 	if w.ns != "" {
 		query += fmt.Sprintf(` AND namespace = $%d`, argIndex)
 		args = append(args, w.ns)
@@ -960,6 +885,7 @@ func (w *postgresWatcher) relist() {
 		labelJSON, _ := json.Marshal(w.labelFilter)
 		query += fmt.Sprintf(` AND labels @> $%d::jsonb`, argIndex)
 		args = append(args, string(labelJSON))
+		_ = argIndex
 	}
 
 	query += ` ORDER BY resource_version ASC`
@@ -975,8 +901,9 @@ func (w *postgresWatcher) relist() {
 		var ns, name, uid string
 		var spec, status, labels, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
+		var deletedAt sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt); err != nil {
 			return
 		}
 
@@ -985,10 +912,16 @@ func (w *postgresWatcher) relist() {
 			continue
 		}
 
-		eventType := watch.Modified
-		if w.initialList {
+		var eventType watch.EventType
+		switch {
+		case deletedAt.Valid:
+			eventType = watch.Deleted
+		case w.initialList:
 			eventType = watch.Added
+		default:
+			eventType = watch.Modified
 		}
+
 		w.advanceRV(rv)
 		select {
 		case w.outCh <- watch.Event{Type: eventType, Object: obj}:

--- a/tests/agent-structured-output/chainsaw-test.yaml
+++ b/tests/agent-structured-output/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
     apply: 30s
     # Extended timeout as model probes can take time to validate availability
     assert: 120s
-    cleanup: 30s
+    cleanup: 3m
   steps:
   - name: deploy-resources
     try:


### PR DESCRIPTION
## Summary

- Replaces hard-delete with soft-delete (`UPDATE SET deleted_at`) in PostgreSQL storage backend
- Fixes 5 E2E test failures caused by `pg_notify` 8KB payload limit on DELETE events (`team-graph`, `team-of-teams`, `model-token-usage`, `query-parameter-ref`, `agent-structured-output`)
- Aligns `agent-structured-output` cleanup timeout with global chainsaw default (30s → 3m)

### How it works

Soft-deleted rows stay in the database with `deleted_at` set and `resource_version` bumped. Watchers detect deletions via relist (polling for `resource_version > lastSeenRV`) — no large payloads through `pg_notify`. A partial unique index (`WHERE deleted_at IS NULL`) prevents the duplicate-key-on-recreate issue that originally motivated hard-delete. A cleanup goroutine purges soft-deleted rows after 5 minutes.

### Also includes

- Label selector filtering in `List()` and `Watch()` (from #1524)
- `storage.ErrNotFound` returns in `Get()`/`Delete()` (from #1523)
- Listener reconnect with exponential backoff (from #1523)
- Bookmark `initial-events-end` annotation sent only once (from #1523)
- `AND deleted_at IS NULL` added to `Update()`/`UpdateStatus()` WHERE clauses

### Supersedes

- #1523 (pre-existing bug fixes)
- #1524 (label selector filtering)
- #1526 (combined PR — hit 8KB limit)

### Validated

- `go vet`, `go build`, `golangci-lint`: clean
- `go test ./...`: all pass
- Local k3s E2E (chainsaw, postgresql backend): 49 pass, 2 skip, 1 infra timeout