### PR TITLE
feat(marketplace): add OpenSpec proposal for marketplace service UI

### DIFF
--- a/openspec/changes/marketplace-service-ui/.openspec.yaml
+++ b/openspec/changes/marketplace-service-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/marketplace-service-ui/design.md
+++ b/openspec/changes/marketplace-service-ui/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The Ark dashboard has two separate pages that deal with installed services:
+
+1. **Marketplace page** (`/marketplace`) — lists items from a GitHub-hosted `marketplace.json` manifest, detects installation status by cross-referencing with cluster resources (CRDs and labeled Deployments via PR #1440), supports install/uninstall actions.
+
+2. **Services page** (`/services`) — lists Helm releases via `ark-api /v1/ark-services`, discovers URLs by matching HTTPRoute annotations to Helm release names, and renders clickable links. This page has known issues: hardcoded port assumptions (port 8080 for localhost-gateway), reliance on nip.io hostnames, and no support for Ingress or LoadBalancer networking setups.
+
+PR #1440 established a pattern for marketplace installation detection: the marketplace manifest declares item metadata, Deployments in the cluster are labeled with `ark.mckinsey.com/marketplace-item`, and the dashboard queries these labeled Deployments via ark-api's `/v1/resources` endpoint with `labelSelector` support. Post-install hooks (Helm jobs) automate the labeling.
+
+This design extends that pattern to also carry UI URL information, and uses it to sunset the services page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Marketplace items that expose a web UI can surface an "Open" link in the dashboard
+- URL discovery works regardless of networking setup (Ingress, Gateway API, LoadBalancer, port-forward)
+- The services page functionality is fully absorbed by the marketplace page
+- Follow the same patterns as PR #1440 (label on Deployment, dashboard-side logic, manifest declares intent)
+
+**Non-Goals:**
+- Embedded/iframe UIs within the dashboard (future work)
+- OIDC token passthrough to marketplace item UIs (future work)
+- Automatic URL detection from Ingress/HTTPRoute/Gateway resources (too fragile across setups)
+- Cross-namespace resource discovery (deferred; requires ClusterRole)
+
+## Decisions
+
+### 1. UI URL carried as annotation on the labeled Deployment
+
+The same Deployment that PR #1440 labels with `ark.mckinsey.com/marketplace-item` also carries an annotation `ark.mckinsey.com/ui-url` with the complete, ready-to-use URL.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ark.mckinsey.com/marketplace-item: phoenix
+  annotations:
+    ark.mckinsey.com/ui-url: "https://phoenix.example.com"
+```
+
+**Why this over auto-discovery from networking resources:**
+Reconstructing a URL from HTTPRoute/Ingress/Service resources requires chasing references (HTTPRoute → Gateway → listener for scheme and port), handling multiple resource types, and still can't reliably determine scheme, external port, or sub-paths. An annotation is explicit, works with any networking setup, and follows the Kubernetes convention of labels for selection and annotations for metadata (like `external-dns.alpha.kubernetes.io/hostname` or `cert-manager.io/cluster-issuer`).
+
+**Why on the Deployment, not a separate ConfigMap or networking resource:**
+The Deployment is already queried for installation detection. Adding an annotation to the same resource means zero additional API calls. Not all items have networking resources (some are local-only), but all installed items have a Deployment.
+
+### 2. Manifest declares UI intent via `ark.ui` field
+
+```json
+{
+  "name": "phoenix",
+  "ark": {
+    "helmReleaseName": "phoenix",
+    "k8sServiceName": "phoenix",
+    "k8sServicePort": 6006,
+    "ui": {
+      "enabled": true
+    }
+  }
+}
+```
+
+`ark.ui.enabled: true` means "this item has a web UI." The dashboard uses this to know which items should show an "Open" button (when a URL is available) or port-forward instructions (when no URL is configured).
+
+Items without `ark.ui` or with `ark.ui.enabled: false` never show UI-related controls.
+
+### 3. Fallback to port-forward instructions
+
+When `ark.ui.enabled: true` but no `ark.mckinsey.com/ui-url` annotation is found on the Deployment, the dashboard renders port-forward instructions using manifest data:
+
+```
+kubectl port-forward svc/phoenix 6006:6006
+```
+
+This uses `ark.k8sServiceName` and `ark.k8sServicePort` which are already in the manifest.
+
+### 4. Dashboard reads annotation in existing detection flow
+
+The dashboard already queries labeled Deployments via ark-api's `/v1/resources` endpoint (PR #1440). The response includes the full Deployment object with metadata. The dashboard reads `metadata.annotations["ark.mckinsey.com/ui-url"]` from the same response — no additional API call.
+
+Flow:
+1. Fetch marketplace manifest (existing)
+2. For items with `ark.ui.enabled`, query labeled Deployment (existing PR #1440 flow)
+3. Read `ark.mckinsey.com/ui-url` annotation from the Deployment response
+4. Attach URL to `MarketplaceItem` as `uiUrl` field
+5. Render "Open" button if `uiUrl` present, port-forward instructions if absent
+
+### 5. Post-install hooks set the annotation
+
+The marketplace repository's post-install hooks (which already label Deployments per PR #1440) are extended to also set the `ark.mckinsey.com/ui-url` annotation. The URL is derived from Helm values at install time.
+
+### 6. Services page sunset via phased removal
+
+Phase 1: Add "Open" button to marketplace page for items with URLs.
+Phase 2: Add "Installed" filter view to marketplace page.
+Phase 3: Remove services page from navigation, add redirect.
+Phase 4: Remove services page code and ark-services API endpoint.
+
+## Risks / Trade-offs
+
+- **Admin must set the annotation for custom networking setups** → Acceptable trade-off. The admin who sets up Ingress/Gateway is the one who knows the URL. Marketplace Helm charts can template the annotation from values. Documentation will cover how to set it manually.
+
+- **URL can become stale if networking changes** → The annotation is static. If an admin changes the Ingress hostname, they need to update the annotation. This matches how other annotation-based systems (external-dns, cert-manager) work. Mitigation: documentation.
+
+- **Depends on PR #1440** → This work cannot start until PR #1440 is merged. Dashboard UI work (card changes, detail page) can be developed in parallel with mocked data.
+
+- **Cross-namespace items won't have URL detection** → Items deployed outside ark-api's namespace can't be queried for Deployment annotations without ClusterRole. Deferred to future work. For now, these items show as "installed" (via PR #1440's `installScope: "cluster"` badge) but without an "Open" button.

--- a/openspec/changes/marketplace-service-ui/proposal.md
+++ b/openspec/changes/marketplace-service-ui/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Marketplace items that expose web UIs (Phoenix, Langfuse, A2A Inspector, etc.) have no way to surface their UI through the Ark dashboard. The current services page attempts this but relies on fragile assumptions about port-forwarding and nip.io routing, making it unreliable across different networking setups (Ingress, Gateway API, LoadBalancer, local). By adding UI URL support directly to the marketplace page, we can provide a reliable "Open" action for installed services and sunset the services page entirely.
+
+## What Changes
+
+- Marketplace items can declare they expose a web UI via a new `ark.ui` field in the marketplace manifest
+- Installed marketplace items carry their externally-reachable URL as a Kubernetes annotation (`ark.mckinsey.com/ui-url`) on the same Deployment that PR #1440 already labels for installation detection
+- The dashboard reads this annotation during marketplace item fetching and renders an "Open" button on marketplace cards and detail pages for installed items with a URL
+- Post-install hooks in the marketplace repository are extended to set the `ui-url` annotation alongside the existing `marketplace-item` label
+- The services page is deprecated and eventually removed, with its functionality absorbed by the marketplace page
+- An "Installed" filter/view on the marketplace page replaces the services page's list of deployed services
+
+## Capabilities
+
+### New Capabilities
+- `marketplace-ui-url`: Annotation-based UI URL discovery for marketplace items, including manifest schema extension, dashboard rendering of "Open" action, and fallback to port-forward instructions when no URL is configured
+- `services-page-sunset`: Deprecation and removal of the services page, with its functionality absorbed by the marketplace page's installed items view
+
+### Modified Capabilities
+
+## Impact
+
+- **Marketplace manifest schema** (`marketplace.json`): New `ark.ui` field on items
+- **Dashboard** (`services/ark-dashboard`): Modified marketplace-fetcher, marketplace-item-card, marketplace detail page; eventually removed services page and ark-services components
+- **Marketplace repository** (external: `mckinsey/agents-at-scale-marketplace`): Post-install hooks updated to annotate Deployments with `ark.mckinsey.com/ui-url`
+- **ark-api**: No changes beyond what PR #1440 already provides (labelSelector on /v1/resources)
+- **Depends on**: PR #1440 (marketplace installation detection) being merged first

--- a/openspec/changes/marketplace-service-ui/specs/marketplace-ui-url/spec.md
+++ b/openspec/changes/marketplace-service-ui/specs/marketplace-ui-url/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Marketplace manifest declares UI availability
+The marketplace manifest `ark` section SHALL support a `ui` object with an `enabled` boolean field. Items with `ark.ui.enabled: true` are treated as having a web UI.
+
+#### Scenario: Item with UI enabled
+- **WHEN** a marketplace item has `ark.ui.enabled: true` in its manifest
+- **THEN** the dashboard SHALL attempt to resolve a UI URL for that item when it is installed
+
+#### Scenario: Item without UI field
+- **WHEN** a marketplace item has no `ark.ui` field or `ark.ui.enabled: false`
+- **THEN** the dashboard SHALL NOT display any UI-related controls for that item
+
+### Requirement: UI URL carried as Deployment annotation
+The UI URL for an installed marketplace item SHALL be stored as the annotation `ark.mckinsey.com/ui-url` on the Deployment that is labeled with `ark.mckinsey.com/marketplace-item`.
+
+#### Scenario: Deployment has ui-url annotation
+- **WHEN** a labeled Deployment has annotation `ark.mckinsey.com/ui-url` with a valid URL
+- **THEN** the dashboard SHALL use that URL as the item's UI URL
+
+#### Scenario: Deployment without ui-url annotation
+- **WHEN** a labeled Deployment does not have the `ark.mckinsey.com/ui-url` annotation
+- **THEN** the dashboard SHALL treat the item as having no configured UI URL
+
+### Requirement: Dashboard reads URL from existing detection query
+The dashboard SHALL extract the `ark.mckinsey.com/ui-url` annotation from the Deployment response that is already fetched for installation detection (PR #1440). No additional API calls SHALL be made for URL resolution.
+
+#### Scenario: URL extracted during installation detection
+- **WHEN** the marketplace fetcher queries a labeled Deployment for installation status
+- **THEN** it SHALL also read the `ark.mckinsey.com/ui-url` annotation from the same response and attach it to the MarketplaceItem as `uiUrl`
+
+### Requirement: MarketplaceItem type extended with uiUrl
+The `MarketplaceItem` TypeScript type SHALL include an optional `uiUrl` string field and an optional `uiEnabled` boolean field.
+
+#### Scenario: Item with resolved URL
+- **WHEN** a MarketplaceItem has `uiUrl` set
+- **THEN** the dashboard SHALL render an "Open" button that opens the URL in a new tab
+
+#### Scenario: Item with UI enabled but no URL
+- **WHEN** a MarketplaceItem has `uiEnabled: true` but no `uiUrl`
+- **THEN** the dashboard SHALL render port-forward instructions using `ark.k8sServiceName` and `ark.k8sServicePort` from the manifest
+
+### Requirement: Marketplace card renders Open button
+The marketplace item card SHALL display an "Open" button for installed items that have a `uiUrl`.
+
+#### Scenario: Installed item with URL on card
+- **WHEN** viewing a marketplace card for an installed item with `uiUrl`
+- **THEN** the card SHALL show both "Installed" status and an "Open" button
+- **AND** clicking "Open" SHALL open the URL in a new browser tab
+
+#### Scenario: Installed item without URL on card
+- **WHEN** viewing a marketplace card for an installed item with `uiEnabled: true` but no `uiUrl`
+- **THEN** the card SHALL show "Installed" status without an "Open" button
+
+### Requirement: Marketplace detail page renders Open action
+The marketplace item detail page SHALL display an "Open" button and port-forward instructions when applicable.
+
+#### Scenario: Detail page with URL
+- **WHEN** viewing the detail page for an installed item with `uiUrl`
+- **THEN** the page SHALL display a prominent "Open" button that opens the URL in a new tab
+
+#### Scenario: Detail page with UI enabled but no URL
+- **WHEN** viewing the detail page for an installed item with `uiEnabled: true` but no `uiUrl`
+- **THEN** the page SHALL display port-forward instructions: `kubectl port-forward svc/{k8sServiceName} {k8sServicePort}:{k8sServicePort}`
+
+### Requirement: Post-install hooks set ui-url annotation
+Marketplace Helm chart post-install hooks SHALL set the `ark.mckinsey.com/ui-url` annotation on the labeled Deployment when the URL is deterministic from install-time values.
+
+#### Scenario: Hook sets annotation after install
+- **WHEN** a marketplace item is installed via Helm and the post-install hook runs
+- **THEN** the hook SHALL patch the Deployment to add the `ark.mckinsey.com/ui-url` annotation with the service URL derived from Helm values
+
+#### Scenario: URL not deterministic at install time
+- **WHEN** a marketplace item is installed but the external URL cannot be determined at install time (e.g., no Ingress configured yet)
+- **THEN** the hook SHALL label the Deployment for detection but MAY omit the `ui-url` annotation

--- a/openspec/changes/marketplace-service-ui/specs/services-page-sunset/spec.md
+++ b/openspec/changes/marketplace-service-ui/specs/services-page-sunset/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Marketplace page has Installed filter
+The marketplace page SHALL provide a way to filter items by installation status, showing only installed items.
+
+#### Scenario: User views installed items
+- **WHEN** a user selects the "Installed" filter on the marketplace page
+- **THEN** only items with `status: "installed"` SHALL be displayed
+
+#### Scenario: Installed view shows UI links
+- **WHEN** viewing installed items that have a `uiUrl`
+- **THEN** each item SHALL show an "Open" button alongside its installed status
+
+### Requirement: Services page removed from navigation
+The services page SHALL be removed from the dashboard sidebar navigation.
+
+#### Scenario: Services page not in nav
+- **WHEN** a user views the dashboard sidebar
+- **THEN** there SHALL be no "Services" navigation entry
+
+### Requirement: Services page route redirects to marketplace
+The `/services` route SHALL redirect to `/marketplace` with the installed filter active.
+
+#### Scenario: Direct navigation to services URL
+- **WHEN** a user navigates to `/services`
+- **THEN** they SHALL be redirected to the marketplace page filtered to installed items
+
+### Requirement: Services page code removed
+The services page component, ark-services table, use-ark-services hook, and ark-services API service SHALL be removed from the dashboard codebase.
+
+#### Scenario: No services page code remains
+- **WHEN** the services page sunset is complete
+- **THEN** the following files SHALL no longer exist: `app/(dashboard)/services/page.tsx`, `components/ark-services/`, `lib/services/ark-services.ts`

--- a/openspec/changes/marketplace-service-ui/tasks.md
+++ b/openspec/changes/marketplace-service-ui/tasks.md
@@ -1,0 +1,39 @@
+## 1. Marketplace Manifest Schema
+
+- [ ] 1.1 Add `ark.ui` field to marketplace manifest schema — add `ui: { enabled: boolean }` to the `GitHubMarketplaceItem` interface in `marketplace-fetcher.ts` and update the marketplace.json.example template
+- [ ] 1.2 Update marketplace items in the marketplace repo (`mckinsey/agents-at-scale-marketplace`) to set `ark.ui.enabled: true` on items with web UIs (Phoenix, Langfuse, A2A Inspector, MCP Inspector)
+
+## 2. Dashboard Type Extensions
+
+- [ ] 2.1 Add `uiUrl?: string` and `uiEnabled?: boolean` fields to `MarketplaceItem` in `marketplace-types.ts`
+- [ ] 2.2 Update `transformGitHubItemToMarketplaceItem()` in `marketplace-fetcher.ts` to map `ark.ui.enabled` to the `uiEnabled` field
+
+## 3. URL Resolution in Dashboard
+
+- [ ] 3.1 Extend the labeled Deployment detection flow (PR #1440's `checkLabeledDeployment`) to also read `ark.mckinsey.com/ui-url` annotation from the Deployment response and return it alongside the installation status
+- [ ] 3.2 Update `fetchMarketplaceItemsFromSource()` in `marketplace-fetcher.ts` to attach the resolved `uiUrl` to MarketplaceItem when `uiEnabled` is true and the annotation is present
+- [ ] 3.3 Add tests for URL resolution: Deployment with annotation returns URL, Deployment without annotation returns undefined
+
+## 4. Marketplace Card UI
+
+- [ ] 4.1 Add "Open" button to `marketplace-item-card.tsx` — render when `item.status === 'installed'` and `item.uiUrl` is present, opens URL in new tab via `window.open`
+- [ ] 4.2 Add tests for marketplace card: renders Open button when uiUrl present, does not render when absent
+
+## 5. Marketplace Detail Page UI
+
+- [ ] 5.1 Add "Open" button to the detail page sidebar (`marketplace/[id]/page.tsx`) — prominent button when `uiUrl` is present
+- [ ] 5.2 Add port-forward instructions to the detail page — render when `uiEnabled` is true but `uiUrl` is absent, using `k8sServiceName` and `k8sServicePort` from manifest
+- [ ] 5.3 Add tests for detail page: Open button renders with URL, port-forward instructions render without URL
+
+## 6. Post-Install Hooks (Marketplace Repo)
+
+- [ ] 6.1 Extend the post-install hook job template in `mckinsey/agents-at-scale-marketplace` to also patch `ark.mckinsey.com/ui-url` annotation on the Deployment, deriving the URL from Helm values
+- [ ] 6.2 Update marketplace Helm charts for Phoenix, Langfuse, A2A Inspector, MCP Inspector to pass UI URL via Helm values to the post-install hook
+
+## 7. Services Page Sunset
+
+- [ ] 7.1 Add "Installed" filter option to the marketplace page — filter items by `status: "installed"`
+- [ ] 7.2 Remove "Services" entry from the dashboard sidebar navigation
+- [ ] 7.3 Add redirect from `/services` to `/marketplace?status=installed`
+- [ ] 7.4 Remove services page code: `app/(dashboard)/services/page.tsx`, `components/ark-services/ark-services-table.tsx`, `components/ark-services/use-ark-services.ts`, `lib/services/ark-services.ts`
+- [ ] 7.5 Evaluate whether `ark-api /v1/ark-services` endpoint can be removed or if other consumers depend on it


### PR DESCRIPTION
## Summary

- Add OpenSpec change proposal for surfacing marketplace item web UIs through the Ark dashboard
- Design uses annotation-based URL discovery (`ark.mckinsey.com/ui-url`) on labeled Deployments, extending PR #1440's detection pattern
- Spec covers marketplace manifest schema extension, dashboard Open button, port-forward fallback, and post-install hooks
- Includes phased plan to sunset the services page in favor of the marketplace page
- Implementation broken into 18 tasks across 7 groups, ready for `/opsx:apply`