### PR TITLE
docs: add observability context to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@ cd docs/           # Documentation site
 npm build          # Build site
 ```
 
+# Observability
+
+Ark uses OpenTelemetry with W3C TraceContext and Baggage propagation for distributed tracing. The operator instruments query dispatch and A2A communication, automatically propagating trace context to downstream executors via HTTP headers. The telemetry subsystem lives in `ark/internal/telemetry/`, and the `ExecutorApp` base class in `lib/ark-sdk/` handles context extraction on the executor side.
+
 # Marketplace
 
 Ark has a separate marketplace repository for add-on components that extend Ark's native capabilities. Marketplace items depend on Ark core — never the other way around.


### PR DESCRIPTION
## Summary

- Add Observability section to CLAUDE.md documenting OTEL distributed tracing architecture
- Makes the W3C TraceContext/Baggage propagation from operator to executors discoverable for agents and developers working on the repo
- Points to `ark/internal/telemetry/` and `ExecutorApp` as key integration points