### PR TITLE
fix(controller): read A2A native contextId from response messages

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -25,8 +25,8 @@ import (
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
 	arka2a "mckinsey.com/ark/internal/a2a"
-	"mckinsey.com/ark/internal/resolution"
 	eventingconfig "mckinsey.com/ark/internal/eventing/config"
+	"mckinsey.com/ark/internal/resolution"
 	"mckinsey.com/ark/internal/telemetry"
 	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
 	otelimpl "mckinsey.com/ark/internal/telemetry/otel"
@@ -453,16 +453,23 @@ func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMet
 		return responseMeta
 	}
 
-	var msgMeta map[string]any
-	if msg, ok := result.Result.(*protocol.Message); ok {
-		msgMeta = msg.Metadata
-	}
-
-	if msgMeta == nil {
+	msg, ok := result.Result.(*protocol.Message)
+	if !ok {
 		return responseMeta
 	}
 
-	arkData, ok := msgMeta[arka2a.QueryExtensionMetadataKey]
+	if msg.ContextID != nil && *msg.ContextID != "" {
+		responseMeta.A2AContextID = *msg.ContextID
+	}
+	if msg.TaskID != nil && *msg.TaskID != "" {
+		responseMeta.A2ATaskID = *msg.TaskID
+	}
+
+	if msg.Metadata == nil {
+		return responseMeta
+	}
+
+	arkData, ok := msg.Metadata[arka2a.QueryExtensionMetadataKey]
 	if !ok {
 		return responseMeta
 	}

--- a/ark/internal/controller/query_controller_dispatch_test.go
+++ b/ark/internal/controller/query_controller_dispatch_test.go
@@ -255,6 +255,46 @@ func TestExtractEngineResponseMeta(t *testing.T) {
 		assert.NotEmpty(t, meta.MessagesRaw)
 	})
 
+	t.Run("extracts native A2A contextId and taskId from message", func(t *testing.T) {
+		contextID := "native-ctx"
+		taskID := "native-task"
+		msg := &protocol.Message{
+			Role:      protocol.MessageRoleAgent,
+			Parts:     []protocol.Part{protocol.NewTextPart("response")},
+			ContextID: &contextID,
+			TaskID:    &taskID,
+		}
+
+		result := &protocol.MessageResult{Result: msg}
+		meta := extractEngineResponseMeta(result)
+		assert.Equal(t, "native-ctx", meta.A2AContextID)
+		assert.Equal(t, "native-task", meta.A2ATaskID)
+	})
+
+	t.Run("ark metadata a2a fields override native message fields", func(t *testing.T) {
+		nativeCtx := "native-ctx"
+		nativeTask := "native-task"
+		msg := &protocol.Message{
+			Role:      protocol.MessageRoleAgent,
+			Parts:     []protocol.Part{protocol.NewTextPart("response")},
+			ContextID: &nativeCtx,
+			TaskID:    &nativeTask,
+			Metadata: map[string]any{
+				arka2a.QueryExtensionMetadataKey: map[string]any{
+					"a2a": map[string]any{
+						"contextId": "ark-ctx",
+						"taskId":    "ark-task",
+					},
+				},
+			},
+		}
+
+		result := &protocol.MessageResult{Result: msg}
+		meta := extractEngineResponseMeta(result)
+		assert.Equal(t, "ark-ctx", meta.A2AContextID)
+		assert.Equal(t, "ark-task", meta.A2ATaskID)
+	})
+
 	t.Run("non-message result returns empty meta", func(t *testing.T) {
 		task := &protocol.Task{ID: "t1"}
 		result := &protocol.MessageResult{Result: task}


### PR DESCRIPTION
## Summary

- The controller now reads `contextId` and `taskId` directly from the A2A `Message` protocol fields, not just from the ark extension metadata map
- This fixes `status.conversationId` not being populated for external executors (e.g. claude-agent-sdk) that set `context_id` on the A2A message but don't populate the ark-specific metadata
- Ark extension metadata fields still take precedence when both are present, preserving backward compatibility with the built-in completions executor
- The controller is now more A2A-native, reducing coupling between executor implementations and ark-specific metadata conventions