### PR TITLE
fix: Use sed to sync ark-sdk instead of python package

### DIFF
--- a/lib/ark-sdk/build.mk
+++ b/lib/ark-sdk/build.mk
@@ -6,9 +6,8 @@ ARK_SDK_OUT := $(OUT)/$(ARK_SDK_LIB_NAME)
 
 # Library-specific variables
 ARK_SDK_VERSION := $(shell cat version.txt)
-# Normalize version to PEP 440 format for wheel filename (e.g., 0.1.58-rc -> 0.1.58rc0)
-# Uses Python's packaging library which handles all edge cases (rc, rc0, rc.1, rc-2, etc.)
-ARK_SDK_PEP440_VERSION := $(shell python3 -c "from packaging.version import Version; print(Version('$(ARK_SDK_VERSION)'))")
+# Normalize version to PEP 440 format for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
+ARK_SDK_PEP440_VERSION := $(shell echo '$(ARK_SDK_VERSION)' | sed 's/-rc\./rc/')
 ARK_SDK_WHEEL_NAME := ark_sdk-$(ARK_SDK_PEP440_VERSION)-py3-none-any.whl
 ARK_SDK_WHL := $(ARK_SDK_OUT)/py-sdk/dist/$(ARK_SDK_WHEEL_NAME)
 ARK_SDK_CRD_FILES := $(wildcard ark/config/crd/bases/ark*.yaml)

--- a/lib/ark-sdk/install.sh
+++ b/lib/ark-sdk/install.sh
@@ -16,8 +16,8 @@ CRD_GLOBS=(
   "../../services/**/crd/*.yml"
 )
 
-# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc -> 0.1.58rc0)
-PEP440_VERSION=$(python3 -c "from packaging.version import Version; print(Version('$(cat ../../version.txt)'))")
+# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 if [[ -e "$OUT_DIR/py-sdk/dist/$WHEEL_NAME" ]]; then

--- a/services/ark-api/sync-ark-sdk.sh
+++ b/services/ark-api/sync-ark-sdk.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc -> 0.1.58rc0)
-PEP440_VERSION=$(python3 -c "from packaging.version import Version; print(Version('$(cat ../../version.txt)'))")
+# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 rm -rf out

--- a/services/ark-mcp/sync-ark-sdk.sh
+++ b/services/ark-mcp/sync-ark-sdk.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc -> 0.1.58rc0)
-PEP440_VERSION=$(python3 -c "from packaging.version import Version; print(Version('$(cat ../../version.txt)'))")
+# Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 rm -rf ark-mcp/out


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 