### PR TITLE
fix: marketplace error handling

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/marketplace-hooks.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/marketplace-hooks.test.tsx
@@ -1,0 +1,158 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { APIError } from '@/lib/api/client';
+import {
+  useGetMarketplaceItemById,
+  useGetMarketplaceItems,
+} from '@/lib/services/marketplace-hooks';
+import { marketplaceService } from '@/lib/services/marketplace';
+
+vi.mock('@/lib/services/marketplace', () => ({
+  marketplaceService: {
+    getMarketplaceItems: vi.fn(),
+    getMarketplaceItemById: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('marketplace hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('useGetMarketplaceItems', () => {
+    it('should fetch and return marketplace items', async () => {
+      const mockResponse = {
+        items: [
+          { id: 'item-1', name: 'Test Item 1' },
+          { id: 'item-2', name: 'Test Item 2' },
+        ],
+        total: 2,
+      };
+
+      vi.mocked(marketplaceService.getMarketplaceItems).mockResolvedValue(
+        mockResponse as any,
+      );
+
+      const { result } = renderHook(() => useGetMarketplaceItems(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(marketplaceService.getMarketplaceItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle 4xx errors without retry', async () => {
+      const error = new APIError('Bad request', 400);
+      vi.mocked(marketplaceService.getMarketplaceItems).mockRejectedValue(
+        error,
+      );
+
+      const { result } = renderHook(() => useGetMarketplaceItems(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBe(error);
+      expect(marketplaceService.getMarketplaceItems).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('useGetMarketplaceItemById', () => {
+    it('should fetch and return a marketplace item', async () => {
+      const mockItem = {
+        id: 'test-item',
+        name: 'Test Item',
+        description: 'Test description',
+      };
+
+      vi.mocked(marketplaceService.getMarketplaceItemById).mockResolvedValue(
+        mockItem as any,
+      );
+
+      const { result } = renderHook(() => useGetMarketplaceItemById('test-item'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual(mockItem);
+      expect(marketplaceService.getMarketplaceItemById).toHaveBeenCalledWith(
+        'test-item',
+      );
+    });
+
+    it('should not retry on 404 errors', async () => {
+      const error = new APIError('Not found', 404);
+      vi.mocked(marketplaceService.getMarketplaceItemById).mockRejectedValue(
+        error,
+      );
+
+      const { result } = renderHook(
+        () => useGetMarketplaceItemById('non-existent'),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(marketplaceService.getMarketplaceItemById).toHaveBeenCalledTimes(1);
+      expect(result.current.error).toBe(error);
+    });
+
+    it('should not retry on 400 errors', async () => {
+      const error = new APIError('Bad request', 400);
+      vi.mocked(marketplaceService.getMarketplaceItemById).mockRejectedValue(
+        error,
+      );
+
+      const { result } = renderHook(() => useGetMarketplaceItemById('bad-id'), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(marketplaceService.getMarketplaceItemById).toHaveBeenCalledTimes(1);
+      expect(result.current.error).toBe(error);
+    });
+
+    it('should not retry on 403 errors', async () => {
+      const error = new APIError('Forbidden', 403);
+      vi.mocked(marketplaceService.getMarketplaceItemById).mockRejectedValue(
+        error,
+      );
+
+      const { result } = renderHook(
+        () => useGetMarketplaceItemById('forbidden-item'),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(marketplaceService.getMarketplaceItemById).toHaveBeenCalledTimes(1);
+      expect(result.current.error).toBe(error);
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/lib/services/marketplace-hooks.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/marketplace-hooks.ts
@@ -23,6 +23,15 @@ export function useGetMarketplaceItemById(id: string) {
     queryKey: ['marketplace', id],
     queryFn: () => marketplaceService.getMarketplaceItemById(id),
     enabled: Boolean(id),
+    retry: (failureCount, error) => {
+      if (error && typeof error === 'object' && 'status' in error) {
+        const status = error.status as number | undefined;
+        if (status && status >= 400 && status < 500) {
+          return false;
+        }
+      }
+      return failureCount < 3;
+    },
   });
 }
 

--- a/services/ark-dashboard/ark-dashboard/lib/services/marketplace-hooks.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/marketplace-hooks.ts
@@ -8,6 +8,7 @@ import type {
   MarketplaceItemDetail,
   MarketplaceResponse,
 } from '@/lib/api/generated/marketplace-types';
+import { retryQueryHandler } from '@/lib/utils/query-retry';
 
 import { marketplaceService } from './marketplace';
 
@@ -15,6 +16,7 @@ export function useGetMarketplaceItems(filters?: MarketplaceFilters) {
   return useQuery<MarketplaceResponse>({
     queryKey: ['marketplace', filters],
     queryFn: () => marketplaceService.getMarketplaceItems(filters),
+    retry: retryQueryHandler,
   });
 }
 
@@ -23,15 +25,7 @@ export function useGetMarketplaceItemById(id: string) {
     queryKey: ['marketplace', id],
     queryFn: () => marketplaceService.getMarketplaceItemById(id),
     enabled: Boolean(id),
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error) {
-        const status = error.status as number | undefined;
-        if (status && status >= 400 && status < 500) {
-          return false;
-        }
-      }
-      return failureCount < 3;
-    },
+    retry: retryQueryHandler,
   });
 }
 

--- a/services/ark-dashboard/ark-dashboard/lib/utils/query-retry.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/utils/query-retry.ts
@@ -1,0 +1,38 @@
+import { APIError } from '@/lib/api/client';
+
+/**
+ * Retry handler for React Query that determines whether a failed query should be retried.
+ *
+ * This prevents unnecessary retries for client errors (4xx) that won't resolve with
+ * repeated attempts, such as 404 Not Found, 400 Bad Request, 401 Unauthorized, etc.
+ *
+ * Retry behavior:
+ * - Client errors (4xx): Don't retry - these are permanent errors caused by the request
+ * - Server errors (5xx): Retry up to 3 times - these may be transient server issues
+ * - Network errors (no status): Retry up to 3 times - these may be transient connectivity issues
+ *
+ * @param failureCount - The number of times the query has failed
+ * @param error - The error that occurred
+ * @returns true to retry, false to stop retrying
+ *
+ * @example
+ * ```typescript
+ * useQuery({
+ *   queryKey: ['item', id],
+ *   queryFn: () => fetchItem(id),
+ *   retry: retryQueryHandler,
+ * });
+ * ```
+ */
+export function retryQueryHandler(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  // Don't retry client errors (4xx) - they won't resolve with retries
+  if (error instanceof APIError && error.status && error.status >= 400 && error.status < 500) {
+    return false;
+  }
+
+  // Retry server errors (5xx) and network errors up to 3 times
+  return failureCount < 3;
+}


### PR DESCRIPTION
Skip retries for 4xx errors in marketplace fetches for faster error feedback

Linked issue: #1538 