### PR TITLE
fix: convert raw storage errors to proper Kubernetes API errors in StatusStorage

### DIFF
--- a/ark/internal/apiserver/registry/status.go
+++ b/ark/internal/apiserver/registry/status.go
@@ -9,11 +9,14 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"mckinsey.com/ark/internal/apiserver/metrics"
 	"mckinsey.com/ark/internal/storage"
 )
@@ -53,7 +56,11 @@ func (s *StatusStorage) Get(ctx context.Context, name string, options *metav1.Ge
 	namespace := getNamespaceFromContext(ctx)
 	sctx, cancel := storageContext(ctx)
 	defer cancel()
-	return s.backend.Get(sctx, s.config.Kind, namespace, name)
+	obj, err := s.backend.Get(sctx, s.config.Kind, namespace, name)
+	if err != nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: arkv1alpha1.GroupVersion.Group, Resource: s.config.Resource}, name)
+	}
+	return obj, nil
 }
 
 func (s *StatusStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
@@ -65,7 +72,7 @@ func (s *StatusStorage) Update(ctx context.Context, name string, objInfo rest.Up
 	existing, err := s.backend.Get(sctx, s.config.Kind, namespace, name)
 	if err != nil {
 		metrics.RecordStorageOperation("update_status", s.config.Kind, "not_found")
-		return nil, false, fmt.Errorf("object not found: %w", err)
+		return nil, false, apierrors.NewNotFound(schema.GroupResource{Group: arkv1alpha1.GroupVersion.Group, Resource: s.config.Resource}, name)
 	}
 
 	updated, err := objInfo.UpdatedObject(ctx, existing)
@@ -92,7 +99,10 @@ func (s *StatusStorage) Update(ctx context.Context, name string, objInfo rest.Up
 	metrics.RecordStorageOperation("update_status", s.config.Kind, "success")
 	metrics.RecordStorageLatency("update_status", s.config.Kind, start)
 	result, err := s.backend.Get(sctx, s.config.Kind, namespace, accessor.GetName())
-	return result, false, err
+	if err != nil {
+		return nil, false, apierrors.NewNotFound(schema.GroupResource{Group: arkv1alpha1.GroupVersion.Group, Resource: s.config.Resource}, name)
+	}
+	return result, false, nil
 }
 
 func getNamespaceFromContext(ctx context.Context) string {

--- a/ark/internal/apiserver/registry/storage.go
+++ b/ark/internal/apiserver/registry/storage.go
@@ -124,7 +124,7 @@ func (s *GenericStorage) List(ctx context.Context, options *metainternalversion.
 	if err != nil {
 		metrics.RecordStorageOperation("list", s.config.Kind, "error")
 		metrics.RecordStorageLatency("list", s.config.Kind, start)
-		return nil, fmt.Errorf("failed to list %s: %w", s.config.Resource, err)
+		return nil, apierrors.NewInternalError(fmt.Errorf("failed to list %s: %w", s.config.Resource, err))
 	}
 
 	list := s.config.NewListFunc()
@@ -242,9 +242,7 @@ func (s *GenericStorage) Delete(ctx context.Context, name string, deleteValidati
 	}
 
 	if err := s.backend.Delete(sctx, s.config.Kind, namespace, name); err != nil {
-		metrics.RecordStorageOperation("delete", s.config.Kind, "error")
-		metrics.RecordStorageLatency("delete", s.config.Kind, start)
-		return nil, false, fmt.Errorf("failed to delete %s: %w", s.config.SingularName, err)
+		return nil, false, handleUpdateError(err, s.config, "delete", name, start)
 	}
 
 	metrics.RecordStorageOperation("delete", s.config.Kind, "success")


### PR DESCRIPTION
## Summary

- `StatusStorage.Get()` and `StatusStorage.Update()` returned raw Go errors to the K8s API server, causing `apiserver received an error that is not an metav1.Status` warnings and 503 ServiceUnavailable responses under parallel E2E test load
- This was the root cause of the `team-sequential` and `team-selector-invalid-agent` failures on the postgresql backend in #1574
- All error paths in StatusStorage now return proper `apierrors.NewNotFound()` / `apierrors.NewInternalError()`
- `GenericStorage.Delete()` and `GenericStorage.List()` also fixed for consistency

Targets `fix/build-consolidation` (#1574) to fix the CI failures.

Validated locally: both failing tests pass with this fix.