### PR TITLE
fix(ci): add ark-completions chart to release and deploy pipelines

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -101,6 +101,16 @@
         },
         {
           "type": "yaml",
+          "path": "ark/executors/completions/chart/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "ark/executors/completions/chart/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
           "path": "services/ark-api/chart/Chart.yaml",
           "jsonpath": "$.version"
         },

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1192,6 +1192,7 @@ jobs:
       matrix:
         chart:
           - ark-controller
+          - ark-completions
           - ark-api
           - ark-dashboard
           - ark-mcp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,6 +208,7 @@ jobs:
       matrix:
         chart:
           - ark-controller
+          - ark-completions
           - ark-api
           - ark-dashboard
           - ark-mcp


### PR DESCRIPTION
## Summary

- The `ark-completions` Helm chart was being built and packaged in the `build-charts` CI job but was missing from the `release-charts` and `deploy-helm-charts` matrices
- Add `ark-completions` to the `release-charts` matrix in `cicd.yaml` so the chart `.tgz` is attached to GitHub releases
- Add `ark-completions` to the `deploy-helm-charts` matrix in `deploy.yml` so the chart is pushed to the OCI container registry
- Add `ark/executors/completions/chart/Chart.yaml` version and appVersion tracking to `release-please-config.json` for automatic version bumps on release