### PR TITLE
feat(ark-cli): enhance status --wait-for-ready with deep readiness checks

### DIFF
--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -161,17 +161,6 @@ runs:
 
         ark status
 
-    - name: Wait for Ark to be fully ready
-      shell: bash
-      run: |
-        echo "Waiting for Ark controller to be ready..."
-
-        # Simple wait for controller to be available (via ark status)
-        # This is sufficient for the validating webhook to work
-        kubectl wait --for=condition=available deployment/ark-controller -n ark-system --timeout=5m
-
-        echo "✓ Ark controller is ready"
-
     - name: Create default model
       shell: bash
       run: |

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/tools/ark-cli/src/commands/status/index.tsx
+++ b/tools/ark-cli/src/commands/status/index.tsx
@@ -14,6 +14,10 @@ import {
   waitForServicesReady,
   type WaitProgress,
 } from '../../lib/waitForReady.js';
+import {
+  runReadinessChecks,
+  type ReadinessCheckResult,
+} from '../../lib/readinessChecks.js';
 import {arkServices} from '../../arkServices.js';
 import type {ArkService} from '../../types/arkService.js';
 import output from '../../lib/output.js';
@@ -365,15 +369,31 @@ export async function checkStatus(
         }
       );
 
-      if (result) {
-        waitSpinner.succeed('All services are ready');
-        process.exit(0);
-      } else {
+      if (!result) {
         waitSpinner.fail(
           `Services did not become ready within ${timeoutSeconds} seconds`
         );
         process.exit(1);
       }
+
+      waitSpinner.succeed('All services are ready');
+
+      const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
+      const remainingSeconds = Math.max(1, timeoutSeconds - elapsedSeconds);
+      const deepResults = await runReadinessChecks(
+        remainingSeconds,
+        (r: ReadinessCheckResult) => {
+          const icon = r.passed ? chalk.green('✓') : chalk.red('✗');
+          const dur = `${(r.durationMs / 1000).toFixed(1)}s`;
+          const suffix = r.message ? ` — ${r.message}` : '';
+          console.log(`  ${icon} ${r.name} (${dur})${suffix}`);
+        }
+      );
+
+      if (deepResults.some((r) => !r.passed)) {
+        process.exit(1);
+      }
+      process.exit(0);
     }
 
     process.exit(0);

--- a/tools/ark-cli/src/lib/readinessChecks.spec.ts
+++ b/tools/ark-cli/src/lib/readinessChecks.spec.ts
@@ -1,0 +1,161 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+const {execa} = await import('execa');
+const {detectStorageBackend, runReadinessChecks} = await import(
+  './readinessChecks.js'
+);
+const mockedExeca = execa as vi.MockedFunction<typeof execa>;
+
+function kubectlOk(stdout = '') {
+  return {exitCode: 0, stdout, stderr: ''} as any;
+}
+
+function kubectlFail(stderr = 'not found') {
+  return {exitCode: 1, stdout: '', stderr} as any;
+}
+
+describe('detectStorageBackend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns etcd when the agents CRD exists', async () => {
+    mockedExeca.mockResolvedValueOnce(kubectlOk('agents.ark.mckinsey.com'));
+    await expect(detectStorageBackend()).resolves.toBe('etcd');
+  });
+
+  it('returns postgresql when the agents CRD is absent', async () => {
+    mockedExeca.mockResolvedValueOnce(kubectlFail());
+    await expect(detectStorageBackend()).resolves.toBe('postgresql');
+  });
+});
+
+describe('runReadinessChecks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty array on etcd without running layers 2-5', async () => {
+    mockedExeca.mockResolvedValueOnce(kubectlOk());
+
+    const results = await runReadinessChecks(60);
+
+    expect(results).toEqual([]);
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops at the first failing layer and reports it', async () => {
+    mockedExeca
+      .mockResolvedValueOnce(kubectlFail())
+      .mockResolvedValueOnce(kubectlFail('timed out'))
+      .mockResolvedValueOnce(kubectlOk());
+
+    const results = await runReadinessChecks(60);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('APIServices available');
+    expect(results[0].passed).toBe(false);
+  });
+
+  it('invokes the progress callback for each result', async () => {
+    mockedExeca
+      .mockResolvedValueOnce(kubectlFail())
+      .mockResolvedValueOnce(kubectlFail('timed out'))
+      .mockResolvedValueOnce(kubectlOk());
+
+    const onProgress = vi.fn();
+    await runReadinessChecks(60, onProgress);
+
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onProgress.mock.calls[0][0]).toMatchObject({
+      name: 'APIServices available',
+      passed: false,
+    });
+  });
+});
+
+describe('runReadinessChecks full postgresql flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs all 4 layers successfully and returns 4 passing results', async () => {
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      if (args[0] === 'get' && args[1] === 'crd') {
+        return Promise.resolve(kubectlFail());
+      }
+      if (args[0] === 'api-resources') {
+        return Promise.resolve(kubectlOk('agents.ark.mckinsey.com\nmodels.ark.mckinsey.com'));
+      }
+      if (args[0] === 'get' && args[1]?.startsWith('model')) {
+        return Promise.resolve(
+          kubectlOk('[{"type":"Ready","status":"True"}]')
+        );
+      }
+      return Promise.resolve(kubectlOk());
+    }) as any);
+
+    const promise = runReadinessChecks(300);
+
+    await vi.runAllTimersAsync();
+    const results = await promise;
+
+    expect(results).toHaveLength(4);
+    expect(results.map((r) => r.name)).toEqual([
+      'APIServices available',
+      'API group registered',
+      'Aggregated API stable',
+      'Controllers reconciling',
+    ]);
+    expect(results.every((r) => r.passed)).toBe(true);
+  });
+
+  it('resets the stable counter when a probe fails transiently', async () => {
+    let aggregatedCallIndex = 0;
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      if (args[0] === 'get' && args[1] === 'crd') {
+        return Promise.resolve(kubectlFail());
+      }
+      if (args[0] === 'wait' && args[2] === 'apiservice') {
+        return Promise.resolve(kubectlOk());
+      }
+      if (args[0] === 'api-resources') {
+        return Promise.resolve(kubectlOk('agents.ark.mckinsey.com'));
+      }
+      if (
+        args[0] === 'get' &&
+        typeof args[1] === 'string' &&
+        args[1].endsWith('ark.mckinsey.com')
+      ) {
+        aggregatedCallIndex += 1;
+        if (aggregatedCallIndex === 7) {
+          return Promise.resolve(kubectlFail('transient'));
+        }
+        return Promise.resolve(kubectlOk());
+      }
+      if (args[0] === 'get' && args[1] === 'model') {
+        return Promise.resolve(
+          kubectlOk('[{"type":"Ready","status":"True"}]')
+        );
+      }
+      return Promise.resolve(kubectlOk());
+    }) as any);
+
+    const promise = runReadinessChecks(600);
+    await vi.runAllTimersAsync();
+    const results = await promise;
+
+    const stable = results.find((r) => r.name === 'Aggregated API stable');
+    expect(stable?.passed).toBe(true);
+    expect(stable?.message).toMatch(/10 consecutive probes/);
+  });
+});

--- a/tools/ark-cli/src/lib/readinessChecks.ts
+++ b/tools/ark-cli/src/lib/readinessChecks.ts
@@ -1,2 +1,266 @@
-// Placeholder — implementation follows
-export {};
+import {execa} from 'execa';
+
+export type StorageBackend = 'etcd' | 'postgresql';
+
+export interface ReadinessCheckResult {
+  name: string;
+  passed: boolean;
+  durationMs: number;
+  message?: string;
+}
+
+export type ReadinessProgress = (result: ReadinessCheckResult) => void;
+
+const PROBE_NAMESPACE = 'ark-readiness-probe';
+const PROBE_MODEL_NAME = 'readiness-probe';
+const STABLE_CONSECUTIVE_REQUIRED = 10;
+const STABLE_POLL_INTERVAL_MS = 2000;
+const API_GROUP_POLL_INTERVAL_MS = 10000;
+const PROBE_POLL_INTERVAL_MS = 1000;
+
+const PROBE_MODEL_MANIFEST = `apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: ${PROBE_MODEL_NAME}
+  namespace: ${PROBE_NAMESPACE}
+spec:
+  type: openai
+  model:
+    value: gpt-4.1-mini
+  config:
+    openai:
+      baseUrl:
+        value: "https://localhost:1/v1"
+      apiKey:
+        value: "probe"
+`;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runKubectl(
+  args: string[],
+  timeoutMs: number,
+  input?: string
+): Promise<{exitCode: number; stdout: string; stderr: string}> {
+  const result = await execa('kubectl', args, {
+    timeout: timeoutMs,
+    reject: false,
+    input,
+  });
+  return {
+    exitCode: result.exitCode ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+export async function detectStorageBackend(): Promise<StorageBackend> {
+  const {exitCode} = await runKubectl(
+    ['get', 'crd', 'agents.ark.mckinsey.com'],
+    10000
+  );
+  return exitCode === 0 ? 'etcd' : 'postgresql';
+}
+
+async function waitForApiServices(
+  timeoutSeconds: number
+): Promise<ReadinessCheckResult> {
+  const start = Date.now();
+  const primary = await runKubectl(
+    [
+      'wait',
+      '--for=condition=Available',
+      'apiservice',
+      'v1alpha1.ark.mckinsey.com',
+      `--timeout=${timeoutSeconds}s`,
+    ],
+    timeoutSeconds * 1000 + 5000
+  );
+  await runKubectl(
+    [
+      'wait',
+      '--for=condition=Available',
+      'apiservice',
+      'v1prealpha1.ark.mckinsey.com',
+      '--timeout=30s',
+    ],
+    35000
+  );
+  return {
+    name: 'APIServices available',
+    passed: primary.exitCode === 0,
+    durationMs: Date.now() - start,
+    message:
+      primary.exitCode === 0
+        ? undefined
+        : (primary.stderr || primary.stdout).trim(),
+  };
+}
+
+async function waitForApiGroup(
+  timeoutSeconds: number
+): Promise<ReadinessCheckResult> {
+  const start = Date.now();
+  const deadline = start + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    const {stdout, exitCode} = await runKubectl(
+      ['api-resources', '--api-group=ark.mckinsey.com', '-o', 'name'],
+      10000
+    );
+    if (exitCode === 0 && /agents\./.test(stdout)) {
+      return {
+        name: 'API group registered',
+        passed: true,
+        durationMs: Date.now() - start,
+      };
+    }
+    await sleep(API_GROUP_POLL_INTERVAL_MS);
+  }
+  return {
+    name: 'API group registered',
+    passed: false,
+    durationMs: Date.now() - start,
+    message: 'timed out waiting for ark.mckinsey.com API group',
+  };
+}
+
+async function waitForAggregatedApiStable(
+  timeoutSeconds: number
+): Promise<ReadinessCheckResult> {
+  const start = Date.now();
+  const deadline = start + timeoutSeconds * 1000;
+  let consecutive = 0;
+  while (Date.now() < deadline) {
+    const probes = await Promise.all([
+      runKubectl(
+        ['get', 'agents.ark.mckinsey.com', '-A', '--request-timeout=5s'],
+        10000
+      ),
+      runKubectl(
+        ['get', 'models.ark.mckinsey.com', '-A', '--request-timeout=5s'],
+        10000
+      ),
+      runKubectl(
+        ['get', 'queries.ark.mckinsey.com', '-A', '--request-timeout=5s'],
+        10000
+      ),
+    ]);
+    if (probes.every((p) => p.exitCode === 0)) {
+      consecutive += 1;
+      if (consecutive >= STABLE_CONSECUTIVE_REQUIRED) {
+        return {
+          name: 'Aggregated API stable',
+          passed: true,
+          durationMs: Date.now() - start,
+          message: `${consecutive} consecutive probes`,
+        };
+      }
+    } else {
+      consecutive = 0;
+    }
+    await sleep(STABLE_POLL_INTERVAL_MS);
+  }
+  return {
+    name: 'Aggregated API stable',
+    passed: false,
+    durationMs: Date.now() - start,
+    message: `only ${consecutive} consecutive successes (need ${STABLE_CONSECUTIVE_REQUIRED})`,
+  };
+}
+
+async function waitForControllerReconciling(
+  timeoutSeconds: number
+): Promise<ReadinessCheckResult> {
+  const start = Date.now();
+  await runKubectl(['create', 'namespace', PROBE_NAMESPACE], 15000);
+  const apply = await runKubectl(
+    ['apply', '-f', '-'],
+    15000,
+    PROBE_MODEL_MANIFEST
+  );
+  if (apply.exitCode !== 0) {
+    await runKubectl(
+      ['delete', 'namespace', PROBE_NAMESPACE, '--wait=false'],
+      10000
+    );
+    return {
+      name: 'Controllers reconciling',
+      passed: false,
+      durationMs: Date.now() - start,
+      message: `failed to apply probe Model: ${(apply.stderr || apply.stdout).trim()}`,
+    };
+  }
+
+  const deadline = start + timeoutSeconds * 1000;
+  let passed = false;
+  while (Date.now() < deadline) {
+    const {stdout, exitCode} = await runKubectl(
+      [
+        'get',
+        'model',
+        PROBE_MODEL_NAME,
+        '-n',
+        PROBE_NAMESPACE,
+        '-o',
+        'jsonpath={.status.conditions}',
+      ],
+      10000
+    );
+    if (exitCode === 0 && stdout && stdout !== 'null' && stdout !== '[]') {
+      passed = true;
+      break;
+    }
+    await sleep(PROBE_POLL_INTERVAL_MS);
+  }
+
+  await runKubectl(
+    ['delete', 'namespace', PROBE_NAMESPACE, '--wait=false'],
+    10000
+  );
+
+  return {
+    name: 'Controllers reconciling',
+    passed,
+    durationMs: Date.now() - start,
+    message: passed
+      ? undefined
+      : 'probe Model got no status conditions within timeout',
+  };
+}
+
+export async function runReadinessChecks(
+  timeoutSeconds: number,
+  onProgress?: ReadinessProgress
+): Promise<ReadinessCheckResult[]> {
+  const backend = await detectStorageBackend();
+  if (backend === 'etcd') {
+    return [];
+  }
+
+  const overallStart = Date.now();
+  const remaining = () =>
+    Math.max(
+      1,
+      timeoutSeconds - Math.floor((Date.now() - overallStart) / 1000)
+    );
+
+  const checks: Array<() => Promise<ReadinessCheckResult>> = [
+    () => waitForApiServices(Math.min(remaining(), 120)),
+    () => waitForApiGroup(Math.min(remaining(), 300)),
+    () => waitForAggregatedApiStable(Math.min(remaining(), 120)),
+    () => waitForControllerReconciling(Math.min(remaining(), 60)),
+  ];
+
+  const results: ReadinessCheckResult[] = [];
+  for (const check of checks) {
+    const result = await check();
+    results.push(result);
+    onProgress?.(result);
+    if (!result.passed) {
+      break;
+    }
+  }
+  return results;
+}

--- a/tools/ark-cli/src/lib/readinessChecks.ts
+++ b/tools/ark-cli/src/lib/readinessChecks.ts
@@ -1,0 +1,2 @@
+// Placeholder — implementation follows
+export {};


### PR DESCRIPTION
## Summary

- Add `tools/ark-cli/src/lib/readinessChecks.ts` with four layered checks mirroring `setup-local.sh:132-220` (APIServices available → API group registered → aggregated API stable → controllers reconciling)
- Auto-detect backend: skip layers 2-5 on etcd (CRDs served directly by kube-apiserver); run them on PostgreSQL (aggregated API server backend)
- Wire `runReadinessChecks()` into `status/index.tsx` after the existing deployment wait; non-zero exit if any layer fails
- Remove the redundant `kubectl wait deployment/ark-controller` step in `.github/actions/test-ark-cli/action.yaml` that duplicated the CLI's own readiness check
- New `readinessChecks.spec.ts` mirroring `waitForReady.spec.ts` (mocks `execa`); covers backend detection, fail-fast, progress callback, full flow, stable-counter reset

## Deferred

Replacing the `setup-local.sh:132-220` defensive block and the ark-specific `kubectl wait` lines in `.github/workflows/cicd.yaml` requires ark-cli to be built/installed *before* those scripts run. That re-ordering is a follow-up PR.