### PR TITLE
fix: remove overzealous error detection in UI test

### DIFF
--- a/tests/pytest/ui-tests/pages/agents_page.py
+++ b/tests/pytest/ui-tests/pages/agents_page.py
@@ -68,7 +68,6 @@ class AgentsPage(BasePage):
             "[role='alert']:has-text('error')",
             "[role='alert']:has-text('Error')",
             "[role='alert']:has-text('500')",
-            "div:has-text('500'):has-text('error')",
             "div:has-text('Internal Server Error')",
             ".error, .alert-error, .notification-error",
             "[class*='error'][class*='banner']",


### PR DESCRIPTION
This would detect an error if any model, agent, tool, etc. had "500" and "error" anywhere in their name or description. This means that we could get false errors for example when a tool describes its errors and a model's timestamped name happened to have a "500" in it.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 