### PR TITLE
fix: resolve apiVersion in Azure model config for AsyncAzureOpenAI

### DIFF
--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/broker.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/broker.py
@@ -1,0 +1,110 @@
+"""Ark broker client for streaming OpenAI-format chunks to the ark-broker service."""
+
+import json
+import logging
+import time
+from typing import Optional
+from urllib.parse import quote
+
+import httpx
+
+from .streaming_config import get_streaming_config, get_streaming_base_url
+
+try:
+    from kubernetes_asyncio.client.api_client import ApiClient
+    from .k8s import init_k8s
+except ImportError:
+    ApiClient = None  # type: ignore[assignment,misc]
+    init_k8s = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+_STREAM_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=None, pool=5.0)
+_COMPLETE_TIMEOUT = httpx.Timeout(10.0)
+
+_cached_broker_url: Optional[str] = None
+_broker_url_cached = False
+
+
+async def discover_broker_url(namespace: str) -> Optional[str]:
+    """Discover the ark-broker streaming base URL from the ark-config-streaming ConfigMap.
+
+    Returns the base URL or None if the ConfigMap is absent or streaming is disabled.
+    Result is cached for the lifetime of the process.
+    """
+    global _cached_broker_url, _broker_url_cached
+    if _broker_url_cached:
+        return _cached_broker_url
+
+    try:
+        from kubernetes_asyncio import client
+        await init_k8s()
+        async with ApiClient() as api:
+            v1 = client.CoreV1Api(api)
+            config = await get_streaming_config(v1, namespace)
+            if config and config.enabled:
+                _cached_broker_url = await get_streaming_base_url(config, namespace, v1)
+            else:
+                _cached_broker_url = None
+    except Exception as e:
+        logger.warning(f"Broker discovery failed: {e}")
+        _cached_broker_url = None
+
+    _broker_url_cached = True
+    return _cached_broker_url
+
+
+class BrokerClient:
+    """Sends OpenAI-format completion chunks to the ark-broker streaming endpoint."""
+
+    def __init__(self, base_url: str, query_name: str, session_id: str = "", agent_name: str = ""):
+        self.base_url = base_url
+        self.query_name = query_name
+        self.session_id = session_id
+        self.agent_name = agent_name
+
+    def _build_chunk(self, content: str, finish_reason: Optional[str] = None) -> bytes:
+        chunk = {
+            "id": self.query_name,
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": f"agent/{self.agent_name}" if self.agent_name else "unknown",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "finish_reason": finish_reason,
+            }],
+            "ark": {
+                "query": self.query_name,
+                "session": self.session_id,
+                "agent": self.agent_name,
+            },
+        }
+        return (json.dumps(chunk) + "\n").encode()
+
+    async def send_chunk(self, content: str, finish_reason: Optional[str] = None) -> None:
+        url = f"{self.base_url}/stream/{quote(self.query_name)}"
+        try:
+            async with httpx.AsyncClient(timeout=_STREAM_TIMEOUT) as http:
+                resp = await http.post(
+                    url,
+                    content=self._build_chunk(content, finish_reason),
+                    headers={"Content-Type": "application/x-ndjson"},
+                )
+                if resp.status_code not in (200, 202):
+                    logger.warning(f"Broker stream returned {resp.status_code} for query {self.query_name}")
+        except Exception as e:
+            logger.warning(f"Failed to send chunk to broker for query {self.query_name}: {e}")
+
+    async def complete(self) -> None:
+        url = f"{self.base_url}/stream/{quote(self.query_name)}/complete"
+        try:
+            async with httpx.AsyncClient(timeout=_COMPLETE_TIMEOUT) as http:
+                resp = await http.post(url, json={})
+                if resp.status_code not in (200, 202):
+                    logger.warning(f"Broker complete returned {resp.status_code} for query {self.query_name}")
+        except Exception as e:
+            logger.warning(f"Failed to notify broker completion for query {self.query_name}: {e}")

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py
@@ -2,8 +2,11 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from .broker import BrokerClient
 
 
 logger = logging.getLogger(__name__)
@@ -75,7 +78,15 @@ class BaseExecutor(ABC):
     def __init__(self, engine_name: str):
         """Initialize the executor with a name."""
         self.engine_name = engine_name
+        self._broker_client: Optional["BrokerClient"] = None
+        self._streamed: bool = False
         logger.info(f"{engine_name} executor initialized")
+
+    async def stream_chunk(self, chunk: str) -> None:
+        """Send a streaming chunk to the broker. No-op if broker not configured."""
+        if self._broker_client:
+            self._streamed = True
+            await self._broker_client.send_chunk(chunk)
 
     @abstractmethod
     async def execute_agent(self, request: ExecutionEngineRequest) -> list[Message]:

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
@@ -249,6 +249,9 @@ class A2AExecutorAdapter(AgentExecutor):
                     message_id="error-response",
                 )
             )
+        finally:
+            self.executor._broker_client = None
+            self.executor._streamed = False
 
     async def cancel(self, context: Any, event_queue: EventQueue) -> None:
         pass

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
@@ -27,6 +27,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from .broker import BrokerClient, discover_broker_url
 from .executor import BaseExecutor
 from .extensions.query import (
     QUERY_EXTENSION_URI,
@@ -208,12 +209,28 @@ class A2AExecutorAdapter(AgentExecutor):
         query_ref = extract_query_ref(context.message)
         request = await resolve_query(query_ref, user_text, conversation_id=conversation_id)
 
+        broker_url = await discover_broker_url(query_ref.namespace)
+        broker = BrokerClient(
+            base_url=broker_url,
+            query_name=query_ref.name,
+            session_id=conversation_id,
+            agent_name=request.agent.name,
+        ) if broker_url else None
+
+        self.executor._broker_client = broker
+        self.executor._streamed = False
+
         try:
             response_messages = await self.executor.execute_agent(request)
             response_text = ""
             for msg in response_messages:
                 if msg.role == "assistant" and msg.content:
                     response_text += msg.content
+
+            if broker:
+                if not self.executor._streamed:
+                    await broker.send_chunk(response_text, finish_reason="stop")
+                await broker.complete()
 
             response_msg = A2AMessage(
                 role="agent",

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
@@ -221,6 +221,9 @@ async def _resolve_provider_config(provider_config_obj: Any, namespace: str) -> 
     base_url_vs = getattr(provider_config_obj, "base_url", None) or getattr(provider_config_obj, "baseUrl", None)
     if base_url_vs:
         config["baseUrl"] = await _resolve_value_source(base_url_vs, namespace)
+    api_version_vs = getattr(provider_config_obj, "api_version", None) or getattr(provider_config_obj, "apiVersion", None)
+    if api_version_vs:
+        config["apiVersion"] = await _resolve_value_source(api_version_vs, namespace)
     if hasattr(provider_config_obj, "properties") and provider_config_obj.properties:
         config["properties"] = provider_config_obj.properties
     return config

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/test_broker.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/test_broker.py
@@ -1,0 +1,169 @@
+"""Tests for broker.py — BrokerClient and discover_broker_url."""
+
+import json
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ark_sdk.broker import BrokerClient, discover_broker_url
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    import ark_sdk.broker as broker_module
+    broker_module._broker_url_cached = False
+    broker_module._cached_broker_url = None
+    yield
+    broker_module._broker_url_cached = False
+    broker_module._cached_broker_url = None
+
+
+class TestBrokerClientBuildChunk:
+    def test_chunk_format(self):
+        client = BrokerClient("http://broker", "my-query", "sess-1", "my-agent")
+        raw = client._build_chunk("hello", finish_reason="stop")
+        chunk = json.loads(raw.decode().strip())
+
+        assert chunk["object"] == "chat.completion.chunk"
+        assert chunk["choices"][0]["delta"]["content"] == "hello"
+        assert chunk["choices"][0]["delta"]["role"] == "assistant"
+        assert chunk["choices"][0]["finish_reason"] == "stop"
+        assert chunk["ark"]["query"] == "my-query"
+        assert chunk["ark"]["session"] == "sess-1"
+        assert chunk["ark"]["agent"] == "my-agent"
+        assert chunk["model"] == "agent/my-agent"
+
+    def test_chunk_no_finish_reason(self):
+        client = BrokerClient("http://broker", "q", "", "a")
+        raw = client._build_chunk("token")
+        chunk = json.loads(raw.decode().strip())
+        assert chunk["choices"][0]["finish_reason"] is None
+
+    def test_chunk_ends_with_newline(self):
+        client = BrokerClient("http://broker", "q", "", "a")
+        raw = client._build_chunk("x")
+        assert raw.endswith(b"\n")
+
+
+class TestBrokerClientSendChunk:
+    @pytest.mark.anyio
+    async def test_sends_chunk_to_correct_url(self):
+        client = BrokerClient("http://broker:3000", "my query", "", "agent")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            await client.send_chunk("hello", finish_reason="stop")
+
+            mock_http.post.assert_called_once()
+            url = mock_http.post.call_args[0][0]
+            assert "my%20query" in url
+            assert url.endswith("/stream/my%20query")
+
+    @pytest.mark.anyio
+    async def test_swallows_http_error(self):
+        client = BrokerClient("http://broker", "q", "", "a")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(side_effect=httpx.ConnectError("unreachable"))
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            await client.send_chunk("hello")
+
+    @pytest.mark.anyio
+    async def test_logs_non_2xx_status(self, caplog):
+        import logging
+        client = BrokerClient("http://broker", "q", "", "a")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            with caplog.at_level(logging.WARNING):
+                await client.send_chunk("hello")
+
+            assert any("500" in r.message for r in caplog.records)
+
+
+class TestBrokerClientComplete:
+    @pytest.mark.anyio
+    async def test_posts_to_complete_url(self):
+        client = BrokerClient("http://broker:3000", "my-query", "", "a")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            await client.complete()
+
+            url = mock_http.post.call_args[0][0]
+            assert url.endswith("/stream/my-query/complete")
+
+    @pytest.mark.anyio
+    async def test_swallows_error(self):
+        client = BrokerClient("http://broker", "q", "", "a")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(side_effect=Exception("boom"))
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            await client.complete()
+
+
+class TestDiscoverBrokerUrl:
+    @pytest.mark.anyio
+    async def test_returns_none_when_config_disabled(self):
+        mock_config = MagicMock()
+        mock_config.enabled = False
+
+        mock_api_client = AsyncMock()
+        mock_api_client.__aenter__ = AsyncMock(return_value=mock_api_client)
+        mock_api_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("ark_sdk.broker.init_k8s", new_callable=AsyncMock), \
+             patch("ark_sdk.broker.ApiClient", return_value=mock_api_client), \
+             patch("ark_sdk.broker.get_streaming_config", new_callable=AsyncMock, return_value=mock_config):
+            result = await discover_broker_url("default")
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_on_k8s_error(self):
+        with patch("ark_sdk.broker.init_k8s", new_callable=AsyncMock, side_effect=Exception("no k8s")):
+            result = await discover_broker_url("default")
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_caches_result(self):
+        mock_config = MagicMock()
+        mock_config.enabled = False
+
+        mock_api_client = AsyncMock()
+        mock_api_client.__aenter__ = AsyncMock(return_value=mock_api_client)
+        mock_api_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("ark_sdk.broker.init_k8s", new_callable=AsyncMock), \
+             patch("ark_sdk.broker.ApiClient", return_value=mock_api_client), \
+             patch("ark_sdk.broker.get_streaming_config", new_callable=AsyncMock, return_value=mock_config) as mock_get:
+            await discover_broker_url("default")
+            await discover_broker_url("default")
+
+        mock_get.assert_called_once()

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
@@ -261,6 +261,116 @@ class TestResolveModelWithSecrets(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.agent.model.config["openai"]["baseUrl"], "https://api.example.com/v1")
         self.assertEqual(request.agent.model.config["openai"]["properties"]["temperature"], 0.7)
 
+    @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)
+    @patch("ark_sdk.client.with_ark_client")
+    async def test_resolves_azure_model_with_api_version(self, mock_with_client, mock_init_k8s):
+        mock_ark = AsyncMock()
+
+        mock_query = MagicMock()
+        mock_query.metadata = {"name": "q1"}
+        mock_query.spec.target.type = "agent"
+        mock_query.spec.target.name = "a1"
+        mock_query.spec.parameters = None
+
+        mock_azure_config = MagicMock()
+        mock_azure_config.api_key = SimpleNamespace(value="azure-key", value_from=None)
+        mock_azure_config.base_url = SimpleNamespace(value="https://my-resource.openai.azure.com", value_from=None)
+        mock_azure_config.api_version = SimpleNamespace(value="2024-04-01-preview", value_from=None)
+        mock_azure_config.apiVersion = None
+        mock_azure_config.properties = None
+
+        mock_model_spec = MagicMock()
+        mock_model_spec.model = SimpleNamespace(value="gpt-4o", value_from=None)
+        mock_model_spec.provider = "azure"
+        mock_model_spec.config = MagicMock()
+        mock_model_spec.config.azure = mock_azure_config
+
+        mock_model_crd = MagicMock()
+        mock_model_crd.spec = mock_model_spec
+
+        mock_agent = MagicMock()
+        mock_agent.metadata = {"name": "a1", "labels": {}}
+        mock_agent.spec.prompt = "hello"
+        mock_agent.spec.description = ""
+        mock_agent.spec.model_ref = MagicMock()
+        mock_agent.spec.model_ref.name = "azure-model"
+        mock_agent.spec.model_ref.namespace = None
+        mock_agent.spec.parameters = None
+        mock_agent.spec.tools = None
+        mock_agent.spec.execution_engine = None
+        mock_agent.spec.executionEngine = None
+
+        mock_ark.queries.a_get = AsyncMock(return_value=mock_query)
+        mock_ark.agents.a_get = AsyncMock(return_value=mock_agent)
+        mock_ark.models.a_get = AsyncMock(return_value=mock_model_crd)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_ark
+        mock_ctx.__aexit__.return_value = False
+        mock_with_client.return_value = mock_ctx
+
+        ref = QueryRef(name="q1", namespace="default")
+        request = await resolve_query(ref, "hi")
+
+        self.assertEqual(request.agent.model.type, "azure")
+        self.assertEqual(request.agent.model.config["azure"]["apiKey"], "azure-key")
+        self.assertEqual(request.agent.model.config["azure"]["baseUrl"], "https://my-resource.openai.azure.com")
+        self.assertEqual(request.agent.model.config["azure"]["apiVersion"], "2024-04-01-preview")
+
+    @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)
+    @patch("ark_sdk.client.with_ark_client")
+    async def test_azure_model_without_api_version_omits_key(self, mock_with_client, mock_init_k8s):
+        mock_ark = AsyncMock()
+
+        mock_query = MagicMock()
+        mock_query.metadata = {"name": "q1"}
+        mock_query.spec.target.type = "agent"
+        mock_query.spec.target.name = "a1"
+        mock_query.spec.parameters = None
+
+        mock_azure_config = MagicMock()
+        mock_azure_config.api_key = SimpleNamespace(value="azure-key", value_from=None)
+        mock_azure_config.base_url = SimpleNamespace(value="https://my-resource.openai.azure.com", value_from=None)
+        mock_azure_config.api_version = None
+        mock_azure_config.apiVersion = None
+        mock_azure_config.properties = None
+
+        mock_model_spec = MagicMock()
+        mock_model_spec.model = SimpleNamespace(value="gpt-4o", value_from=None)
+        mock_model_spec.provider = "azure"
+        mock_model_spec.config = MagicMock()
+        mock_model_spec.config.azure = mock_azure_config
+
+        mock_model_crd = MagicMock()
+        mock_model_crd.spec = mock_model_spec
+
+        mock_agent = MagicMock()
+        mock_agent.metadata = {"name": "a1", "labels": {}}
+        mock_agent.spec.prompt = "hello"
+        mock_agent.spec.description = ""
+        mock_agent.spec.model_ref = MagicMock()
+        mock_agent.spec.model_ref.name = "azure-model"
+        mock_agent.spec.model_ref.namespace = None
+        mock_agent.spec.parameters = None
+        mock_agent.spec.tools = None
+        mock_agent.spec.execution_engine = None
+        mock_agent.spec.executionEngine = None
+
+        mock_ark.queries.a_get = AsyncMock(return_value=mock_query)
+        mock_ark.agents.a_get = AsyncMock(return_value=mock_agent)
+        mock_ark.models.a_get = AsyncMock(return_value=mock_model_crd)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_ark
+        mock_ctx.__aexit__.return_value = False
+        mock_with_client.return_value = mock_ctx
+
+        ref = QueryRef(name="q1", namespace="default")
+        request = await resolve_query(ref, "hi")
+
+        self.assertEqual(request.agent.model.type, "azure")
+        self.assertNotIn("apiVersion", request.agent.model.config.get("azure", {}))
+
 
 class TestConversationIdPassthrough(unittest.IsolatedAsyncioTestCase):
     @patch("ark_sdk.k8s.init_k8s", new_callable=AsyncMock)

--- a/scripts/default-setup.sh
+++ b/scripts/default-setup.sh
@@ -73,7 +73,7 @@ echo "  API Key: ${api_key:0:20}..."
 # Create or update AIGW secret
 echo "Creating/updating AIGW secret..."
 kubectl create secret generic aigw-secret \
-    --from-literal=api-key="$api_key" \
+    --from-literal=token="$api_key" \
     --dry-run=client -o yaml | kubectl apply -f -
 
 if [[ $? -eq 0 ]]; then
@@ -105,7 +105,7 @@ spec:
         valueFrom:
           secretKeyRef:
             name: aigw-secret
-            key: api-key
+            key: token
       apiVersion:
         value: "$api_version"
 EOF

--- a/scripts/default-setup.sh
+++ b/scripts/default-setup.sh
@@ -73,7 +73,7 @@ echo "  API Key: ${api_key:0:20}..."
 # Create or update AIGW secret
 echo "Creating/updating AIGW secret..."
 kubectl create secret generic aigw-secret \
-    --from-literal=token="$api_key" \
+    --from-literal=api-key="$api_key" \
     --dry-run=client -o yaml | kubectl apply -f -
 
 if [[ $? -eq 0 ]]; then
@@ -105,7 +105,7 @@ spec:
         valueFrom:
           secretKeyRef:
             name: aigw-secret
-            key: token
+            key: api-key
       apiVersion:
         value: "$api_version"
 EOF


### PR DESCRIPTION
## Summary
- `_resolve_provider_config` in the query extension was not mapping `apiVersion` from the Azure provider config into the resolved model config dict
- `AsyncAzureOpenAI` requires `api_version` at construction time and raises `ValueError` if missing
- Added `apiVersion` resolution alongside the existing `apiKey`, `baseUrl` mappings
- Added two unit tests: one verifying `apiVersion` is resolved when present, one verifying it is absent from config when not set