### PR TITLE
chore: docs created

### DIFF
--- a/docs/content/user-guide/_meta.js
+++ b/docs/content/user-guide/_meta.js
@@ -12,6 +12,7 @@ export default {
   tools: 'Creating Tools and MCP Servers',
   'workflow-templates': 'Workflow Templates',
   files: 'Managing Files',
+  'executor-credentials': 'Configuring Executor Credentials',
   'ark-cli': 'The Ark CLI',
 
   '---patterns': { type: 'separator', title: 'Patterns and guidance' },

--- a/docs/content/user-guide/_meta.js
+++ b/docs/content/user-guide/_meta.js
@@ -12,8 +12,10 @@ export default {
   tools: 'Creating Tools and MCP Servers',
   'workflow-templates': 'Workflow Templates',
   files: 'Managing Files',
-  'executor-credentials': 'Configuring Executor Credentials',
   'ark-cli': 'The Ark CLI',
+
+  '---configuration': { type: 'separator', title: 'Configuration' },
+  'executor-credentials': 'Configuring Executor Credentials',
 
   '---patterns': { type: 'separator', title: 'Patterns and guidance' },
   'tips-on-building-agentic-use-cases': 'Tips on Building Agentic Use Cases',

--- a/docs/content/user-guide/executor-credentials.mdx
+++ b/docs/content/user-guide/executor-credentials.mdx
@@ -1,3 +1,8 @@
+---
+title: Configuring Executor Credentials
+description: Configure credentials for agents to authenticate with external services using Kubernetes Secrets
+---
+
 # Configuring Executor Credentials
 
 Some agents need to authenticate with external services (GitHub, APIs, etc.). Credentials are configured at the executor deployment level using Kubernetes Secrets.
@@ -19,7 +24,7 @@ kubectl create secret generic github-credentials \
 
 ```bash
 helm upgrade executor-claude-agent-sdk ./chart \
-  --set extraEnvFrom[0].secretRef.name=github-credentials
+  --set 'extraEnvFrom[0].secretRef.name=github-credentials'
 ```
 
 3. Use the executor in your agent:
@@ -32,14 +37,28 @@ metadata:
 spec:
   executionEngine:
     name: executor-claude-agent-sdk
-  model:
-    ref: claude-sonnet
+  modelRef:
+    name: claude-sonnet
   prompt: |
     You are a GitHub automation assistant.
     Use the gh CLI to interact with repositories.
 ```
 
 The agent will now have access to `GITHUB_TOKEN` and can use authenticated `gh` CLI commands.
+
+### Verifying Credentials
+
+To verify the credentials are properly injected, you can check the pod environment:
+
+```bash
+kubectl exec -it <executor-pod-name> -- env | grep GITHUB_TOKEN
+```
+
+Or test the agent's ability to use authenticated commands by running a simple query:
+
+```bash
+ark query github-agent "List my GitHub repositories using the gh CLI"
+```
 
 ## How It Works
 

--- a/docs/content/user-guide/executor-credentials.mdx
+++ b/docs/content/user-guide/executor-credentials.mdx
@@ -1,0 +1,56 @@
+# Configuring Executor Credentials
+
+Some agents need to authenticate with external services (GitHub, APIs, etc.). Credentials are configured at the executor deployment level using Kubernetes Secrets.
+
+## For Claude Agent SDK Executor
+
+See the [executor documentation](https://github.com/mckinsey/agents-at-scale-marketplace/tree/main/executors/claude-agent-sdk#credential-injection) for detailed setup instructions.
+
+### Quick Example
+
+1. Create a Kubernetes Secret with your credentials:
+
+```bash
+kubectl create secret generic github-credentials \
+  --from-literal=GITHUB_TOKEN=ghp_xxxxxxxxxxxxx
+```
+
+2. Configure the executor to load the secret:
+
+```bash
+helm upgrade executor-claude-agent-sdk ./chart \
+  --set extraEnvFrom[0].secretRef.name=github-credentials
+```
+
+3. Use the executor in your agent:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: github-agent
+spec:
+  executionEngine:
+    name: executor-claude-agent-sdk
+  model:
+    ref: claude-sonnet
+  prompt: |
+    You are a GitHub automation assistant.
+    Use the gh CLI to interact with repositories.
+```
+
+The agent will now have access to `GITHUB_TOKEN` and can use authenticated `gh` CLI commands.
+
+## How It Works
+
+- Credentials are injected as environment variables into the executor pod via Kubernetes Secrets
+- The executor forwards these environment variables to the Claude Code subprocess
+- Tools like `gh`, `git`, and `curl` automatically discover credentials from the environment
+- All agents using the same executor deployment share the same credentials
+
+## Security Notes
+
+- Credentials are scoped per-executor deployment, not per-agent
+- Use Kubernetes RBAC to control which service accounts can access which Secrets
+- For production, use fine-grained access tokens (e.g., GitHub fine-grained PATs) with minimal required permissions
+- Never commit credentials to version control

--- a/docs/content/user-guide/executor-credentials.mdx
+++ b/docs/content/user-guide/executor-credentials.mdx
@@ -57,7 +57,7 @@ kubectl exec -it <executor-pod-name> -- env | grep GITHUB_TOKEN
 Or test the agent's ability to use authenticated commands by running a simple query:
 
 ```bash
-ark query github-agent "List my GitHub repositories using the gh CLI"
+ark query agent/github-agent "List my GitHub repositories using the gh CLI"
 ```
 
 ## How It Works


### PR DESCRIPTION
Added user guide documentation for configuring executor credentials via Kubernetes Secrets, enabling agents to authenticate with external services like GitHub.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #1552 