### PR TITLE
fix(dashboard): allow cross-origin dev access for nip.io hostname

### DIFF
--- a/services/ark-dashboard/ark-dashboard/next.config.ts
+++ b/services/ark-dashboard/ark-dashboard/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 import path from 'path';
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['dashboard.default.127.0.0.1.nip.io'],
   output: 'standalone',
   outputFileTracingRoot: path.join(__dirname, './'),
   basePath: process.env.ARK_DASHBOARD_BASE_PATH || '',


### PR DESCRIPTION
## Summary

- Next.js 16.2+ blocks cross-origin requests to dev resources (HMR, fonts) by default (vercel/next.js#91507)
- DevSpace serves the dashboard via `dashboard.default.127.0.0.1.nip.io`, which triggers this cross-origin block
- Add `allowedDevOrigins` to `next.config.ts` so HMR and dev assets load correctly through the DevSpace ingress