### PR TITLE
fix: align tool type naming in docs and fark CLI (#109)

### DIFF
--- a/docs/content/reference/resources/agent.mdx
+++ b/docs/content/reference/resources/agent.mdx
@@ -34,7 +34,7 @@ spec:
     
   # Tools the agent can use
   tools:
-    - type: built-in  # System-provided tools (terminate, noop)
+    - type: builtin  # System-provided tools (terminate, noop)
       name: terminate
     - type: http      # HTTP tool references
       name: my-http-tool

--- a/docs/content/reference/resources/tools.mdx
+++ b/docs/content/reference/resources/tools.mdx
@@ -260,9 +260,9 @@ Reference system-provided builtin tools by name:
 
 ```yaml
 tools:
-  - type: built-in
+  - type: builtin
     name: terminate  # End conversation with final response
-  - type: built-in
+  - type: builtin
     name: noop       # No-operation (testing/debugging)
 ```
 

--- a/docs/content/user-guide/samples/teams/team-strategies.mdx
+++ b/docs/content/user-guide/samples/teams/team-strategies.mdx
@@ -309,7 +309,7 @@ spec:
   prompt: "You coordinate the team. Use terminate tool when task is complete."
   tools:
   - name: terminate
-    type: built-in
+    type: builtin
 ```
 
 The terminate tool stops team execution and returns current results without processing remaining members or turns.

--- a/tools/fark/cmd/fark/command_options.go
+++ b/tools/fark/cmd/fark/command_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -313,6 +314,39 @@ func (r *ResourceIdentifier) UpdateFromFlags(spec *AgentSpec) error {
 	}
 }
 
+// parseAgentTools parses tool specifiers of the form "name" or "name:type".
+// When no type is given, "builtin" is assumed. Valid types match the AgentTool
+// CRD enum: builtin, http, mcp, agent, team.
+func parseAgentTools(tools []string) ([]arkv1alpha1.AgentTool, error) {
+	validTypes := map[string]bool{
+		"builtin": true,
+		"http":    true,
+		"mcp":     true,
+		"agent":   true,
+		"team":    true,
+	}
+	agentTools := make([]arkv1alpha1.AgentTool, 0, len(tools))
+	for _, raw := range tools {
+		name := raw
+		toolType := "builtin"
+		if idx := strings.LastIndex(raw, ":"); idx != -1 {
+			name = raw[:idx]
+			toolType = raw[idx+1:]
+		}
+		if !validTypes[toolType] {
+			return nil, fmt.Errorf("invalid tool type %q for tool %q (expected one of: builtin, http, mcp, agent, team)", toolType, name)
+		}
+		if name == "" {
+			return nil, fmt.Errorf("tool name cannot be empty in %q", raw)
+		}
+		agentTools = append(agentTools, arkv1alpha1.AgentTool{
+			Type: toolType,
+			Name: name,
+		})
+	}
+	return agentTools, nil
+}
+
 // createAgentFromFlags creates an agent from flags
 func (r *ResourceIdentifier) createAgentFromFlags(spec *AgentSpec) error {
 	if spec.Prompt == "" {
@@ -330,15 +364,10 @@ func (r *ResourceIdentifier) createAgentFromFlags(spec *AgentSpec) error {
 		}
 	}
 
-	// Add tools if provided
-	// TODO: "custom" type is deprecated - consider adding --tool-type flag or fetching tool type from cluster
 	if len(spec.Tools) > 0 {
-		agentTools := make([]arkv1alpha1.AgentTool, 0, len(spec.Tools))
-		for _, toolName := range spec.Tools {
-			agentTools = append(agentTools, arkv1alpha1.AgentTool{
-				Type: "custom",
-				Name: toolName,
-			})
+		agentTools, err := parseAgentTools(spec.Tools)
+		if err != nil {
+			return err
 		}
 		agentSpec.Tools = agentTools
 	}


### PR DESCRIPTION
## Summary
- Fix docs examples to use `builtin` (no hyphen) matching CRD enum
- Replace hardcoded `custom` tool type in fark CLI with explicit types

Closes #109