### PR TITLE
fix: disable protobuf in aggregated API server to prevent encoding failures

### DIFF
--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -35,6 +35,21 @@ var (
 	ParameterCodec = runtime.NewParameterCodec(Scheme)
 )
 
+type jsonOnlyNegotiatedSerializer struct {
+	serializer.CodecFactory
+}
+
+func (s jsonOnlyNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	all := s.CodecFactory.SupportedMediaTypes()
+	result := make([]runtime.SerializerInfo, 0, len(all))
+	for _, info := range all {
+		if info.MediaType != runtime.ContentTypeProtobuf {
+			result = append(result, info)
+		}
+	}
+	return result
+}
+
 func init() {
 	utilruntime.Must(arkv1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(arkv1prealpha1.AddToScheme(Scheme))
@@ -99,6 +114,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	serverConfig := genericapiserver.NewConfig(Codecs)
+	serverConfig.Serializer = jsonOnlyNegotiatedSerializer{Codecs}
 	serverConfig.EffectiveVersion = compatibility.DefaultBuildEffectiveVersion()
 	serverConfig.RequestTimeout = 24 * time.Hour
 	serverConfig.MinRequestTimeout = 86400


### PR DESCRIPTION
## Summary

- Ark types don't implement the protobuf marshalling interface, so when kubectl negotiates protobuf (its preferred encoding), the API server accepts the content type but fails to encode responses
- Under parallel e2e test load this generates a flood of 500 errors which causes the kube-aggregator to return 503s for API discovery, manifesting as intermittent "server is currently unable to handle the request" failures
- Fix wraps the CodecFactory in a NegotiatedSerializer that filters protobuf from SupportedMediaTypes(), so the server never advertises protobuf support and clients negotiate JSON instead
- Only affects the postgresql aggregated API server path