### PR TITLE
docs(chainsaw): add kubectl wait antipattern guidance

### DIFF
--- a/.claude/agents/ark-build-manager.md
+++ b/.claude/agents/ark-build-manager.md
@@ -69,6 +69,8 @@ Classify each failure into one of these categories and delegate accordingly:
 - Timeout issues in LLM-dependent tests
 - CRD schema changes not reflected in test fixtures
 - Mock service configuration drift
+- Antipattern: `kubectl wait --for=condition=...` crashing with nil accessor error — use chainsaw `assert` with JMESPath instead (see chainsaw skill Antipatterns section)
+**Antipattern check**: When a chainsaw test fails with `.status.conditions accessor error: <nil> is of the type <nil>`, use the **chainsaw** skill to replace the `kubectl wait` command with a chainsaw assert block.
 
 ### Category: E2E CLI Test Failures
 **Indicators**: `e2e-cli-tests` in job name, pytest failures in logs

--- a/.claude/skills/chainsaw/SKILL.md
+++ b/.claude/skills/chainsaw/SKILL.md
@@ -39,6 +39,64 @@ tests/my-test/
     └── a05-query.yaml      # Query last
 ```
 
+## Antipatterns
+
+### `kubectl wait` for CRD conditions
+
+**Never** use `kubectl wait --for=condition=Established` to check CRD readiness. This command crashes with a type error when `.status.conditions` is `nil` (a known kubectl bug: kubernetes/kubernetes#66439):
+
+```
+error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}
+```
+
+Use a chainsaw `assert` with JMESPath instead — it polls gracefully and waits for the field to appear:
+
+```yaml
+# Bad - crashes if .status.conditions is nil
+- script:
+    content: |
+      kubectl apply -f my-crd.yaml
+      kubectl wait --for=condition=Established crd/my-crd.example.com --timeout=60s
+
+# Good - polls until condition appears, no nil crash
+- script:
+    content: |
+      kubectl apply -f my-crd.yaml
+- assert:
+    resource:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: my-crd.example.com
+      status:
+        (conditions[?type == 'Established']):
+          - status: "True"
+```
+
+This pattern converts a brittle timeout into an explicit condition check. The same applies to any resource whose `.status.conditions` may start as `nil`.
+
+### Shell scripts for condition checking
+
+Avoid using shell scripts with `kubectl get` + `jq` to validate resource state when chainsaw assertions can express the check declaratively. Shell scripts fail immediately on unexpected `nil` values; assertions retry until the condition is met or the timeout expires.
+
+```yaml
+# Bad - fails immediately if field is absent
+- script:
+    content: |
+      val=$(kubectl get myresource foo -o jsonpath='{.status.phase}')
+      [ "$val" = "Ready" ] || exit 1
+
+# Good - retries until condition is true
+- assert:
+    resource:
+      apiVersion: example.com/v1
+      kind: MyResource
+      metadata:
+        name: foo
+      status:
+        phase: Ready
+```
+
 ## Environment Variables
 
 For real LLM tests (not mock-llm):


### PR DESCRIPTION
## Summary
- Add Antipatterns section to chainsaw skill with kubectl wait and shell-script antipatterns, recommending chainsaw assert with JMESPath
- Update ark-build-manager agent to reference the antipattern check when diagnosing chainsaw failures with nil accessor errors

Applies the improvements Claude suggested in the #1789 review. Orphaned from PR #1776 which was squash-merged before this commit landed.