### PR TITLE
feat: simplify marketplace spec — current namespace only

### DIFF
--- a/openspec/changes/2026-04-01-marketplace-services/design.md
+++ b/openspec/changes/2026-04-01-marketplace-services/design.md
@@ -30,10 +30,10 @@ $ kubectl get agents,mcpservers,a2aservers -A | grep phoenix
 
 **Goals:**
 - Infrastructure services show correct installation status in dashboard
-- Marketplace items can surface their web UIs with "Open" button
+- Marketplace items can surface their web UIs with "Open" button (or custom label)
 - Solution only works for items in the same namespace as ark-api (namespace-scoped detection)
 - No post-install hooks or complex patching required
-- Leverage existing Helm and Kubernetes standards (no custom labels)
+- Leverage existing Helm and Kubernetes standards
 - Retire the services page in favor of enhanced marketplace page
 
 **Non-Goals:**
@@ -44,32 +44,41 @@ $ kubectl get agents,mcpservers,a2aservers -A | grep phoenix
 
 ## Decisions
 
-### 1. Use Helm releases for installation detection
+### 1. Use Helm releases with chart annotations for installation detection
 
-Query Helm releases via the existing `/v1/ark-services` endpoint to determine if a marketplace item is installed.
+Query Helm releases via the `/v1/marketplace-items` endpoint and match using the `ark.mckinsey.com/marketplace-item-name` annotation baked into `Chart.yaml`.
+
+```yaml
+# Chart.yaml for phoenix
+apiVersion: v2
+name: phoenix
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "services/phoenix"
+```
 
 ```typescript
 // Detection flow
-const releases = await fetch('/v1/ark-services?list_all_services=true')
+const releases = await fetch('/v1/marketplace-items')
 const isInstalled = releases.items.some(r =>
-  r.name === item.ark.helmReleaseName && r.status === 'deployed'
+  r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
+  && r.status === 'deployed'
 )
 ```
 
-**Why Helm releases over Deployment labels:**
-Helm releases are the source of truth for "this was installed." They're always present when something is installed via Helm, survive pod restarts and deployment disruptions, and ark-api already reads them via `/v1/ark-services`. This eliminates the need for custom labels, post-install hooks, and RBAC expansion for Deployment reads.
+**Why chart annotations over Helm release name matching:**
+Release names are chosen at install time by the user (`helm install my-obs ./phoenix-chart`). Chart annotations are baked in at build time and survive regardless of naming. This eliminates fragile coupling between release names and marketplace manifest entries.
 
 **What this enables:**
 - Single detection mechanism (no two-tier CRD + fallback)
 - Rich metadata available (version, revision, status, updated timestamp)
 - No additional resources to label or patch
-- Consistent with existing services page pattern
+- Users can name their releases freely
 
 **Trade-off accepted:** Namespace-scoped detection only. Helm releases are stored as Secrets in the release namespace, and ark-api uses a Role (not ClusterRole), so it can only detect items in its own namespace.
 
-### 2. Use Service annotations for UI URLs
+### 2. Use Service annotations for UI URLs and labels
 
-For marketplace items with web UIs, store the externally-reachable URL as an annotation on the Kubernetes Service resource.
+For marketplace items with web UIs, store the externally-reachable URL and optional display label as annotations on the Kubernetes Service resource.
 
 ```yaml
 apiVersion: v1
@@ -79,7 +88,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: "phoenix"  # Helm adds this automatically
   annotations:
-    ark.mckinsey.com/ui-url: "https://phoenix.example.com"
+    ark.mckinsey.com/marketplace-item-ui-url: "https://phoenix.example.com"
+    ark.mckinsey.com/marketplace-item-ui-label: "Dashboard"
 spec:
   ports:
     - port: 6006
@@ -91,85 +101,76 @@ Services are the network entry point and map 1:1 to endpoints. Service metadata 
 **Why annotations not Chart.yaml:**
 Chart.yaml annotations are static (baked in at chart build time) and cannot be overridden at install time. Service annotations are runtime-configurable from Helm values, allowing admins to specify the URL for their specific networking setup.
 
+**Multi-UI support via `marketplace-item-ui-label`:**
+Some marketplace items expose multiple Services with UIs. For example, an Argo Workflows item might have a MinIO UI and an Argo dashboard. The `marketplace-item-ui-label` annotation lets each Service specify its display label. If absent, the dashboard falls back to "Open".
+
 **Example Helm chart template:**
 ```yaml
 # templates/service.yaml
 metadata:
   annotations:
     {{- if .Values.uiUrl }}
-    ark.mckinsey.com/ui-url: "{{ .Values.uiUrl }}"
+    ark.mckinsey.com/marketplace-item-ui-url: "{{ .Values.uiUrl }}"
+    {{- end }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: "{{ .Values.uiLabel }}"
     {{- end }}
 ```
 
 ### 3. Query Services using Helm's standard label
 
-To retrieve UI URLs, query Services for a Helm release using the standard `app.kubernetes.io/instance` label, then extract `ark.mckinsey.com/ui-url` annotations.
+To retrieve UI URLs, query Services for a Helm release using the standard `app.kubernetes.io/instance` label, then extract `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label` annotations.
 
 **Why `app.kubernetes.io/instance`:**
-Helm automatically sets `app.kubernetes.io/instance: "{{ .Release.Name }}"` on all resources per [Helm best practices](https://helm.sh/docs/chart_best_practices/labels/). This is a Kubernetes standard label - no need to add custom labels.
+Helm automatically sets `app.kubernetes.io/instance: "{{ .Release.Name }}"` on all resources per [Helm best practices](https://helm.sh/docs/chart_best_practices/labels/). This is a Kubernetes standard label — no need to add custom labels.
 
 **Multi-Service support:**
-A single Helm release can create multiple Services (e.g., frontend + admin UIs). This query finds all Services for that release, each potentially having different `ui-url` annotations.
+A single Helm release can create multiple Services (e.g., dashboard + admin UIs). This query finds all Services for that release, each potentially having different UI URL and label annotations.
 
 **Query pattern:**
 ```typescript
-GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${helmReleaseName}
+GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${releaseName}
 ```
 
-**Requires:** `/v1/resources` endpoint with `labelSelector` parameter support (added by PR #1440).
+**Requires:** `/v1/resources` endpoint with `labelSelector` parameter support — single shared implementation used across all resource types (added by PR #1440).
 
-### 4. Marketplace manifest declares UI intent
+### 4. No manifest-level UI declaration needed
 
-Extend marketplace manifest with `ark.ui.enabled` field to indicate which items have web UIs.
-
-```json
-{
-  "name": "phoenix",
-  "ark": {
-    "helmReleaseName": "phoenix",
-    "namespace": "phoenix",
-    "k8sServiceName": "phoenix",
-    "k8sServicePort": 6006,
-    "ui": {
-      "enabled": true
-    }
-  }
-}
-```
-
-**Why static UI declaration:**
-The manifest declares "this item has a UI" as static metadata. The actual URL comes from the Helm install (environment-specific). This allows the dashboard to skip Service queries for items without UIs.
+The presence of the `ark.mckinsey.com/marketplace-item-ui-url` annotation on a Service is the signal that a UI exists. No `ark.ui.enabled` field is needed in the marketplace manifest.
 
 **Conditional query logic:**
-- Dashboard only queries Services (Decision 3) when **both** conditions are true:
-  1. `item.ark.ui.enabled === true` (manifest declares UI)
-  2. `item.status === 'installed'` (Helm release deployed)
-- If UI URL found: show "Open" button
-- If no UI URL: item installed but URL not configured
+- Dashboard queries Services (Decision 3) for all installed marketplace items
+- If any matching Service has a `marketplace-item-ui-url` annotation: show button with label from `marketplace-item-ui-label` (or "Open" as fallback)
+- If no UI URL annotation found: item is installed but has no UI
 
 ### 5. Complete detection and UI URL flow
 
 The dashboard combines Decisions 1-4 into a single flow. For each marketplace item:
 
 ```typescript
-// Decision 1: Check if Helm release is deployed
-const releases = await arkApi.getServices(namespace, true)
-const isInstalled = releases.items.some(r =>
-  r.name === item.ark.helmReleaseName && r.status === 'deployed'
+// Decision 1: Check if Helm release is deployed (by chart annotation)
+const releases = await arkApi.getMarketplaceItems(namespace)
+const matchingRelease = releases.items.find(r =>
+  r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
+  && r.status === 'deployed'
 )
 
-// Decision 4: Only query Services if installed AND UI enabled
-if (isInstalled && item.ark.ui?.enabled) {
+if (matchingRelease) {
   // Decision 3: Query Services using standard Helm label
   const services = await k8sApi.getServices({
-    labelSelector: `app.kubernetes.io/instance=${item.ark.helmReleaseName}`
+    labelSelector: `app.kubernetes.io/instance=${matchingRelease.name}`
   })
-  // Decision 2: Extract UI URL from Service annotation
-  const uiUrl = services.items[0]?.metadata.annotations?.['ark.mckinsey.com/ui-url']
 
-  if (uiUrl) {
-    return <Button onClick={() => window.open(uiUrl)}>Open</Button>
-  }
+  // Decision 2: Extract UI URLs and labels from Service annotations
+  const uis = services.items
+    .filter(svc => svc.metadata.annotations?.['ark.mckinsey.com/marketplace-item-ui-url'])
+    .map(svc => ({
+      url: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-url'],
+      label: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-label'] || 'Open'
+    }))
+
+  // Render buttons for each UI
+  uis.forEach(ui => <Button onClick={() => window.open(ui.url)}>{ui.label}</Button>)
 }
 ```
 
@@ -178,7 +179,7 @@ if (isInstalled && item.ark.ui?.enabled) {
 The services page functionality is fully absorbed by the marketplace page. Users access installed service UIs through the marketplace page instead.
 
 **Implementation steps:**
-1. Add "Open" button to marketplace cards for items with UI URLs
+1. Add buttons to marketplace cards for items with UI URLs (using label or "Open" fallback)
 2. Add "Installed" filter view to marketplace page
 3. Remove services page from navigation
 4. Remove services page code and components
@@ -189,10 +190,9 @@ The marketplace manifest includes an `installScope` field to distinguish between
 
 ```json
 {
-  "name": "phoenix",
-  "installScope": "cluster",
+  "name": "services/phoenix",
+  "installScope": "namespace",
   "ark": {
-    "helmReleaseName": "phoenix",
     "namespace": "phoenix"
   }
 }
@@ -243,53 +243,68 @@ Users need to understand detection limitations. Cluster-scoped items (like opera
 
 ### ark-api (this repo)
 
-**No new endpoints needed.** Uses existing:
-- `/v1/ark-services?list_all_services=true` — for Helm release queries
-- `/v1/resources/v1/Service?labelSelector=...` — for Service queries (requires `labelSelector` support from PR #1440)
+**New endpoint:** `/v1/marketplace-items` — queries Helm releases and returns them for dashboard consumption. Replaces `/v1/ark-services` for this use case.
+
+**Existing endpoint:** `/v1/resources/v1/Service?labelSelector=...` — for Service queries. `labelSelector` must be a single shared implementation used across all resource types (requires support from PR #1440).
 
 **RBAC:** Already has permissions to read Helm releases (Secrets) and Services in its namespace. No expansion needed.
 
 ### Dashboard (this repo)
 
 **Modified files:**
-- `lib/services/marketplace-fetcher.ts` — Detection logic using `/v1/ark-services`
+- `lib/services/marketplace-fetcher.ts` — Detection logic using `/v1/marketplace-items`
 - `lib/services/kubernetes.ts` — Service query helper using `labelSelector`
-- `components/cards/marketplace-item-card.tsx` — "Open" button when `uiUrl` present
-- `lib/api/generated/marketplace-types.ts` — Add `uiUrl` and `uiEnabled` fields
+- `components/cards/marketplace-item-card.tsx` — UI buttons with labels when URL annotations present
+- `lib/api/generated/marketplace-types.ts` — Add `uiUrl` and `uiLabel` fields
 
 **Detection flow:**
 ```typescript
 async function getInstalledMarketplaceItems(items: MarketplaceItem[]) {
-  // Query all Helm releases once
-  const releases = await fetch('/v1/ark-services?list_all_services=true')
+  const releases = await fetch('/v1/marketplace-items')
 
   return items.map(item => {
-    // Check if this item's Helm release exists and is deployed
-    const isInstalled = releases.items.some(r =>
-      r.name === item.ark.helmReleaseName && r.status === 'deployed'
+    const matchingRelease = releases.items.find(r =>
+      r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
+      && r.status === 'deployed'
     )
-    let uiUrl = undefined
 
-    // Only query Services if installed AND manifest declares UI
-    if (isInstalled && item.ark.ui?.enabled) {
+    let uis: { url: string; label: string }[] = []
+
+    if (matchingRelease) {
       const services = await fetch(
-        `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${item.ark.helmReleaseName}`
+        `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${matchingRelease.name}`
       )
-      uiUrl = services.items[0]?.metadata.annotations?.['ark.mckinsey.com/ui-url']
+      uis = services.items
+        .filter(svc => svc.metadata.annotations?.['ark.mckinsey.com/marketplace-item-ui-url'])
+        .map(svc => ({
+          url: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-url'],
+          label: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-label'] || 'Open'
+        }))
     }
 
-    return { ...item, status: isInstalled ? 'installed' : 'available', uiUrl }
+    return {
+      ...item,
+      status: matchingRelease ? 'installed' : 'available',
+      uis
+    }
   })
 }
 ```
 
 ### Marketplace Charts (agents-at-scale-marketplace repo)
 
-**For each chart with a web UI (phoenix, langfuse, a2a-inspector, mcp-inspector):**
+**For each chart:**
 
-1. **No label changes needed** — Helm already adds `app.kubernetes.io/instance: "{{ .Release.Name }}"` to all resources
+1. **Add marketplace item annotation to Chart.yaml:**
+```yaml
+# Chart.yaml
+apiVersion: v2
+name: phoenix
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "services/phoenix"
+```
 
-2. **Add annotation to Service template:**
+2. **For charts with a web UI, add annotations to Service template:**
 ```yaml
 # templates/service.yaml
 apiVersion: v1
@@ -298,39 +313,41 @@ metadata:
   name: {{ include "phoenix.fullname" . }}
   annotations:
     {{- if .Values.uiUrl }}
-    ark.mckinsey.com/ui-url: "{{ .Values.uiUrl }}"
+    ark.mckinsey.com/marketplace-item-ui-url: "{{ .Values.uiUrl }}"
+    {{- end }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: "{{ .Values.uiLabel }}"
     {{- end }}
 spec:
   # ... existing spec
 ```
 
-3. **Update values.yaml with UI URL config:**
+3. **Update values.yaml with UI config:**
 ```yaml
 # values.yaml
-# UI URL configuration (environment-specific)
-uiUrl: ""  # Set via --set uiUrl=https://phoenix.example.com
+uiUrl: ""      # Set via --set uiUrl=https://phoenix.example.com
+uiLabel: ""    # Set via --set uiLabel="Dashboard" (defaults to "Open" if empty)
 ```
 
 4. **Update marketplace.json:**
 ```json
 {
-  "name": "phoenix",
+  "name": "services/phoenix",
+  "installScope": "namespace",
   "ark": {
-    "helmReleaseName": "phoenix",
-    "ui": {
-      "enabled": true
-    }
+    "namespace": "phoenix"
   }
 }
 ```
 
 **Install examples:**
 ```bash
-# URL configured
+# URL and label configured
 helm install phoenix ./chart \
-  --set uiUrl=https://phoenix.example.com
+  --set uiUrl=https://phoenix.example.com \
+  --set uiLabel="Phoenix Dashboard"
 
-# Local dev (no URL configured)
+# Local dev (no URL configured — no "Open" button shown)
 helm install phoenix ./chart
 ```
 
@@ -338,25 +355,26 @@ helm install phoenix ./chart
 
 **For chart authors** (marketplace repo CONTRIBUTING.md):
 ```markdown
+## Marketplace Item Detection
+
+Add the `ark.mckinsey.com/marketplace-item-name` annotation to your Chart.yaml:
+  ark.mckinsey.com/marketplace-item-name: "<type>/<name>"
+
 ## UI URL Configuration
 
 If your marketplace item has a web UI:
-
-1. Add `ark.ui.enabled: true` to marketplace.json
-2. Add `ark.mckinsey.com/ui-url` annotation to Service template, templated from `.Values.uiUrl`
-3. Add `uiUrl: ""` to values.yaml with example usage in comments
+1. Add `ark.mckinsey.com/marketplace-item-ui-url` annotation to Service template, templated from `.Values.uiUrl`
+2. Optionally add `ark.mckinsey.com/marketplace-item-ui-label` for a custom button label (defaults to "Open")
+3. Add `uiUrl: ""` and `uiLabel: ""` to values.yaml
 ```
 
 **For users** (dashboard or marketplace docs):
 ```markdown
 ## Accessing Marketplace Item UIs
 
-Items with web UIs show an "Open" button when installed with a configured URL:
+Items with web UIs show a button (labeled per the chart author, or "Open") when installed with a configured URL:
 
-```bash
-# Set the externally-reachable URL for your networking setup
-helm install <item> --set uiUrl=<your-url>
+  helm install <item> --set uiUrl=<your-url> --set uiLabel="My Dashboard"
 
-# Without URL configuration, item shows as installed but no "Open" button appears
-```
+Without URL configuration, item shows as installed but no button appears.
 ```

--- a/openspec/changes/2026-04-01-marketplace-services/design.md
+++ b/openspec/changes/2026-04-01-marketplace-services/design.md
@@ -2,51 +2,50 @@
 
 ## Context
 
-The Ark dashboard has two issues with marketplace services:
+The Ark marketplace page has two issues:
 
-1. **Installation detection** — Infrastructure services (Phoenix, Langfuse, A2A Inspector, MCP Inspector) show as "not installed" even when successfully deployed. Dashboard detection queries Ark CRDs via export service, but these infrastructure services create only standard Kubernetes resources (Deployments, Services, HTTPRoutes) without Ark CRDs.
+1. **Installation detection** — Marketplace items (Phoenix, Langfuse, A2A Inspector, MCP Inspector) show as "not installed" even when deployed. Dashboard detection queries Ark CRDs, but these items create only standard Kubernetes resources.
 
-2. **UI access** — Marketplace items with web UIs have no way to surface those UIs through the dashboard. The services page (`/services`) attempts this but makes brittle assumptions about port-forwarding and nip.io routing, making it unreliable across deployment modes (Ingress, Gateway API, LoadBalancer, local).
+2. **UI access** — Items with web UIs have no way to surface them. The services page makes brittle assumptions about port-forwarding and nip.io routing.
 
-Evidence of problem 1:
+Evidence:
 ```bash
-# Helm + pods running
-$ helm list -A | grep phoenix
-phoenix  phoenix  1  deployed  ✓
+$ helm list | grep phoenix
+phoenix  default  1  deployed  ✓
 
-# No Ark CRDs exist
-$ kubectl get agents,mcpservers,a2aservers -A | grep phoenix
-(empty)  ✗
+$ kubectl get agents,mcpservers -A | grep phoenix
+(empty)
 
-# Dashboard shows: "Get" (not installed)  ✗
+# Dashboard shows: "Get" (not installed)
 ```
 
-**Prior work:**
-- PR #1440 initially proposed Deployment labeling with post-install hooks
-- PR #1598 extended this to include UI URL annotations on Deployments
-- Community feedback suggested simplifying to use Helm releases directly
+**Prior work:** PR #1440 (Deployment labeling), PR #1598 (UI URL annotations on Deployments). Community feedback suggested using Helm releases directly.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Infrastructure services show correct installation status in dashboard
-- Marketplace items can surface their web UIs with "Open" button (or custom label)
-- Solution only works for items in the same namespace as ark-api (namespace-scoped detection)
-- No post-install hooks or complex patching required
+- Marketplace page shows items in the user's current namespace
+- Items show correct installation status
+- Items with web UIs get an "Open" button (or custom label)
+- No post-install hooks or complex patching
 - Leverage existing Helm and Kubernetes standards
-- Retire the services page in favor of enhanced marketplace page
+- Retire the services page
 
 **Non-Goals:**
-- Embedded/iframe UIs within the dashboard (future work)
-- OIDC token passthrough to marketplace item UIs (future work)
-- Automatic URL detection from Ingress/HTTPRoute/Gateway resources (too fragile across setups)
-- Cross-namespace resource discovery (deferred; requires ClusterRole)
+- Cross-namespace discovery (marketplace = current namespace only)
+- Embedded/iframe UIs within the dashboard
+- OIDC token passthrough to item UIs
+- Automatic URL detection from Ingress/HTTPRoute/Gateway
 
 ## Decisions
 
-### 1. Use Helm releases with chart annotations for installation detection
+### 1. Marketplace page is current-namespace only
 
-Query Helm releases via the `/v1/marketplace-items` endpoint and match using the `ark.mckinsey.com/marketplace-item-name` annotation baked into `Chart.yaml`.
+The marketplace page shows what is installed in the user's current namespace. Detection queries Helm releases in that namespace. If a user installs something, it goes to their namespace.
+
+### 2. Detect installed items via chart annotations
+
+Query Helm releases via `/v1/marketplace-items` and match using the `ark.mckinsey.com/marketplace-item-name` annotation in `Chart.yaml`.
 
 ```yaml
 # Chart.yaml for phoenix
@@ -57,7 +56,6 @@ annotations:
 ```
 
 ```typescript
-// Detection flow
 const releases = await fetch('/v1/marketplace-items')
 const isInstalled = releases.items.some(r =>
   r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
@@ -65,20 +63,12 @@ const isInstalled = releases.items.some(r =>
 )
 ```
 
-**Why chart annotations over Helm release name matching:**
-Release names are chosen at install time by the user (`helm install my-obs ./phoenix-chart`). Chart annotations are baked in at build time and survive regardless of naming. This eliminates fragile coupling between release names and marketplace manifest entries.
+**Why chart annotations over release name matching:**
+Release names are chosen at install time. Chart annotations are baked in at build time and survive regardless of naming.
 
-**What this enables:**
-- Single detection mechanism (no two-tier CRD + fallback)
-- Rich metadata available (version, revision, status, updated timestamp)
-- No additional resources to label or patch
-- Users can name their releases freely
+### 3. UI URLs and labels via Service annotations
 
-**Trade-off accepted:** Namespace-scoped detection only. Helm releases are stored as Secrets in the release namespace, and ark-api uses a Role (not ClusterRole), so it can only detect items in its own namespace.
-
-### 2. Use Service annotations for UI URLs and labels
-
-For marketplace items with web UIs, store the externally-reachable URL and optional display label as annotations on the Kubernetes Service resource.
+Store the externally-reachable URL and optional display label as annotations on the Kubernetes Service.
 
 ```yaml
 apiVersion: v1
@@ -86,7 +76,7 @@ kind: Service
 metadata:
   name: phoenix
   labels:
-    app.kubernetes.io/instance: "phoenix"  # Helm adds this automatically
+    app.kubernetes.io/instance: "phoenix"
   annotations:
     ark.mckinsey.com/marketplace-item-ui-url: "https://phoenix.example.com"
     ark.mckinsey.com/marketplace-item-ui-label: "Dashboard"
@@ -95,16 +85,9 @@ spec:
     - port: 6006
 ```
 
-**Why Service annotations over Deployment annotations (PR #1598 original approach):**
-Services are the network entry point and map 1:1 to endpoints. Service metadata is templatable from Helm values at install time (no post-install patching needed). This aligns with Kubernetes conventions where networking metadata lives on Service resources.
+**Multi-UI support:** Some items expose multiple Services with UIs (e.g., Argo Workflows: MinIO + Argo dashboard). Each Service can have its own URL and label. If label is absent, dashboard shows "Open".
 
-**Why annotations not Chart.yaml:**
-Chart.yaml annotations are static (baked in at chart build time) and cannot be overridden at install time. Service annotations are runtime-configurable from Helm values, allowing admins to specify the URL for their specific networking setup.
-
-**Multi-UI support via `marketplace-item-ui-label`:**
-Some marketplace items expose multiple Services with UIs. For example, an Argo Workflows item might have a MinIO UI and an Argo dashboard. The `marketplace-item-ui-label` annotation lets each Service specify its display label. If absent, the dashboard falls back to "Open".
-
-**Example Helm chart template:**
+**Helm chart template:**
 ```yaml
 # templates/service.yaml
 metadata:
@@ -117,264 +100,92 @@ metadata:
     {{- end }}
 ```
 
-### 3. Query Services using Helm's standard label
+### 4. Query Services using Helm's standard label
 
-To retrieve UI URLs, query Services for a Helm release using the standard `app.kubernetes.io/instance` label, then extract `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label` annotations.
+Query Services for a Helm release using `app.kubernetes.io/instance`, then extract UI annotations.
 
-**Why `app.kubernetes.io/instance`:**
-Helm automatically sets `app.kubernetes.io/instance: "{{ .Release.Name }}"` on all resources per [Helm best practices](https://helm.sh/docs/chart_best_practices/labels/). This is a Kubernetes standard label — no need to add custom labels.
-
-**Multi-Service support:**
-A single Helm release can create multiple Services (e.g., dashboard + admin UIs). This query finds all Services for that release, each potentially having different UI URL and label annotations.
-
-**Query pattern:**
 ```typescript
 GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${releaseName}
 ```
 
-**Requires:** `/v1/resources` endpoint with `labelSelector` parameter support — single shared implementation used across all resource types (added by PR #1440).
+Helm automatically sets this label on all resources. Single shared `labelSelector` implementation on the `/v1/resources` endpoint.
 
-### 4. No manifest-level UI declaration needed
+### 5. No manifest-level UI declaration
 
-The presence of the `ark.mckinsey.com/marketplace-item-ui-url` annotation on a Service is the signal that a UI exists. No `ark.ui.enabled` field is needed in the marketplace manifest.
+The `ark.mckinsey.com/marketplace-item-ui-url` annotation on a Service is the signal a UI exists. No `ark.ui.enabled` manifest field needed.
 
-**Conditional query logic:**
-- Dashboard queries Services (Decision 3) for all installed marketplace items
-- If any matching Service has a `marketplace-item-ui-url` annotation: show button with label from `marketplace-item-ui-label` (or "Open" as fallback)
-- If no UI URL annotation found: item is installed but has no UI
-
-### 5. Complete detection and UI URL flow
-
-The dashboard combines Decisions 1-4 into a single flow. For each marketplace item:
+### 6. Complete flow
 
 ```typescript
-// Decision 1: Check if Helm release is deployed (by chart annotation)
 const releases = await arkApi.getMarketplaceItems(namespace)
-const matchingRelease = releases.items.find(r =>
-  r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
-  && r.status === 'deployed'
-)
 
-if (matchingRelease) {
-  // Decision 3: Query Services using standard Helm label
-  const services = await k8sApi.getServices({
-    labelSelector: `app.kubernetes.io/instance=${matchingRelease.name}`
-  })
+return items.map(item => {
+  const release = releases.items.find(r =>
+    r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
+    && r.status === 'deployed'
+  )
 
-  // Decision 2: Extract UI URLs and labels from Service annotations
-  const uis = services.items
-    .filter(svc => svc.metadata.annotations?.['ark.mckinsey.com/marketplace-item-ui-url'])
-    .map(svc => ({
-      url: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-url'],
-      label: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-label'] || 'Open'
-    }))
+  let uis: { url: string; label: string }[] = []
 
-  // Render buttons for each UI
-  uis.forEach(ui => <Button onClick={() => window.open(ui.url)}>{ui.label}</Button>)
-}
-```
-
-### 6. Services page sunset
-
-The services page functionality is fully absorbed by the marketplace page. Users access installed service UIs through the marketplace page instead.
-
-**Implementation steps:**
-1. Add buttons to marketplace cards for items with UI URLs (using label or "Open" fallback)
-2. Add "Installed" filter view to marketplace page
-3. Remove services page from navigation
-4. Remove services page code and components
-
-### 7. Namespace vs cluster-scoped detection
-
-The marketplace manifest includes an `installScope` field to distinguish between namespace-scoped and cluster-scoped deployments (addresses [#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522)).
-
-```json
-{
-  "name": "services/phoenix",
-  "installScope": "namespace",
-  "ark": {
-    "namespace": "phoenix"
+  if (release) {
+    const services = await k8sApi.getServices({
+      labelSelector: `app.kubernetes.io/instance=${release.name}`
+    })
+    uis = services.items
+      .filter(svc => svc.metadata.annotations?.['ark.mckinsey.com/marketplace-item-ui-url'])
+      .map(svc => ({
+        url: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-url'],
+        label: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-label'] || 'Open'
+      }))
   }
-}
+
+  return { ...item, status: release ? 'installed' : 'available', uis }
+})
 ```
 
-**Scope values:**
-- `"namespace"`: Item deployed in the same namespace as ark-api — detection supported
-- `"cluster"`: Item may be deployed in different namespace or cluster-wide — detection not supported, requires manual verification
+### 7. Services page sunset
 
-**Dashboard behavior:**
-- **Namespace-scoped items**: Show "Installed" when Helm release detected in ark-api's namespace
-- **Cluster-scoped items**: Always show "Get" with scope badge indicating manual verification needed
-- Badge displayed on marketplace cards: `[Namespace]` or `[Cluster]`
-
-**Why this matters:**
-Users need to understand detection limitations. Cluster-scoped items (like operators) may be installed but won't auto-detect due to namespace-scoped RBAC. The badge sets correct expectations.
-
-**Implementation:**
-```typescript
-// In marketplace card
-{item.installScope === 'cluster' && (
-  <Badge>Cluster</Badge>
-)}
-{item.installScope === 'namespace' && (
-  <Badge>Namespace</Badge>
-)}
-```
+1. Add buttons to marketplace cards for items with UI URLs
+2. Add "Installed" filter to marketplace page
+3. Remove services page and components
 
 ## Risks / Trade-offs
 
-**Namespace limitation** — ark-api can only detect items in its own namespace due to Role-scoped RBAC (not ClusterRole). Items deployed to other namespaces cannot be auto-detected.
+**URL configuration burden** — Admins must set `uiUrl` at install time. Acceptable because the admin who sets up networking knows the URL.
 
-*Mitigation:* Marketplace manifest can include `installScope: "cluster"` badge to inform users. Future work could add ClusterRole option for cluster-wide detection.
-
-**URL configuration burden** — Admins must set the `uiUrl` Helm value at install time for their networking setup (Ingress hostname, LoadBalancer IP, etc.).
-
-*Mitigation:* This is acceptable because the admin who sets up networking knows the URL. Chart templates can provide sensible defaults (localhost + port for local dev).
-
-**URL staleness** — If admin changes Ingress hostname after install, the Service annotation becomes stale.
-
-*Mitigation:* This matches how other annotation-based systems work (external-dns, cert-manager). Admin must update annotation when networking changes. Helm upgrade with new values updates the annotation.
-
-**HTTPRoute auto-discovery** — The `/v1/ark-services` endpoint already discovers HTTPRoutes and constructs URLs. Why not use this?
-
-*Mitigation:* HTTPRoute discovery only works for Gateway API deployments, not Ingress, LoadBalancer, or port-forward setups (the "fragile assumptions" mentioned in #1596). Explicit Service annotations work universally across all deployment modes.
+**URL staleness** — If networking changes, the annotation becomes stale. `helm upgrade` with new values fixes it.
 
 ## Implementation Notes
 
 ### ark-api (this repo)
 
-**New endpoint:** `/v1/marketplace-items` — queries Helm releases and returns them for dashboard consumption. Replaces `/v1/ark-services` for this use case.
+**New endpoint:** `/v1/marketplace-items` — queries Helm releases in current namespace.
 
-**Existing endpoint:** `/v1/resources/v1/Service?labelSelector=...` — for Service queries. `labelSelector` must be a single shared implementation used across all resource types (requires support from PR #1440).
+**Existing endpoint:** `/v1/resources/v1/Service?labelSelector=...` — single shared `labelSelector` implementation.
 
-**RBAC:** Already has permissions to read Helm releases (Secrets) and Services in its namespace. No expansion needed.
+**RBAC:** Already has permissions. No expansion needed.
 
 ### Dashboard (this repo)
 
 **Modified files:**
-- `lib/services/marketplace-fetcher.ts` — Detection logic using `/v1/marketplace-items`
-- `lib/services/kubernetes.ts` — Service query helper using `labelSelector`
-- `components/cards/marketplace-item-card.tsx` — UI buttons with labels when URL annotations present
-- `lib/api/generated/marketplace-types.ts` — Add `uiUrl` and `uiLabel` fields
+- `lib/services/marketplace-fetcher.ts` — detection logic
+- `lib/services/kubernetes.ts` — Service query helper
+- `components/cards/marketplace-item-card.tsx` — UI buttons
+- `lib/api/generated/marketplace-types.ts` — add `uis` field
 
-**Detection flow:**
-```typescript
-async function getInstalledMarketplaceItems(items: MarketplaceItem[]) {
-  const releases = await fetch('/v1/marketplace-items')
-
-  return items.map(item => {
-    const matchingRelease = releases.items.find(r =>
-      r.chart?.metadata?.annotations?.['ark.mckinsey.com/marketplace-item-name'] === item.name
-      && r.status === 'deployed'
-    )
-
-    let uis: { url: string; label: string }[] = []
-
-    if (matchingRelease) {
-      const services = await fetch(
-        `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${matchingRelease.name}`
-      )
-      uis = services.items
-        .filter(svc => svc.metadata.annotations?.['ark.mckinsey.com/marketplace-item-ui-url'])
-        .map(svc => ({
-          url: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-url'],
-          label: svc.metadata.annotations['ark.mckinsey.com/marketplace-item-ui-label'] || 'Open'
-        }))
-    }
-
-    return {
-      ...item,
-      status: matchingRelease ? 'installed' : 'available',
-      uis
-    }
-  })
-}
-```
+**Removed:**
+- Services page and ark-services components
 
 ### Marketplace Charts (agents-at-scale-marketplace repo)
 
-**For each chart:**
+1. Add `ark.mckinsey.com/marketplace-item-name` to `Chart.yaml`
+2. Add `ark.mckinsey.com/marketplace-item-ui-url` to Service template (from `.Values.uiUrl`)
+3. Optionally add `ark.mckinsey.com/marketplace-item-ui-label` (from `.Values.uiLabel`)
+4. Add `uiUrl: ""` and `uiLabel: ""` to `values.yaml`
 
-1. **Add marketplace item annotation to Chart.yaml:**
-```yaml
-# Chart.yaml
-apiVersion: v2
-name: phoenix
-annotations:
-  ark.mckinsey.com/marketplace-item-name: "services/phoenix"
-```
-
-2. **For charts with a web UI, add annotations to Service template:**
-```yaml
-# templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "phoenix.fullname" . }}
-  annotations:
-    {{- if .Values.uiUrl }}
-    ark.mckinsey.com/marketplace-item-ui-url: "{{ .Values.uiUrl }}"
-    {{- end }}
-    {{- if .Values.uiLabel }}
-    ark.mckinsey.com/marketplace-item-ui-label: "{{ .Values.uiLabel }}"
-    {{- end }}
-spec:
-  # ... existing spec
-```
-
-3. **Update values.yaml with UI config:**
-```yaml
-# values.yaml
-uiUrl: ""      # Set via --set uiUrl=https://phoenix.example.com
-uiLabel: ""    # Set via --set uiLabel="Dashboard" (defaults to "Open" if empty)
-```
-
-4. **Update marketplace.json:**
-```json
-{
-  "name": "services/phoenix",
-  "installScope": "namespace",
-  "ark": {
-    "namespace": "phoenix"
-  }
-}
-```
-
-**Install examples:**
+**Install example:**
 ```bash
-# URL and label configured
 helm install phoenix ./chart \
   --set uiUrl=https://phoenix.example.com \
   --set uiLabel="Phoenix Dashboard"
-
-# Local dev (no URL configured — no "Open" button shown)
-helm install phoenix ./chart
-```
-
-### Documentation
-
-**For chart authors** (marketplace repo CONTRIBUTING.md):
-```markdown
-## Marketplace Item Detection
-
-Add the `ark.mckinsey.com/marketplace-item-name` annotation to your Chart.yaml:
-  ark.mckinsey.com/marketplace-item-name: "<type>/<name>"
-
-## UI URL Configuration
-
-If your marketplace item has a web UI:
-1. Add `ark.mckinsey.com/marketplace-item-ui-url` annotation to Service template, templated from `.Values.uiUrl`
-2. Optionally add `ark.mckinsey.com/marketplace-item-ui-label` for a custom button label (defaults to "Open")
-3. Add `uiUrl: ""` and `uiLabel: ""` to values.yaml
-```
-
-**For users** (dashboard or marketplace docs):
-```markdown
-## Accessing Marketplace Item UIs
-
-Items with web UIs show a button (labeled per the chart author, or "Open") when installed with a configured URL:
-
-  helm install <item> --set uiUrl=<your-url> --set uiLabel="My Dashboard"
-
-Without URL configuration, item shows as installed but no button appears.
 ```

--- a/openspec/changes/2026-04-01-marketplace-services/proposal.md
+++ b/openspec/changes/2026-04-01-marketplace-services/proposal.md
@@ -12,77 +12,80 @@ Marketplace items that expose web UIs have no reliable way to surface their UI t
 
 ## What Changes
 
-- Marketplace items are detected by querying Helm releases and matching release names to manifest `helmReleaseName`
-- Service annotations carry UI URLs (`ark.mckinsey.com/ui-url`) for items with web interfaces
-- Marketplace manifest extends with `ark.ui.enabled` field to declare UI intent and `installScope` field to indicate namespace vs cluster-scoped deployment
-- Dashboard queries Helm releases via ark-api's existing `/v1/ark-services` endpoint
-- Dashboard queries Services using Helm's standard label `app.kubernetes.io/instance={helmReleaseName}` to retrieve UI URLs
-- Dashboard renders "Open" button on marketplace cards and detail pages when UI is enabled and URL is configured
+- Marketplace items are detected by querying Helm releases and checking for the `ark.mckinsey.com/marketplace-item-name` chart annotation
+- Service annotations carry UI URLs (`ark.mckinsey.com/marketplace-item-ui-url`) and optional display labels (`ark.mckinsey.com/marketplace-item-ui-label`) for items with web interfaces
+- Marketplace manifest extends with `installScope` field to indicate namespace vs cluster-scoped deployment
+- Dashboard queries Helm releases via ark-api's `/v1/marketplace-items` endpoint
+- Dashboard queries Services using Helm's standard label `app.kubernetes.io/instance` to retrieve UI URLs
+- Dashboard renders "Open" button (or custom label) on marketplace cards and detail pages when a UI URL annotation is present
 - Dashboard displays scope badge (namespace/cluster) to indicate detection capability and deployment scope
 - Services page is deprecated and removed, with functionality absorbed by marketplace page
 
-## Why Helm Releases
+## Why Helm Releases with Chart Annotations
 
 - Source of truth: Helm release exists if and only if item was installed via Helm
 - Survives disruptions: Helm releases persist through pod restarts, deployment failures
 - Rich metadata: Contains version, revision, status, updated timestamp
-- Already implemented: `/v1/ark-services` endpoint queries Helm releases
-- Direct name matching: marketplace.json `helmReleaseName` matches Helm release name
+- Annotation-based matching: `ark.mckinsey.com/marketplace-item-name` in `Chart.yaml` is baked in at build time and survives regardless of what the user names their release
 - No RBAC expansion: ark-api already has permissions to read Helm releases
-- No additional metadata: Use existing release names, no new annotations needed
+- No fragile name coupling: Users can name their Helm release anything and detection still works
 
 ## Why Service Annotations for UI URLs
 
 - Runtime configurable: Service annotations set from Helm values at install time
 - Network entry point: Service is the natural place for URL metadata
-- Standard Helm labels: Query Services using `app.kubernetes.io/instance={helmReleaseName}` (automatically added by Helm)
-- Multi-Service support: Finds all Services for a Helm release (supports multiple UIs per marketplace item)
+- Standard Helm labels: Query Services using `app.kubernetes.io/instance` (automatically added by Helm)
+- Multi-Service support: Finds all Services for a Helm release (supports multiple UIs per marketplace item via `marketplace-item-ui-label`)
 - Network agnostic: URL annotation works with any setup (Ingress, Gateway API, LoadBalancer, port-forward)
 
 ## Capabilities
 
 ### New Capabilities
-- `helm-release-detection`: Dashboard detects installed marketplace items by querying Helm releases and matching names
-- `ui-url-discovery`: Service annotations provide UI endpoint URLs
-- `marketplace-ui-enabled`: Marketplace manifest declares UI intent
-- `marketplace-open-action`: Dashboard renders "Open" action for installed items when UI enabled and URL configured
+- `marketplace-item-listing`: Dashboard detects installed marketplace items by querying Helm releases and matching chart annotations
+- `ui-url-discovery`: Service annotations provide UI endpoint URLs with optional display labels
+- `marketplace-open-action`: Dashboard renders "Open" action (or custom label) for installed items when UI URL annotation is present
 - `services-page-sunset`: Services page deprecated and removed, functionality absorbed by marketplace page
 
 ### Modified Capabilities
-- `marketplace-installation-detection`: Detection via Helm release name matching
+- `marketplace-installation-detection`: Detection via `ark.mckinsey.com/marketplace-item-name` chart annotation
 
 ## Impact
 
 ### ark-api
-- Uses existing `/v1/ark-services` endpoint for Helm release queries
-- Requires `/v1/resources` endpoint with `labelSelector` parameter support
+- Exposes `/v1/marketplace-items` endpoint for Helm release queries (replaces `/v1/ark-services` for this use case)
+- Requires `/v1/resources` endpoint with `labelSelector` parameter support (single shared implementation)
 - ark-api already has RBAC to read Helm releases (Secrets) and Services in its namespace
 - **Namespace limitation:** Can only detect items in same namespace as ark-api
 
 ### Dashboard
 - Modified: `marketplace-fetcher.ts`, `marketplace-item-card.tsx`, marketplace detail page
-- Query Helm releases via `/v1/ark-services?list_all_services=true`
-- Match releases by name: `release.name == item.ark.helmReleaseName`
-- Query Services by Helm label: `GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance={helmReleaseName}`
-- Extract `ui-url` annotations from all matching Services (supports multiple UIs)
-- Extended types: Add `uiUrl` and `uiEnabled` to `MarketplaceItem`
+- Query Helm releases via `/v1/marketplace-items`
+- Match releases by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] == item.name`
+- Query Services by Helm label: `GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance={releaseName}`
+- Extract `marketplace-item-ui-url` and `marketplace-item-ui-label` annotations from all matching Services (supports multiple UIs)
+- Extended types: Add `uiUrl`, `uiLabel` to `MarketplaceItem`
 - Remove: Services page and ark-services components
 
 ### Marketplace Repository
-- Service templates include `ark.mckinsey.com/ui-url` annotation
-- Annotation set from Helm values at install time
-- Marketplace manifest extended with `ark.ui` field
-- No Chart.yaml changes needed
+- `Chart.yaml` includes `ark.mckinsey.com/marketplace-item-name` annotation (e.g., `services/phoenix`)
+- Service templates include `ark.mckinsey.com/marketplace-item-ui-url` annotation (set from Helm values)
+- Service templates optionally include `ark.mckinsey.com/marketplace-item-ui-label` annotation (e.g., "Dashboard", "MinIO Console")
+- Marketplace manifest extended with `installScope` field
+- No `helmReleaseName` needed in manifest for detection purposes
 
 ## Alternatives Considered
 
-**Custom Service labels:** Adding `ark.mckinsey.com/marketplace-item` label to Services. Not needed since Helm already adds standard `app.kubernetes.io/instance={releaseName}` label to all resources.
+**Helm release name matching:** Matching marketplace.json `helmReleaseName` to Helm release name. Fragile because users can name their release anything (`helm install observability ./phoenix-chart`). Chart annotation is baked in at build time and survives regardless.
 
-**Chart.yaml annotations:** Adding marketplace metadata to Chart.yaml. Not needed since manifest `helmReleaseName` already matches Helm release name.
+**Custom Service labels:** Adding `ark.mckinsey.com/marketplace-item` label to Services. Not needed since Helm already adds standard `app.kubernetes.io/instance` label to all resources.
+
+**Chart.yaml annotations for UI URLs:** Chart.yaml annotations are static (baked in at build time) and cannot be overridden at install time. Service annotations are runtime-configurable from Helm values.
 
 **Deployment resources:** Would require additional RBAC permissions and doesn't align with the network entry point concept for UI URLs.
 
 **Auto-discovery from HTTPRoute/Ingress:** Too fragile across different networking setups and cannot reliably determine URLs.
+
+**`ark.ui.enabled` manifest field:** Unnecessary. The presence of the `ark.mckinsey.com/marketplace-item-ui-url` annotation on a Service is the signal that a UI exists. No separate manifest flag needed.
 
 ## References
 

--- a/openspec/changes/2026-04-01-marketplace-services/proposal.md
+++ b/openspec/changes/2026-04-01-marketplace-services/proposal.md
@@ -2,93 +2,79 @@
 
 ## Why
 
-**Problem 1: Infrastructure services don't show as installed** ([#1269](https://github.com/mckinsey/agents-at-scale-ark/issues/1269))
+**Problem 1: Marketplace items don't show as installed** ([#1269](https://github.com/mckinsey/agents-at-scale-ark/issues/1269))
 
-Infrastructure marketplace services (Phoenix, Langfuse, A2A Inspector, MCP Inspector) show as "not installed" in the dashboard even when successfully deployed. Dashboard detection only checks Ark CRDs, but these services create only standard Kubernetes resources.
+Marketplace items (Phoenix, Langfuse, A2A Inspector, MCP Inspector) show as "not installed" in the dashboard even when deployed. Dashboard detection only checks Ark CRDs, but these items create standard Kubernetes resources without Ark CRDs.
 
 **Problem 2: No way to access marketplace item UIs** (addresses part of [#1596](https://github.com/mckinsey/agents-at-scale-ark/issues/1596))
 
-Marketplace items that expose web UIs have no reliable way to surface their UI through the dashboard. The current services page attempts this but relies on fragile assumptions about networking setups, making it unreliable across different environments. By adding UI URL support directly to the marketplace page, we can provide a reliable "Open" action for installed services and sunset the services page entirely.
+Marketplace items with web UIs have no way to surface them through the dashboard. The services page relies on fragile networking assumptions. By adding UI URL support to the marketplace page, we provide a reliable "Open" action and sunset the services page.
 
 ## What Changes
 
-- Marketplace items are detected by querying Helm releases and checking for the `ark.mckinsey.com/marketplace-item-name` chart annotation
-- Service annotations carry UI URLs (`ark.mckinsey.com/marketplace-item-ui-url`) and optional display labels (`ark.mckinsey.com/marketplace-item-ui-label`) for items with web interfaces
-- Marketplace manifest extends with `installScope` field to indicate namespace vs cluster-scoped deployment
+- Marketplace page shows items in the user's current namespace only
+- Items are detected by querying Helm releases and checking the `ark.mckinsey.com/marketplace-item-name` chart annotation
+- Service annotations carry UI URLs (`ark.mckinsey.com/marketplace-item-ui-url`) and optional display labels (`ark.mckinsey.com/marketplace-item-ui-label`)
 - Dashboard queries Helm releases via ark-api's `/v1/marketplace-items` endpoint
-- Dashboard queries Services using Helm's standard label `app.kubernetes.io/instance` to retrieve UI URLs
-- Dashboard renders "Open" button (or custom label) on marketplace cards and detail pages when a UI URL annotation is present
-- Dashboard displays scope badge (namespace/cluster) to indicate detection capability and deployment scope
-- Services page is deprecated and removed, with functionality absorbed by marketplace page
+- Dashboard queries Services using Helm's standard `app.kubernetes.io/instance` label to retrieve UI URLs
+- Dashboard renders buttons on marketplace cards when a UI URL annotation is present
+- Services page is removed, functionality absorbed by marketplace page
 
 ## Why Helm Releases with Chart Annotations
 
 - Source of truth: Helm release exists if and only if item was installed via Helm
 - Survives disruptions: Helm releases persist through pod restarts, deployment failures
-- Rich metadata: Contains version, revision, status, updated timestamp
-- Annotation-based matching: `ark.mckinsey.com/marketplace-item-name` in `Chart.yaml` is baked in at build time and survives regardless of what the user names their release
+- Rich metadata: version, revision, status, updated timestamp
+- Annotation-based matching: `ark.mckinsey.com/marketplace-item-name` in `Chart.yaml` is baked in at build time, survives regardless of release naming
 - No RBAC expansion: ark-api already has permissions to read Helm releases
-- No fragile name coupling: Users can name their Helm release anything and detection still works
 
 ## Why Service Annotations for UI URLs
 
-- Runtime configurable: Service annotations set from Helm values at install time
+- Runtime configurable: set from Helm values at install time
 - Network entry point: Service is the natural place for URL metadata
-- Standard Helm labels: Query Services using `app.kubernetes.io/instance` (automatically added by Helm)
-- Multi-Service support: Finds all Services for a Helm release (supports multiple UIs per marketplace item via `marketplace-item-ui-label`)
-- Network agnostic: URL annotation works with any setup (Ingress, Gateway API, LoadBalancer, port-forward)
+- Standard Helm labels: query using `app.kubernetes.io/instance` (added by Helm automatically)
+- Multi-Service support: multiple UIs per marketplace item via `marketplace-item-ui-label`
+- Network agnostic: works with Ingress, Gateway API, LoadBalancer, port-forward
 
 ## Capabilities
 
-### New Capabilities
-- `marketplace-item-listing`: Dashboard detects installed marketplace items by querying Helm releases and matching chart annotations
-- `ui-url-discovery`: Service annotations provide UI endpoint URLs with optional display labels
-- `marketplace-open-action`: Dashboard renders "Open" action (or custom label) for installed items when UI URL annotation is present
-- `services-page-sunset`: Services page deprecated and removed, functionality absorbed by marketplace page
+### New
+- `marketplace-item-listing`: Detect installed items by querying Helm releases and matching chart annotations
+- `ui-url-discovery`: Service annotations provide UI URLs with optional display labels
+- `marketplace-open-action`: Dashboard renders buttons for installed items with UI URLs
+- `services-page-sunset`: Services page removed, absorbed by marketplace page
 
-### Modified Capabilities
+### Modified
 - `marketplace-installation-detection`: Detection via `ark.mckinsey.com/marketplace-item-name` chart annotation
 
 ## Impact
 
 ### ark-api
-- Exposes `/v1/marketplace-items` endpoint for Helm release queries (replaces `/v1/ark-services` for this use case)
-- Requires `/v1/resources` endpoint with `labelSelector` parameter support (single shared implementation)
-- ark-api already has RBAC to read Helm releases (Secrets) and Services in its namespace
-- **Namespace limitation:** Can only detect items in same namespace as ark-api
+- Exposes `/v1/marketplace-items` endpoint for Helm release queries
+- Requires `labelSelector` parameter on `/v1/resources` (single shared implementation)
+- Already has RBAC to read Helm releases (Secrets) and Services in its namespace
 
 ### Dashboard
-- Modified: `marketplace-fetcher.ts`, `marketplace-item-card.tsx`, marketplace detail page
 - Query Helm releases via `/v1/marketplace-items`
-- Match releases by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] == item.name`
-- Query Services by Helm label: `GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance={releaseName}`
-- Extract `marketplace-item-ui-url` and `marketplace-item-ui-label` annotations from all matching Services (supports multiple UIs)
-- Extended types: Add `uiUrl`, `uiLabel` to `MarketplaceItem`
-- Remove: Services page and ark-services components
+- Match by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] == item.name`
+- Query Services by Helm label to extract UI URLs and labels
+- Add `uis` field to `MarketplaceItem` type
+- Remove services page and ark-services components
 
 ### Marketplace Repository
-- `Chart.yaml` includes `ark.mckinsey.com/marketplace-item-name` annotation (e.g., `services/phoenix`)
-- Service templates include `ark.mckinsey.com/marketplace-item-ui-url` annotation (set from Helm values)
-- Service templates optionally include `ark.mckinsey.com/marketplace-item-ui-label` annotation (e.g., "Dashboard", "MinIO Console")
-- Marketplace manifest extended with `installScope` field
-- No `helmReleaseName` needed in manifest for detection purposes
+- `Chart.yaml` includes `ark.mckinsey.com/marketplace-item-name` annotation
+- Service templates include `ark.mckinsey.com/marketplace-item-ui-url` annotation
+- Service templates optionally include `ark.mckinsey.com/marketplace-item-ui-label` annotation
 
 ## Alternatives Considered
 
-**Helm release name matching:** Matching marketplace.json `helmReleaseName` to Helm release name. Fragile because users can name their release anything (`helm install observability ./phoenix-chart`). Chart annotation is baked in at build time and survives regardless.
+**Helm release name matching:** Fragile — users can name releases anything. Chart annotation is baked in at build time.
 
-**Custom Service labels:** Adding `ark.mckinsey.com/marketplace-item` label to Services. Not needed since Helm already adds standard `app.kubernetes.io/instance` label to all resources.
+**`ark.ui.enabled` manifest field:** Unnecessary. Annotation presence on the Service is the signal.
 
-**Chart.yaml annotations for UI URLs:** Chart.yaml annotations are static (baked in at build time) and cannot be overridden at install time. Service annotations are runtime-configurable from Helm values.
-
-**Deployment resources:** Would require additional RBAC permissions and doesn't align with the network entry point concept for UI URLs.
-
-**Auto-discovery from HTTPRoute/Ingress:** Too fragile across different networking setups and cannot reliably determine URLs.
-
-**`ark.ui.enabled` manifest field:** Unnecessary. The presence of the `ark.mckinsey.com/marketplace-item-ui-url` annotation on a Service is the signal that a UI exists. No separate manifest flag needed.
+**Auto-discovery from HTTPRoute/Ingress:** Too fragile across networking setups.
 
 ## References
 
-- [Labels and Selectors - Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 - [Recommended Labels - Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
 - [Helm Labels and Annotations Best Practices](https://helm.sh/docs/chart_best_practices/labels/)

--- a/openspec/changes/2026-04-01-marketplace-services/tasks.md
+++ b/openspec/changes/2026-04-01-marketplace-services/tasks.md
@@ -6,62 +6,69 @@
 
 - [ ] 0.5.1 Update `list_grouped_resources()` in `services/ark-api/ark-api/src/ark_api/api/v1/resources.py`
 - [ ] 0.5.2 Add parameter: `labelSelector: Optional[str] = Query(None, description="Kubernetes label selector (e.g., 'app.kubernetes.io/instance=phoenix')")`
-- [ ] 0.5.3 Pass `label_selector=labelSelector` to `api_resource.get()` call
+- [ ] 0.5.3 Pass `label_selector=labelSelector` to `api_resource.get()` call — single shared implementation used across all resource types
 - [ ] 0.5.4 Update function docstring to document labelSelector parameter
 - [ ] 0.5.5 Add tests in `services/ark-api/ark-api/tests/api/test_resources.py` for label selector filtering
 - [ ] 0.5.6 Test manually: `GET /v1/resources/v1/Service?namespace=phoenix&labelSelector=app.kubernetes.io/instance=phoenix`
 - [ ] 0.5.7 Verify OpenAPI spec auto-generates with new parameter
 
+## 0.6 Add `/v1/marketplace-items` Endpoint to ark-api
+
+- [ ] 0.6.1 Create `/v1/marketplace-items` endpoint that queries Helm releases (replaces `/v1/ark-services` for marketplace use case)
+- [ ] 0.6.2 Return release metadata including `chart.metadata.annotations` so dashboard can read `ark.mckinsey.com/marketplace-item-name`
+- [ ] 0.6.3 Add tests for the new endpoint
+
 ## 1. Marketplace Manifest Schema
 
-- [ ] 1.1 Add `ark.ui` field to marketplace manifest schema — add `ui: { enabled: boolean }` to the `GitHubMarketplaceItem` interface in `marketplace-fetcher.ts`
-- [ ] 1.2 Add `installScope` field to `GitHubMarketplaceItem` interface — add `installScope?: 'namespace' | 'cluster'` to support scope badges ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
-- [ ] 1.3 Update marketplace items in the marketplace repo (`mckinsey/agents-at-scale-marketplace`) to set `ark.ui.enabled: true` on items with web UIs (Phoenix, Langfuse, A2A Inspector, MCP Inspector)
-- [ ] 1.4 Update marketplace items to set `installScope: "namespace"` or `installScope: "cluster"` based on deployment scope
+- [ ] 1.1 Add `installScope` field to `GitHubMarketplaceItem` interface — add `installScope?: 'namespace' | 'cluster'` to support scope badges ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
+- [ ] 1.2 Update marketplace items in the marketplace repo (`mckinsey/agents-at-scale-marketplace`) to set `installScope: "namespace"` or `installScope: "cluster"` based on deployment scope
+- [ ] 1.3 Update marketplace item names in marketplace.json to use `<type>/<name>` format (e.g., `services/phoenix`)
 
-## 2. Dashboard Type Extensions
+## 2. Marketplace Chart Annotations
 
-- [ ] 2.1 Add `uiUrl?: string` field to `MarketplaceItem` in `marketplace-types.ts`
-- [ ] 2.2 Add `installScope?: 'namespace' | 'cluster'` field to `MarketplaceItem` in `marketplace-types.ts`
-- [ ] 2.3 Update `transformGitHubItemToMarketplaceItem()` in `marketplace-fetcher.ts` to include `uiUrl` and `installScope` fields in the returned object
+- [ ] 2.1 Add `ark.mckinsey.com/marketplace-item-name` annotation to each chart's `Chart.yaml` (e.g., `services/phoenix`)
+- [ ] 2.2 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-url` annotation to Service template, templated from `.Values.uiUrl`
+- [ ] 2.3 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-label` annotation to Service template, templated from `.Values.uiLabel`
+- [ ] 2.4 Add `uiUrl: ""` and `uiLabel: ""` to `values.yaml` for charts with web UIs
 
-## 3. Helm Release Detection in Dashboard
+## 3. Dashboard Type Extensions
 
-- [ ] 3.1 Update `getInstalledMarketplaceItems()` in `marketplace-fetcher.ts` to query Helm releases via `/v1/ark-services?list_all_services=true`
-- [ ] 3.2 Check if release name matches `item.ark.helmReleaseName` AND `release.status === 'deployed'`
-- [ ] 3.3 Remove old CRD-based detection logic
-- [ ] 3.4 Add tests: Helm release with status='deployed' detected, Helm release with other status not detected, no matching release returns not installed
+- [ ] 3.1 Add `uis?: { url: string; label: string }[]` field to `MarketplaceItem` in `marketplace-types.ts`
+- [ ] 3.2 Add `installScope?: 'namespace' | 'cluster'` field to `MarketplaceItem` in `marketplace-types.ts`
+- [ ] 3.3 Update `transformGitHubItemToMarketplaceItem()` in `marketplace-fetcher.ts` to include `uis` and `installScope` fields
 
-## 4. Service Query and URL Resolution in Dashboard
+## 4. Marketplace Item Listing in Dashboard
 
-- [ ] 4.1 Create helper function in `kubernetes.ts`: `getServiceUIUrl(helmReleaseName: string, namespace: string): Promise<string | undefined>`
-- [ ] 4.2 Query Services via `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${helmReleaseName}&namespace=${namespace}`
-- [ ] 4.3 Extract `ark.mckinsey.com/ui-url` annotation from first matching Service
-- [ ] 4.4 Return undefined if no Services found or annotation missing
-- [ ] 4.5 Update `fetchMarketplaceItemsFromSource()` to call `getServiceUIUrl()` when `isInstalled && item.ark.ui?.enabled`
-- [ ] 4.6 Attach resolved `uiUrl` to MarketplaceItem
-- [ ] 4.7 Add tests: Service with annotation returns URL, Service without annotation returns undefined, no Services returns undefined
+- [ ] 4.1 Update `getInstalledMarketplaceItems()` in `marketplace-fetcher.ts` to query Helm releases via `/v1/marketplace-items`
+- [ ] 4.2 Match by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] === item.name`
+- [ ] 4.3 Only match releases with `status === 'deployed'`
+- [ ] 4.4 Remove old CRD-based detection logic
+- [ ] 4.5 Add tests: chart annotation match detected, no annotation returns not installed, non-deployed status not detected
 
-## 5. Marketplace Card UI
+## 5. Service Query and URL Resolution in Dashboard
 
-- [ ] 5.1 Add "Open" button to `marketplace-item-card.tsx` — render when `item.status === 'installed'` and `item.uiUrl` is present
-- [ ] 5.2 Button opens URL in new tab via `window.open(item.uiUrl, '_blank')`
-- [ ] 5.3 Add scope badge to marketplace card — render `[Namespace]` or `[Cluster]` badge based on `item.installScope` value ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
-- [ ] 5.4 Badge styling: namespace badge uses neutral color, cluster badge uses warning color to indicate manual verification needed
-- [ ] 5.5 Add tests: renders Open button when uiUrl present, does not render when uiUrl absent, renders correct scope badge
+- [ ] 5.1 Create helper function in `kubernetes.ts`: `getServiceUIs(releaseName: string, namespace: string): Promise<{ url: string; label: string }[]>`
+- [ ] 5.2 Query Services via `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${releaseName}&namespace=${namespace}`
+- [ ] 5.3 Extract `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label` annotations from matching Services
+- [ ] 5.4 Return `{ url, label }` pairs — use "Open" as fallback label when `marketplace-item-ui-label` is absent
+- [ ] 5.5 Update `fetchMarketplaceItemsFromSource()` to call `getServiceUIs()` for all installed items
+- [ ] 5.6 Attach resolved `uis` array to MarketplaceItem
+- [ ] 5.7 Add tests: Service with both annotations returns url+label, Service with url only returns url+"Open", no Services returns empty array, multiple Services returns multiple entries
 
-## 6. Marketplace Detail Page UI
+## 6. Marketplace Card UI
 
-- [ ] 6.1 Add "Open" button to the detail page — prominent button when `item.uiUrl` is present
-- [ ] 6.2 Button opens URL in new tab
-- [ ] 6.3 Add tests: Open button renders with URL, no button when URL absent
+- [ ] 6.1 Add UI buttons to `marketplace-item-card.tsx` — render for each entry in `item.uis` when `item.status === 'installed'`
+- [ ] 6.2 Button text uses `ui.label` (e.g., "Dashboard", "MinIO Console") or "Open" fallback
+- [ ] 6.3 Button opens URL in new tab via `window.open(ui.url, '_blank')`
+- [ ] 6.4 Add scope badge to marketplace card — render `[Namespace]` or `[Cluster]` badge based on `item.installScope` value ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
+- [ ] 6.5 Badge styling: namespace badge uses neutral color, cluster badge uses warning color to indicate manual verification needed
+- [ ] 6.6 Add tests: renders buttons with correct labels when uis present, does not render when uis absent, renders correct scope badge
 
-## 7. Marketplace Charts — Service Annotations
+## 7. Marketplace Detail Page UI
 
-- [ ] 7.1 Add `uiUrl: ""` to `services/.../chart/values.yaml`
-- [ ] 7.2 Update Service template with `ark.mckinsey.com/ui-url` annotation
-- [ ] 7.3 Update marketplace.json: add `"ui": { "enabled": true }`
-- [ ] 7.4 Test deployment and verify annotation
+- [ ] 7.1 Add UI buttons to the detail page — one per entry in `item.uis`
+- [ ] 7.2 Buttons open URL in new tab with correct label
+- [ ] 7.3 Add tests: buttons render with URLs and labels, no buttons when uis absent
 
 ## 8. Services Page Sunset
 
@@ -72,36 +79,39 @@
   - `components/ark-services/ark-services-table.tsx`
   - `components/ark-services/use-ark-services.ts`
   - `lib/services/ark-services.ts` (if no other consumers)
-- [ ] 8.4 Keep `/v1/ark-services` endpoint in ark-api (used by new detection logic)
+- [ ] 8.4 Keep `/v1/ark-services` endpoint in ark-api (may be used by other consumers)
 
 ## 9. Integration Testing
 
-- [ ] 9.1 Deploy Langfuse with URL: verify detection and Open button
-- [ ] 9.2 Deploy A2A Inspector with URL: verify detection and Open button
-- [ ] 9.3 Test Helm release with status != 'deployed' (e.g., 'failed'): should not show as installed
-- [ ] 9.4 Test Service query returns multiple Services: verify first one's URL is used
-- [ ] 9.5 Test namespace limitation: deploy item to different namespace, verify not detected
-- [ ] 9.6 Test scope badges: namespace-scoped items show `[Namespace]` badge, cluster-scoped items show `[Cluster]` badge
+- [ ] 9.1 Deploy Phoenix with chart annotation and URL: verify detection and UI button
+- [ ] 9.2 Deploy item with custom release name (`helm install my-obs ./phoenix-chart`): verify annotation-based detection still works
+- [ ] 9.3 Deploy item with multiple Services (e.g., two UIs): verify both buttons render with correct labels
+- [ ] 9.4 Test Helm release with status != 'deployed' (e.g., 'failed'): should not show as installed
+- [ ] 9.5 Test Service query returns Service without UI annotation: no button rendered
+- [ ] 9.6 Test namespace limitation: deploy item to different namespace, verify not detected
+- [ ] 9.7 Test scope badges: namespace-scoped items show `[Namespace]` badge, cluster-scoped items show `[Cluster]` badge
 
 ## 10. Documentation
 
 ### Marketplace Repository (agents-at-scale-marketplace)
-- [ ] 10.1 Update `CONTRIBUTING.md` with UI URL configuration section
-- [ ] 10.2 Document for contributors: add `ark.ui.enabled: true` to marketplace.json for items with UIs
-- [ ] 10.3 Document Service annotation pattern: `ark.mckinsey.com/ui-url` templated from `.Values.uiUrl`
-- [ ] 10.4 Provide template example for Service annotation in values.yaml
-- [ ] 10.5 Document install examples: `helm install <item> --set uiUrl=<your-url>`
+- [ ] 10.1 Update `CONTRIBUTING.md` with marketplace item detection section (Chart.yaml annotation)
+- [ ] 10.2 Update `CONTRIBUTING.md` with UI URL and label configuration section
+- [ ] 10.3 Document Service annotation pattern: `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label`
+- [ ] 10.4 Provide template example for Service annotations in values.yaml
+- [ ] 10.5 Document install examples: `helm install <item> --set uiUrl=<url> --set uiLabel="Dashboard"`
 
 ### Ark Dashboard Documentation (this repo)
 - [ ] 10.6 Document marketplace UI URL feature in Ark docs
 - [ ] 10.7 Explain namespace limitation for marketplace detection
-- [ ] 10.8 Add user guide: how to configure UI URLs when installing marketplace items
-- [ ] 10.9 Add troubleshooting: "Item shows installed but no Open button" → check `uiUrl` value set
+- [ ] 10.8 Add user guide: how to configure UI URLs and labels when installing marketplace items
+- [ ] 10.9 Add troubleshooting: "Item shows installed but no button" → check `uiUrl` value set
 - [ ] 10.10 Document Services page sunset
 
 ## 11. Verification
 
-- [ ] 11.1 Verify Helm release detection works for all infrastructure services
-- [ ] 11.2 Verify Services page removed and marketplace page has "Installed" filter
-- [ ] 11.3 Verify UI URLs display correctly when configured
-- [ ] 11.4 Verify namespace-scoped detection works as expected
+- [ ] 11.1 Verify chart annotation-based detection works for all marketplace items
+- [ ] 11.2 Verify custom release names still detected correctly
+- [ ] 11.3 Verify Services page removed and marketplace page has "Installed" filter
+- [ ] 11.4 Verify UI buttons display correctly with labels when configured
+- [ ] 11.5 Verify multi-UI items show multiple buttons with correct labels
+- [ ] 11.6 Verify namespace-scoped detection works as expected

--- a/openspec/changes/2026-04-01-marketplace-services/tasks.md
+++ b/openspec/changes/2026-04-01-marketplace-services/tasks.md
@@ -2,116 +2,76 @@
 
 - [x] 0.1 `/v1/ark-services` endpoint queries Helm releases via pyhelm3 (existing)
 
-## 0.5 Add labelSelector Parameter to ark-api
+## 1. ark-api: labelSelector Parameter
 
-- [ ] 0.5.1 Update `list_grouped_resources()` in `services/ark-api/ark-api/src/ark_api/api/v1/resources.py`
-- [ ] 0.5.2 Add parameter: `labelSelector: Optional[str] = Query(None, description="Kubernetes label selector (e.g., 'app.kubernetes.io/instance=phoenix')")`
-- [ ] 0.5.3 Pass `label_selector=labelSelector` to `api_resource.get()` call — single shared implementation used across all resource types
-- [ ] 0.5.4 Update function docstring to document labelSelector parameter
-- [ ] 0.5.5 Add tests in `services/ark-api/ark-api/tests/api/test_resources.py` for label selector filtering
-- [ ] 0.5.6 Test manually: `GET /v1/resources/v1/Service?namespace=phoenix&labelSelector=app.kubernetes.io/instance=phoenix`
-- [ ] 0.5.7 Verify OpenAPI spec auto-generates with new parameter
+- [ ] 1.1 Add `labelSelector` parameter to `list_grouped_resources()` in `services/ark-api/ark-api/src/ark_api/api/v1/resources.py`
+- [ ] 1.2 Pass `label_selector=labelSelector` to `api_resource.get()` call — single shared implementation
+- [ ] 1.3 Add tests for label selector filtering
+- [ ] 1.4 Test manually: `GET /v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=phoenix`
 
-## 0.6 Add `/v1/marketplace-items` Endpoint to ark-api
+## 2. ark-api: `/v1/marketplace-items` Endpoint
 
-- [ ] 0.6.1 Create `/v1/marketplace-items` endpoint that queries Helm releases (replaces `/v1/ark-services` for marketplace use case)
-- [ ] 0.6.2 Return release metadata including `chart.metadata.annotations` so dashboard can read `ark.mckinsey.com/marketplace-item-name`
-- [ ] 0.6.3 Add tests for the new endpoint
+- [ ] 2.1 Create endpoint that queries Helm releases in current namespace
+- [ ] 2.2 Return release metadata including `chart.metadata.annotations`
+- [ ] 2.3 Add tests
 
-## 1. Marketplace Manifest Schema
+## 3. Marketplace Chart Annotations (agents-at-scale-marketplace repo)
 
-- [ ] 1.1 Add `installScope` field to `GitHubMarketplaceItem` interface — add `installScope?: 'namespace' | 'cluster'` to support scope badges ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
-- [ ] 1.2 Update marketplace items in the marketplace repo (`mckinsey/agents-at-scale-marketplace`) to set `installScope: "namespace"` or `installScope: "cluster"` based on deployment scope
-- [ ] 1.3 Update marketplace item names in marketplace.json to use `<type>/<name>` format (e.g., `services/phoenix`)
+- [ ] 3.1 Add `ark.mckinsey.com/marketplace-item-name` annotation to each chart's `Chart.yaml`
+- [ ] 3.2 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-url` annotation to Service template (from `.Values.uiUrl`)
+- [ ] 3.3 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-label` annotation to Service template (from `.Values.uiLabel`)
+- [ ] 3.4 Add `uiUrl: ""` and `uiLabel: ""` to `values.yaml` for charts with web UIs
 
-## 2. Marketplace Chart Annotations
+## 4. Dashboard: Type Extensions
 
-- [ ] 2.1 Add `ark.mckinsey.com/marketplace-item-name` annotation to each chart's `Chart.yaml` (e.g., `services/phoenix`)
-- [ ] 2.2 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-url` annotation to Service template, templated from `.Values.uiUrl`
-- [ ] 2.3 For charts with web UIs, add `ark.mckinsey.com/marketplace-item-ui-label` annotation to Service template, templated from `.Values.uiLabel`
-- [ ] 2.4 Add `uiUrl: ""` and `uiLabel: ""` to `values.yaml` for charts with web UIs
+- [ ] 4.1 Add `uis?: { url: string; label: string }[]` field to `MarketplaceItem` in `marketplace-types.ts`
+- [ ] 4.2 Update `transformGitHubItemToMarketplaceItem()` to include `uis` field
 
-## 3. Dashboard Type Extensions
+## 5. Dashboard: Marketplace Item Detection
 
-- [ ] 3.1 Add `uis?: { url: string; label: string }[]` field to `MarketplaceItem` in `marketplace-types.ts`
-- [ ] 3.2 Add `installScope?: 'namespace' | 'cluster'` field to `MarketplaceItem` in `marketplace-types.ts`
-- [ ] 3.3 Update `transformGitHubItemToMarketplaceItem()` in `marketplace-fetcher.ts` to include `uis` and `installScope` fields
+- [ ] 5.1 Update `getInstalledMarketplaceItems()` in `marketplace-fetcher.ts` to query `/v1/marketplace-items`
+- [ ] 5.2 Match by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] === item.name`
+- [ ] 5.3 Only match releases with `status === 'deployed'`
+- [ ] 5.4 Remove old CRD-based detection logic
+- [ ] 5.5 Add tests
 
-## 4. Marketplace Item Listing in Dashboard
+## 6. Dashboard: Service Query and URL Resolution
 
-- [ ] 4.1 Update `getInstalledMarketplaceItems()` in `marketplace-fetcher.ts` to query Helm releases via `/v1/marketplace-items`
-- [ ] 4.2 Match by chart annotation: `release.chart.metadata.annotations["ark.mckinsey.com/marketplace-item-name"] === item.name`
-- [ ] 4.3 Only match releases with `status === 'deployed'`
-- [ ] 4.4 Remove old CRD-based detection logic
-- [ ] 4.5 Add tests: chart annotation match detected, no annotation returns not installed, non-deployed status not detected
+- [ ] 6.1 Create helper: `getServiceUIs(releaseName: string, namespace: string): Promise<{ url: string; label: string }[]>`
+- [ ] 6.2 Query Services via `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${releaseName}`
+- [ ] 6.3 Extract `marketplace-item-ui-url` and `marketplace-item-ui-label` annotations
+- [ ] 6.4 Use "Open" as fallback label
+- [ ] 6.5 Call `getServiceUIs()` for all installed items
+- [ ] 6.6 Add tests
 
-## 5. Service Query and URL Resolution in Dashboard
+## 7. Dashboard: Marketplace Card UI
 
-- [ ] 5.1 Create helper function in `kubernetes.ts`: `getServiceUIs(releaseName: string, namespace: string): Promise<{ url: string; label: string }[]>`
-- [ ] 5.2 Query Services via `/v1/resources/v1/Service?labelSelector=app.kubernetes.io/instance=${releaseName}&namespace=${namespace}`
-- [ ] 5.3 Extract `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label` annotations from matching Services
-- [ ] 5.4 Return `{ url, label }` pairs — use "Open" as fallback label when `marketplace-item-ui-label` is absent
-- [ ] 5.5 Update `fetchMarketplaceItemsFromSource()` to call `getServiceUIs()` for all installed items
-- [ ] 5.6 Attach resolved `uis` array to MarketplaceItem
-- [ ] 5.7 Add tests: Service with both annotations returns url+label, Service with url only returns url+"Open", no Services returns empty array, multiple Services returns multiple entries
+- [ ] 7.1 Add buttons to `marketplace-item-card.tsx` for each entry in `item.uis`
+- [ ] 7.2 Button text from `ui.label`, opens URL in new tab
+- [ ] 7.3 Add tests
 
-## 6. Marketplace Card UI
+## 8. Dashboard: Marketplace Detail Page UI
 
-- [ ] 6.1 Add UI buttons to `marketplace-item-card.tsx` — render for each entry in `item.uis` when `item.status === 'installed'`
-- [ ] 6.2 Button text uses `ui.label` (e.g., "Dashboard", "MinIO Console") or "Open" fallback
-- [ ] 6.3 Button opens URL in new tab via `window.open(ui.url, '_blank')`
-- [ ] 6.4 Add scope badge to marketplace card — render `[Namespace]` or `[Cluster]` badge based on `item.installScope` value ([#1522](https://github.com/mckinsey/agents-at-scale-ark/issues/1522))
-- [ ] 6.5 Badge styling: namespace badge uses neutral color, cluster badge uses warning color to indicate manual verification needed
-- [ ] 6.6 Add tests: renders buttons with correct labels when uis present, does not render when uis absent, renders correct scope badge
+- [ ] 8.1 Add buttons to detail page for each entry in `item.uis`
+- [ ] 8.2 Add tests
 
-## 7. Marketplace Detail Page UI
+## 9. Services Page Sunset
 
-- [ ] 7.1 Add UI buttons to the detail page — one per entry in `item.uis`
-- [ ] 7.2 Buttons open URL in new tab with correct label
-- [ ] 7.3 Add tests: buttons render with URLs and labels, no buttons when uis absent
+- [ ] 9.1 Add "Installed" filter to marketplace page
+- [ ] 9.2 Remove "Services" from sidebar navigation
+- [ ] 9.3 Remove services page code and components
+- [ ] 9.4 Keep `/v1/ark-services` endpoint (may have other consumers)
 
-## 8. Services Page Sunset
+## 10. Integration Testing
 
-- [ ] 8.1 Add "Installed" filter option to the marketplace page — filter items by `status: "installed"`
-- [ ] 8.2 Remove "Services" entry from the dashboard sidebar navigation
-- [ ] 8.3 Remove services page code:
-  - `app/(dashboard)/services/page.tsx`
-  - `components/ark-services/ark-services-table.tsx`
-  - `components/ark-services/use-ark-services.ts`
-  - `lib/services/ark-services.ts` (if no other consumers)
-- [ ] 8.4 Keep `/v1/ark-services` endpoint in ark-api (may be used by other consumers)
+- [ ] 10.1 Deploy item with chart annotation and URL: verify detection and button
+- [ ] 10.2 Deploy item with custom release name: verify annotation-based detection works
+- [ ] 10.3 Deploy item with multiple Services: verify multiple buttons with labels
+- [ ] 10.4 Test failed Helm release: should not show as installed
+- [ ] 10.5 Test Service without UI annotation: no button
 
-## 9. Integration Testing
+## 11. Documentation
 
-- [ ] 9.1 Deploy Phoenix with chart annotation and URL: verify detection and UI button
-- [ ] 9.2 Deploy item with custom release name (`helm install my-obs ./phoenix-chart`): verify annotation-based detection still works
-- [ ] 9.3 Deploy item with multiple Services (e.g., two UIs): verify both buttons render with correct labels
-- [ ] 9.4 Test Helm release with status != 'deployed' (e.g., 'failed'): should not show as installed
-- [ ] 9.5 Test Service query returns Service without UI annotation: no button rendered
-- [ ] 9.6 Test namespace limitation: deploy item to different namespace, verify not detected
-- [ ] 9.7 Test scope badges: namespace-scoped items show `[Namespace]` badge, cluster-scoped items show `[Cluster]` badge
-
-## 10. Documentation
-
-### Marketplace Repository (agents-at-scale-marketplace)
-- [ ] 10.1 Update `CONTRIBUTING.md` with marketplace item detection section (Chart.yaml annotation)
-- [ ] 10.2 Update `CONTRIBUTING.md` with UI URL and label configuration section
-- [ ] 10.3 Document Service annotation pattern: `ark.mckinsey.com/marketplace-item-ui-url` and `ark.mckinsey.com/marketplace-item-ui-label`
-- [ ] 10.4 Provide template example for Service annotations in values.yaml
-- [ ] 10.5 Document install examples: `helm install <item> --set uiUrl=<url> --set uiLabel="Dashboard"`
-
-### Ark Dashboard Documentation (this repo)
-- [ ] 10.6 Document marketplace UI URL feature in Ark docs
-- [ ] 10.7 Explain namespace limitation for marketplace detection
-- [ ] 10.8 Add user guide: how to configure UI URLs and labels when installing marketplace items
-- [ ] 10.9 Add troubleshooting: "Item shows installed but no button" → check `uiUrl` value set
-- [ ] 10.10 Document Services page sunset
-
-## 11. Verification
-
-- [ ] 11.1 Verify chart annotation-based detection works for all marketplace items
-- [ ] 11.2 Verify custom release names still detected correctly
-- [ ] 11.3 Verify Services page removed and marketplace page has "Installed" filter
-- [ ] 11.4 Verify UI buttons display correctly with labels when configured
-- [ ] 11.5 Verify multi-UI items show multiple buttons with correct labels
-- [ ] 11.6 Verify namespace-scoped detection works as expected
+- [ ] 11.1 Update marketplace repo CONTRIBUTING.md with chart annotation and UI URL sections
+- [ ] 11.2 Document install examples with `--set uiUrl` and `--set uiLabel`
+- [ ] 11.3 Document services page sunset


### PR DESCRIPTION
## Summary
- Marketplace page always shows the user's current namespace — no cross-namespace detection
- Drop `installScope`, cluster-scoped badges, and namespace limitation hedging
- Streamline proposal, design, and tasks — 186 additions, 429 deletions
- Core approach unchanged: chart annotation detection + Service annotation UI URLs + labels