### PR TITLE
fix: create namespace before coverage PVC on etcd backend

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -107,6 +107,7 @@ fi
 
 if [ "${INSTALL_COVERAGE}" = "true" ]; then
   echo "=== Including coverage collection in Helm install ==="
+  kubectl create namespace ark-system 2>/dev/null || true
   kubectl -n ark-system apply -f "${SCRIPT_DIR}/coverage-pvc.yaml" || echo "Coverage PVC may already exist"
   HELM_ARGS+=(
     --set controllerManager.container.env.GOCOVERDIR=/workspace/coverage


### PR DESCRIPTION
## Summary
- Fix E2E setup failure on etcd: `ark-system` namespace doesn't exist when coverage PVC is created
- On postgresql the namespace is created earlier by the storage chart install, so it only fails on etcd
- One-line fix: `kubectl create namespace ark-system` before the PVC apply