### PR TITLE
fix: Fix race condition in test_create_agent_with_tools

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Label } from '@radix-ui/react-label';
 import { Maximize2, Minimize2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
@@ -135,14 +135,16 @@ export function ToolEditor({
   });
 
   const selectedType = form.watch('type');
+  const { reset } = form;
 
-  useEffect(() => {
-    if (open) {
-      form.reset();
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      reset();
       setIsInputSchemaExpanded(false);
       setIsAnnotationsExpanded(false);
     }
-  }, [open, form]);
+    onOpenChange(newOpen);
+  };
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     let parsedInputSchema: Record<string, unknown> | undefined;
@@ -182,11 +184,11 @@ export function ToolEditor({
     };
 
     onSave(toolSpec);
-    onOpenChange(false);
+    handleOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Create New Tool</DialogTitle>
@@ -464,7 +466,7 @@ export function ToolEditor({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => onOpenChange(false)}
+                onClick={() => handleOpenChange(false)}
                 disabled={form.formState.isSubmitting}>
                 Cancel
               </Button>

--- a/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Label } from '@radix-ui/react-label';
 import { Maximize2, Minimize2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
@@ -136,14 +136,13 @@ export function ToolEditor({
 
   const selectedType = form.watch('type');
 
-  const handleOpenChange = (newOpen: boolean) => {
-    if (!newOpen) {
+  useEffect(() => {
+    if (open) {
       form.reset();
       setIsInputSchemaExpanded(false);
       setIsAnnotationsExpanded(false);
     }
-    onOpenChange(newOpen);
-  };
+  }, [open, form]);
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     let parsedInputSchema: Record<string, unknown> | undefined;
@@ -183,11 +182,11 @@ export function ToolEditor({
     };
 
     onSave(toolSpec);
-    handleOpenChange(false);
+    onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Create New Tool</DialogTitle>
@@ -465,7 +464,7 @@ export function ToolEditor({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => handleOpenChange(false)}
+                onClick={() => onOpenChange(false)}
                 disabled={form.formState.isSubmitting}>
                 Cancel
               </Button>

--- a/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
@@ -135,11 +135,10 @@ export function ToolEditor({
   });
 
   const selectedType = form.watch('type');
-  const { reset } = form;
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
-      reset();
+      form.reset();
       setIsInputSchemaExpanded(false);
       setIsAnnotationsExpanded(false);
     }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -891,5 +891,18 @@ chainsaw test tests/ --test-dir tests/queries --pause-on-failure
 
 ### Validation
 - Each test should pass independently when run individually
+
+## Playwright UI Testing
+
+### Radix UI Select
+
+Radix UI Select uses Floating UI to position the dropdown portal after mount. Until positioning completes, the portal DOM nodes can be replaced, causing "element was detached from the DOM". Wait for `[role='listbox'][data-side]` — Floating UI sets `data-side` once positioning is done.
+
+```python
+trigger.click()
+page.locator("[role='listbox'][data-side]").wait_for(state="visible", timeout=15000)
+page.locator("[role='option']:has-text('HTTP')").first.click()
+```
+
 - Query tests should reach `phase: done`
 - No RBAC permission errors in events

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -87,8 +87,8 @@ class ToolsPage(BasePage):
         type_trigger.wait_for(state="visible", timeout=15000)
         type_trigger.click()
         
+        self.page.locator("[role='listbox'][data-side]").wait_for(state="visible", timeout=15000)
         http_option = self.page.locator("[role='option']:has-text('HTTP')").first
-        http_option.wait_for(state="visible", timeout=15000)
         http_option.click()
         
         description_input = self.page.locator("input#description, input[name='description'], [role='dialog'] input:nth-of-type(2)").first

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -84,32 +84,20 @@ class ToolsPage(BasePage):
         logger.info(f"Name in name input is {name_input.input_value()}")
         
         type_trigger = self.page.locator("button#type, button[name='type'], [role='combobox']:has-text('Select'), [data-slot='trigger']").first
-        type_trigger.wait_for(state="visible", timeout=5000)
+        type_trigger.wait_for(state="visible", timeout=15000)
         type_trigger.click()
         
-        self.wait_for_dropdown_options()
-        for attempt in range(3):
-            try:
-                http_option = self.page.get_by_role("option", name="HTTP", exact=True)
-                if http_option.count() == 0:
-                    http_option = self.page.locator("[role='option']:has-text('HTTP')").first
-                http_option.wait_for(state="visible", timeout=5000)
-                self.page.wait_for_timeout(300)
-                http_option.click(force=True, timeout=5000)
-                break
-            except Exception as e:
-                logger.info(f"HTTP option click failed (attempt {attempt + 1}/3): {e}")
-                if attempt < 2:
-                    type_trigger.click()
-                    self.wait_for_dropdown_options()
+        http_option = self.page.locator("[role='option']:has-text('HTTP')").first
+        http_option.wait_for(state="visible", timeout=15000)
+        http_option.click()
         
         description_input = self.page.locator("input#description, input[name='description'], [role='dialog'] input:nth-of-type(2)").first
-        description_input.wait_for(state="visible", timeout=5000)
+        description_input.wait_for(state="visible", timeout=15000)
         description_input.fill(description)
         
         input_schema = '{"type": "object", "properties": {"city": {"type": "string", "description": "City name to get coordinates for"}}, "required": ["city"]}'
         schema_textarea = self.page.locator("textarea#inputSchema, textarea[name='inputSchema'], [role='dialog'] textarea").first
-        schema_textarea.wait_for(state="visible", timeout=5000)
+        schema_textarea.wait_for(state="visible", timeout=15000)
         schema_textarea.fill(input_schema)
         
         dialog = self.page.locator("[role='dialog'], [data-slot='dialog-content']").first
@@ -137,13 +125,8 @@ class ToolsPage(BasePage):
         save_button.scroll_into_view_if_needed()
         save_button.click(force=True)
         
-        error_banner = self.page.locator("[data-sonner-toast][data-type='error'], [role='alert']:not([role='dialog'] *)").first
-        if error_banner.count() > 0 and error_banner.is_visible():
-            error_text = error_banner.inner_text()
-            logger.error(f"Tool creation error: {error_text}")
-        
         popup_visible = self._check_toast_popup()
-        logger.info(f"Success popup visible: {popup_visible}")
+        logger.info(f"Toast visible: {popup_visible}")
         
         self.wait_for_modal_close()
         
@@ -228,7 +211,10 @@ class ToolsPage(BasePage):
             description=tool_data["description"],
             url=tool_data["url"]
         )
-        
-        logger.info(f"Tool created successfully: {result['name']}")
+
+        if result['in_table']:
+            logger.info(f"Tool created successfully: {result['name']}")
+        else:
+            logger.info("Tool not visible in table")
         
         return result


### PR DESCRIPTION
The test_create_agent_with_tools test was intermittently failing with "Tool creation popup should be visible" and a form validation error of "Name is required", despite logs confirming the name was correctly filled.

Root cause: Radix UI Select renders its options into a DOM portal and uses Floating UI to calculate positioning after mount. Until Floating UI completes its positioning pass, the portal DOM nodes can be replaced mid-render. Playwright holds a reference to the original node, which becomes detached, causing repeated "element was detached from the DOM" retries until timeout. The previous retry loop worked around this by re-clicking the trigger to reopen the dropdown, but this introduced other fragility.

Fix: wait for `[role='listbox'][data-side]` to be visible before clicking the HTTP option. Floating UI sets the `data-side` attribute once positioning is complete and the DOM is stable. This gives a reliable signal that the option is safe to click.

Also:
- Increases all the timeouts in that part of the page
- Removes the error banner check which seemed to just match to a white square; any field validation error text will be found when looking for the toast
- Updates the final message to avoid the situation where the test falsely reports that the tool was created and then fails because the tool was not in fact created

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101