### PR TITLE
fix: upgrade Go to 1.26.2 for CVE-2026-27140

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -192,7 +192,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -1047,7 +1047,7 @@ jobs:
       - name: Setup Go for coverage tools
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Install Python coverage tools
         run: |
@@ -1293,7 +1293,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-coverage.outputs.found == 'false'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
           cache-dependency-path: ark/go.sum
 

--- a/ark/go.mod
+++ b/ark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/tools/fark/go.mod
+++ b/tools/fark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark/tools/fark
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
CVE-2026-27140 (CVSS 8.8 HIGH) — code execution vulnerability in SWIG code generation in cmd/go. SWIG filenames containing 'cgo' with crafted payloads bypass trust checks, enabling arbitrary code execution at build time. Affects Go < 1.25.9 and Go 1.26.0–1.26.1.

The Dockerfiles were already updated to 1.26.2 in a prior dependabot PR. This commit updates the remaining pinned versions in go.mod and CI workflow files.

References:
- https://cve.circl.lu/api/cve/CVE-2026-27140
- https://pkg.go.dev/vuln/GO-2026-4871
- https://go.dev/cl/763768

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 