### PR TITLE
fix: wait for ServiceMonitor CRD established condition using chainsaw assert

### DIFF
--- a/tests/prometheus-tls-config/chainsaw-test.yaml
+++ b/tests/prometheus-tls-config/chainsaw-test.yaml
@@ -76,7 +76,6 @@ spec:
               if ! kubectl get crd servicemonitors.monitoring.coreos.com >/dev/null 2>&1; then
                 echo "ServiceMonitor CRD not found. Installing..."
                 kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-                kubectl wait --for=condition=established crd/servicemonitors.monitoring.coreos.com --timeout=60s
               else
                 echo "ServiceMonitor CRD already installed"
               fi
@@ -86,6 +85,9 @@ spec:
               kind: CustomResourceDefinition
               metadata:
                 name: servicemonitors.monitoring.coreos.com
+              status:
+                (conditions[?type == 'Established']):
+                  - status: "True"
 
     - name: apply-service-monitor
       try:


### PR DESCRIPTION
This test can fail due to a race condition on .status.conditions for CRDs, causing a type error:
```
        === STDOUT
        ServiceMonitor CRD not found. Installing...
        customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
        === STDERR
        error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}
```
See https://github.com/mckinsey/agents-at-scale-ark/actions/runs/24137682742/job/70430703342 for an example of this failure.

The fix changes how we check for the Established condition; the chainsaw assert will wait for a value to appear without crashing, while the kubectl wait crashes because it was <nil> instead of an interface. This is an old known issue in kubectl apparently : https://github.com/kubernetes/kubernetes/issues/66439

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 