### PR TITLE
fix: resolve unparam lint for makeRelation in WAL consumer tests

### DIFF
--- a/ark/internal/storage/postgresql/wal_consumer_test.go
+++ b/ark/internal/storage/postgresql/wal_consumer_test.go
@@ -149,7 +149,7 @@ func TestNudgeWatchersByKindEmptyNamespace(t *testing.T) {
 	allNs := newTestWatcher()
 	specific := newTestWatcher()
 	backend := newTestBackendWithWatchers(map[string][]*postgresWatcher{
-		"Agent/":          {allNs},
+		"Agent/":           {allNs},
 		"Agent/production": {specific},
 	})
 

--- a/ark/internal/storage/postgresql/wal_consumer_test.go
+++ b/ark/internal/storage/postgresql/wal_consumer_test.go
@@ -309,10 +309,10 @@ func TestProcessWALDataUpdateMessage(t *testing.T) {
 	})
 
 	relations := map[uint32]*pglogrepl.RelationMessage{
-		1: makeRelation(1, "kind", "namespace"),
+		2: makeRelation(2, "kind", "namespace"),
 	}
 
-	update := encodeUpdateMessage(1, makeTuple("Model", "prod"))
+	update := encodeUpdateMessage(2, makeTuple("Model", "prod"))
 
 	backend.processWALData(update, relations)
 
@@ -330,10 +330,10 @@ func TestProcessWALDataDeleteMessage(t *testing.T) {
 	})
 
 	relations := map[uint32]*pglogrepl.RelationMessage{
-		1: makeRelation(1, "kind", "namespace"),
+		3: makeRelation(3, "kind", "namespace"),
 	}
 
-	del := encodeDeleteMessage(1)
+	del := encodeDeleteMessage(3)
 	backend.processWALData(del, relations)
 
 	select {


### PR DESCRIPTION
## Summary
- Use varied relation IDs (1, 2, 3) across tests to satisfy the unparam linter