### PR TITLE
fix: fixed URL backslash chars

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/files.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/files.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/api/files-client', () => ({
     get: vi.fn(),
     delete: vi.fn(),
   },
-  FILES_API_BASE_URL: '/api/v1/proxy/services/file-gateway-api',
+  FILES_API_BASE_URL: '/api/v1/proxy/services/file-gateway-api/',
 }));
 
 describe('filesService', () => {
@@ -39,7 +39,7 @@ describe('filesService', () => {
 
       const result = await filesService.list();
 
-      expect(filesApiClient.get).toHaveBeenCalledWith('/files', {
+      expect(filesApiClient.get).toHaveBeenCalledWith('files', {
         params: {},
       });
       expect(result).toEqual(mockResponse);
@@ -62,7 +62,7 @@ describe('filesService', () => {
 
       const result = await filesService.list({ prefix: 'dir1/' });
 
-      expect(filesApiClient.get).toHaveBeenCalledWith('/files', {
+      expect(filesApiClient.get).toHaveBeenCalledWith('files', {
         params: { prefix: 'dir1/' },
       });
       expect(result).toEqual(mockResponse);
@@ -83,7 +83,7 @@ describe('filesService', () => {
         continuation_token: 'token-abc',
       });
 
-      expect(filesApiClient.get).toHaveBeenCalledWith('/files', {
+      expect(filesApiClient.get).toHaveBeenCalledWith('files', {
         params: {
           prefix: 'documents/',
           max_keys: 50,
@@ -101,7 +101,7 @@ describe('filesService', () => {
       await filesService.delete('test-file.txt');
 
       expect(filesApiClient.delete).toHaveBeenCalledWith(
-        '/files/test-file.txt',
+        'files/test-file.txt',
       );
     });
 
@@ -111,7 +111,7 @@ describe('filesService', () => {
       await filesService.delete('folder/file with spaces.txt');
 
       expect(filesApiClient.delete).toHaveBeenCalledWith(
-        '/files/folder%2Ffile%20with%20spaces.txt',
+        'files/folder%2Ffile%20with%20spaces.txt',
       );
     });
   });
@@ -126,7 +126,7 @@ describe('filesService', () => {
 
       const result = await filesService.deleteDirectory('test-dir/');
 
-      expect(filesApiClient.delete).toHaveBeenCalledWith('/directories', {
+      expect(filesApiClient.delete).toHaveBeenCalledWith('directories', {
         params: { prefix: 'test-dir/' },
       });
       expect(result).toEqual(mockResponse);

--- a/services/ark-dashboard/ark-dashboard/lib/api/files-client.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/files-client.ts
@@ -1,6 +1,6 @@
 import { APIClient } from './client';
 
-export const FILES_API_BASE_URL = '/api/v1/proxy/services/file-gateway-api';
+export const FILES_API_BASE_URL = '/api/v1/proxy/services/file-gateway-api/';
 
 export const filesApiClient = new APIClient(FILES_API_BASE_URL, {
   'Content-Type': 'application/json',

--- a/services/ark-dashboard/ark-dashboard/lib/services/files.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/files.ts
@@ -7,7 +7,7 @@ import type {
 
 export const filesService = {
   async list(params: ListFilesParams = {}): Promise<ListFilesResponse> {
-    const response = await filesApiClient.get<ListFilesResponse>('/files', {
+    const response = await filesApiClient.get<ListFilesResponse>('files', {
       params: {
         ...(params.prefix !== undefined && { prefix: params.prefix }),
         ...(params.max_keys !== undefined && { max_keys: params.max_keys }),
@@ -49,23 +49,23 @@ export const filesService = {
         reject(new Error('Upload failed'));
       });
 
-      xhr.open('POST', `${FILES_API_BASE_URL}/files`);
+      xhr.open('POST', `${FILES_API_BASE_URL}files`);
       xhr.send(formData);
     });
   },
 
   async delete(key: string): Promise<void> {
-    await filesApiClient.delete(`/files/${encodeURIComponent(key)}`);
+    await filesApiClient.delete(`files/${encodeURIComponent(key)}`);
   },
 
   download(key: string): void {
-    const url = `${FILES_API_BASE_URL}/files/${encodeURIComponent(key)}/download`;
+    const url = `${FILES_API_BASE_URL}files/${encodeURIComponent(key)}/download`;
     window.open(url, '_blank');
   },
 
   async deleteDirectory(prefix: string): Promise<DeleteDirectoryResponse> {
     const response = await filesApiClient.delete<DeleteDirectoryResponse>(
-      '/directories',
+      'directories',
       {
         params: { prefix },
       },


### PR DESCRIPTION
Added trailing / to base URL and removed leading / from endpoints because filesApiClient uses a relative base path (/api/v1/proxy/services/file-gateway-api) instead of an absolute origin like other services (window.location.origin), so leading slashes in endpoints cause new URL() to treat them as absolute paths from origin, ignoring the base path entirely.