### PR TITLE
docs: add upgrade and cross-cluster migration guide for Ark

### DIFF
--- a/docs/content/reference/upgrading.mdx
+++ b/docs/content/reference/upgrading.mdx
@@ -27,7 +27,6 @@ ark install -y --ark-version 0.2.0
 Useful flags:
 
 - `--marketplace-version <version>` — pin the marketplace chart version
-- `--wait-for-ready <timeout>` — block until Ark is ready (e.g. `--wait-for-ready 2m`); requires `-y`
 
 Run `ark install --help` for the full list.
 
@@ -57,7 +56,6 @@ Useful flags:
 
 - `-n, --namespace <namespace>` — export from a single namespace
 - `-t, --types <types>` — comma-separated list of resource types (e.g. `-t models,agents,teams`)
-- `-l, --labels <selector>` — filter by label selector
 
 <Callout type="warning">
 Not included in the default export: `queries`, `memories`, `executionengines`, `a2atasks`, and any non-Ark CRDs such as Argo `WorkflowTemplate`. Back those up separately with `kubectl get <kind> -A -o yaml` if you need them on the destination.

--- a/docs/content/reference/upgrading.mdx
+++ b/docs/content/reference/upgrading.mdx
@@ -12,6 +12,73 @@ Ark uses [Semantic Versioning](https://semver.org/). The technical details are i
 
 A detailed record of every change is documented in [`CHANGELOG.md`](https://github.com/mckinsey/agents-at-scale-ark/blob/main/.github/CHANGELOG.md).
 
+## Installing a New Version of Ark
+
+Two scenarios are covered here: upgrading an existing Ark installation in place, and migrating resources to a different cluster.
+
+### Upgrading in place
+
+To move an existing cluster to a new Ark version, reinstall with `--ark-version`:
+
+```bash
+ark install -y --ark-version 0.2.0
+```
+
+Useful flags:
+
+- `--marketplace-version <version>` — pin the marketplace chart version
+- `--wait-for-ready <timeout>` — block until Ark is ready (e.g. `--wait-for-ready 2m`); requires `-y`
+
+Run `ark install --help` for the full list.
+
+Your CRD instances (agents, models, teams, tools, mcpservers, a2aservers, queries, memories, executionengines, a2atasks) are **preserved automatically** across the upgrade. The Ark CRDs are installed with the `helm.sh/resource-policy: keep` annotation, so they survive `ark uninstall` and are adopted by the reinstall. Non-Ark resources (for example, Argo `WorkflowTemplate`s) are not touched by Ark's Helm releases at all.
+
+<Callout type="info">
+What is not preserved:
+- **Broker state** — `ark-broker` is an in-memory event bus; messages, chunks, traces, events, sessions, and any conversation history held there are wiped when the broker pod restarts.
+- **In-flight query execution** — the `Query` CRD record survives, but the executor pod processing it is gone. Such queries are typically stuck and need to be cleaned up manually.
+
+Also review the version-specific sections below for manual migration steps that apply to the version you upgraded to.
+</Callout>
+
+### Migrating to a different cluster
+
+To move resources to a new cluster, use `ark export` on the source and `ark import` on the destination. This flow assumes the destination has a fresh Ark install with no overlapping resources.
+
+#### 1. Export from the source cluster
+
+```bash
+ark export -o ark-export.yaml
+```
+
+This captures Ark CRD instances for: `secrets`, `tools`, `models`, `agents`, `teams`, `mcpservers`, `a2aservers`.
+
+Useful flags:
+
+- `-n, --namespace <namespace>` — export from a single namespace
+- `-t, --types <types>` — comma-separated list of resource types (e.g. `-t models,agents,teams`)
+- `-l, --labels <selector>` — filter by label selector
+
+<Callout type="warning">
+Not included in the default export: `queries`, `memories`, `executionengines`, `a2atasks`, and any non-Ark CRDs such as Argo `WorkflowTemplate`. Back those up separately with `kubectl get <kind> -A -o yaml` if you need them on the destination.
+</Callout>
+
+#### 2. Install Ark on the destination cluster
+
+```bash
+ark install -y --ark-version 0.2.0
+```
+
+#### 3. Import the exported resources
+
+```bash
+ark import ark-export.yaml
+```
+
+<Callout type="warning">
+`ark import` uses `kubectl create`, which fails for any resource that already exists on the destination. Run it against a clean install, or delete conflicting instances first with `kubectl delete -f ark-export.yaml`.
+</Callout>
+
 ## Unreleased
 
 ### OpenAI-Compatible Endpoints Removed


### PR DESCRIPTION
## Summary
- Adds a new "Installing a New Version of Ark" section to `docs/content/reference/upgrading.mdx`
- Covers two scenarios: **in-place upgrade** (`ark install --ark-version X`) and **cross-cluster migration** (`ark export` → fresh `ark install` → `ark import`)
- Documents what survives and what does not across each flow, and flags the known gaps in the current CLI behavior

## Testing performed
Tested live against a minikube cluster with the `samples/cobol-demo/` loaded (8 agents, 3 teams, 4 MCPServers, 2 Argo `WorkflowTemplate`s). This test surfaced two bugs that the doc now explicitly warns about.

| Step | Command | Result |
|---|---|---|
| Baseline | `kubectl apply -f samples/cobol-demo/{mcpserver,agents,teams}.yaml` + `workflows/*.yaml` | All resources applied |
| Export | `ark export -o /tmp/ark-export.yaml` | 60 resources exported (8 Agent, 4 MCPServer, 13 Secret, 3 Team, 32 Tool, **0 WorkflowTemplate**) |
| Uninstall | `ark uninstall -y` | Pods uninstalled; **CRDs preserved** via `helm.sh/resource-policy: keep`; all CRD instances survived |
| Install | `ark install -y --wait-for-ready 5m` | Installed; adopted surviving CRDs; became ready |
| Import | `ark import /tmp/ark-export.yaml` | **Failed with `AlreadyExists` on all 60 resources** — import uses `kubectl create`, not `apply` |
| Final state | | Cluster fully intact (no data loss); all cobol demo agents / teams / mcpservers / workflowtemplates still present |

### Findings fed back into the doc
- The in-place upgrade flow is far simpler than originally drafted — CRD instances are preserved by the `keep` annotation, so `ark install --ark-version X` is sufficient. Export/import is **not** needed for a version bump on the same cluster.
- `ark export` silently omits Argo `WorkflowTemplate` (and other non-Ark CRDs). The doc now flags this and tells users to back those up separately.
- `ark import` fails on any existing resource. The doc now calls this out and tells users the flow is for clean destinations only.

### Follow-up issues filed
- #1933 — `fix: ark import fails on existing resources, blocking re-runs and partial-destination migrations`
- #1934 — `feat: ark export should include Argo workflow resources`

Once those land, the "Migrating to a different cluster" warnings in this doc can be relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)