### PR TITLE
fix: resolve Radix Select option detachment in tool editor

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Label } from '@radix-ui/react-label';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
 
@@ -134,7 +134,7 @@ export function ToolEditor({
     },
   });
 
-  const selectedType = form.watch('type');
+  const selectedType = useWatch({ control: form.control, name: 'type' });
 
   useEffect(() => {
     if (open) {

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -911,13 +911,20 @@ chainsaw test tests/ --test-dir tests/queries --pause-on-failure
 
 ### Radix UI Select
 
-Radix UI Select uses Floating UI to position the dropdown portal after mount. Until positioning completes, the portal DOM nodes can be replaced, causing "element was detached from the DOM". Wait for `[role='listbox'][data-side]` — Floating UI sets `data-side` once positioning is done.
+Two things make Radix UI Select options unstable for Playwright:
+
+1. **Floating UI positioning**: The dropdown portal DOM nodes are replaced when Floating UI calculates position, causing "element was detached from the DOM". Floating UI sets `data-side` once positioning is done.
+2. **Open animation**: `data-side` is set before the entry animation (zoom-in, slide-in) finishes. Playwright sees the bounding box still changing and reports "element is not stable". Radix sets `data-state="open"` only after the animation completes.
+
+Wait for both before clicking:
 
 ```python
 trigger.click()
-page.locator("[role='listbox'][data-side]").wait_for(state="visible", timeout=15000)
+page.locator("[role='listbox'][data-side][data-state='open']").wait_for(state="visible", timeout=15000)
 page.locator("[role='option']:has-text('HTTP')").first.click()
 ```
+
+If options are still detaching after this, the likely cause is a parent component re-rendering while the dropdown is open (e.g. a `form.watch()` call in React Hook Form re-rendering on blur/validation). Fix it in the component by replacing `form.watch(name)` with `useWatch({ control, name })`, which only re-renders when the field value changes.
 
 - Query tests should reach `phase: done`
 - No RBAC permission errors in events

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -87,7 +87,7 @@ class ToolsPage(BasePage):
         type_trigger.wait_for(state="visible", timeout=15000)
         type_trigger.click()
         
-        self.page.locator("[role='listbox'][data-side]").wait_for(state="visible", timeout=15000)
+        self.page.locator("[role='listbox'][data-side][data-state='open']").wait_for(state="visible", timeout=15000)
         http_option = self.page.locator("[role='option']:has-text('HTTP')").first
         http_option.click()
         


### PR DESCRIPTION
Two causes were stacking: form.watch() in ToolEditor re-rendered the component on every blur/validation state change (including when the SelectTrigger loses focus on open), causing Floating UI to replace DOM nodes while the dropdown was open; and the data-side wait in the test resolved before the entry animation finished, leaving options unstable.

- Replace form.watch('type') with useWatch({ control, name: 'type' }) so ToolEditor only re-renders when the type value actually changes, not on unrelated formState updates
- Update test to wait for data-state='open' in addition to data-side, ensuring the zoom/slide animation has completed before clicking
- Update tests/CLAUDE.md with the full pattern and root cause explanation

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 