### PR TITLE
fix(ci): stabilize release pipeline and k3s CI reliability

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -69,7 +69,7 @@ runs:
       with:
         metrics-enabled: false
         traefik-enabled: false
-        k3s-channel: latest
+        k3s-channel: stable
 
     - name: Run setup-e2e script
       shell: bash

--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -76,7 +76,7 @@ runs:
       with:
         metrics-enabled: false
         traefik-enabled: false
-        k3s-channel: latest
+        k3s-channel: stable
 
     - name: Install Ark CLI
       shell: bash

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1365,7 +1365,7 @@ jobs:
         with:
           metrics-enabled: false
           traefik-enabled: false
-          k3s-channel: latest
+          k3s-channel: stable
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -347,7 +347,7 @@ jobs:
         with:
           metrics-enabled: false
           traefik-enabled: false
-          k3s-channel: latest
+          k3s-channel: stable
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/lib/ark-sdk/build.mk
+++ b/lib/ark-sdk/build.mk
@@ -7,7 +7,7 @@ ARK_SDK_OUT := $(OUT)/$(ARK_SDK_LIB_NAME)
 # Library-specific variables
 ARK_SDK_VERSION := $(shell cat version.txt)
 # Normalize version to PEP 440 format for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
-ARK_SDK_PEP440_VERSION := $(shell echo '$(ARK_SDK_VERSION)' | sed 's/-rc\./rc/')
+ARK_SDK_PEP440_VERSION := $(shell echo '$(ARK_SDK_VERSION)' | sed 's/-rc\.\([0-9]*\)/rc\1/;s/-rc$$/rc0/')
 ARK_SDK_WHEEL_NAME := ark_sdk-$(ARK_SDK_PEP440_VERSION)-py3-none-any.whl
 ARK_SDK_WHL := $(ARK_SDK_OUT)/py-sdk/dist/$(ARK_SDK_WHEEL_NAME)
 ARK_SDK_CRD_FILES := $(wildcard ark/config/crd/bases/ark*.yaml)

--- a/lib/ark-sdk/install.sh
+++ b/lib/ark-sdk/install.sh
@@ -17,7 +17,7 @@ CRD_GLOBS=(
 )
 
 # Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
-PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\.\([0-9]*\)/rc\1/;s/-rc$/rc0/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 if [[ -e "$OUT_DIR/py-sdk/dist/$WHEEL_NAME" ]]; then

--- a/services/ark-api/sync-ark-sdk.sh
+++ b/services/ark-api/sync-ark-sdk.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
-PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\.\([0-9]*\)/rc\1/;s/-rc$/rc0/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 rm -rf out

--- a/services/ark-mcp/sync-ark-sdk.sh
+++ b/services/ark-mcp/sync-ark-sdk.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Get PEP 440 normalized version for wheel filename (e.g., 0.1.58-rc.3 -> 0.1.58rc3)
-PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\./rc/')
+PEP440_VERSION=$(cat ../../version.txt | sed 's/-rc\.\([0-9]*\)/rc\1/;s/-rc$/rc0/')
 WHEEL_NAME="ark_sdk-${PEP440_VERSION}-py3-none-any.whl"
 
 rm -rf ark-mcp/out


### PR DESCRIPTION
## Summary
- Fix PEP440 version conversion for bare `-rc` suffix: release-please sets `version.txt` to `0.1.60-rc` (no trailing number) on first RC; sed only handled `-rc.N` format, causing wheel filename mismatch (`ark_sdk-0.1.60-rc` vs Python-normalized `ark_sdk-0.1.60rc0`)
- Pin k3s to `stable` channel in all CI jobs to avoid flaky downloads when `latest` resolves to a newly-published release not yet propagated on CDN