### PR TITLE
feat(broker-sessions): live sessions tab with proxy, persistence, and per-chat ids

### DIFF
--- a/.claude/agents/ark-build-manager.md
+++ b/.claude/agents/ark-build-manager.md
@@ -349,6 +349,34 @@ pytest -sv tests/test_file_gateway.py
 kind delete cluster --name ark-e2e-test
 ```
 
+## Documentation Updates
+
+When fixing builds or making changes that affect how Ark is built, deployed, or configured, check whether the documentation in `./docs` needs updating. The docs site is built with Next.js and MDX.
+
+### When to update docs
+- CI/CD workflow changes (`.github/workflows/`) — update the CI/CD reference docs
+- New service endpoints or API changes — update API reference
+- Build process changes (Makefiles, Dockerfiles, devspace configs) — update setup/deployment guides
+- New CRDs or config options (helm values, env vars) — update configuration reference
+- New skills or agent definitions — update the developer tooling docs
+
+### How to update docs
+```bash
+cd docs/
+npm install    # if needed
+make docs      # runs the docs site with live-reload for preview
+```
+
+Key directories:
+- `docs/pages/` — MDX content pages
+- `docs/pages/guides/` — how-to guides
+- `docs/pages/reference/` — API and configuration reference
+
+### Keep CLAUDE.md files current
+When changes affect build instructions, project structure, or development workflows, update the relevant `CLAUDE.md` files:
+- Root `CLAUDE.md` — project-wide build instructions, structure overview
+- Service-level `CLAUDE.md` (e.g. `services/ark-api/CLAUDE.md`) — service-specific guidelines
+
 ## Core Principles
 
 - **Full picture first**: Check all runs from the current day, not just the latest failure
@@ -359,3 +387,4 @@ kind delete cluster --name ark-e2e-test
 - **Distinguish flaky from broken**: A test that passes on retry is flaky, not broken
 - **Don't mask failures**: Fix root causes, don't disable tests or skip checks
 - **Report clearly**: The user needs to understand what's broken, why, and what to do
+- **Update docs alongside fixes**: When a fix changes build/deploy/config behavior, update `./docs` and `CLAUDE.md` files in the same PR

--- a/openspec/changes/archive/2026-04-01-broker-sessions-tab/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-01-broker-sessions-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/archive/2026-04-01-broker-sessions-tab/proposal.md
+++ b/openspec/changes/archive/2026-04-01-broker-sessions-tab/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+The broker page has tabs for traces, messages, chunks, and events — but no tab for sessions. The `/sessions` endpoint is now live (merged via #1457) and provides a materialized view of all sessions and queries. Adding a Sessions tab to the broker page lets developers inspect session state in real-time alongside the other streams.
+
+## What Changes
+
+- Add a "Sessions" tab to the broker page that connects via SSE to `/sessions?watch=true`
+- Match the visual style of existing stream tabs (Card, bg-muted scrollable area, chevron expand, timestamp + ID per row)
+- Only connect SSE for the active tab to prevent browser connection exhaustion
+
+## Capabilities
+
+### New Capabilities
+- `broker-sessions-tab`: Sessions tab on the broker page with live SSE updates, expand/collapse JSON, purge, auto-scroll
+
+### Modified Capabilities
+
+## Impact
+
+- `services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx` — add SessionsLiveView component and Sessions tab

--- a/services/ark-api/ark-api/src/ark_api/api/v1/broker.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/broker.py
@@ -32,7 +32,7 @@ async def get_broker_url(memory_name: str) -> Optional[str]:
         async with with_ark_client(None, VERSION) as client:
             memory_dicts = await get_all_memory_resources(client, memory_name)
             if not memory_dicts:
-                logger.warning(f"No memory resource found with name: {memory_name}")
+                logger.warning("No memory resource found for requested name")
                 return None
             return get_memory_service_address(memory_dicts[0])
     except Exception as e:
@@ -232,6 +232,15 @@ async def get_chunks(
     )
 
 
+@router.get("/sessions")
+async def get_sessions(
+    watch: bool = Query(False, description="Stream sessions via SSE"),
+    memory: str = Query("default", description="Memory resource name"),
+):
+    """Get or stream sessions from the broker. Sessions are global broker state, not memory-scoped, but the memory parameter selects which broker service to query."""
+    return await proxy_broker_request(memory, "/sessions", watch, {})
+
+
 async def proxy_broker_delete(memory: str, path: str):
     """Proxy DELETE requests to broker."""
     broker_url = await get_broker_url(memory)
@@ -280,3 +289,9 @@ async def purge_messages(memory: str = Query("default", description="Memory reso
 async def purge_chunks(memory: str = Query("default", description="Memory resource name")):
     """Purge all chunks from the broker."""
     return await proxy_broker_delete(memory, "/stream")
+
+
+@router.delete("/sessions")
+async def purge_sessions(memory: str = Query("default", description="Memory resource name")):
+    """Purge all sessions from the broker."""
+    return await proxy_broker_delete(memory, "/sessions")

--- a/services/ark-api/ark-api/tests/api/test_broker.py
+++ b/services/ark-api/ark-api/tests/api/test_broker.py
@@ -511,6 +511,80 @@ class TestBrokerAPI(unittest.TestCase):
         self.assertEqual(data["error"]["type"], "connection_error")
 
 
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_get_sessions_success(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"sessions": []}
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.get("/v1/broker/sessions")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"sessions": []})
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.proxy_sse_stream')
+    def test_get_sessions_watch(self, mock_proxy_sse, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        async def mock_stream():
+            yield "data: session\n\n"
+
+        mock_proxy_sse.return_value = mock_stream()
+
+        response = self.client.get("/v1/broker/sessions?watch=true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "text/event-stream; charset=utf-8")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    def test_get_sessions_memory_not_available(self, mock_get_broker_url):
+        mock_get_broker_url.return_value = None
+
+        response = self.client.get("/v1/broker/sessions?memory=unavailable")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "service_unavailable")
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    @patch('ark_api.api.v1.broker.httpx.AsyncClient')
+    def test_purge_sessions_success(self, mock_async_client, mock_get_broker_url):
+        mock_get_broker_url.return_value = "http://broker:8080"
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"success": True}
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        response = self.client.delete("/v1/broker/sessions")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+
+    @patch('ark_api.api.v1.broker.get_broker_url', new_callable=AsyncMock)
+    def test_purge_sessions_memory_not_available(self, mock_get_broker_url):
+        mock_get_broker_url.return_value = None
+
+        response = self.client.delete("/v1/broker/sessions?memory=unavailable")
+
+        self.assertEqual(response.status_code, 503)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"]["type"], "service_unavailable")
+
+
 class TestHelperFunctions(unittest.IsolatedAsyncioTestCase):
 
     @patch('ark_api.api.v1.broker.get_all_memory_resources')

--- a/services/ark-broker/chart/templates/deployment.yaml
+++ b/services/ark-broker/chart/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.traceFileName }}"
             - name: EVENT_FILE_PATH
               value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.eventFileName }}"
+            - name: SESSIONS_FILE_PATH
+              value: "{{ .Values.persistence.mountPath }}/{{ .Values.persistence.sessionsFileName }}"
             {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:

--- a/services/ark-broker/chart/values.yaml
+++ b/services/ark-broker/chart/values.yaml
@@ -77,6 +77,8 @@ persistence:
   traceFileName: oteltraces.json
   # Filename for the event data
   eventFileName: events.json
+  # Filename for the sessions data
+  sessionsFileName: sessions.json
   # Use existing PVC instead of creating a new one
   existingClaim: ""
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/sessions-view-component.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/sessions-view-component.test.tsx
@@ -1,91 +1,232 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
-import { Provider as JotaiProvider } from 'jotai';
-import {
-  AppRouterContext,
-  type AppRouterInstance,
-} from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import BrokerPage from '@/app/(dashboard)/broker/page';
-import { SidebarProvider } from '@/components/ui/sidebar';
+import { SessionsView } from '@/app/(dashboard)/broker/page';
 
-vi.mock('@/lib/services/memories', () => ({
-  memoriesService: {
-    getAll: vi.fn().mockResolvedValue([]),
-  },
-}));
-
-const MockRouter = ({ children }: { children: React.ReactNode }) => {
-  const mockRouter: AppRouterInstance = {
-    back: vi.fn(),
-    forward: vi.fn(),
-    push: vi.fn(),
-    replace: vi.fn(),
-    refresh: vi.fn(),
-    prefetch: vi.fn(),
-  };
-
-  return (
-    <AppRouterContext.Provider value={mockRouter}>
-      {children}
-    </AppRouterContext.Provider>
-  );
+type ESInstance = {
+  url: string;
+  onopen: ((ev?: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onerror: ((ev?: unknown) => void) | null;
+  close: ReturnType<typeof vi.fn>;
 };
 
-let queryClient: QueryClient;
+const esInstances: ESInstance[] = [];
 
-beforeEach(() => {
-  queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-});
-
-global.EventSource = vi.fn(() => ({
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  close: vi.fn(),
-  readyState: 0,
-  url: '',
-  withCredentials: false,
-  CONNECTING: 0,
-  OPEN: 1,
-  CLOSED: 2,
-  onerror: null,
-  onmessage: null,
-  onopen: null,
-  dispatchEvent: vi.fn(),
-})) as unknown as typeof EventSource;
-
-function renderBrokerPage() {
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <JotaiProvider>
-        <SidebarProvider>
-          <MockRouter>
-            <BrokerPage />
-          </MockRouter>
-        </SidebarProvider>
-      </JotaiProvider>
-    </QueryClientProvider>,
-  );
+class MockEventSource {
+  url: string;
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  close = vi.fn();
+  constructor(url: string) {
+    this.url = url;
+    esInstances.push(this as unknown as ESInstance);
+  }
 }
 
-describe('SessionsView Component', () => {
-  it('should render all tab options including the new Sessions tab', async () => {
-    renderBrokerPage();
+beforeEach(() => {
+  esInstances.length = 0;
+  (global as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  global.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function latestES(): ESInstance {
+  return esInstances[esInstances.length - 1];
+}
+
+function emit(data: unknown) {
+  act(() => {
+    latestES().onmessage?.({ data: JSON.stringify(data) });
+  });
+}
+
+describe('SessionsView', () => {
+  it('renders Waiting for data... initially', () => {
+    render(<SessionsView memory="default" />);
+    expect(screen.getByText(/waiting for data/i)).toBeDefined();
+  });
+
+  it('opens EventSource with correct URL on mount', () => {
+    render(<SessionsView memory="default" />);
+    expect(esInstances).toHaveLength(1);
+    expect(latestES().url).toBe('/api/v1/broker/sessions?memory=default&watch=true');
+  });
+
+  it('cleans up EventSource on unmount', () => {
+    const { unmount } = render(<SessionsView memory="default" />);
+    const es = latestES();
+    unmount();
+    expect(es.close).toHaveBeenCalled();
+  });
+
+  it('renders a session row when an SSE message arrives', async () => {
+    render(<SessionsView memory="default" />);
+    emit({
+      sessionId: 'sess-1',
+      session: { lastActivity: '2025-01-01T12:00:00.000Z', foo: 'bar' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText('sess-1')).toBeDefined();
+    });
+    expect(screen.queryByText(/waiting for data/i)).toBeNull();
+  });
+
+  it('ignores malformed SSE messages', () => {
+    render(<SessionsView memory="default" />);
+    act(() => {
+      latestES().onmessage?.({ data: 'not-json' });
+    });
+    act(() => {
+      latestES().onmessage?.({ data: JSON.stringify({ foo: 'bar' }) });
+    });
+    expect(screen.getByText(/waiting for data/i)).toBeDefined();
+  });
+
+  it('sorts sessions by lastActivity descending', async () => {
+    render(<SessionsView memory="default" />);
+    emit({
+      sessionId: 'older',
+      session: { lastActivity: '2025-01-01T10:00:00.000Z' },
+    });
+    emit({
+      sessionId: 'newer',
+      session: { lastActivity: '2025-01-02T10:00:00.000Z' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText('newer')).toBeDefined();
+    });
+    const olderEl = screen.getByText('older');
+    const newerEl = screen.getByText('newer');
+    // eslint-disable-next-line no-bitwise
+    const newerFirst =
+      newerEl.compareDocumentPosition(olderEl) &
+      Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(newerFirst).toBeTruthy();
+  });
+
+  it('expand/collapse toggles pretty-printed JSON', async () => {
+    const user = userEvent.setup();
+    render(<SessionsView memory="default" />);
+    emit({
+      sessionId: 'sess-1',
+      session: { lastActivity: '2025-01-01T12:00:00.000Z', data: 'value' },
+    });
+    await waitFor(() => screen.getByText('sess-1'));
+
+    const expandBtn = screen.getByRole('button', { name: /expand session/i });
+    expect(expandBtn.getAttribute('aria-expanded')).toBe('false');
+
+    await user.click(expandBtn);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /collapse session/i }),
+      ).toBeDefined();
+    });
+    expect(screen.getByText(/"data": "value"/)).toBeDefined();
+
+    const collapseBtn = screen.getByRole('button', {
+      name: /collapse session/i,
+    });
+    await user.click(collapseBtn);
+    await waitFor(() => {
+      expect(screen.queryByText(/"data": "value"/)).toBeNull();
+    });
+  });
+
+  it('Purge button calls DELETE and clears the store', async () => {
+    const user = userEvent.setup();
+    render(<SessionsView memory="default" />);
+    emit({
+      sessionId: 'sess-1',
+      session: { lastActivity: '2025-01-01T12:00:00.000Z' },
+    });
+    await waitFor(() => screen.getByText('sess-1'));
+
+    await user.click(screen.getByRole('button', { name: /purge/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /traces/i })).toBeDefined();
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/broker/sessions?memory=default', {
+        method: 'DELETE',
+      });
     });
+    await waitFor(() => {
+      expect(screen.getByText(/waiting for data/i)).toBeDefined();
+    });
+  });
 
-    expect(screen.getByRole('tab', { name: /messages/i })).toBeDefined();
-    expect(screen.getByRole('tab', { name: /chunks/i })).toBeDefined();
-    expect(screen.getByRole('tab', { name: /events/i })).toBeDefined();
-    expect(screen.getByRole('tab', { name: /sessions/i })).toBeDefined();
+  it('Purge swallows fetch errors', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network')) as unknown as typeof fetch;
+    const user = userEvent.setup();
+    render(<SessionsView memory="default" />);
+    await user.click(screen.getByRole('button', { name: /purge/i }));
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it('Auto-scroll toggle state changes', async () => {
+    const user = userEvent.setup();
+    render(<SessionsView memory="default" />);
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    await user.click(toggle);
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-checked')).toBe('false');
+    });
+  });
+
+  it('connection dot turns green on EventSource.onopen', async () => {
+    const { container } = render(<SessionsView memory="default" />);
+    const dot = container.querySelector('span.rounded-full');
+    expect(dot?.className).toContain('bg-gray-300');
+    act(() => {
+      latestES().onopen?.();
+    });
+    await waitFor(() => {
+      expect(
+        container.querySelector('span.rounded-full')?.className,
+      ).toContain('bg-green-500');
+    });
+  });
+
+  it('handles sessions missing lastActivity in sort and row render', async () => {
+    render(<SessionsView memory="default" />);
+    emit({ sessionId: 'no-activity-a', session: { foo: 'a' } });
+    emit({ sessionId: 'no-activity-b', session: { foo: 'b' } });
+    emit({
+      sessionId: 'with-activity',
+      session: { lastActivity: '2025-01-02T10:00:00.000Z' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText('with-activity')).toBeDefined();
+    });
+    expect(screen.getByText('no-activity-a')).toBeDefined();
+    expect(screen.getByText('no-activity-b')).toBeDefined();
+  });
+
+  it('connection dot turns gray on EventSource.onerror', async () => {
+    const { container } = render(<SessionsView memory="default" />);
+    act(() => {
+      latestES().onopen?.();
+    });
+    await waitFor(() => {
+      expect(
+        container.querySelector('span.rounded-full')?.className,
+      ).toContain('bg-green-500');
+    });
+    act(() => {
+      latestES().onerror?.();
+    });
+    await waitFor(() => {
+      expect(
+        container.querySelector('span.rounded-full')?.className,
+      ).toContain('bg-gray-300');
+    });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/useSSEStream.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(dashboard)/broker/useSSEStream.test.tsx
@@ -1,0 +1,291 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSSEStream } from '@/app/(dashboard)/broker/page';
+
+vi.mock('@/lib/analytics/singleton', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { trackEvent } from '@/lib/analytics/singleton';
+
+type ESInstance = {
+  url: string;
+  onopen: ((ev?: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onerror: ((ev?: unknown) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const esInstances: ESInstance[] = [];
+
+class MockEventSource {
+  url: string;
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  close = vi.fn();
+  constructor(url: string) {
+    this.url = url;
+    esInstances.push(this as unknown as ESInstance);
+  }
+}
+
+function latestES(): ESInstance {
+  return esInstances[esInstances.length - 1];
+}
+
+function makeFetchResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+  };
+}
+
+const defaultPage = { items: [], total: 0, hasMore: false, nextCursor: undefined };
+
+beforeEach(() => {
+  esInstances.length = 0;
+  (global as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  global.fetch = vi.fn().mockResolvedValue(makeFetchResponse(defaultPage)) as unknown as typeof fetch;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe('useSSEStream', () => {
+  it('returns initial state when endpoint is null', () => {
+    const { result } = renderHook(() => useSSEStream(null, 'mem'));
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not open EventSource when endpoint is null', () => {
+    renderHook(() => useSSEStream(null, 'mem'));
+    expect(esInstances).toHaveLength(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches initial page and opens EventSource when endpoint set', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeFetchResponse({ items: [{ timestamp: '2024-01-01T00:00:00Z', foo: 1 }], total: 1, hasMore: false }),
+    );
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/broker/messages?memory=mem&limit=1000'),
+      expect.any(Object),
+    );
+    expect(esInstances).toHaveLength(1);
+    expect(latestES().url).toContain('watch=true');
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('disconnects and clears state when endpoint transitions to null', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeFetchResponse({ items: [{ timestamp: 't' }], total: 1, hasMore: false }),
+    );
+    const { result, rerender } = renderHook(
+      ({ ep }: { ep: string | null }) => useSSEStream(ep, 'mem'),
+      { initialProps: { ep: '/v1/broker/messages' as string | null } },
+    );
+    await flush();
+    const es = latestES();
+    rerender({ ep: null });
+    await flush();
+    expect(es.close).toHaveBeenCalled();
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('exercises initial fetch with error body in response', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeFetchResponse({ error: { message: 'boom' } }),
+    );
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    // connect() runs after and clears error; we just verify no crash and ES opened
+    expect(esInstances.length).toBeGreaterThanOrEqual(1);
+    expect(result.current).toBeDefined();
+  });
+
+  it('exercises initial fetch rejection path', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'));
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    expect(result.current).toBeDefined();
+  });
+
+  it('ignores AbortError', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(abortErr);
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('appends streamed entries on SSE message', async () => {
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    act(() => {
+      latestES().onmessage?.({ data: JSON.stringify({ timestamp: '2024-01-01T00:00:00Z', hello: 'world' }) });
+    });
+    expect(result.current.entries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets error when SSE message contains error object', async () => {
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    act(() => {
+      latestES().onmessage?.({ data: JSON.stringify({ error: { message: 'stream-boom' } }) });
+    });
+    expect(result.current.error).toBe('stream-boom');
+  });
+
+  it('swallows malformed SSE JSON', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    act(() => {
+      latestES().onmessage?.({ data: 'not-json{' });
+    });
+    expect(result.current.error).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('sets isConnected on onopen', async () => {
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    act(() => {
+      latestES().onopen?.();
+    });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('handles onerror by disconnecting and scheduling reconnect', async () => {
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    act(() => {
+      latestES().onopen?.();
+    });
+    expect(result.current.isConnected).toBe(true);
+    const firstES = latestES();
+    act(() => {
+      firstES.onerror?.();
+    });
+    expect(result.current.isConnected).toBe(false);
+    expect(firstES.close).toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+    expect(esInstances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('purge DELETEs with memory param and clears state + fires trackEvent', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeFetchResponse({ items: [{ timestamp: 't' }], total: 1, hasMore: false }),
+    );
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mymem'));
+    await flush();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(makeFetchResponse({}, true));
+    await act(async () => {
+      await result.current.purge();
+    });
+    const deleteCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      c => (c[1] as { method?: string })?.method === 'DELETE',
+    );
+    expect(deleteCall).toBeTruthy();
+    expect(deleteCall?.[0]).toContain('memory=mymem');
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.hasMore).toBe(false);
+    expect(trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'broker_data_purged' }),
+    );
+  });
+
+  it('purge failure triggers toast.error (no crash)', async () => {
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(makeFetchResponse({}, false, 500));
+    await act(async () => {
+      await result.current.purge();
+    });
+    const { toast } = await import('sonner');
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('loadMore fetches next page when cursor available', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeFetchResponse({ items: [{ timestamp: 't' }], total: 2, hasMore: true, nextCursor: 5 }),
+    );
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    // Init loop fetches until hasMore false; second call returns no more.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeFetchResponse({ items: [{ timestamp: 't2' }], total: 2, hasMore: true, nextCursor: 10 }),
+    );
+    await act(async () => {
+      result.current.loadMore();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it('loadMore no-ops when hasMore is false', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeFetchResponse({ items: [], total: 0, hasMore: false }),
+    );
+    const { result } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    const callsBefore = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    act(() => {
+      result.current.loadMore();
+    });
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore);
+  });
+
+  it('memory change triggers reconnect with new URL', async () => {
+    const { rerender } = renderHook(
+      ({ mem }: { mem: string }) => useSSEStream('/v1/broker/messages', mem),
+      { initialProps: { mem: 'mem1' } },
+    );
+    await flush();
+    expect(latestES().url).toContain('memory=mem1');
+    rerender({ mem: 'mem2' });
+    await flush();
+    const urls = esInstances.map(e => e.url);
+    expect(urls.some(u => u.includes('memory=mem2'))).toBe(true);
+  });
+
+  it('unmount closes EventSource and aborts inflight fetch', async () => {
+    const { unmount } = renderHook(() => useSSEStream('/v1/broker/messages', 'mem'));
+    await flush();
+    const es = latestES();
+    unmount();
+    expect(es.close).toHaveBeenCalled();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/chat-history.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/chat-history.test.ts
@@ -130,14 +130,24 @@ describe('Chat History Atoms', () => {
   });
 
   describe('createNewSessionId', () => {
-    it('should return a string starting with session-', () => {
-      const id = createNewSessionId();
-      expect(id).toMatch(/^session-\d+$/);
+    it('should return chat-<name>-<shortsha> format', () => {
+      const id = createNewSessionId('coding-team');
+      expect(id).toMatch(/^chat-coding-team-[0-9a-f]{7}$/);
     });
 
-    it('should return unique session IDs', () => {
-      const ids = new Set(Array.from({ length: 10 }, () => createNewSessionId()));
-      expect(ids.size).toBeGreaterThanOrEqual(1);
+    it('should return unique session IDs for the same name', () => {
+      const ids = new Set(
+        Array.from({ length: 10 }, () => createNewSessionId('planner')),
+      );
+      expect(ids.size).toBe(10);
+    });
+
+    it('should embed the chat name so distinct chats produce distinct ids', () => {
+      const a = createNewSessionId('coding-team');
+      const b = createNewSessionId('code-reviewer');
+      expect(a).not.toEqual(b);
+      expect(a.startsWith('chat-coding-team-')).toBe(true);
+      expect(b.startsWith('chat-code-reviewer-')).toBe(true);
     });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/embedded-chat-panel.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/embedded-chat-panel.test.tsx
@@ -94,7 +94,10 @@ function renderEmbeddedChatPanel(props: {
 }
 
 describe('EmbeddedChatPanel', () => {
-  it('should use persisted conversation ID as sessionId when available', () => {
+  it('should not reuse a persisted conversation ID from another chat', () => {
+    // The old behavior bled the global lastConversationId into every new chat
+    // popup, so two distinct chats ended up with the same broker sessionId.
+    // Each chat popup should now mint its own chat-<name>-<sha> id.
     sessionStorage.setItem(
       'last-conversation-id',
       JSON.stringify('persisted-session-123'),
@@ -103,7 +106,8 @@ describe('EmbeddedChatPanel', () => {
     renderEmbeddedChatPanel({ name: 'test-agent', type: 'agent' });
 
     const atomValue = store.get(lastConversationIdAtom);
-    expect(atomValue).toBe('persisted-session-123');
+    expect(atomValue).toMatch(/^chat-test-agent-[0-9a-f]{7}$/);
+    expect(atomValue).not.toBe('persisted-session-123');
   });
 
   it('should persist new sessionId to atom on new chat creation', async () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
@@ -97,17 +97,33 @@ describe('useChatSession', () => {
   });
 
   describe('initial state', () => {
-    it('should return empty messages and a session ID', () => {
+    it('should return empty messages and a chat-<name>-<shortsha> session ID', () => {
       const { result } = renderHook(
         () => useChatSession({ name: 'test-agent', type: 'agent' }),
         { wrapper },
       );
       expect(result.current.messages).toEqual([]);
-      expect(result.current.sessionId).toMatch(/^session-/);
+      expect(result.current.sessionId).toMatch(/^chat-test-agent-[0-9a-f]{7}$/);
       expect(result.current.isProcessing).toBe(false);
       expect(result.current.error).toBeNull();
       expect(result.current.tokenUsage).toBeUndefined();
       expect(result.current.messageTokenUsage).toBeUndefined();
+    });
+
+    it('should give distinct chats distinct session ids even when one chat has already opened', () => {
+      const first = renderHook(
+        () => useChatSession({ name: 'coding-team', type: 'team' }),
+        { wrapper },
+      );
+      const second = renderHook(
+        () => useChatSession({ name: 'code-reviewer', type: 'agent' }),
+        { wrapper },
+      );
+      expect(first.result.current.sessionId).toMatch(/^chat-coding-team-/);
+      expect(second.result.current.sessionId).toMatch(/^chat-code-reviewer-/);
+      expect(first.result.current.sessionId).not.toEqual(
+        second.result.current.sessionId,
+      );
     });
   });
 

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { PageHeader } from '@/components/common/page-header';
@@ -17,17 +17,6 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { trackEvent } from '@/lib/analytics/singleton';
-import {
-  getSessionDisplayNameFromEntries,
-  groupEntriesBySession,
-  sortEntriesByTimestampAndSequence,
-} from '@/lib/broker/session-utils';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { BASE_BREADCRUMBS } from '@/lib/constants/breadcrumbs';
 import { type Memory, memoriesService } from '@/lib/services/memories';
 
@@ -67,7 +56,7 @@ function extractItemTimestamp(item: unknown): string {
   return new Date().toISOString();
 }
 
-function useSSEStream(endpoint: string, memory: string) {
+function useSSEStream(endpoint: string | null, memory: string) {
   const [streamedEntries, setStreamedEntries] = useState<StreamEntry[]>([]);
   const [fetchedEntries, setFetchedEntries] = useState<StreamEntry[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -83,6 +72,7 @@ function useSSEStream(endpoint: string, memory: string) {
 
   const connect = useCallback(
     (cursor?: number) => {
+      if (!endpoint) return;
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
       }
@@ -140,6 +130,7 @@ function useSSEStream(endpoint: string, memory: string) {
 
   const fetchPage = useCallback(
     async (cursor?: number) => {
+      if (!endpoint) return null;
       abortControllerRef.current?.abort();
       abortControllerRef.current = new AbortController();
 
@@ -229,7 +220,7 @@ function useSSEStream(endpoint: string, memory: string) {
       trackEvent({
         name: 'broker_data_purged',
         properties: {
-          streamType: endpoint.split('/').pop(),
+          streamType: endpoint?.split('/').pop(),
           memoryName: memory,
         },
       });
@@ -241,9 +232,21 @@ function useSSEStream(endpoint: string, memory: string) {
   }, [endpoint, memory]);
 
   useEffect(() => {
+    mountedRef.current = true;
+
+    if (!endpoint) {
+      disconnect();
+      setStreamedEntries([]);
+      setFetchedEntries([]);
+      nextCursorRef.current = undefined;
+      setHasMore(true);
+      setError(null);
+      initialFetchDoneRef.current = false;
+      return;
+    }
+
     if (initialFetchDoneRef.current) return;
     initialFetchDoneRef.current = true;
-    mountedRef.current = true;
 
     async function init() {
       let cursor: number | undefined;
@@ -273,7 +276,7 @@ function useSSEStream(endpoint: string, memory: string) {
       abortControllerRef.current?.abort();
       initialFetchDoneRef.current = false;
     };
-  }, [connect, disconnect, fetchPage]);
+  }, [endpoint, connect, disconnect, fetchPage]);
 
   const entries = [...streamedEntries, ...fetchedEntries];
 
@@ -289,23 +292,6 @@ interface StreamViewProps {
   error: string | null;
   onPurge: () => void;
   onLoadMore?: () => void;
-}
-
-interface SessionsViewProps {
-  title: string;
-  eventEntries: StreamEntry[];
-  chunkEntries: StreamEntry[];
-  traceEntries: StreamEntry[];
-  messageEntries: StreamEntry[];
-  eventsConnected: boolean;
-  chunksConnected: boolean;
-  tracesConnected: boolean;
-  messagesConnected: boolean;
-  error: string | null;
-  onPurgeEvents: () => void;
-  onPurgeChunks: () => void;
-  onPurgeTraces: () => void;
-  onPurgeMessages: () => void;
 }
 
 function StreamView({
@@ -424,117 +410,73 @@ function StreamView({
   );
 }
 
-function SessionsView({
-  title,
-  eventEntries,
-  chunkEntries,
-  traceEntries,
-  messageEntries,
-  eventsConnected,
-  chunksConnected,
-  tracesConnected,
-  messagesConnected,
-  error,
-  onPurgeEvents,
-  onPurgeChunks,
-  onPurgeTraces,
-  onPurgeMessages,
-}: SessionsViewProps) {
+function SessionsLiveView() {
+  const [store, setStore] = useState<Record<string, unknown>>({});
+  const [isConnected, setIsConnected] = useState(false);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [autoScroll, setAutoScroll] = useState(true);
-  const [expandedSessions, setExpandedSessions] = useState<Set<string>>(
-    new Set(),
-  );
-  const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set());
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const allEntries = useMemo(() => {
-    const combined = [
-      ...eventEntries,
-      ...chunkEntries,
-      ...traceEntries,
-      ...messageEntries,
-    ];
-    return sortEntriesByTimestampAndSequence(combined);
-  }, [eventEntries, chunkEntries, traceEntries, messageEntries]);
+  useEffect(() => {
+    const es = new EventSource('/api/v1/broker/sessions?watch=true');
+    const sessions: Record<string, unknown> = {};
+
+    es.onopen = () => setIsConnected(true);
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.sessionId && data.session) {
+          sessions[data.sessionId] = data.session;
+          setStore({ sessions: { ...sessions } });
+        }
+      } catch {
+      }
+    };
+    es.onerror = () => setIsConnected(false);
+
+    return () => es.close();
+  }, []);
 
   useEffect(() => {
     if (autoScroll && containerRef.current) {
       containerRef.current.scrollTop = 0;
     }
-  }, [allEntries, autoScroll]);
+  }, [store, autoScroll]);
 
-  const queryToSessionMapRef = useRef<Record<string, string>>({});
-
-  const queryToSessionMap = queryToSessionMapRef.current;
-
-  const groupedBySession = groupEntriesBySession(allEntries, queryToSessionMap);
-
-  const sortedSessions = Object.entries(groupedBySession).sort((a, b) => {
-    const aLatest = a[1][0]?.timestamp || '';
-    const bLatest = b[1][0]?.timestamp || '';
-    return aLatest.localeCompare(bLatest);
+  const sessions = (store as { sessions?: Record<string, unknown> }).sessions || {};
+  const sessionIds = Object.keys(sessions).sort((a, b) => {
+    const aSession = sessions[a] as { lastActivity?: string };
+    const bSession = sessions[b] as { lastActivity?: string };
+    return new Date(bSession.lastActivity || 0).getTime() - new Date(aSession.lastActivity || 0).getTime();
   });
 
-  const toggleSession = (sessionId: string) => {
-    setExpandedSessions(prev => {
+  const toggleExpanded = (id: string) => {
+    setExpandedIds(prev => {
       const next = new Set(prev);
-      if (next.has(sessionId)) {
-        next.delete(sessionId);
-      } else {
-        next.add(sessionId);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };
 
-  const toggleEvent = (eventId: string) => {
-    setExpandedEvents(prev => {
-      const next = new Set(prev);
-      if (next.has(eventId)) {
-        next.delete(eventId);
-      } else {
-        next.add(eventId);
-      }
-      return next;
-    });
-  };
-
-  const handlePurgeAll = async () => {
-    await Promise.all([
-      onPurgeEvents(),
-      onPurgeChunks(),
-      onPurgeTraces(),
-      onPurgeMessages(),
-    ]);
+  const handlePurge = async () => {
+    try {
+      await fetch('/api/v1/broker/sessions', { method: 'DELETE' });
+      setStore({ sessions: {} });
+    } catch {
+    }
   };
 
   return (
     <Card className="flex h-full flex-col">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <div className="flex items-center gap-2">
-          <CardTitle className="text-base font-medium">{title}</CardTitle>
-          <div className="flex items-center gap-1">
-            <span
-              className={`h-2 w-2 rounded-full ${eventsConnected ? 'bg-green-500' : 'bg-gray-300'}`}
-              title="Events"
-            />
-            <span
-              className={`h-2 w-2 rounded-full ${chunksConnected ? 'bg-green-500' : 'bg-gray-300'}`}
-              title="Chunks"
-            />
-            <span
-              className={`h-2 w-2 rounded-full ${tracesConnected ? 'bg-green-500' : 'bg-gray-300'}`}
-              title="Traces"
-            />
-            <span
-              className={`h-2 w-2 rounded-full ${messagesConnected ? 'bg-green-500' : 'bg-gray-300'}`}
-              title="Messages"
-            />
-          </div>
+          <CardTitle className="text-base font-medium">Sessions</CardTitle>
+          <span className={`h-2 w-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-gray-300'}`} />
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={handlePurgeAll}>
-            Purge All
+          <Button variant="outline" size="sm" onClick={handlePurge}>
+            Purge
           </Button>
           <label className="flex items-center gap-1.5 text-sm">
             <Switch checked={autoScroll} onCheckedChange={setAutoScroll} />
@@ -543,93 +485,41 @@ function SessionsView({
         </div>
       </CardHeader>
       <CardContent className="flex-1 overflow-hidden">
-        {error && (
-          <div className="mb-2 rounded bg-red-100 p-2 text-sm text-red-700">
-            {error}
-          </div>
-        )}
         <div
           ref={containerRef}
           className="bg-muted h-[calc(100vh-280px)] overflow-x-hidden overflow-y-auto rounded-md p-2 font-mono text-xs">
-          {allEntries.length === 0 ? (
+          {sessionIds.length === 0 ? (
             <div className="text-muted-foreground flex h-full items-center justify-center">
               Waiting for data...
             </div>
           ) : (
-            <>
-              {sortedSessions.map(([sessionId, sessionEntries]) => {
-                const isSessionExpanded = expandedSessions.has(sessionId);
-                const displayName = getSessionDisplayNameFromEntries(
-                  sessionEntries,
-                  sessionId,
-                );
-                return (
-                  <div
-                    key={sessionId}
-                    className="border-border mb-2 rounded border p-2">
-                    <div
-                      className="flex cursor-pointer items-center gap-2"
-                      onClick={() => toggleSession(sessionId)}>
-                      {isSessionExpanded ? (
-                        <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
+            sessionIds.map(sid => {
+              const isExpanded = expandedIds.has(sid);
+              return (
+                <div key={sid} className="border-border mb-1 overflow-hidden border-b pb-1 last:border-b-0">
+                  <div className="flex min-w-0 items-center gap-1">
+                    <span
+                      className="flex shrink-0 cursor-pointer items-center gap-1"
+                      onClick={() => toggleExpanded(sid)}>
+                      {isExpanded ? (
+                        <ChevronDown className="text-muted-foreground h-3 w-3 shrink-0" />
                       ) : (
-                        <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                        <ChevronRight className="text-muted-foreground h-3 w-3 shrink-0" />
                       )}
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="font-semibold">
-                              Session: {displayName}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>{sessionId}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <span className="text-muted-foreground ml-auto">
-                        ({sessionEntries.length} events)
-                      </span>
-                    </div>
-                    {isSessionExpanded && (
-                      <div className="mt-2 ml-6 space-y-1">
-                        {sessionEntries.map(entry => {
-                          const isEventExpanded = expandedEvents.has(entry.id);
-                          return (
-                            <div
-                              key={entry.id}
-                              className="border-border overflow-hidden border-b pb-1 last:border-b-0">
-                              <div className="flex min-w-0 items-center gap-1">
-                                <span
-                                  className="flex shrink-0 cursor-pointer items-center gap-1"
-                                  onClick={() => toggleEvent(entry.id)}>
-                                  {isEventExpanded ? (
-                                    <ChevronDown className="text-muted-foreground h-3 w-3 shrink-0" />
-                                  ) : (
-                                    <ChevronRight className="text-muted-foreground h-3 w-3 shrink-0" />
-                                  )}
-                                  <span>{entry.timestamp}</span>
-                                </span>
-                                {!isEventExpanded && (
-                                  <span className="text-muted-foreground w-0 flex-1 truncate">
-                                    {JSON.stringify(entry.data)}
-                                  </span>
-                                )}
-                              </div>
-                              {isEventExpanded && (
-                                <pre className="mt-1 break-all whitespace-pre-wrap">
-                                  {JSON.stringify(entry.data, null, 2)}
-                                </pre>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
+                    </span>
+                    <span className="text-muted-foreground shrink-0">
+                      {(sessions[sid] as { lastActivity?: string })?.lastActivity?.substring(0, 19) || ''}Z
+                    </span>
+                    <span className="truncate">{sid}</span>
                   </div>
-                );
-              })}
-            </>
+                  {isExpanded && (
+                    <pre className="mt-1 whitespace-pre-wrap break-all pl-5">
+                      {JSON.stringify(sessions[sid], null, 2)}
+                    </pre>
+                  )}
+                </div>
+              );
+            })
           )}
         </div>
       </CardContent>
@@ -641,11 +531,12 @@ export default function BrokerPage() {
   const [memories, setMemories] = useState<Memory[]>([]);
   const [selectedMemory, setSelectedMemory] = useState<string>('default');
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState('traces');
 
-  const traces = useSSEStream('/v1/broker/traces', selectedMemory);
-  const messages = useSSEStream('/v1/broker/messages', selectedMemory);
-  const chunks = useSSEStream('/v1/broker/chunks', selectedMemory);
-  const events = useSSEStream('/v1/broker/events', selectedMemory);
+  const traces = useSSEStream(activeTab === 'traces' ? '/v1/broker/traces' : null, selectedMemory);
+  const messages = useSSEStream(activeTab === 'messages' ? '/v1/broker/messages' : null, selectedMemory);
+  const chunks = useSSEStream(activeTab === 'chunks' ? '/v1/broker/chunks' : null, selectedMemory);
+  const events = useSSEStream(activeTab === 'events' ? '/v1/broker/events' : null, selectedMemory);
 
   useEffect(() => {
     async function fetchMemories() {
@@ -673,6 +564,7 @@ export default function BrokerPage() {
           defaultValue="traces"
           className="flex-1"
           onValueChange={tab => {
+            setActiveTab(tab);
             trackEvent({
               name: 'broker_tab_changed',
               properties: { tabName: tab },
@@ -762,24 +654,7 @@ export default function BrokerPage() {
             />
           </TabsContent>
           <TabsContent value="sessions" className="mt-4 flex-1">
-            <SessionsView
-              title="Sessions"
-              eventEntries={events.entries}
-              chunkEntries={chunks.entries}
-              traceEntries={traces.entries}
-              messageEntries={messages.entries}
-              eventsConnected={events.isConnected}
-              chunksConnected={chunks.isConnected}
-              tracesConnected={traces.isConnected}
-              messagesConnected={messages.isConnected}
-              error={
-                events.error || chunks.error || traces.error || messages.error
-              }
-              onPurgeEvents={events.purge}
-              onPurgeChunks={chunks.purge}
-              onPurgeTraces={traces.purge}
-              onPurgeMessages={messages.purge}
-            />
+            <SessionsLiveView />
           </TabsContent>
         </Tabs>
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -56,7 +56,7 @@ function extractItemTimestamp(item: unknown): string {
   return new Date().toISOString();
 }
 
-function useSSEStream(endpoint: string | null, memory: string) {
+export function useSSEStream(endpoint: string | null, memory: string) {
   const [streamedEntries, setStreamedEntries] = useState<StreamEntry[]>([]);
   const [fetchedEntries, setFetchedEntries] = useState<StreamEntry[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -410,7 +410,7 @@ function StreamView({
   );
 }
 
-function SessionsView() {
+export function SessionsView({ memory }: { memory: string }) {
   const [store, setStore] = useState<Record<string, unknown>>({});
   const [isConnected, setIsConnected] = useState(false);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -418,7 +418,7 @@ function SessionsView() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const es = new EventSource('/api/v1/broker/sessions?watch=true');
+    const es = new EventSource(`/api/v1/broker/sessions?memory=${encodeURIComponent(memory)}&watch=true`);
     const sessions: Record<string, unknown> = {};
 
     es.onopen = () => setIsConnected(true);
@@ -435,7 +435,7 @@ function SessionsView() {
     es.onerror = () => setIsConnected(false);
 
     return () => es.close();
-  }, []);
+  }, [memory]);
 
   useEffect(() => {
     if (autoScroll && containerRef.current) {
@@ -461,7 +461,7 @@ function SessionsView() {
 
   const handlePurge = async () => {
     try {
-      await fetch('/api/v1/broker/sessions', { method: 'DELETE' });
+      await fetch(`/api/v1/broker/sessions?memory=${encodeURIComponent(memory)}`, { method: 'DELETE' });
       setStore({ sessions: {} });
     } catch {
     }
@@ -498,18 +498,23 @@ function SessionsView() {
               return (
                 <div key={sid} className="border-border mb-1 overflow-hidden border-b pb-1 last:border-b-0">
                   <div className="flex min-w-0 items-center gap-1">
-                    <span
-                      className="flex shrink-0 cursor-pointer items-center gap-1"
+                    <button
+                      type="button"
+                      aria-label={isExpanded ? 'Collapse session' : 'Expand session'}
+                      aria-expanded={isExpanded}
+                      className="flex shrink-0 cursor-pointer items-center gap-1 bg-transparent p-0"
                       onClick={() => toggleExpanded(sid)}>
                       {isExpanded ? (
                         <ChevronDown className="text-muted-foreground h-3 w-3 shrink-0" />
                       ) : (
                         <ChevronRight className="text-muted-foreground h-3 w-3 shrink-0" />
                       )}
-                    </span>
-                    <span className="text-muted-foreground shrink-0">
-                      {(sessions[sid] as { lastActivity?: string })?.lastActivity?.substring(0, 19) || ''}Z
-                    </span>
+                    </button>
+                    {(sessions[sid] as { lastActivity?: string })?.lastActivity && (
+                      <span className="text-muted-foreground shrink-0">
+                        {(sessions[sid] as { lastActivity?: string }).lastActivity!.substring(0, 19)}Z
+                      </span>
+                    )}
                     <span className="truncate">{sid}</span>
                   </div>
                   {isExpanded && (
@@ -654,7 +659,7 @@ export default function BrokerPage() {
             />
           </TabsContent>
           <TabsContent value="sessions" className="mt-4 flex-1">
-            <SessionsView />
+            <SessionsView memory={selectedMemory} />
           </TabsContent>
         </Tabs>
       </div>

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -410,7 +410,7 @@ function StreamView({
   );
 }
 
-function SessionsLiveView() {
+function SessionsView() {
   const [store, setStore] = useState<Record<string, unknown>>({});
   const [isConnected, setIsConnected] = useState(false);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -654,7 +654,7 @@ export default function BrokerPage() {
             />
           </TabsContent>
           <TabsContent value="sessions" className="mt-4 flex-1">
-            <SessionsLiveView />
+            <SessionsView />
           </TabsContent>
         </Tabs>
       </div>

--- a/services/ark-dashboard/ark-dashboard/atoms/chat-history.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/chat-history.ts
@@ -1,4 +1,5 @@
 import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+import { v4 as uuidv4 } from 'uuid';
 
 import type { ExtendedChatMessage } from '@/lib/types/chat-message';
 
@@ -29,4 +30,5 @@ export const chatHistoryAtom = atomWithStorage<ChatHistoryMap>(
   { getOnInit: false },
 );
 
-export const createNewSessionId = () => `session-${Date.now()}`;
+export const createNewSessionId = (name: string) =>
+  `chat-${name}-${uuidv4().slice(0, 7)}`;

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -511,6 +511,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/broker/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sessions
+         * @description Get or stream sessions from the broker. Sessions are global broker state, not memory-scoped, but the memory parameter selects which broker service to query.
+         */
+        get: operations["get_sessions_v1_broker_sessions_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Purge Sessions
+         * @description Purge all sessions from the broker.
+         */
+        delete: operations["purge_sessions_v1_broker_sessions_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/broker/traces": {
         parameters: {
             query?: never;
@@ -4859,6 +4883,72 @@ export interface operations {
         };
     };
     purge_messages_v1_broker_messages_delete: {
+        parameters: {
+            query?: {
+                /** @description Memory resource name */
+                memory?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sessions_v1_broker_sessions_get: {
+        parameters: {
+            query?: {
+                /** @description Stream sessions via SSE */
+                watch?: boolean;
+                /** @description Memory resource name */
+                memory?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_sessions_v1_broker_sessions_delete: {
         parameters: {
             query?: {
                 /** @description Memory resource name */

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
@@ -50,17 +50,18 @@ export function useChatSession({
   );
   const chatKey = `${type}-${name}`;
 
-  const initSessionIdRef = useRef<string>(
-    lastConversationId || createNewSessionId(),
-  );
+  const pendingSessionIdRef = useRef<string | null>(null);
 
   const chatSession = useMemo(() => {
     const existing = chatHistory?.[chatKey];
     if (existing?.messages !== undefined && existing?.sessionId) {
       return existing;
     }
-    return { messages: [], sessionId: initSessionIdRef.current };
-  }, [chatHistory, chatKey]);
+    if (!pendingSessionIdRef.current) {
+      pendingSessionIdRef.current = createNewSessionId(name);
+    }
+    return { messages: [], sessionId: pendingSessionIdRef.current };
+  }, [chatHistory, chatKey, name]);
 
   const chatMessages = chatSession.messages;
   const sessionId = chatSession.sessionId;
@@ -68,14 +69,15 @@ export function useChatSession({
 
   useEffect(() => {
     if (!chatHistory?.[chatKey]) {
-      const sessionIdToUse = initSessionIdRef.current;
+      const sessionIdToUse = pendingSessionIdRef.current ?? createNewSessionId(name);
+      pendingSessionIdRef.current = sessionIdToUse;
       setLastConversationId(sessionIdToUse);
       setChatHistory(prev => ({
         ...(prev || {}),
         [chatKey]: { messages: [], sessionId: sessionIdToUse },
       }));
     }
-  }, [chatKey, chatHistory, setChatHistory, setLastConversationId]);
+  }, [chatKey, chatHistory, name, setChatHistory, setLastConversationId]);
 
   const updateChatMessages = useCallback(
     (
@@ -745,8 +747,8 @@ export function useChatSession({
   );
 
   const clearChat = useCallback(() => {
-    const newSessionId = createNewSessionId();
-    initSessionIdRef.current = newSessionId;
+    const newSessionId = createNewSessionId(name);
+    pendingSessionIdRef.current = newSessionId;
     setLastConversationId(newSessionId);
     setChatHistory(prev => ({
       ...(prev || {}),
@@ -758,7 +760,7 @@ export function useChatSession({
       },
     }));
     setError(null);
-  }, [chatKey, setChatHistory, setLastConversationId]);
+  }, [chatKey, name, setChatHistory, setLastConversationId]);
 
   return {
     messages: chatMessages,


### PR DESCRIPTION
## Summary
- ark-dashboard: new live Sessions tab on the Broker page (SSE-streamed) showing real-time sessions and their queries
- ark-api: GET + DELETE `/v1/broker/sessions` proxy to ark-broker, with SSE streaming, mirroring the events route
- ark-broker chart: `SESSIONS_FILE_PATH` env var so sessions persist across pod restarts (gated on `persistence.enabled`)
- ark-dashboard: each chat popup now generates its own `chat-<name>-<shortsha>` session id (was: every popup reused the first chat's id via the global `lastConversationId` atom)
- ark-dashboard: regenerated `types.ts` for the new sessions endpoints
- ark-dashboard: SessionsView now uses the `selectedMemory` state for EventSource and purge calls
- ark-dashboard: conditional rendering for lastActivity timestamp (no lone 'Z')
- ark-api: remove user-controlled data from broker log warning (pre-existing log injection)
- sonar-project.properties: exclude generated types.ts from CPD duplication detection

Fixes #1810

Verified end-to-end via Playwright: opened two distinct agent chats and confirmed two distinct rows (`chat-planner-...`, `chat-code-reviewer-...`) in the broker Sessions tab.