### PR TITLE
fix: remove duplicate sonar pull_request trigger

### DIFF
--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -1,9 +1,6 @@
 name: SonarQube Scan
 
 on:
-  pull_request:
-    branches: ["main"]
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
sonar_scan.yaml had both a direct pull_request trigger and a workflow_call trigger. Since cicd.yaml already calls this workflow after builds complete, the direct trigger caused two CE tasks to be submitted to SonarQube per PR push. SonarQube's per-project CE queue cancels older queued tasks when a newer one arrives, causing intermittent scan cancellations.

Removing the direct pull_request trigger so sonar only runs via cicd.yaml, which also provides better coverage data from build artifacts.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 