### PR TITLE
docs: add "Why Ark?" framing to README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Ark is a declarative toolkit for building and hosting distributed AI agents. By 
 
 Built on Kubernetes, Ark lets you deploy a dev-friendly cluster in minutes or scale agentic workloads across existing infrastructure. Leverage proven patterns for security, monitoring, and RBAC—avoiding bespoke overhead while maintaining a portable, production-ready foundation for your AI projects.
 
+## Why Ark?
+
+Ark is designed for rapid, democratic development of agentic systems. The entire stack is built on open-source Kubernetes technology designed for running distributed systems. It can run comfortably on a single developer's machine or be deployed into a Kubernetes cluster across multi-cloud and on-prem environments. Developers and operations teams have full visibility into the entire stack, from the highest to the lowest levels.
+
+Because each workload is a declarative specification of agent behavior rather than proprietary code, teams can re-platform individual use cases onto specialized or proprietary stacks when needed, typically with minimal migration overhead.
+
 ## Features
 
 - **Declarative Agents** — Define agents as Kubernetes custom resources with prompts, tools, and model references

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -14,7 +14,11 @@ Ark provides resources for:
 - [Tool integrations](./user-guide/tools).
 - [Memory persistence](./reference/resources/memory).
 
-Ark emphasizes a declarative approach to building agentic solutions, separating the definition of how agents should behave from the underlying implementation of how they are run. This encourages teams to build portable solutions that can be moved across different stacks as the agentic space evolves.
+## Why Ark?
+
+Ark is designed for rapid, democratic development of agentic systems. The entire stack is built on open-source Kubernetes technology designed for running distributed systems. It can run comfortably on a single developer's machine or be deployed into a Kubernetes cluster across multi-cloud and on-prem environments. Developers and operations teams have full visibility into the entire stack, from the highest to the lowest levels.
+
+Because each workload is a declarative specification of agent behavior rather than proprietary code, teams can re-platform individual use cases onto specialized or proprietary stacks when needed, typically with minimal migration overhead.
 
 Find out more about the [core concepts of Ark](./core-concepts).
 


### PR DESCRIPTION
## Summary
- Add "Why Ark?" section to README.md and docs introduction page
- Articulates core value proposition: rapid democratic development on open-source Kubernetes, laptop-to-cloud flexibility, full stack visibility, and workload portability through declarative specs