### PR TITLE
docs: update Pentest #2 findings with DataArt v1.1 retest results

### DIFF
--- a/docs/content/operations-guide/penetration-testing-reports.mdx
+++ b/docs/content/operations-guide/penetration-testing-reports.mdx
@@ -76,60 +76,60 @@ Dashboard lacks protective HTTP headers.
 
 - **Assessment Period:** December 2025
 - **Assessor:** DataArt
-- **Remediation Status:** January 2026
-- **Overall Risk Level:** Medium-Low, remediated to Low
+- **Remediation Status:** March 31, 2026 (v1.1 retest)
+- **Overall Risk Level:** Medium-Low, M1 remediated
 
 | Risk Level | Count | Status |
 |------------|--------|---------|
 | Critical | 0 | - |
 | High | 0 | - |
 | Medium | 1 | Remediated |
-| Low | 5 | Remediated |
+| Low | 5 | Open |
 
-##### M1. Clickjacking Protection
+##### M1. Potential clickjacking attack
 
-Dashboard and API lacked X-Frame-Options and Content-Security-Policy frame-ancestors headers.
-
-**Resolution - Remediated**
-
-Added security headers to all Ingress configurations including X-Frame-Options: DENY and Content-Security-Policy: frame-ancestors 'none'.
-
-##### L1. Overly Permissive RBAC Roles
-
-The ark-deployer ClusterRole had cluster-wide delete permissions.
+Dashboard and API lacked X-Frame-Options and Content-Security-Policy headers, allowing potential clickjacking attacks against admin functionality.
 
 **Resolution - Remediated**
 
-Removed delete permissions from ark-deployer. Deployment automation limited to create, update, and patch operations.
+Confirmed remediated on March 31, 2026. Application now includes both X-Frame-Options and Content-Security-Policy headers.
 
-##### L2. Container Security Hardening
+##### L1. [Kubernetes] Overly permissive RBAC roles
 
-Services missing comprehensive security contexts.
+Service accounts had overly permissive privileges including wildcard verbs, secrets access, and pods/exec permissions across roles (all-access, argo-workflows-workflow-controller, ark-api-sa-role).
 
-**Resolution - Remediated**
+**Status - Open**
 
-Added pod and container security contexts: runAsNonRoot, runAsUser, fsGroup, seccompProfile, privilege escalation prevention, and capability dropping.
+RBAC roles require review following the principle of least privilege to mitigate privilege escalation risks.
 
-##### L3. Missing Security Headers
+##### L2. [Kubernetes] Insecure container parameters
 
-Ingress configurations lacked protective HTTP headers.
+Containers missing security hardening: allowPrivilegeEscalation not set to false, no Linux hardening (AppArmor/SELinux/seccomp), processes running as root, and writable root filesystems.
 
-**Resolution - Remediated**
+**Status - Open**
 
-Added X-Content-Type-Options, X-XSS-Protection, Strict-Transport-Security, and Referrer-Policy headers to all Ingress configurations.
+Container security contexts require hardening per CIS Kubernetes and Docker benchmarks.
 
-##### L4. TLS Version Control
+##### L3. Security headers misconfiguration
 
-Gateway accepted outdated TLS versions.
+Application responses missing X-Content-Type-Options, Content-Security-Policy, and Referrer-Policy headers.
 
-**Resolution - Remediated**
+**Status - Open**
 
-Configured Gateway resources to enforce TLS 1.2 and TLS 1.3 only.
+Security headers need to be added to all responses returning HTML content.
 
-##### L5. Weak Cipher Suites
+##### L4. Cipher suites without PFS are supported
 
-Gateway accepted weak cipher suites.
+Server supported TLS cipher suites using RSA key exchange without Forward Secrecy (AES128-SHA, AES256-SHA, AES128-SHA256, AES256-SHA256).
 
-**Resolution - Remediated**
+**Status - Open**
 
-Configured strong cipher suites with forward secrecy (ECDHE-based ciphers).
+Server should be configured to only permit cipher suites with perfect forward secrecy.
+
+##### L5. Ciphers suites with weak CBC mode are supported
+
+Server supported cipher suites using CBC mode, vulnerable to padding oracle attacks (POODLE, Zombie POODLE, GOLDENDOODLE).
+
+**Status - Open**
+
+Server should be reconfigured to exclusively permit high-grade cipher suites without CBC mode.

--- a/docs/content/operations-guide/penetration-testing-reports.mdx
+++ b/docs/content/operations-guide/penetration-testing-reports.mdx
@@ -86,7 +86,7 @@ Dashboard lacks protective HTTP headers.
 | Medium | 1 | Remediated |
 | Low | 5 | Open |
 
-##### M1. Potential clickjacking attack
+##### M1. Clickjacking Protection
 
 Dashboard and API lacked X-Frame-Options and Content-Security-Policy headers, allowing potential clickjacking attacks against admin functionality.
 
@@ -94,7 +94,7 @@ Dashboard and API lacked X-Frame-Options and Content-Security-Policy headers, al
 
 Confirmed remediated on March 31, 2026. Application now includes both X-Frame-Options and Content-Security-Policy headers.
 
-##### L1. [Kubernetes] Overly permissive RBAC roles
+##### L1. Overly Permissive RBAC Roles
 
 Service accounts had overly permissive privileges including wildcard verbs, secrets access, and pods/exec permissions across roles (all-access, argo-workflows-workflow-controller, ark-api-sa-role).
 
@@ -102,7 +102,7 @@ Service accounts had overly permissive privileges including wildcard verbs, secr
 
 RBAC roles require review following the principle of least privilege to mitigate privilege escalation risks.
 
-##### L2. [Kubernetes] Insecure container parameters
+##### L2. Container Security Hardening
 
 Containers missing security hardening: allowPrivilegeEscalation not set to false, no Linux hardening (AppArmor/SELinux/seccomp), processes running as root, and writable root filesystems.
 
@@ -110,7 +110,7 @@ Containers missing security hardening: allowPrivilegeEscalation not set to false
 
 Container security contexts require hardening per CIS Kubernetes and Docker benchmarks.
 
-##### L3. Security headers misconfiguration
+##### L3. Missing Security Headers
 
 Application responses missing X-Content-Type-Options, Content-Security-Policy, and Referrer-Policy headers.
 
@@ -118,7 +118,7 @@ Application responses missing X-Content-Type-Options, Content-Security-Policy, a
 
 Security headers need to be added to all responses returning HTML content.
 
-##### L4. Cipher suites without PFS are supported
+##### L4. TLS Version Control
 
 Server supported TLS cipher suites using RSA key exchange without Forward Secrecy (AES128-SHA, AES256-SHA, AES128-SHA256, AES256-SHA256).
 
@@ -126,7 +126,7 @@ Server supported TLS cipher suites using RSA key exchange without Forward Secrec
 
 Server should be configured to only permit cipher suites with perfect forward secrecy.
 
-##### L5. Ciphers suites with weak CBC mode are supported
+##### L5. Weak Cipher Suites
 
 Server supported cipher suites using CBC mode, vulnerable to padding oracle attacks (POODLE, Zombie POODLE, GOLDENDOODLE).
 


### PR DESCRIPTION
## Summary
- Update Pentest #2 section with DataArt v1.1 retest results (March 31, 2026)
- M1 (Potential clickjacking attack) confirmed remediated
- L1–L5 findings updated to Open status per retest
- Finding titles aligned with original PDF report

🤖 Generated with [Claude Code](https://claude.com/claude-code)