### PR TITLE
docs(dashboard): proposal to refactor YAML view using resources API

### DIFF
--- a/openspec/changes/refactor-yaml-view/.openspec.yaml
+++ b/openspec/changes/refactor-yaml-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/refactor-yaml-view/design.md
+++ b/openspec/changes/refactor-yaml-view/design.md
@@ -2,55 +2,59 @@
 
 The dashboard's Agent Studio and Team form both have a YAML view toggle that displays the resource as Kubernetes CRD YAML. Both currently build YAML by concatenating strings line-by-line, manually adding each known field. This approach silently drops fields that weren't included at implementation time — notably `executionEngine`, `overrides`, `skills`, and `annotations` for agents.
 
-`js-yaml` is already a project dependency (used in `workflow-dag-viewer.tsx`). The `AgentDetailResponse` and team response types from the API contain all fields needed. The YAML view is read-only (one-way: form state → YAML display).
+The `/v1/resources/apis/{group}/{version}/{kind}/{name}` API endpoint already exists and returns the raw Kubernetes object. The dashboard already uses it for workflows, workflow templates, and execution engines. `js-yaml` is already a project dependency.
 
 ## Goals / Non-Goals
 
 **Goals:**
 - All CRD fields appear in the YAML view without manual per-field handling
-- Form-managed fields reflect live edits; non-form fields show saved values
-- Shared serialization logic reusable across agent and team forms (and future resource forms)
-- Strip runtime-only fields (`status`, `id`, `managedFields`) from YAML output
+- Zero per-resource maintenance — new CRD fields appear automatically
+- Shared cleanup/serialization logic reusable across any resource form
+- Strip runtime-only fields (`status`, `managedFields`, etc.) from YAML output
+- Lay groundwork for future PUT support (YAML edit → save back)
 
 **Non-Goals:**
-- Two-way YAML editing (editing YAML to update form state)
-- Fetching raw Kubernetes resources from the `/v1/resources/` endpoint
+- Two-way YAML editing (editing YAML to update form state) — future work
+- New API endpoints — the resources API already does what we need
 - Changing the YamlViewer component itself (it receives a string, that contract stays)
 
 ## Decisions
 
-### 1. Structured object + js-yaml over manual string concatenation
+### 1. Fetch raw K8s resource from resources API, not rebuild from form state
 
-Build a plain JavaScript object matching the CRD shape, then serialize with `yaml.dump()`.
+Call `GET /v1/resources/apis/ark.mckinsey.com/v1alpha1/Agent/{name}` to get the actual Kubernetes object, clean it, and serialize to YAML.
 
-**Why:** Eliminates the entire class of "forgot to add field X" bugs. `js-yaml` handles nesting, arrays, and multiline strings (block scalar style for prompts) automatically. Adding a new CRD field means adding it to the object spread, not writing string formatting logic.
+**Why:** Eliminates the entire class of "forgot to add field X" bugs permanently. No per-resource builder functions needed. The resources API already exists and is used by workflows, execution engines, and workflow templates in the dashboard. New CRD fields appear with zero code changes.
 
-**Alternative considered:** Template literals with tagged templates. Rejected because it still requires manual field handling and doesn't handle nested structures or YAML escaping.
+**Trade-off:** The YAML view shows the last-saved state, not live form edits. This is acceptable because:
+- The YAML view's purpose is "what does this CRD manifest look like?" — the saved state is the correct answer
+- Showing unsaved changes in the YAML would be misleading for copy/paste into `kubectl apply`
+- This is consistent with how `kubectl get -o yaml` works
 
-### 2. Two-layer architecture: shared utility + per-form spec builders
+**Alternative considered:** Building a spec object from form state + API data and serializing with js-yaml. Rejected because it still requires per-resource builder functions that must be updated when CRDs change — the same maintenance problem, just in a different form.
 
-`lib/utils/kubernetes-yaml.ts` handles the resource-agnostic concerns (CRD envelope, null stripping, serialization). Per-form `yaml.ts` files handle resource-specific field merging.
+### 2. Single shared utility for cleanup and serialization
 
-**Why:** Follows existing dashboard patterns — `kubernetes-validation.ts` in `lib/utils/` handles shared K8s concerns, while `utils.ts` in each form directory handles form-specific transforms. The spec builder is co-located with the form that uses it, just like parameter transforms already are.
+`lib/utils/kubernetes-yaml.ts` handles all resource-agnostic concerns: stripping runtime fields, recursive null removal, and js-yaml serialization. No per-form files needed.
 
-**Alternative considered:** Single utility file with per-resource functions. Rejected because it would create coupling between unrelated resources and doesn't match the existing co-location pattern.
+**Why:** Since we're fetching the raw resource, there's nothing resource-specific to handle. The same cleanup logic applies to any Kubernetes resource. One utility, used everywhere.
 
-### 3. Merge agent object with form state, not rebuild from scratch
+### 3. Service methods for raw resource fetching
 
-Start from the API response object (which has all fields), then override with current form watch values for form-managed fields.
+Add a `getRawResource` method to the agent and team services that calls the resources API endpoint. This follows the existing pattern in `engines.ts` and `workflows.ts`.
 
-**Why:** Non-form-editable fields like `overrides` and `annotations` automatically appear without any explicit handling. New fields added to the API response will appear in YAML without code changes, unless they're also added to the form (in which case the form builder needs updating anyway).
+**Why:** Keeps the API call co-located with other service methods. The dashboard proxy at `/api/v1/resources/...` already forwards these to the ark-api.
 
-### 4. Recursive null/empty stripping utility
+### 4. Fetch on mount + re-fetch on save, not on every render
 
-A shared `stripEmpty()` function recursively removes `null`, `undefined`, empty strings, empty arrays, and empty objects before serialization.
+Fetch the raw resource when the YAML view is first shown, and re-fetch after successful saves. Don't re-fetch on every form change.
 
-**Why:** The API response contains many nullable fields. Without stripping, the YAML would be cluttered with `field: null` entries that aren't meaningful in a CRD manifest. This matches the behavior of the backend's `clean_resource_for_yaml()` in the export endpoint.
+**Why:** Avoids unnecessary API calls. The YAML shows saved state, so it only needs to update when the saved state changes.
 
 ## Risks / Trade-offs
 
-**[YAML formatting differences]** → `js-yaml` may produce slightly different formatting than the hand-built strings (e.g., quoting rules, key ordering). This is cosmetic and correct — `js-yaml` produces valid YAML. Users who copy/paste YAML may notice minor differences from what they're used to.
+**[Extra API call]** → One additional GET per resource when YAML view is toggled. Mitigated by only fetching when the YAML tab is active, and caching until next save. The resources API is fast (direct K8s proxy).
 
-**[Field ordering]** → `js-yaml` serializes in object key insertion order. The spec builder should construct the object with fields in the conventional CRD order (description, modelRef, executionEngine, prompt, parameters, tools) to produce readable output. → Mitigated by explicit field ordering in the builder function.
+**[YAML formatting differences]** → `js-yaml` may produce slightly different formatting than the hand-built strings (e.g., quoting rules, key ordering). This is cosmetic and correct — `js-yaml` produces valid YAML.
 
-**[Multiline prompt formatting]** → `js-yaml` uses block scalar style (`|`) for multiline strings by default with `lineWidth: -1`. Need to verify this produces clean output for prompts with special characters. → Test with representative prompts during implementation.
+**[Stale YAML during edits]** → YAML won't reflect unsaved form changes. This is by design — a feature, not a bug — since the YAML represents the actual cluster state.

--- a/openspec/changes/refactor-yaml-view/design.md
+++ b/openspec/changes/refactor-yaml-view/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The dashboard's Agent Studio and Team form both have a YAML view toggle that displays the resource as Kubernetes CRD YAML. Both currently build YAML by concatenating strings line-by-line, manually adding each known field. This approach silently drops fields that weren't included at implementation time — notably `executionEngine`, `overrides`, `skills`, and `annotations` for agents.
+
+`js-yaml` is already a project dependency (used in `workflow-dag-viewer.tsx`). The `AgentDetailResponse` and team response types from the API contain all fields needed. The YAML view is read-only (one-way: form state → YAML display).
+
+## Goals / Non-Goals
+
+**Goals:**
+- All CRD fields appear in the YAML view without manual per-field handling
+- Form-managed fields reflect live edits; non-form fields show saved values
+- Shared serialization logic reusable across agent and team forms (and future resource forms)
+- Strip runtime-only fields (`status`, `id`, `managedFields`) from YAML output
+
+**Non-Goals:**
+- Two-way YAML editing (editing YAML to update form state)
+- Fetching raw Kubernetes resources from the `/v1/resources/` endpoint
+- Changing the YamlViewer component itself (it receives a string, that contract stays)
+
+## Decisions
+
+### 1. Structured object + js-yaml over manual string concatenation
+
+Build a plain JavaScript object matching the CRD shape, then serialize with `yaml.dump()`.
+
+**Why:** Eliminates the entire class of "forgot to add field X" bugs. `js-yaml` handles nesting, arrays, and multiline strings (block scalar style for prompts) automatically. Adding a new CRD field means adding it to the object spread, not writing string formatting logic.
+
+**Alternative considered:** Template literals with tagged templates. Rejected because it still requires manual field handling and doesn't handle nested structures or YAML escaping.
+
+### 2. Two-layer architecture: shared utility + per-form spec builders
+
+`lib/utils/kubernetes-yaml.ts` handles the resource-agnostic concerns (CRD envelope, null stripping, serialization). Per-form `yaml.ts` files handle resource-specific field merging.
+
+**Why:** Follows existing dashboard patterns — `kubernetes-validation.ts` in `lib/utils/` handles shared K8s concerns, while `utils.ts` in each form directory handles form-specific transforms. The spec builder is co-located with the form that uses it, just like parameter transforms already are.
+
+**Alternative considered:** Single utility file with per-resource functions. Rejected because it would create coupling between unrelated resources and doesn't match the existing co-location pattern.
+
+### 3. Merge agent object with form state, not rebuild from scratch
+
+Start from the API response object (which has all fields), then override with current form watch values for form-managed fields.
+
+**Why:** Non-form-editable fields like `overrides` and `annotations` automatically appear without any explicit handling. New fields added to the API response will appear in YAML without code changes, unless they're also added to the form (in which case the form builder needs updating anyway).
+
+### 4. Recursive null/empty stripping utility
+
+A shared `stripEmpty()` function recursively removes `null`, `undefined`, empty strings, empty arrays, and empty objects before serialization.
+
+**Why:** The API response contains many nullable fields. Without stripping, the YAML would be cluttered with `field: null` entries that aren't meaningful in a CRD manifest. This matches the behavior of the backend's `clean_resource_for_yaml()` in the export endpoint.
+
+## Risks / Trade-offs
+
+**[YAML formatting differences]** → `js-yaml` may produce slightly different formatting than the hand-built strings (e.g., quoting rules, key ordering). This is cosmetic and correct — `js-yaml` produces valid YAML. Users who copy/paste YAML may notice minor differences from what they're used to.
+
+**[Field ordering]** → `js-yaml` serializes in object key insertion order. The spec builder should construct the object with fields in the conventional CRD order (description, modelRef, executionEngine, prompt, parameters, tools) to produce readable output. → Mitigated by explicit field ordering in the builder function.
+
+**[Multiline prompt formatting]** → `js-yaml` uses block scalar style (`|`) for multiline strings by default with `lineWidth: -1`. Need to verify this produces clean output for prompts with special characters. → Test with representative prompts during implementation.

--- a/openspec/changes/refactor-yaml-view/proposal.md
+++ b/openspec/changes/refactor-yaml-view/proposal.md
@@ -4,15 +4,16 @@ The Agent Studio and Team form YAML views manually build YAML strings line-by-li
 
 ## What Changes
 
-- Replace manual YAML string concatenation in `agent-form.tsx` and `team-form.tsx` with structured object building and `js-yaml` serialization
-- Create a shared utility for Kubernetes CRD YAML serialization (envelope wrapping, null stripping, status removal)
-- Create per-form spec builder functions that merge API data with live form state
-- All agent/team fields now appear in YAML output automatically, including previously missing ones
+- Fetch raw Kubernetes resources via the existing `/v1/resources/` API instead of reconstructing YAML from form state
+- Create a shared utility to clean raw K8s objects (strip status, managedFields, etc.) and serialize with `js-yaml`
+- Replace manual YAML string concatenation in `agent-form.tsx` and `team-form.tsx` with a single fetch + clean + serialize call
+- All CRD fields appear automatically — no per-resource builder functions needed
+- Opens the path for future PUT support (edit YAML → save back)
 
 ## Capabilities
 
 ### New Capabilities
-- `kubernetes-yaml-serialization`: Shared utility for converting Kubernetes resource objects to clean YAML strings, with recursive null/empty stripping and status field removal
+- `kubernetes-yaml-serialization`: Shared utility for cleaning raw Kubernetes resource objects and serializing to YAML, with recursive null/empty stripping and runtime field removal
 
 ### Modified Capabilities
 - `execution-engine-dropdown`: The execution engine reference will now be visible in the Agent Studio YAML view when configured
@@ -20,8 +21,9 @@ The Agent Studio and Team form YAML views manually build YAML strings line-by-li
 ## Impact
 
 - `services/ark-dashboard/ark-dashboard/lib/utils/kubernetes-yaml.ts` — new shared utility
-- `services/ark-dashboard/ark-dashboard/components/forms/agent-form/yaml.ts` — new agent spec builder
-- `services/ark-dashboard/ark-dashboard/components/forms/agent-form/agent-form.tsx` — replace `agentYaml` useMemo
-- `services/ark-dashboard/ark-dashboard/components/forms/team-form/yaml.ts` — new team spec builder
-- `services/ark-dashboard/ark-dashboard/components/forms/team-form/team-form.tsx` — replace `teamYaml` useMemo
+- `services/ark-dashboard/ark-dashboard/lib/services/agents.ts` — add `getRawResource` method
+- `services/ark-dashboard/ark-dashboard/lib/services/teams.ts` — add `getRawResource` method (if not already present)
+- `services/ark-dashboard/ark-dashboard/components/forms/agent-form/agent-form.tsx` — replace `agentYaml` useMemo with fetch-based approach
+- `services/ark-dashboard/ark-dashboard/components/forms/team-form/team-form.tsx` — replace `teamYaml` useMemo with fetch-based approach
+- No new API endpoints — uses existing `/v1/resources/apis/ark.mckinsey.com/v1alpha1/{Kind}/{name}`
 - No new dependencies — `js-yaml` is already installed

--- a/openspec/changes/refactor-yaml-view/proposal.md
+++ b/openspec/changes/refactor-yaml-view/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Agent Studio and Team form YAML views manually build YAML strings line-by-line, cherry-picking known fields. This causes missing fields in the YAML output (`executionEngine`, `overrides`, `skills`, `annotations` are all absent), and every CRD schema change requires updating the string concatenation logic. The `executionEngine` omission is actively confusing users who have configured execution engines but don't see them in the YAML view.
+
+## What Changes
+
+- Replace manual YAML string concatenation in `agent-form.tsx` and `team-form.tsx` with structured object building and `js-yaml` serialization
+- Create a shared utility for Kubernetes CRD YAML serialization (envelope wrapping, null stripping, status removal)
+- Create per-form spec builder functions that merge API data with live form state
+- All agent/team fields now appear in YAML output automatically, including previously missing ones
+
+## Capabilities
+
+### New Capabilities
+- `kubernetes-yaml-serialization`: Shared utility for converting Kubernetes resource objects to clean YAML strings, with recursive null/empty stripping and status field removal
+
+### Modified Capabilities
+- `execution-engine-dropdown`: The execution engine reference will now be visible in the Agent Studio YAML view when configured
+
+## Impact
+
+- `services/ark-dashboard/ark-dashboard/lib/utils/kubernetes-yaml.ts` — new shared utility
+- `services/ark-dashboard/ark-dashboard/components/forms/agent-form/yaml.ts` — new agent spec builder
+- `services/ark-dashboard/ark-dashboard/components/forms/agent-form/agent-form.tsx` — replace `agentYaml` useMemo
+- `services/ark-dashboard/ark-dashboard/components/forms/team-form/yaml.ts` — new team spec builder
+- `services/ark-dashboard/ark-dashboard/components/forms/team-form/team-form.tsx` — replace `teamYaml` useMemo
+- No new dependencies — `js-yaml` is already installed

--- a/openspec/changes/refactor-yaml-view/specs/execution-engine-dropdown/spec.md
+++ b/openspec/changes/refactor-yaml-view/specs/execution-engine-dropdown/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Execution engine reference appears in Agent Studio YAML view
+The Agent Studio YAML view SHALL display the `executionEngine` field when an execution engine is configured for the agent, regardless of whether the experimental execution engine feature flag is enabled.
+
+#### Scenario: Agent with execution engine shows it in YAML
+- **WHEN** an agent has an execution engine reference set
+- **AND** the user toggles the YAML view in Agent Studio
+- **THEN** the YAML output includes `executionEngine` with `name` (and `namespace` if set)
+
+#### Scenario: Agent without execution engine omits it from YAML
+- **WHEN** an agent does not have an execution engine reference
+- **AND** the user toggles the YAML view in Agent Studio
+- **THEN** the YAML output does not include an `executionEngine` field

--- a/openspec/changes/refactor-yaml-view/specs/kubernetes-yaml-serialization/spec.md
+++ b/openspec/changes/refactor-yaml-view/specs/kubernetes-yaml-serialization/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: toKubernetesYaml produces valid CRD YAML from a resource object
+The `toKubernetesYaml` function SHALL accept a resource object with `apiVersion`, `kind`, `metadata`, and `spec` fields and return a valid YAML string suitable for `kubectl apply`.
+
+#### Scenario: Standard agent resource
+- **WHEN** called with an agent resource object containing apiVersion, kind, metadata (name, namespace), and spec (description, modelRef, executionEngine, prompt, tools)
+- **THEN** the returned string is valid YAML containing all provided fields in the standard CRD structure
+
+#### Scenario: Standard team resource
+- **WHEN** called with a team resource object containing apiVersion, kind, metadata, and spec (description, strategy, members, selector, graph)
+- **THEN** the returned string is valid YAML containing all provided fields in the standard CRD structure
+
+### Requirement: Null and empty values are stripped recursively
+The serialization SHALL recursively remove `null`, `undefined`, empty string, empty array, and empty object values before producing YAML output.
+
+#### Scenario: Nullable fields are omitted
+- **WHEN** a resource object has fields set to `null` or `undefined`
+- **THEN** those fields do not appear in the YAML output
+
+#### Scenario: Empty arrays and objects are omitted
+- **WHEN** a resource object has empty arrays `[]` or empty objects `{}`
+- **THEN** those fields do not appear in the YAML output
+
+#### Scenario: Nested null values are stripped
+- **WHEN** a nested object has all null/empty fields, making the parent effectively empty
+- **THEN** the parent field is also omitted from the YAML output
+
+### Requirement: Runtime-only fields are excluded
+The serialization SHALL strip fields that are not part of the CRD spec manifest: `status`, `id`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`.
+
+#### Scenario: Status field is stripped
+- **WHEN** a resource object includes a `status` field
+- **THEN** the `status` field does not appear in the YAML output
+
+#### Scenario: UI-only id field is stripped
+- **WHEN** a resource object includes an `id` field (added for dashboard UI compatibility)
+- **THEN** the `id` field does not appear in the YAML output
+
+### Requirement: Multiline strings use YAML block scalar style
+The serialization SHALL render multiline string values (e.g., prompts) using YAML block scalar style (`|`) for readability.
+
+#### Scenario: Agent prompt with newlines
+- **WHEN** a resource spec contains a `prompt` field with newline characters
+- **THEN** the YAML output renders the prompt using block scalar style (`|`) with preserved line breaks
+
+### Requirement: Agent spec builder merges form state with API data
+The `buildAgentSpec` function SHALL produce a spec object by taking form-managed fields from the current form state and non-form fields from the agent API response.
+
+#### Scenario: Form-managed fields reflect live edits
+- **WHEN** the user has edited description, prompt, modelRef, executionEngine, tools, or parameters in the form
+- **THEN** the YAML output reflects the current form values, not the last-saved API values
+
+#### Scenario: Non-form fields pass through from API response
+- **WHEN** the agent has `overrides`, `annotations`, or `skills` set in the API response
+- **THEN** those fields appear in the YAML output with their saved values
+
+#### Scenario: Execution engine reference is included
+- **WHEN** an agent has an execution engine configured (either from form state or API response)
+- **THEN** the YAML output includes an `executionEngine` field with the `name` (and optionally `namespace`)
+
+### Requirement: Team spec builder merges form state with API data
+The `buildTeamSpec` function SHALL produce a spec object by taking form-managed fields from the current form state and non-form fields from the team API response.
+
+#### Scenario: Team members and graph reflect current state
+- **WHEN** the user has modified team members or graph edges
+- **THEN** the YAML output reflects the current form values
+
+#### Scenario: All team fields appear in YAML
+- **WHEN** a team has description, strategy, loops, maxTurns, members, selector, and graph configured
+- **THEN** all fields appear in the YAML output

--- a/openspec/changes/refactor-yaml-view/specs/kubernetes-yaml-serialization/spec.md
+++ b/openspec/changes/refactor-yaml-view/specs/kubernetes-yaml-serialization/spec.md
@@ -1,71 +1,67 @@
 ## ADDED Requirements
 
-### Requirement: toKubernetesYaml produces valid CRD YAML from a resource object
-The `toKubernetesYaml` function SHALL accept a resource object with `apiVersion`, `kind`, `metadata`, and `spec` fields and return a valid YAML string suitable for `kubectl apply`.
+### Requirement: cleanKubernetesResource strips runtime fields from raw K8s objects
+The `cleanKubernetesResource` function SHALL accept a raw Kubernetes resource object and return a cleaned copy with runtime-only fields removed: `status`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`, `selfLink`, and `deletionTimestamp` from metadata.
 
-#### Scenario: Standard agent resource
-- **WHEN** called with an agent resource object containing apiVersion, kind, metadata (name, namespace), and spec (description, modelRef, executionEngine, prompt, tools)
-- **THEN** the returned string is valid YAML containing all provided fields in the standard CRD structure
+#### Scenario: Raw agent resource is cleaned
+- **WHEN** called with a raw Kubernetes Agent object containing `status`, `metadata.managedFields`, `metadata.creationTimestamp`, `metadata.resourceVersion`, and `metadata.uid`
+- **THEN** the returned object contains `apiVersion`, `kind`, `metadata` (with only `name`, `namespace`, `labels`, `annotations`), and `spec` — all runtime fields are removed
 
-#### Scenario: Standard team resource
-- **WHEN** called with a team resource object containing apiVersion, kind, metadata, and spec (description, strategy, members, selector, graph)
-- **THEN** the returned string is valid YAML containing all provided fields in the standard CRD structure
+#### Scenario: Raw team resource is cleaned
+- **WHEN** called with a raw Kubernetes Team object
+- **THEN** the same runtime fields are stripped, preserving only the CRD manifest fields
 
 ### Requirement: Null and empty values are stripped recursively
-The serialization SHALL recursively remove `null`, `undefined`, empty string, empty array, and empty object values before producing YAML output.
+The cleanup SHALL recursively remove `null`, `undefined`, empty string, empty array, and empty object values before serialization.
 
 #### Scenario: Nullable fields are omitted
 - **WHEN** a resource object has fields set to `null` or `undefined`
-- **THEN** those fields do not appear in the YAML output
-
-#### Scenario: Empty arrays and objects are omitted
-- **WHEN** a resource object has empty arrays `[]` or empty objects `{}`
-- **THEN** those fields do not appear in the YAML output
+- **THEN** those fields do not appear in the output
 
 #### Scenario: Nested null values are stripped
 - **WHEN** a nested object has all null/empty fields, making the parent effectively empty
-- **THEN** the parent field is also omitted from the YAML output
+- **THEN** the parent field is also omitted from the output
 
-### Requirement: Runtime-only fields are excluded
-The serialization SHALL strip fields that are not part of the CRD spec manifest: `status`, `id`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`.
+#### Scenario: Valid falsy values are preserved
+- **WHEN** a resource object has fields set to `0` or `false`
+- **THEN** those fields are preserved in the output
 
-#### Scenario: Status field is stripped
-- **WHEN** a resource object includes a `status` field
-- **THEN** the `status` field does not appear in the YAML output
+### Requirement: toKubernetesYaml serializes a cleaned resource to YAML
+The `toKubernetesYaml` function SHALL accept a raw Kubernetes resource object, clean it, and return a valid YAML string suitable for `kubectl apply`.
 
-#### Scenario: UI-only id field is stripped
-- **WHEN** a resource object includes an `id` field (added for dashboard UI compatibility)
-- **THEN** the `id` field does not appear in the YAML output
+#### Scenario: Full round-trip from raw resource to YAML
+- **WHEN** called with a raw Kubernetes resource
+- **THEN** the returned string is valid YAML with runtime fields stripped and nulls removed
 
-### Requirement: Multiline strings use YAML block scalar style
-The serialization SHALL render multiline string values (e.g., prompts) using YAML block scalar style (`|`) for readability.
-
-#### Scenario: Agent prompt with newlines
+#### Scenario: Multiline strings use block scalar style
 - **WHEN** a resource spec contains a `prompt` field with newline characters
 - **THEN** the YAML output renders the prompt using block scalar style (`|`) with preserved line breaks
 
-### Requirement: Agent spec builder merges form state with API data
-The `buildAgentSpec` function SHALL produce a spec object by taking form-managed fields from the current form state and non-form fields from the agent API response.
+### Requirement: Agent service exposes raw resource fetching
+The agent service SHALL provide a method to fetch the raw Kubernetes Agent resource via the existing `/v1/resources/apis/ark.mckinsey.com/v1alpha1/Agent/{name}` endpoint.
 
-#### Scenario: Form-managed fields reflect live edits
-- **WHEN** the user has edited description, prompt, modelRef, executionEngine, tools, or parameters in the form
-- **THEN** the YAML output reflects the current form values, not the last-saved API values
+#### Scenario: Fetch raw agent resource
+- **WHEN** `getRawResource(name)` is called on the agent service
+- **THEN** it returns the raw Kubernetes object from the resources API
 
-#### Scenario: Non-form fields pass through from API response
-- **WHEN** the agent has `overrides`, `annotations`, or `skills` set in the API response
-- **THEN** those fields appear in the YAML output with their saved values
+### Requirement: Team service exposes raw resource fetching
+The team service SHALL provide a method to fetch the raw Kubernetes Team resource via the existing `/v1/resources/apis/ark.mckinsey.com/v1alpha1/Team/{name}` endpoint.
 
-#### Scenario: Execution engine reference is included
-- **WHEN** an agent has an execution engine configured (either from form state or API response)
-- **THEN** the YAML output includes an `executionEngine` field with the `name` (and optionally `namespace`)
+#### Scenario: Fetch raw team resource
+- **WHEN** `getRawResource(name)` is called on the team service
+- **THEN** it returns the raw Kubernetes object from the resources API
 
-### Requirement: Team spec builder merges form state with API data
-The `buildTeamSpec` function SHALL produce a spec object by taking form-managed fields from the current form state and non-form fields from the team API response.
+### Requirement: YAML view fetches on activation and re-fetches on save
+The YAML view in agent and team forms SHALL fetch the raw resource when the YAML tab is first activated, and re-fetch after a successful save.
 
-#### Scenario: Team members and graph reflect current state
-- **WHEN** the user has modified team members or graph edges
-- **THEN** the YAML output reflects the current form values
+#### Scenario: YAML view shows saved state on toggle
+- **WHEN** the user toggles the YAML view for an existing agent
+- **THEN** the dashboard fetches the raw resource and displays the cleaned YAML
 
-#### Scenario: All team fields appear in YAML
-- **WHEN** a team has description, strategy, loops, maxTurns, members, selector, and graph configured
-- **THEN** all fields appear in the YAML output
+#### Scenario: YAML view updates after save
+- **WHEN** the user saves changes to the agent and the YAML view is active
+- **THEN** the YAML view re-fetches the raw resource and displays the updated YAML
+
+#### Scenario: YAML view for new unsaved resource
+- **WHEN** the user is creating a new agent that has not been saved yet
+- **THEN** the YAML view shows an appropriate empty state or message (no resource exists to fetch)

--- a/openspec/changes/refactor-yaml-view/tasks.md
+++ b/openspec/changes/refactor-yaml-view/tasks.md
@@ -1,21 +1,24 @@
 ## 1. Shared Utility
 
-- [ ] 1.1 Create `lib/utils/kubernetes-yaml.ts` with `stripEmpty` function that recursively removes null, undefined, empty strings, empty arrays, and empty objects from a nested object
-- [ ] 1.2 Add `toKubernetesYaml` function that accepts a `{ apiVersion, kind, metadata, spec }` object, strips runtime fields (`status`, `id`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`), runs `stripEmpty`, and serializes with `js-yaml` (`yaml.dump` with `lineWidth: -1` for clean multiline strings)
-- [ ] 1.3 Add unit tests for `stripEmpty` (null values, nested empties, preserves valid falsy values like `0` and `false`) and `toKubernetesYaml` (full CRD output, status stripping, multiline prompt handling)
+- [ ] 1.1 Create `lib/utils/kubernetes-yaml.ts` with `cleanKubernetesResource` function that strips runtime fields (`status`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`, `selfLink`, `deletionTimestamp`) and recursively removes null/undefined/empty values
+- [ ] 1.2 Add `toKubernetesYaml` function that calls `cleanKubernetesResource` and serializes the result with `js-yaml` (`yaml.dump` with `lineWidth: -1` for clean multiline strings)
+- [ ] 1.3 Add unit tests for `cleanKubernetesResource` (runtime field stripping, nested null removal, preserves `0` and `false`) and `toKubernetesYaml` (full YAML output, multiline prompt handling)
 
-## 2. Agent Form YAML Builder
+## 2. Service Methods
 
-- [ ] 2.1 Create `components/forms/agent-form/yaml.ts` with `buildAgentSpec` function that merges form state (description, modelRef, executionEngine, prompt, tools, parameters) with agent API response (overrides, annotations, skills), returning a plain spec object with fields in conventional CRD order
-- [ ] 2.2 Replace the `agentYaml` useMemo in `agent-form.tsx` (lines 118-183) with calls to `buildAgentSpec` and `toKubernetesYaml`
-- [ ] 2.3 Verify execution engine reference appears in YAML when configured
+- [ ] 2.1 Add `getRawResource(name: string)` to `lib/services/agents.ts` that calls `GET /api/v1/resources/apis/ark.mckinsey.com/v1alpha1/Agent/{name}`
+- [ ] 2.2 Add `getRawResource(name: string)` to the team service that calls `GET /api/v1/resources/apis/ark.mckinsey.com/v1alpha1/Team/{name}`
 
-## 3. Team Form YAML Builder
+## 3. Agent Form Integration
 
-- [ ] 3.1 Create `components/forms/team-form/yaml.ts` with `buildTeamSpec` function that merges form state (description, strategy, loops, maxTurns, members, selector, graph) with team API response
-- [ ] 3.2 Replace the `teamYaml` useMemo in `team-form.tsx` with calls to `buildTeamSpec` and `toKubernetesYaml`
+- [ ] 3.1 Replace the `agentYaml` useMemo in `agent-form.tsx` with state that fetches via `getRawResource`, cleans with `toKubernetesYaml`, and re-fetches on save
+- [ ] 3.2 Handle the new-agent case (no saved resource yet) with an appropriate empty state
 
-## 4. Validation
+## 4. Team Form Integration
 
-- [ ] 4.1 Run `npm run build` to verify TypeScript compilation
-- [ ] 4.2 Run existing tests to confirm no regressions
+- [ ] 4.1 Replace the `teamYaml` useMemo in `team-form.tsx` with the same fetch-based pattern
+
+## 5. Validation
+
+- [ ] 5.1 Run `npm run build` to verify TypeScript compilation
+- [ ] 5.2 Run existing tests to confirm no regressions

--- a/openspec/changes/refactor-yaml-view/tasks.md
+++ b/openspec/changes/refactor-yaml-view/tasks.md
@@ -1,0 +1,21 @@
+## 1. Shared Utility
+
+- [ ] 1.1 Create `lib/utils/kubernetes-yaml.ts` with `stripEmpty` function that recursively removes null, undefined, empty strings, empty arrays, and empty objects from a nested object
+- [ ] 1.2 Add `toKubernetesYaml` function that accepts a `{ apiVersion, kind, metadata, spec }` object, strips runtime fields (`status`, `id`, `managedFields`, `creationTimestamp`, `resourceVersion`, `uid`, `generation`), runs `stripEmpty`, and serializes with `js-yaml` (`yaml.dump` with `lineWidth: -1` for clean multiline strings)
+- [ ] 1.3 Add unit tests for `stripEmpty` (null values, nested empties, preserves valid falsy values like `0` and `false`) and `toKubernetesYaml` (full CRD output, status stripping, multiline prompt handling)
+
+## 2. Agent Form YAML Builder
+
+- [ ] 2.1 Create `components/forms/agent-form/yaml.ts` with `buildAgentSpec` function that merges form state (description, modelRef, executionEngine, prompt, tools, parameters) with agent API response (overrides, annotations, skills), returning a plain spec object with fields in conventional CRD order
+- [ ] 2.2 Replace the `agentYaml` useMemo in `agent-form.tsx` (lines 118-183) with calls to `buildAgentSpec` and `toKubernetesYaml`
+- [ ] 2.3 Verify execution engine reference appears in YAML when configured
+
+## 3. Team Form YAML Builder
+
+- [ ] 3.1 Create `components/forms/team-form/yaml.ts` with `buildTeamSpec` function that merges form state (description, strategy, loops, maxTurns, members, selector, graph) with team API response
+- [ ] 3.2 Replace the `teamYaml` useMemo in `team-form.tsx` with calls to `buildTeamSpec` and `toKubernetesYaml`
+
+## 4. Validation
+
+- [ ] 4.1 Run `npm run build` to verify TypeScript compilation
+- [ ] 4.2 Run existing tests to confirm no regressions


### PR DESCRIPTION
## Summary

- Add openspec change proposal for refactoring Agent Studio and Team form YAML views
- Use existing `/v1/resources/` API to fetch raw K8s objects instead of manual string concatenation
- Fixes missing `executionEngine`, `overrides`, `skills`, and `annotations` in YAML output
- Shared cleanup utility strips runtime fields and serializes with js-yaml
- Zero per-resource maintenance — new CRD fields appear automatically