### PR TITLE
fix: executor marketplace type added

### DIFF
--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/marketplace/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/marketplace/page.tsx
@@ -9,7 +9,7 @@ import {
   Server,
   SquarePlay,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { MarketplaceItemCard } from '@/components/cards/marketplace-item-card';
 import { PageHeader } from '@/components/common/page-header';
@@ -50,13 +50,20 @@ export default function MarketplacePage() {
 
   const pageTitle = data ? `Marketplace (${data.items.length})` : 'Marketplace';
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setCurrentPage(1);
+      setFilters(prev => ({
+        ...prev,
+        search: searchQuery || undefined,
+      }));
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   const handleSearch = (value: string) => {
     setSearchQuery(value);
-    setCurrentPage(1); // Reset to first page on search
-    setFilters(prev => ({
-      ...prev,
-      search: value || undefined,
-    }));
   };
 
   const handleCategoryChange = (category: string) => {

--- a/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.test.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.test.ts
@@ -151,6 +151,22 @@ describe('POST /api/marketplace/[id]/install', () => {
     expect(data.arkCommand).toBe('ark install marketplace/agents/my-agent');
   });
 
+  it('should use executors in arkCommand for executor type', async () => {
+    mockGetRawMarketplaceItemById.mockResolvedValueOnce({
+      ...baseItem,
+      type: 'executor',
+    });
+
+    const request = createRequest('http://localhost/api/marketplace/my-executor/install', {
+      method: 'POST',
+      body: JSON.stringify({ mode: 'command' }),
+    });
+    const response = await POST(request, { params: Promise.resolve({ id: 'my-executor' }) });
+    const data = await response.json();
+
+    expect(data.arkCommand).toBe('ark install marketplace/executors/my-executor');
+  });
+
   it('should execute helm and return success in direct mode when helm available', async () => {
     mockGetRawMarketplaceItemById.mockResolvedValueOnce({ ...baseItem });
     mockExecSuccess({ stdout: 'v3.12.0', stderr: '' });

--- a/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.ts
@@ -25,6 +25,14 @@ async function checkHelmAvailable(): Promise<{
   }
 }
 
+function getMarketplaceCategoryPath(
+  itemType?: 'service' | 'agent' | 'demo' | 'executor',
+): string {
+  if (itemType === 'service') return 'services';
+  if (itemType === 'executor') return 'executors';
+  return 'agents';
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -79,7 +87,7 @@ export async function POST(
     // Return the command for user to run
     if (mode === 'command') {
       // Generate both helm and ark CLI commands
-      const arkCommand = `ark install marketplace/${item.type === 'service' ? 'services' : 'agents'}/${id}`;
+      const arkCommand = `ark install marketplace/${getMarketplaceCategoryPath(item.type)}/${id}`;
 
       return NextResponse.json({
         status: 'command',
@@ -103,9 +111,7 @@ export async function POST(
           status: 'command',
           name: item.name || id,
           helmCommand,
-          arkCommand: `ark install marketplace/${
-            item.type === 'service' ? 'services' : 'agents'
-          }/${id}`,
+          arkCommand: `ark install marketplace/${getMarketplaceCategoryPath(item.type)}/${id}`,
           namespace: ark.namespace,
           message:
             'Direct installation not available. Run this command in your terminal:',
@@ -133,9 +139,7 @@ export async function POST(
         status: 'command',
         name: item.name || id,
         helmCommand,
-        arkCommand: `ark install marketplace/${
-          item.type === 'service' ? 'services' : 'agents'
-        }/${id}`,
+        arkCommand: `ark install marketplace/${getMarketplaceCategoryPath(item.type)}/${id}`,
         namespace: ark.namespace,
         message:
           'Direct installation not available. Run this command in your terminal:',

--- a/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/marketplace/[id]/install/route.ts
@@ -25,6 +25,10 @@ async function checkHelmAvailable(): Promise<{
   }
 }
 
+/**
+ * Maps source item type to marketplace installation path category.
+ * Services and executors have dedicated paths; agents and demos use 'agents'.
+ */
 function getMarketplaceCategoryPath(
   itemType?: 'service' | 'agent' | 'demo' | 'executor',
 ): string {

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/marketplace-types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/marketplace-types.ts
@@ -37,7 +37,8 @@ export type MarketplaceItemType =
   | 'component'
   | 'template'
   | 'plugin'
-  | 'demo';
+  | 'demo'
+  | 'executor';
 
 export type MarketplaceItemStatus =
   | 'available'

--- a/services/ark-dashboard/ark-dashboard/lib/services/marketplace-fetcher.test.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/marketplace-fetcher.test.ts
@@ -129,6 +129,20 @@ describe('marketplace-fetcher', () => {
         expect(result.type).toBe('service')
       })
 
+      it('maps "demo" to "demo"', () => {
+        const result = transformGitHubItemToMarketplaceItem(
+          makeGitHubItem({ type: 'demo' }),
+        )
+        expect(result.type).toBe('demo')
+      })
+
+      it('maps "executor" to "executor"', () => {
+        const result = transformGitHubItemToMarketplaceItem(
+          makeGitHubItem({ type: 'executor' }),
+        )
+        expect(result.type).toBe('executor')
+      })
+
       it('maps undefined type to "component"', () => {
         const result = transformGitHubItemToMarketplaceItem(
           makeGitHubItem(),

--- a/services/ark-dashboard/ark-dashboard/lib/services/marketplace-fetcher.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/marketplace-fetcher.ts
@@ -12,7 +12,7 @@ interface GitHubMarketplaceItem {
   name: string;
   displayName?: string;
   description: string;
-  type?: 'service' | 'agent' | 'demo';
+  type?: 'service' | 'agent' | 'demo' | 'executor';
   version?: string;
   author?: string;
   homepage?: string;
@@ -87,10 +87,11 @@ function mapCategoryFromGitHub(category?: string): MarketplaceCategory {
   return 'tools'; // default category
 }
 
-function mapTypeFromGitHub(type?: 'service' | 'agent' | 'demo'): MarketplaceItemType {
+function mapTypeFromGitHub(type?: 'service' | 'agent' | 'demo' | 'executor'): MarketplaceItemType {
   if (type === 'agent') return 'template';
   if (type === 'service') return 'service';
   if (type === 'demo') return 'demo';
+  if (type === 'executor') return 'executor';
   return 'component'; // default type
 }
 


### PR DESCRIPTION
Executor type support added to generate correct marketplace install paths (executors/ instead of agents/)