### PR TITLE
fix: webhook match conditions

### DIFF
--- a/ark/config/webhook/manifests.yaml
+++ b/ark/config/webhook/manifests.yaml
@@ -12,6 +12,9 @@ webhooks:
       namespace: system
       path: /mutate-ark-mckinsey-com-v1alpha1-model
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: mmodel-v1.kb.io
   rules:
   - apiGroups:
@@ -32,6 +35,9 @@ webhooks:
       namespace: system
       path: /mutate-ark-mckinsey-com-v1alpha1-query
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: mquery-v1.kb.io
   rules:
   - apiGroups:
@@ -52,6 +58,9 @@ webhooks:
       namespace: system
       path: /mutate-ark-mckinsey-com-v1alpha1-team
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: mteam-v1.kb.io
   rules:
   - apiGroups:
@@ -78,6 +87,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1alpha1-mcpserver
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vmcpserver-v1.kb.io
   rules:
   - apiGroups:
@@ -98,6 +110,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1alpha1-model
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vmodel-v1.kb.io
   rules:
   - apiGroups:
@@ -118,6 +133,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1alpha1-query
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vquery-v1.kb.io
   rules:
   - apiGroups:
@@ -138,6 +156,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1alpha1-team
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vteam-v1.kb.io
   rules:
   - apiGroups:
@@ -158,6 +179,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1alpha1-tool
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vtool-v1.kb.io
   rules:
   - apiGroups:
@@ -178,6 +202,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1prealpha1-a2aserver
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: va2aserver-v1prealpha1.kb.io
   rules:
   - apiGroups:
@@ -198,6 +225,9 @@ webhooks:
       namespace: system
       path: /validate-ark-mckinsey-com-v1prealpha1-executionengine
   failurePolicy: Fail
+  matchConditions:
+  - name: not-being-deleted
+    expression: "!has(object.metadata.deletionTimestamp)"
   name: vexecutionengine-v1prealpha1.kb.io
   rules:
   - apiGroups:

--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -64,6 +64,30 @@ webhooks:
           - v1alpha1
         resources:
           - models
+  - name: mquery-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
+    clientConfig:
+      service:
+        name: ark-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-ark-mckinsey-com-v1alpha1-query
+    failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds | default 10 }}
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - ark.mckinsey.com
+        apiVersions:
+          - v1alpha1
+        resources:
+          - queries
   - name: mteam-v1.kb.io
     matchConditions:
     - name: not-being-deleted

--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -17,6 +17,9 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -38,6 +41,9 @@ webhooks:
         resources:
           - agents
   - name: mmodel-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -59,6 +65,9 @@ webhooks:
         resources:
           - models
   - name: mteam-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -98,6 +107,9 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -119,6 +131,9 @@ webhooks:
         resources:
           - agents
   - name: vmcpserver-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -140,6 +155,9 @@ webhooks:
         resources:
           - mcpserver
   - name: vmodel-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -161,6 +179,9 @@ webhooks:
         resources:
           - models
   - name: vquery-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -182,6 +203,9 @@ webhooks:
         resources:
           - queries
   - name: vteam-v1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -208,6 +232,9 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -229,6 +256,9 @@ webhooks:
         resources:
           - tools
   - name: va2aserver-v1prealpha1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service
@@ -250,6 +280,9 @@ webhooks:
         resources:
           - a2aservers
   - name: vexecutionengine-v1prealpha1.kb.io
+    matchConditions:
+    - name: not-being-deleted
+      expression: "!has(object.metadata.deletionTimestamp)"
     clientConfig:
       service:
         name: ark-webhook-service

--- a/services/ark-api/ark-api/pyproject.toml
+++ b/services/ark-api/ark-api/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 package = true
 
 [tool.uv.sources]
-ark-sdk = { path = "out/ark_sdk-0.1.55-py3-none-any.whl" }
+ark-sdk = { path = "out/ark_sdk-0.1.57-py3-none-any.whl" }
 
 [tool.coverage.run]
 data_file = "coverage/.coverage"

--- a/services/ark-api/ark-api/uv.lock
+++ b/services/ark-api/ark-api/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -237,7 +237,7 @@ dependencies = [
 requires-dist = [
     { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.0" },
     { name = "aiofiles", specifier = ">=24.1.0" },
-    { name = "ark-sdk", path = "out/ark_sdk-0.1.55-py3-none-any.whl" },
+    { name = "ark-sdk", path = "out/ark_sdk-0.1.57-py3-none-any.whl" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "coverage", specifier = ">=7.10.4" },
     { name = "dpath", specifier = ">=2.2.0" },
@@ -265,8 +265,8 @@ requires-dist = [
 
 [[package]]
 name = "ark-sdk"
-version = "0.1.55"
-source = { path = "out/ark_sdk-0.1.55-py3-none-any.whl" }
+version = "0.1.57"
+source = { path = "out/ark_sdk-0.1.57-py3-none-any.whl" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
     { name = "build" },
@@ -276,15 +276,15 @@ dependencies = [
     { name = "kubernetes-asyncio" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest" },
     { name = "python-dateutil" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 wheels = [
-    { filename = "ark_sdk-0.1.55-py3-none-any.whl", hash = "sha256:e62d1d2f26fbd85920288d68769a038d4bd81c62e182c8ca011acf9491a026f5" },
+    { filename = "ark_sdk-0.1.57-py3-none-any.whl", hash = "sha256:8a601d261c9b0dbfbd96e690b8c79d4e02b94427cd34671f468b9a882b14eb57" },
 ]
 
 [package.metadata]
@@ -298,11 +298,11 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
-    { name = "python-jose", extras = ["cryptography"], specifier = "==3.5.0" },
     { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8.19.14" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
     { name = "urllib3", specifier = ">=2.1.0,<3.0.0" },
@@ -784,18 +784,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -2058,6 +2046,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2114,25 +2116,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2225,18 +2208,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]

--- a/tests/agent-partial-tool-invalid/chainsaw-test.yaml
+++ b/tests/agent-partial-tool-invalid/chainsaw-test.yaml
@@ -28,7 +28,7 @@ spec:
               kubectl wait --for=condition=ready pod -l app=mock-geocoding-api -n $NAMESPACE --timeout=60s
               MOCK_URL="http://mock-geocoding-api.$NAMESPACE.svc.cluster.local"
               kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-                curl -f -s "${MOCK_URL}/v1/search?name=New+York&count=1"
+                curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/search?name=New+York&count=1"
             env:
               - name: NAMESPACE
                 value: ($namespace)

--- a/tests/agent-partial-tool/chainsaw-test.yaml
+++ b/tests/agent-partial-tool/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
               kubectl wait --for=condition=ready pod -l app=mock-geocoding-api -n $NAMESPACE --timeout=60s
               MOCK_URL="http://mock-geocoding-api.$NAMESPACE.svc.cluster.local"
               kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-                curl -f -s "${MOCK_URL}/v1/search?name=New+York&count=1"
+                curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/search?name=New+York&count=1"
             env:
               - name: NAMESPACE
                 value: ($namespace)

--- a/tests/agent-tools/chainsaw-test.yaml
+++ b/tests/agent-tools/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
         content: |
           MOCK_URL="http://mock-weather-api.$NAMESPACE.svc.cluster.local"
           kubectl run test-mock-weather-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-            curl -f -s "${MOCK_URL}/v1/forecast?latitude=40.71&longitude=-74.01&current_weather=true"
+            curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/forecast?latitude=40.71&longitude=-74.01&current_weather=true"
         env:
         - name: NAMESPACE
           value: ($namespace)

--- a/tests/llm-tests/agent-partial-tool/chainsaw-test.yaml
+++ b/tests/llm-tests/agent-partial-tool/chainsaw-test.yaml
@@ -33,7 +33,7 @@ spec:
               kubectl wait --for=condition=ready pod -l app=mock-geocoding-api -n $NAMESPACE --timeout=60s
               MOCK_URL="http://mock-geocoding-api.$NAMESPACE.svc.cluster.local"
               kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-                curl -f -s "${MOCK_URL}/v1/search?name=New+York&count=1"
+                curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/search?name=New+York&count=1"
             env:
               - name: NAMESPACE
                 value: ($namespace)

--- a/tests/llm-tests/agent-tools/chainsaw-test.yaml
+++ b/tests/llm-tests/agent-tools/chainsaw-test.yaml
@@ -33,7 +33,7 @@ spec:
               kubectl wait --for=condition=ready pod -l app=mock-weather-api -n $NAMESPACE --timeout=60s
               MOCK_URL="http://mock-weather-api.$NAMESPACE.svc.cluster.local"
               kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-                curl -f -s "${MOCK_URL}/v1/forecast?latitude=40.71&longitude=-74.01&current_weather=true"
+                curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/forecast?latitude=40.71&longitude=-74.01&current_weather=true"
             env:
               - name: NAMESPACE
                 value: ($namespace)

--- a/tests/query-tool-target/chainsaw-test.yaml
+++ b/tests/query-tool-target/chainsaw-test.yaml
@@ -27,7 +27,7 @@ spec:
         content: |
           MOCK_URL="http://mock-geocoding-api.$NAMESPACE.svc.cluster.local"
           kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-            curl -f -s "${MOCK_URL}/v1/search?name=New+York&count=1"
+            curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/search?name=New+York&count=1"
         env:
           - name: NAMESPACE
             value: ($namespace)

--- a/tests/weather-chicago/chainsaw-test.yaml
+++ b/tests/weather-chicago/chainsaw-test.yaml
@@ -130,7 +130,7 @@ spec:
         content: |
           MOCK_URL="http://mock-weather-api.$NAMESPACE.svc.cluster.local"
           kubectl run test-mock-ready --image=curlimages/curl --rm -i --restart=Never -n $NAMESPACE -- \
-            curl -f -s "${MOCK_URL}/v1/search?name=Chicago&count=1"
+            curl -f -s --retry 5 --retry-connrefused --retry-delay 1 "${MOCK_URL}/v1/search?name=Chicago&count=1"
         timeout: 30s
     - apply:
         file: manifests/a05-weather-agent.yaml


### PR DESCRIPTION
Webhook fixes which should help with webhook errors in the e2e tests by reducing the number of UPDATE calls when objects are deleted, something which happens frequently in the e2e runs. 

- Adds matchConditions to all Ark admission webhooks to exclude UPDATE requests where the resource is already being deleted. The controller removes finalizers via Update() when a resource has a deletionTimestamp, which previously triggered the webhook unnecessarily. Under parallel test load this caused intermittent 503 errors during cleanup. This reduces webhook calls per resource lifecycle from 3 to 2 (CREATE, finalizer-add UPDATE, and formerly finalizer-remove UPDATE).

- The mquery-v1.kb.io mutating webhook was added to config/webhook/manifests.yaml in https://github.com/mckinsey/agents-at-scale-ark/commit/f7f82f33aeb266fd85d024f87d6929a109dc07d5 but was never added to the Helm chart template. When deployed via Helm, type:messages queries were never migrated to type:user, causing the completions executor to fail with "cannot unmarshal array into Go value of type string". 

- Race between pod readiness and kube-proxy propagation caused connection refused errors on the first curl attempt when connecting to mock-llm. Retry up to 5 times with 1s delay to handle the race reliably.


## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 