### PR TITLE
docs(openspec): propose splitting aggregated API server into its own deployment

### DIFF
--- a/openspec/changes/split-apiserver-deployment/.openspec.yaml
+++ b/openspec/changes/split-apiserver-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/split-apiserver-deployment/design.md
+++ b/openspec/changes/split-apiserver-deployment/design.md
@@ -61,25 +61,38 @@ WAL logical replication uses a named replication slot. Multiple consumers on the
 - Leader election within the apiserver Deployment picks the WAL-consumer replica (`ark-apiserver-leader` Lease)
 - Non-leader replicas still serve API reads — they just skip the WAL setup path
 
-### Decision: Upgrade path uses a Helm pre-upgrade hook, not a staged rollout
+### Decision: Two separate Helm charts, not one chart with conditional templates
 
-The Helm upgrade from current topology to split must be zero-data-loss and require no manual intervention. The pre-upgrade hook:
-1. Applies the `ark-apiserver` Deployment and Service
-2. Blocks until the `ark-apiserver` pods are Ready and the APIService reports `Available=True`
-3. Flips the APIService selector from `ark-controller` pods to `ark-apiserver` pods
-4. Only then returns, allowing Helm to proceed with the `ark-controller` Deployment upgrade (drop apiserver args, switch to `--role=controller`)
+`ark/dist/chart` remains the ark-controller chart (reconcilers, webhooks, CRDs). A new chart `ark/dist/chart-apiserver` owns the apiserver Deployment, the `ark-apiserver` Service, the `APIService` CR, and the apiserver-side RBAC. Operators install one chart on etcd (`ark-controller` only) and two charts on PostgreSQL (`ark-apiserver` first, then `ark-controller`).
 
-At no point between steps 1 and 3 is the APIService unavailable. Rollback via `helm rollback` reverses the hook. The approach is one-way with respect to intent (we are moving to split), but fully reversible in practice via Helm's own rollback semantics.
+Rationale:
+- The two Deployments have independent lifecycles (upgrades, rollbacks, scale decisions). Independent Helm releases match that.
+- Values schemas diverge: `ark-apiserver` needs PG connection config and replica count; `ark-controller` needs neither.
+- RBAC is naturally split: each chart creates the ServiceAccount it needs and only the permissions that role requires.
+- Upgrade ordering is expressed directly as "install/upgrade `ark-apiserver` first, then `ark-controller`" instead of smuggled through template conditionals and hooks inside one chart.
 
-**Alternative considered**: staged rollout over two releases with a `deployment.split` flag defaulting `false`, then flipped `true` in a follow-up release. Rejected — it forces us to carry the combined code path for at least one release, which reintroduces the readiness ambiguity the split is meant to eliminate.
+**Alternative considered**: one chart with `.Values.storage.backend` gating conditional templates for the apiserver Deployment. Rejected — it couples two release lifecycles, hides the apiserver upgrade path inside hooks of a chart named `ark-controller`, and makes it harder to version the apiserver independently (e.g., ship an apiserver-only patch for a perf fix without bumping the controller chart).
 
-### Decision: Controller waits for apiserver via init container plus the Helm hook
+**Alternative considered**: an umbrella `ark-operator` chart that depends on both. Deferred — not needed for v1 of the split; operators can install both charts with a two-line `helm install` script. An umbrella chart can be added later without blocking this change.
 
-Startup ordering matters: if `ark-controller` starts its informers before `ark-apiserver` is serving, LIST+WATCH requests fail and restart backoff kicks in. Two mechanisms in defence:
-1. The Helm pre-upgrade hook above (covers Helm upgrade flow)
-2. `ark-controller` Deployment init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available` (covers pod restarts after the upgrade is complete)
+### Decision: Upgrade path is a two-step Helm install, no cross-chart hooks
 
-Either alone is probably sufficient; both together is cheap insurance.
+The migration from the current embedded topology to the split topology is:
+
+1. `helm install ark-apiserver ark/dist/chart-apiserver --wait` — creates the new Deployment, Service, and RBAC. The chart also takes ownership of the `APIService` CR, updating its selector to `app.kubernetes.io/name=ark-apiserver`. At this point the APIService endpoints flip from the old controller pods (which are still running the embedded apiserver) to the new apiserver pods.
+2. `helm upgrade ark-controller ark/dist/chart` — the new chart version drops the apiserver args/ports from the controller Deployment and sets `--role=controller`. Existing reconcilers continue as the pod rolls.
+
+Between step 1 and step 2 the cluster is briefly in a mixed state: the new apiserver pods serve the API, the old controller pods still have the embedded apiserver running but it is no longer reachable because the Service no longer selects them. This is intentional — there is no window where the APIService is unavailable, because step 1 completes before step 2 begins. The embedded apiserver in the old controller pods is harmless until those pods roll out of existence in step 2.
+
+Rollback is per-chart: `helm rollback ark-controller` reverts the controller changes; if the apiserver chart also needs rollback, `helm rollback ark-apiserver` reverses step 1 and the APIService selector returns to the old controller pods.
+
+**Alternative considered**: a single-chart pre-upgrade hook that installs the apiserver resources and flips the APIService selector in one Helm transaction. Rejected — it smuggles two release lifecycles through one hook. It also makes it hard to upgrade the apiserver without touching the controller chart (and vice versa) once the migration is complete.
+
+### Decision: Controller waits for apiserver via init container
+
+Startup ordering matters: if `ark-controller` starts its informers before `ark-apiserver` is serving, LIST+WATCH requests fail and restart backoff kicks in. The `ark-controller` Deployment includes an init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available`. This covers both the initial install (where `helm install ark-apiserver` runs before `helm install ark-controller`) and any controller pod restart after the split is established.
+
+We do not need a cross-chart Helm hook: the two-step install ordering plus the init container is sufficient. Operators or CI who run the commands out of order are caught by the init container blocking.
 
 ### Decision: `ark-apiserver` Service name stable across backends
 
@@ -101,5 +114,7 @@ With split deployments mandatory on the backend that used to need the probe Mode
 
 - Does the reconciler's client-side informer cache need any tuning now that watches traverse more hops (resync intervals, throttling)?
 - Should we measure the write-latency impact on a representative benchmark (e.g., 1 k Models reconciling in parallel) before cutting over, or is "works in E2E" sufficient evidence?
-- Separate Helm chart (`ark-apiserver`) vs. same chart with conditional templates? Separate chart is cleaner for versioning but adds a new release artefact. Current proposal: same chart, conditional templates.
-- Do we ship the change in a single release (upgrade-in-place via the pre-upgrade hook) or gate it behind a release-note-documented manual step? Current proposal: single release, automated upgrade.
+- Do we ship the change in a single release (operators run the two `helm install` / `helm upgrade` commands themselves) or provide an umbrella `ark-operator` chart that encapsulates the two-step install? Current proposal: two separate installs, umbrella chart deferred.
+- Does `make dev` / `devspace dev` need to spin up both charts, or do we keep a single-process local-dev path that bypasses the split? Likely the former (honour the production topology), but confirm with the dev-experience owners.
+- Who owns WAL leader failover testing under load? §6 covers perf but not the reliability case of the apiserver leader pod dying mid-reconcile.
+- What does post-split log grep look like for operators whose runbooks assume `kubectl logs deployment/ark-controller` contains API server messages? §5.4 flags it; need to decide whether to ship a migration helper (e.g., a `docs/operator-migration.md`).

--- a/openspec/changes/split-apiserver-deployment/design.md
+++ b/openspec/changes/split-apiserver-deployment/design.md
@@ -21,72 +21,85 @@ The 10-consecutive-probe aggregated-API stability check and the probe Model chec
 
 **Goals:**
 - Deployment readiness means exactly what it says: `ark-apiserver` Ready = API is serving; `ark-controller` Ready = reconcilers started
-- Remove the probe Model check from `ark status --wait-for-ready` and `setup-local.sh` once the split is the default
+- Remove the probe Model check from both `ark status --wait-for-ready` and `setup-local.sh`
 - Enable independent horizontal scaling of the API server (read-heavy) separately from reconcilers (leader-elected singleton)
 - Independent rolling upgrades (a server-side fix like #1841 lands without touching reconcilers)
-- Backward compatibility: existing installs keep working on `combined` mode until the next major
+- Zero-data-loss Helm upgrade from the current embedded topology to the split topology
 
 **Non-Goals:**
-- Changing the etcd-backed path (CRDs continue to be served by kube-apiserver; no split needed)
+- Changing the etcd-backed path (CRDs continue to be served by kube-apiserver; no split needed, single Deployment stays)
 - Multi-writer WAL consumers — WAL consumption stays singleton, scaling the API Deployment does not imply N WAL consumers
 - API schema changes — the `ark.mckinsey.com/v1alpha1` and `v1prealpha1` groups are untouched
 - Moving webhooks out of the controller process — webhooks stay with reconcilers
+- Preserving the embedded-in-controller topology as a supported production configuration
 
 ## Decisions
 
-### Decision: Single binary with `--role` flag, not two separate binaries
+### Decision: Single binary with required `--role={apiserver,controller}` flag
 
-Keeping one binary avoids a second image build, a second entry in the release process, and a second place where version drift can occur. `--role={combined,apiserver,controller}` branches at startup. The `combined` role preserves today's behaviour byte-for-byte.
+One binary avoids a second image build, a second release artefact, and a second place where version drift can occur. `--role` branches at startup. There is no `combined` fallback — operators explicitly choose a role, and the Helm chart wires them correctly for each backend.
 
-**Alternative considered**: two binaries (`ark-apiserver`, `ark-controller`). Rejected — the Go code is shared (schemes, storage, validation), and separate binaries would either duplicate it or require a shared lib package. The `--role` flag is strictly simpler.
+**Alternative considered**: two binaries (`ark-apiserver`, `ark-controller`). Rejected — Go code is shared (schemes, storage, validation), separate binaries would either duplicate it or need a shared lib package. The `--role` flag is strictly simpler.
+
+**Alternative considered**: keep a `combined` role as an escape hatch for migration. Rejected — it preserves the readiness ambiguity that motivates this work, forces three-way branching through `main.go` / the Helm chart / the CLI, and keeps a deprecated code path alive indefinitely. The cost of solving upgrade as a one-way Helm-hook problem (see below) is lower than the cost of carrying a legacy mode.
+
+### Decision: Etcd backend stays single-Deployment
+
+On etcd, CRDs are registered in kube-apiserver directly and there is no aggregated API server. Running a second Deployment in `apiserver` mode would have nothing to do. Etcd backend deploys only the `controller` role Deployment, which is indistinguishable from today's etcd install except that `--role=controller` is now passed explicitly.
 
 ### Decision: WAL consumer lives on the apiserver side, not the controller side
 
-The WAL consumer's job is to translate PG change events into watch notifications for API-server-side WATCH streams. In `combined` mode it happens to be in the same process as the reconciler; conceptually it is part of the API server. After the split, watchers that the reconciler's informer opens go through the full k8s API path (kube-apiserver → APIService proxy → ark-apiserver → WAL consumer → stream back). This matches how every other aggregated API works.
+The WAL consumer's job is to translate PG change events into watch notifications for API-server-side WATCH streams. Conceptually it is part of the API server. After the split, watchers opened by the reconciler's informer go through the full k8s API path (kube-apiserver → APIService proxy → ark-apiserver → WAL consumer → stream back). This matches how every other aggregated API works.
 
 **Alternative considered**: WAL consumer on the controller side, with reconcilers reading PG directly. Rejected — breaks the single-source-of-truth model (API server becomes advisory), and makes `kubectl watch agents` from outside the cluster see a different stream than what the reconciler sees.
 
-### Decision: Single WAL consumer even when API Deployment has N replicas
+### Decision: Single WAL consumer even when the apiserver Deployment has N replicas
 
 WAL logical replication uses a named replication slot. Multiple consumers on the same slot corrupt the stream. Therefore:
-- The API Deployment may have N replicas for read scaling
+- The apiserver Deployment may have N replicas for read scaling
 - Only one replica runs the WAL consumer; the others serve reads only
-- Leader election within the API Deployment picks the WAL-consumer replica (`ark-apiserver-leader` Lease)
+- Leader election within the apiserver Deployment picks the WAL-consumer replica (`ark-apiserver-leader` Lease)
 - Non-leader replicas still serve API reads — they just skip the WAL setup path
 
-### Decision: Controller waits for apiserver via Helm hook + init container
+### Decision: Upgrade path uses a Helm pre-upgrade hook, not a staged rollout
+
+The Helm upgrade from current topology to split must be zero-data-loss and require no manual intervention. The pre-upgrade hook:
+1. Applies the `ark-apiserver` Deployment and Service
+2. Blocks until the `ark-apiserver` pods are Ready and the APIService reports `Available=True`
+3. Flips the APIService selector from `ark-controller` pods to `ark-apiserver` pods
+4. Only then returns, allowing Helm to proceed with the `ark-controller` Deployment upgrade (drop apiserver args, switch to `--role=controller`)
+
+At no point between steps 1 and 3 is the APIService unavailable. Rollback via `helm rollback` reverses the hook. The approach is one-way with respect to intent (we are moving to split), but fully reversible in practice via Helm's own rollback semantics.
+
+**Alternative considered**: staged rollout over two releases with a `deployment.split` flag defaulting `false`, then flipped `true` in a follow-up release. Rejected — it forces us to carry the combined code path for at least one release, which reintroduces the readiness ambiguity the split is meant to eliminate.
+
+### Decision: Controller waits for apiserver via init container plus the Helm hook
 
 Startup ordering matters: if `ark-controller` starts its informers before `ark-apiserver` is serving, LIST+WATCH requests fail and restart backoff kicks in. Two mechanisms in defence:
-1. Helm post-install hook `ark-apiserver-wait` that blocks until the APIService reports `Available=True`
-2. `ark-controller` Deployment uses an init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available`
+1. The Helm pre-upgrade hook above (covers Helm upgrade flow)
+2. `ark-controller` Deployment init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available` (covers pod restarts after the upgrade is complete)
 
 Either alone is probably sufficient; both together is cheap insurance.
 
-### Decision: `deployment.split` is a per-release Helm value, not auto-detected
+### Decision: `ark-apiserver` Service name stable across backends
 
-Making the chart behave differently based on cluster state introduces implicit behaviour that is hard to debug. An explicit `deployment.split: true|false` in values, defaulting `false` for one release, CI-flipped in the same release, and promoted to `true` default in the following release, makes the rollout observable and revertable.
+The `APIService` CR points to `ark-system/ark-apiserver`. On the PostgreSQL backend that Service is rendered with selector `app.kubernetes.io/name=ark-apiserver`. On etcd the Service is not rendered because there is no aggregated API server. Users who reference `ark-apiserver.ark-system.svc` in code keep working on PostgreSQL.
 
-### Decision: Keep `ark-apiserver` Service name stable across modes
+### Decision: `readinessChecks.ts` drops the probe Model path entirely
 
-The `APIService` CR points to `ark-system/ark-apiserver`. That Service exists today with a selector that matches `ark-controller` pods. After split, the same Service name persists but its selector flips to `app.kubernetes.io/name=ark-apiserver`. The APIService CR is unchanged. Users who reference `ark-apiserver.ark-system.svc` in code keep working.
-
-### Decision: `readinessChecks.ts` collapses layer 5 into layer 0 when split is detected
-
-Detection is cheap: `kubectl get deployment ark-apiserver -n ark-system` succeeds iff split is enabled. When both `ark-apiserver` and `ark-controller` Deployments exist, layer 0 (`waitForDeploymentReady` per service) covers what layer 5 previously needed. The probe Model code path is kept for the transition period (combined mode) and removed when combined mode is deprecated.
+With split deployments mandatory on the backend that used to need the probe Model, there is no scenario where the probe is required. Layer 5 (`waitForControllerReconciling`) is deleted. `ark-apiserver` is added to the list of core services that layer 0 waits for when the PostgreSQL backend is detected (no CRD present).
 
 ## Risks / Trade-offs
 
-- **Extra network hops for reconciler writes**: today the reconciler's k8s client talks to the embedded API server in-process (µs). After the split, writes go client → kube-apiserver → APIService proxy → ark-apiserver pod → PG (likely 1–5 ms). Reads stay on local informer cache, so latency is only on writes (status updates). For a busy cluster with high status-update frequency, this is measurable. Benchmark before making split the default.
+- **Extra network hops for reconciler writes**: today the reconciler's k8s client talks to the embedded API server in-process (µs). After the split, writes go client → kube-apiserver → APIService proxy → ark-apiserver pod → PG (likely 1–5 ms). Reads stay on local informer cache, so latency is only on writes (status updates). For a busy cluster with high status-update frequency, this is measurable. Benchmark before cutting over.
 - **Two sets of logs/metrics**: debugging becomes "which Deployment has the problem?". Partially offset by clearer signals (each Deployment now reports its own readiness accurately).
-- **Helm complexity**: conditional template rendering, two Deployments, two Services (or one with flipped selector), init container, Helm hook. More to review, more to break.
-- **Migration risk**: existing clusters running `combined` must flip to `split` at some point. If the flip is not in-place-upgradeable (e.g., PG connection pool collision), operators need a documented downtime window. Acceptance criterion: `helm upgrade` from combined to split must succeed on a live cluster with zero data loss.
-- **WAL leader election adds moving parts**: replication slot races are a known class of bug (see PR #1763 context). The switchover from one WAL consumer pod to another during a split-mode rolling upgrade must be tested under load.
+- **Helm upgrade blast radius**: the pre-upgrade hook is critical path. A bug in the hook script means the upgrade fails and operators must roll back. Mitigation: CI integration test that runs `helm upgrade` from an existing PostgreSQL install with seeded Agent/Model/Query resources and verifies all resources are still queryable after the upgrade.
+- **WAL leader election adds moving parts**: replication slot races are a known class of bug (see PR #1763). The switchover from one WAL consumer pod to another during a split-mode rolling upgrade must be tested under load.
 - **"embedded" pattern disappears**: some users may have workflows that assume the API server lives in `ark-controller` logs. Communicate via release notes and docs.
 
 ## Open Questions
 
 - Does the reconciler's client-side informer cache need any tuning now that watches traverse more hops (resync intervals, throttling)?
-- For `combined` mode during the transition, should the `ark-apiserver` Service selector remain `ark-controller` (as today) or switch to a label added to both Deployments (e.g., `ark.mckinsey.com/component=apiserver`)? The latter future-proofs without breaking today.
-- Should we measure the write-latency impact on a representative benchmark (e.g., 1 k Models reconciling in parallel) before promoting split to default, or is "works in E2E" sufficient evidence?
-- Separate Helm chart (`ark-apiserver`) vs. same chart with conditional templates? Separate chart is cleaner for versioning but adds a new release artefact.
-- When combined mode is removed, do we also remove the `--role=combined` code path, or keep it as a dev convenience (single process = easier local debugging)?
+- Should we measure the write-latency impact on a representative benchmark (e.g., 1 k Models reconciling in parallel) before cutting over, or is "works in E2E" sufficient evidence?
+- Separate Helm chart (`ark-apiserver`) vs. same chart with conditional templates? Separate chart is cleaner for versioning but adds a new release artefact. Current proposal: same chart, conditional templates.
+- Do we ship the change in a single release (upgrade-in-place via the pre-upgrade hook) or gate it behind a release-note-documented manual step? Current proposal: single release, automated upgrade.

--- a/openspec/changes/split-apiserver-deployment/design.md
+++ b/openspec/changes/split-apiserver-deployment/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Ark supports two storage backends: the default etcd (CRDs registered directly, served by kube-apiserver) and PostgreSQL (served by an embedded aggregated API server via `k8s.io/apiserver`, `APIService` resource, PG-backed storage, `pglogrepl` WAL streaming for watch notifications).
+
+In the PostgreSQL path, the same ark-controller pod runs:
+- The aggregated API server as a `Manager.Runnable` (`ark/cmd/main.go:setupEmbeddedApiserver` calls `mgr.Add(server)`)
+- The controller-runtime Manager with reconcilers for Agent/Model/Query/Team/MCPServer/ExecutionEngine/A2AServer
+- Webhooks for validation and mutation
+- The WAL consumer (`ark/internal/storage/postgresql/wal_consumer.go`) that streams PG change events to informer caches
+
+`ark-apiserver` Service selects `app.kubernetes.io/name=ark-controller` — proving the same pod hosts both responsibilities. Readiness probes and Deployment `Available` conditions therefore cannot distinguish "API serving" from "reconcilers reconciling".
+
+This ambiguity has driven three notable incidents:
+- PR #1527 — aggregated API accepted reads while reconcilers were not yet caught up; needed warmup loop in `setup-local.sh`
+- PR #1637 — `kubectl patch` + `rollout restart` for coverage config killed the controller pod mid-test, leaving a ~57 s window where API served but reconcilers were idle; needed a probe Model write to detect
+- PR #1841 — intermittent 503s under load; needed to disable protobuf support in the apiserver
+
+The 10-consecutive-probe aggregated-API stability check and the probe Model check in `setup-local.sh:132-220` exist because the pod's readiness signal is coarser than the failure modes it sees.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deployment readiness means exactly what it says: `ark-apiserver` Ready = API is serving; `ark-controller` Ready = reconcilers started
+- Remove the probe Model check from `ark status --wait-for-ready` and `setup-local.sh` once the split is the default
+- Enable independent horizontal scaling of the API server (read-heavy) separately from reconcilers (leader-elected singleton)
+- Independent rolling upgrades (a server-side fix like #1841 lands without touching reconcilers)
+- Backward compatibility: existing installs keep working on `combined` mode until the next major
+
+**Non-Goals:**
+- Changing the etcd-backed path (CRDs continue to be served by kube-apiserver; no split needed)
+- Multi-writer WAL consumers — WAL consumption stays singleton, scaling the API Deployment does not imply N WAL consumers
+- API schema changes — the `ark.mckinsey.com/v1alpha1` and `v1prealpha1` groups are untouched
+- Moving webhooks out of the controller process — webhooks stay with reconcilers
+
+## Decisions
+
+### Decision: Single binary with `--role` flag, not two separate binaries
+
+Keeping one binary avoids a second image build, a second entry in the release process, and a second place where version drift can occur. `--role={combined,apiserver,controller}` branches at startup. The `combined` role preserves today's behaviour byte-for-byte.
+
+**Alternative considered**: two binaries (`ark-apiserver`, `ark-controller`). Rejected — the Go code is shared (schemes, storage, validation), and separate binaries would either duplicate it or require a shared lib package. The `--role` flag is strictly simpler.
+
+### Decision: WAL consumer lives on the apiserver side, not the controller side
+
+The WAL consumer's job is to translate PG change events into watch notifications for API-server-side WATCH streams. In `combined` mode it happens to be in the same process as the reconciler; conceptually it is part of the API server. After the split, watchers that the reconciler's informer opens go through the full k8s API path (kube-apiserver → APIService proxy → ark-apiserver → WAL consumer → stream back). This matches how every other aggregated API works.
+
+**Alternative considered**: WAL consumer on the controller side, with reconcilers reading PG directly. Rejected — breaks the single-source-of-truth model (API server becomes advisory), and makes `kubectl watch agents` from outside the cluster see a different stream than what the reconciler sees.
+
+### Decision: Single WAL consumer even when API Deployment has N replicas
+
+WAL logical replication uses a named replication slot. Multiple consumers on the same slot corrupt the stream. Therefore:
+- The API Deployment may have N replicas for read scaling
+- Only one replica runs the WAL consumer; the others serve reads only
+- Leader election within the API Deployment picks the WAL-consumer replica (`ark-apiserver-leader` Lease)
+- Non-leader replicas still serve API reads — they just skip the WAL setup path
+
+### Decision: Controller waits for apiserver via Helm hook + init container
+
+Startup ordering matters: if `ark-controller` starts its informers before `ark-apiserver` is serving, LIST+WATCH requests fail and restart backoff kicks in. Two mechanisms in defence:
+1. Helm post-install hook `ark-apiserver-wait` that blocks until the APIService reports `Available=True`
+2. `ark-controller` Deployment uses an init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available`
+
+Either alone is probably sufficient; both together is cheap insurance.
+
+### Decision: `deployment.split` is a per-release Helm value, not auto-detected
+
+Making the chart behave differently based on cluster state introduces implicit behaviour that is hard to debug. An explicit `deployment.split: true|false` in values, defaulting `false` for one release, CI-flipped in the same release, and promoted to `true` default in the following release, makes the rollout observable and revertable.
+
+### Decision: Keep `ark-apiserver` Service name stable across modes
+
+The `APIService` CR points to `ark-system/ark-apiserver`. That Service exists today with a selector that matches `ark-controller` pods. After split, the same Service name persists but its selector flips to `app.kubernetes.io/name=ark-apiserver`. The APIService CR is unchanged. Users who reference `ark-apiserver.ark-system.svc` in code keep working.
+
+### Decision: `readinessChecks.ts` collapses layer 5 into layer 0 when split is detected
+
+Detection is cheap: `kubectl get deployment ark-apiserver -n ark-system` succeeds iff split is enabled. When both `ark-apiserver` and `ark-controller` Deployments exist, layer 0 (`waitForDeploymentReady` per service) covers what layer 5 previously needed. The probe Model code path is kept for the transition period (combined mode) and removed when combined mode is deprecated.
+
+## Risks / Trade-offs
+
+- **Extra network hops for reconciler writes**: today the reconciler's k8s client talks to the embedded API server in-process (µs). After the split, writes go client → kube-apiserver → APIService proxy → ark-apiserver pod → PG (likely 1–5 ms). Reads stay on local informer cache, so latency is only on writes (status updates). For a busy cluster with high status-update frequency, this is measurable. Benchmark before making split the default.
+- **Two sets of logs/metrics**: debugging becomes "which Deployment has the problem?". Partially offset by clearer signals (each Deployment now reports its own readiness accurately).
+- **Helm complexity**: conditional template rendering, two Deployments, two Services (or one with flipped selector), init container, Helm hook. More to review, more to break.
+- **Migration risk**: existing clusters running `combined` must flip to `split` at some point. If the flip is not in-place-upgradeable (e.g., PG connection pool collision), operators need a documented downtime window. Acceptance criterion: `helm upgrade` from combined to split must succeed on a live cluster with zero data loss.
+- **WAL leader election adds moving parts**: replication slot races are a known class of bug (see PR #1763 context). The switchover from one WAL consumer pod to another during a split-mode rolling upgrade must be tested under load.
+- **"embedded" pattern disappears**: some users may have workflows that assume the API server lives in `ark-controller` logs. Communicate via release notes and docs.
+
+## Open Questions
+
+- Does the reconciler's client-side informer cache need any tuning now that watches traverse more hops (resync intervals, throttling)?
+- For `combined` mode during the transition, should the `ark-apiserver` Service selector remain `ark-controller` (as today) or switch to a label added to both Deployments (e.g., `ark.mckinsey.com/component=apiserver`)? The latter future-proofs without breaking today.
+- Should we measure the write-latency impact on a representative benchmark (e.g., 1 k Models reconciling in parallel) before promoting split to default, or is "works in E2E" sufficient evidence?
+- Separate Helm chart (`ark-apiserver`) vs. same chart with conditional templates? Separate chart is cleaner for versioning but adds a new release artefact.
+- When combined mode is removed, do we also remove the `--role=combined` code path, or keep it as a dev convenience (single process = easier local debugging)?

--- a/openspec/changes/split-apiserver-deployment/proposal.md
+++ b/openspec/changes/split-apiserver-deployment/proposal.md
@@ -8,38 +8,40 @@ Splitting into two Deployments makes each pod's Ready condition mean exactly wha
 
 ## What Changes
 
-- `ark/cmd/main.go` gains a `--role={combined,apiserver,controller}` flag (default `combined` for backward compatibility)
-- In `apiserver` mode, the process only starts the embedded aggregated API server + WAL consumer; no reconcilers, no webhooks
-- In `controller` mode, the process only starts controller-runtime (reconcilers + webhooks) and talks to the aggregated API via the normal k8s client path (kube-apiserver → `APIService` proxy → `ark-apiserver` Service)
-- Helm chart `ark/dist/chart` adds a second `Deployment` (`ark-apiserver`) when `storage.backend=postgresql` and `deployment.split=true`; `ark-controller` Deployment stops serving the API in that mode
+- `ark/cmd/main.go` takes a required `--role={apiserver,controller}` flag
+- In `apiserver` role, the process only starts the embedded aggregated API server + WAL consumer; no reconcilers, no webhooks
+- In `controller` role, the process only starts controller-runtime (reconcilers + webhooks) and talks to the aggregated API via the normal k8s client path (kube-apiserver → `APIService` proxy → `ark-apiserver` Service)
+- Helm chart `ark/dist/chart` always renders a `controller` Deployment. When `storage.backend=postgresql` it additionally renders an `apiserver` Deployment. Etcd backend stays single-Deployment (no aggregated API server is needed on etcd)
 - Two leader-election Leases: `ark-apiserver-leader` (for the WAL consumer singleton) and `ark-controller-leader` (for the reconciler loop)
-- `ark-apiserver` Service selector flips to `app.kubernetes.io/name=ark-apiserver` when split is enabled
-- Startup ordering: `ark-controller` waits on `ark-apiserver` readiness (init container or Helm hook)
-- `tools/ark-cli/src/lib/readinessChecks.ts` drops layer 5 when both Deployments exist and are Ready — the probe Model is no longer needed
-- Migration path: `storage.backend=postgresql` + `deployment.split=false` (default) keeps the embedded behaviour; CI flips `deployment.split=true` first; docs/defaults follow after a release cycle of burn-in
+- `ark-apiserver` Service selector points at `app.kubernetes.io/name=ark-apiserver` on PostgreSQL; Service is not rendered on etcd
+- Startup ordering: `ark-controller` waits on `ark-apiserver` readiness via init container plus a Helm pre-upgrade hook
+- Helm upgrade from the current embedded topology to the split topology is one-way and zero-data-loss: the pre-upgrade hook brings up `ark-apiserver`, the APIService selector flips, then `ark-controller` is upgraded to drop the embedded API server args
+- `tools/ark-cli/src/lib/readinessChecks.ts` drops the probe Model check entirely — layer 0 covers reconciler readiness via the `ark-controller` Deployment's `Ready` condition
+- `setup-local.sh:132-220` is reduced to per-Deployment `kubectl wait` calls, dropping the API-group poll / aggregated-API stability / probe Model blocks
+- No `combined` role, no `deployment.split` value, no transitional escape hatch. A clean two-role topology is the single supported production configuration
 
 ## Capabilities
 
 ### New Capabilities
-- `split-apiserver-deployment`: the aggregated API server runs as its own Deployment, distinct from the reconciler Deployment, with per-component readiness probes and independent lifecycle
+- `split-apiserver-deployment`: the aggregated API server runs as its own Deployment on the PostgreSQL backend, distinct from the reconciler Deployment, with per-component readiness probes and independent lifecycle
 
 ### Modified Capabilities
-- `postgresql-backend`: no longer implies "embedded in ark-controller" — the backend is served by the dedicated `ark-apiserver` Deployment when split is enabled
+- `postgresql-backend`: served by a dedicated `ark-apiserver` Deployment. The embedded-in-controller implementation is removed
 
 ## Impact
 
-- `ark/cmd/main.go` — `--role` flag, conditional setup paths
-- `ark/cmd/apiserver/` — optional new entrypoint (or keep single binary with role flag)
-- `ark/internal/apiserver/server.go` — no changes expected; already a `Manager.Runnable`
-- `ark/internal/storage/postgresql/wal_consumer.go` — confirm WAL consumer belongs on the apiserver side; add leader-election within the apiserver fleet
-- `ark/dist/chart/templates/manager/manager.yaml` — skip API server ports/args when `deployment.split=true`
-- `ark/dist/chart/templates/apiserver/deployment.yaml` — new file, rendered only when `deployment.split=true`
-- `ark/dist/chart/templates/apiserver/service.yaml` — selector flips based on split mode
-- `ark/dist/chart/templates/apiserver/apiservice.yaml` — unchanged target, selector follows the Service
-- `ark/dist/chart/templates/apiserver/rbac.yaml` — split RBAC: API-side gets PG secrets, controller-side drops them
-- `ark/dist/chart/values.yaml` — `deployment.split` flag and per-role image/replicas/resources
+- `ark/cmd/main.go` — `--role` flag becomes required; role-scoped setup paths; no fallthrough
+- `ark/internal/apiserver/server.go` — unchanged (already a `Manager.Runnable`)
+- `ark/internal/storage/postgresql/wal_consumer.go` — lifecycle scoped to the apiserver role; add leader-election within the apiserver replica set
+- `ark/dist/chart/templates/manager/manager.yaml` — renamed/refactored to the controller-only Deployment; drop apiserver args/ports
+- `ark/dist/chart/templates/apiserver/deployment.yaml` — new file, rendered only when `storage.backend=postgresql`
+- `ark/dist/chart/templates/apiserver/service.yaml` — selector `app.kubernetes.io/name=ark-apiserver`, rendered only when `storage.backend=postgresql`
+- `ark/dist/chart/templates/apiserver/apiservice.yaml` — rendered only when `storage.backend=postgresql`; selector flip handled as part of the pre-upgrade hook ordering
+- `ark/dist/chart/templates/apiserver/rbac.yaml` — split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
+- `ark/dist/chart/templates/hooks/pre-upgrade-apiserver.yaml` — new file, pre-upgrade Helm hook that brings up `ark-apiserver` and waits for APIService `Available=True` before the controller Deployment rollout proceeds
+- `ark/dist/chart/values.yaml` — per-role image/replicas/resources blocks; no mode flag
 - `ark/dist/chart/values.schema.json` — schema updates
-- `.github/actions/setup-e2e/setup-local.sh` — add `DEPLOYMENT_SPLIT` arg and pass-through to Helm; lines 184-220 (probe Model) can be removed once split is the default
-- `tools/ark-cli/src/lib/readinessChecks.ts` — when split is detected (both Deployments exist), skip `waitForControllerReconciling`; rely on `kubectl wait` against each Deployment
-- `tools/ark-cli/src/arkServices.ts` — add `ark-apiserver` as a core service so layer 0 covers it automatically
+- `.github/actions/setup-e2e/setup-local.sh` — drop lines 132-220 and rely on per-Deployment `kubectl wait`
+- `tools/ark-cli/src/lib/readinessChecks.ts` — drop `waitForControllerReconciling`; add `ark-apiserver` to the deployments polled at layer 0 when the PostgreSQL backend is detected
+- `tools/ark-cli/src/arkServices.ts` — add `ark-apiserver` as a core service
 - No changes to controller reconcilers, webhooks, or CRD definitions

--- a/openspec/changes/split-apiserver-deployment/proposal.md
+++ b/openspec/changes/split-apiserver-deployment/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The ark-controller binary runs two distinct responsibilities in one process: the aggregated API server (`k8s.io/apiserver`) and the controller-runtime Manager (reconcilers, webhooks). The `ark-apiserver` Service selects the same pod via `app.kubernetes.io/name=ark-controller`, so Deployment readiness is ambiguous — `Ready=True` conflates "API serving" with "reconcilers reconciling".
+
+This ambiguity has caused repeated E2E flakiness. PR #1637 / #1763 documented a ~57 s window where the API served CRDs but reconcilers were idle (`tool-type-deprecation-warning`, `team-selector-invalid-agent` failures), requiring a throwaway Model probe in `setup-local.sh` to distinguish the two states. PR #1914 ports that probe into `ark status --wait-for-ready`, inheriting its problems: resource footprint, cleanup leaks on abnormal exit, race conditions between parallel clients.
+
+Splitting into two Deployments makes each pod's Ready condition mean exactly what it says and removes the need for the probe Model entirely.
+
+## What Changes
+
+- `ark/cmd/main.go` gains a `--role={combined,apiserver,controller}` flag (default `combined` for backward compatibility)
+- In `apiserver` mode, the process only starts the embedded aggregated API server + WAL consumer; no reconcilers, no webhooks
+- In `controller` mode, the process only starts controller-runtime (reconcilers + webhooks) and talks to the aggregated API via the normal k8s client path (kube-apiserver → `APIService` proxy → `ark-apiserver` Service)
+- Helm chart `ark/dist/chart` adds a second `Deployment` (`ark-apiserver`) when `storage.backend=postgresql` and `deployment.split=true`; `ark-controller` Deployment stops serving the API in that mode
+- Two leader-election Leases: `ark-apiserver-leader` (for the WAL consumer singleton) and `ark-controller-leader` (for the reconciler loop)
+- `ark-apiserver` Service selector flips to `app.kubernetes.io/name=ark-apiserver` when split is enabled
+- Startup ordering: `ark-controller` waits on `ark-apiserver` readiness (init container or Helm hook)
+- `tools/ark-cli/src/lib/readinessChecks.ts` drops layer 5 when both Deployments exist and are Ready — the probe Model is no longer needed
+- Migration path: `storage.backend=postgresql` + `deployment.split=false` (default) keeps the embedded behaviour; CI flips `deployment.split=true` first; docs/defaults follow after a release cycle of burn-in
+
+## Capabilities
+
+### New Capabilities
+- `split-apiserver-deployment`: the aggregated API server runs as its own Deployment, distinct from the reconciler Deployment, with per-component readiness probes and independent lifecycle
+
+### Modified Capabilities
+- `postgresql-backend`: no longer implies "embedded in ark-controller" — the backend is served by the dedicated `ark-apiserver` Deployment when split is enabled
+
+## Impact
+
+- `ark/cmd/main.go` — `--role` flag, conditional setup paths
+- `ark/cmd/apiserver/` — optional new entrypoint (or keep single binary with role flag)
+- `ark/internal/apiserver/server.go` — no changes expected; already a `Manager.Runnable`
+- `ark/internal/storage/postgresql/wal_consumer.go` — confirm WAL consumer belongs on the apiserver side; add leader-election within the apiserver fleet
+- `ark/dist/chart/templates/manager/manager.yaml` — skip API server ports/args when `deployment.split=true`
+- `ark/dist/chart/templates/apiserver/deployment.yaml` — new file, rendered only when `deployment.split=true`
+- `ark/dist/chart/templates/apiserver/service.yaml` — selector flips based on split mode
+- `ark/dist/chart/templates/apiserver/apiservice.yaml` — unchanged target, selector follows the Service
+- `ark/dist/chart/templates/apiserver/rbac.yaml` — split RBAC: API-side gets PG secrets, controller-side drops them
+- `ark/dist/chart/values.yaml` — `deployment.split` flag and per-role image/replicas/resources
+- `ark/dist/chart/values.schema.json` — schema updates
+- `.github/actions/setup-e2e/setup-local.sh` — add `DEPLOYMENT_SPLIT` arg and pass-through to Helm; lines 184-220 (probe Model) can be removed once split is the default
+- `tools/ark-cli/src/lib/readinessChecks.ts` — when split is detected (both Deployments exist), skip `waitForControllerReconciling`; rely on `kubectl wait` against each Deployment
+- `tools/ark-cli/src/arkServices.ts` — add `ark-apiserver` as a core service so layer 0 covers it automatically
+- No changes to controller reconcilers, webhooks, or CRD definitions

--- a/openspec/changes/split-apiserver-deployment/proposal.md
+++ b/openspec/changes/split-apiserver-deployment/proposal.md
@@ -11,11 +11,12 @@ Splitting into two Deployments makes each pod's Ready condition mean exactly wha
 - `ark/cmd/main.go` takes a required `--role={apiserver,controller}` flag
 - In `apiserver` role, the process only starts the embedded aggregated API server + WAL consumer; no reconcilers, no webhooks
 - In `controller` role, the process only starts controller-runtime (reconcilers + webhooks) and talks to the aggregated API via the normal k8s client path (kube-apiserver → `APIService` proxy → `ark-apiserver` Service)
-- Helm chart `ark/dist/chart` always renders a `controller` Deployment. When `storage.backend=postgresql` it additionally renders an `apiserver` Deployment. Etcd backend stays single-Deployment (no aggregated API server is needed on etcd)
+- `ark/dist/chart` remains the `ark-controller` chart — reconcilers, webhooks, CRDs. On the split it drops the apiserver args/ports and sets `--role=controller`
+- New chart `ark/dist/chart-apiserver` owns the `ark-apiserver` Deployment, the `ark-apiserver` Service (selector `app.kubernetes.io/name=ark-apiserver`), the `APIService` CR, and the apiserver-side RBAC. Installed only on the PostgreSQL backend
+- Two Helm releases on PostgreSQL (`ark-apiserver` + `ark-controller`); one Helm release on etcd (`ark-controller` only)
 - Two leader-election Leases: `ark-apiserver-leader` (for the WAL consumer singleton) and `ark-controller-leader` (for the reconciler loop)
-- `ark-apiserver` Service selector points at `app.kubernetes.io/name=ark-apiserver` on PostgreSQL; Service is not rendered on etcd
-- Startup ordering: `ark-controller` waits on `ark-apiserver` readiness via init container plus a Helm pre-upgrade hook
-- Helm upgrade from the current embedded topology to the split topology is one-way and zero-data-loss: the pre-upgrade hook brings up `ark-apiserver`, the APIService selector flips, then `ark-controller` is upgraded to drop the embedded API server args
+- Startup ordering via install order (`ark-apiserver` first) plus an `ark-controller` init container that blocks on APIService `Available=True`; no cross-chart Helm hooks
+- Upgrade from the current embedded topology is a two-step sequence: (1) `helm install ark-apiserver ark/dist/chart-apiserver --wait` takes ownership of the APIService and flips the endpoints to the new pods; (2) `helm upgrade ark-controller ark/dist/chart` drops the embedded apiserver args. No window where the APIService is unavailable
 - `tools/ark-cli/src/lib/readinessChecks.ts` drops the probe Model check entirely — layer 0 covers reconciler readiness via the `ark-controller` Deployment's `Ready` condition
 - `setup-local.sh:132-220` is reduced to per-Deployment `kubectl wait` calls, dropping the API-group poll / aggregated-API stability / probe Model blocks
 - No `combined` role, no `deployment.split` value, no transitional escape hatch. A clean two-role topology is the single supported production configuration
@@ -33,14 +34,16 @@ Splitting into two Deployments makes each pod's Ready condition mean exactly wha
 - `ark/cmd/main.go` — `--role` flag becomes required; role-scoped setup paths; no fallthrough
 - `ark/internal/apiserver/server.go` — unchanged (already a `Manager.Runnable`)
 - `ark/internal/storage/postgresql/wal_consumer.go` — lifecycle scoped to the apiserver role; add leader-election within the apiserver replica set
-- `ark/dist/chart/templates/manager/manager.yaml` — renamed/refactored to the controller-only Deployment; drop apiserver args/ports
-- `ark/dist/chart/templates/apiserver/deployment.yaml` — new file, rendered only when `storage.backend=postgresql`
-- `ark/dist/chart/templates/apiserver/service.yaml` — selector `app.kubernetes.io/name=ark-apiserver`, rendered only when `storage.backend=postgresql`
-- `ark/dist/chart/templates/apiserver/apiservice.yaml` — rendered only when `storage.backend=postgresql`; selector flip handled as part of the pre-upgrade hook ordering
-- `ark/dist/chart/templates/apiserver/rbac.yaml` — split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
-- `ark/dist/chart/templates/hooks/pre-upgrade-apiserver.yaml` — new file, pre-upgrade Helm hook that brings up `ark-apiserver` and waits for APIService `Available=True` before the controller Deployment rollout proceeds
-- `ark/dist/chart/values.yaml` — per-role image/replicas/resources blocks; no mode flag
-- `ark/dist/chart/values.schema.json` — schema updates
+- `ark/dist/chart/templates/manager/manager.yaml` — drop apiserver args/ports; set `--role=controller`
+- `ark/dist/chart/templates/init/wait-for-apiserver.yaml` — `ark-controller` init container block that waits on APIService `Available=True`
+- `ark/dist/chart/values.yaml` — drop apiserver-related values; controller-only config remains
+- `ark/dist/chart-apiserver/` — new chart directory
+- `ark/dist/chart-apiserver/Chart.yaml` — name `ark-apiserver`, version aligned with the operator release
+- `ark/dist/chart-apiserver/values.yaml` + `values.schema.json` — apiserver image/replicas/resources, PG connection config, `ark-apiserver-leader` Lease config
+- `ark/dist/chart-apiserver/templates/deployment.yaml` — runs `--role=apiserver`
+- `ark/dist/chart-apiserver/templates/service.yaml` — selector `app.kubernetes.io/name=ark-apiserver`, name `ark-apiserver` (stable across migrations)
+- `ark/dist/chart-apiserver/templates/apiservice.yaml` — `APIService` CR targeting the Service; owned by this chart
+- `ark/dist/chart-apiserver/templates/rbac.yaml` — apiserver ServiceAccount + PG secret access
 - `.github/actions/setup-e2e/setup-local.sh` — drop lines 132-220 and rely on per-Deployment `kubectl wait`
 - `tools/ark-cli/src/lib/readinessChecks.ts` — drop `waitForControllerReconciling`; add `ark-apiserver` to the deployments polled at layer 0 when the PostgreSQL backend is detected
 - `tools/ark-cli/src/arkServices.ts` — add `ark-apiserver` as a core service

--- a/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
+++ b/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
@@ -1,14 +1,8 @@
 ## ADDED Requirements
 
-### Requirement: Operator binary supports per-role startup
+### Requirement: Operator binary requires explicit role
 
-The ark-controller binary SHALL accept a `--role={combined,apiserver,controller}` flag. In `combined` mode the process behaves exactly as the current implementation (embedded aggregated API server + reconcilers + webhooks). In `apiserver` mode the process starts only the aggregated API server and the WAL consumer. In `controller` mode the process starts only the controller-runtime Manager (reconcilers + webhooks) and communicates with the aggregated API via a standard Kubernetes client.
-
-#### Scenario: combined mode preserves current behaviour
-
-- **WHEN** the binary is started with `--role=combined` or no role flag
-- **THEN** both the aggregated API server and the reconcilers run in the same process, using the same leader-election Lease as today
-- **AND** no behaviour visible to Helm charts, CLI, or clients changes
+The ark-controller binary SHALL accept a required `--role={apiserver,controller}` flag. In `apiserver` mode the process starts only the aggregated API server and the WAL consumer. In `controller` mode the process starts only the controller-runtime Manager (reconcilers + webhooks) and communicates with the aggregated API via a standard Kubernetes client. The binary SHALL fail fast with a clear error message if the flag is missing or has an unrecognised value.
 
 #### Scenario: apiserver role skips reconcilers
 
@@ -16,7 +10,7 @@ The ark-controller binary SHALL accept a `--role={combined,apiserver,controller}
 - **THEN** `setupEmbeddedApiserver()` runs and the API server binds its port
 - **AND** the WAL consumer is started behind leader-election against `ark-apiserver-leader` Lease
 - **AND** no reconcilers, webhooks, or controller-runtime caches are started
-- **AND** non-leader replicas serve read traffic without running the WAL consumer
+- **AND** non-leader replicas serve read traffic without opening a PG replication slot
 
 #### Scenario: controller role skips apiserver
 
@@ -26,35 +20,41 @@ The ark-controller binary SHALL accept a `--role={combined,apiserver,controller}
 - **AND** the Manager's k8s client reaches the aggregated API via kube-apiserver → APIService proxy → `ark-apiserver` Service
 - **AND** leader election uses the `ark-controller-leader` Lease
 
-### Requirement: Helm chart renders two Deployments when split is enabled
+#### Scenario: missing role flag fails the process
 
-The `ark/dist/chart` chart SHALL accept a `deployment.split` boolean value (default `false`). When `deployment.split=true` and `storage.backend=postgresql`, the chart renders two Deployments: `ark-apiserver` and `ark-controller`. When `deployment.split=false` (or `storage.backend=etcd`), the chart renders a single `ark-controller` Deployment as today.
+- **WHEN** the binary is started without `--role`
+- **THEN** the process exits with a non-zero status and a log message indicating the flag is required
 
-#### Scenario: combined mode renders one Deployment
+### Requirement: Helm chart renders topology per backend
 
-- **WHEN** `helm install ark-controller ark/dist/chart --set deployment.split=false`
-- **THEN** a single `ark-controller` Deployment is rendered, running `--role=combined`
-- **AND** the `ark-apiserver` Service selector points to pods labelled `app.kubernetes.io/name=ark-controller`
+On `storage.backend=etcd`, the chart SHALL render a single `ark-controller` Deployment running `--role=controller` and no `ark-apiserver` Deployment, Service, or APIService. On `storage.backend=postgresql`, the chart SHALL additionally render an `ark-apiserver` Deployment, an `ark-apiserver` Service with selector `app.kubernetes.io/name=ark-apiserver`, and an `APIService` resource targeting that Service.
 
-#### Scenario: split mode renders two Deployments with ordered startup
+#### Scenario: etcd backend renders a single Deployment
 
-- **WHEN** `helm install ark-controller ark/dist/chart --set deployment.split=true --set storage.backend=postgresql`
+- **WHEN** `helm install ark-controller ark/dist/chart --set storage.backend=etcd`
+- **THEN** one `ark-controller` Deployment is rendered, running `--role=controller`
+- **AND** no `ark-apiserver` Deployment, Service, or APIService is present
+- **AND** existing etcd-backend functionality is unchanged
+
+#### Scenario: postgresql backend renders two Deployments with ordered startup
+
+- **WHEN** `helm install ark-controller ark/dist/chart --set storage.backend=postgresql`
 - **THEN** an `ark-apiserver` Deployment is rendered running `--role=apiserver`
 - **AND** an `ark-controller` Deployment is rendered running `--role=controller`
+- **AND** the `ark-apiserver` Service has selector `app.kubernetes.io/name=ark-apiserver`
 - **AND** the `ark-controller` Deployment includes an init container `wait-for-apiserver` that blocks on APIService `Available=True`
-- **AND** the `ark-apiserver` Service selector points to pods labelled `app.kubernetes.io/name=ark-apiserver`
-- **AND** a Helm post-install hook blocks chart completion until the APIService reports `Available=True`
+- **AND** a Helm pre-upgrade hook ensures the APIService is `Available` before the controller rollout proceeds
 
-#### Scenario: upgrading from combined to split preserves cluster state
+#### Scenario: upgrading from embedded topology to split preserves cluster state
 
-- **WHEN** `helm upgrade` is run on a cluster currently running `deployment.split=false` with existing Agent/Model/Query resources, with `--set deployment.split=true`
+- **WHEN** `helm upgrade` runs on a cluster currently running the embedded topology (single `ark-controller` Deployment with `storage.backend=postgresql`) with existing Agent/Model/Query resources
 - **THEN** the upgrade succeeds without data loss
-- **AND** existing resources remain queryable via the aggregated API both during and after the upgrade
-- **AND** reconciliation of existing resources resumes without manual intervention
+- **AND** existing resources remain queryable via the aggregated API throughout the upgrade (no window where the APIService is unavailable)
+- **AND** reconciliation of existing resources resumes on the new `ark-controller` Deployment without manual intervention
 
 ### Requirement: Per-role readiness probes distinguish API serving from reconciler liveness
 
-Each Deployment SHALL expose a `/readyz` endpoint that reports readiness specific to its role. `ark-apiserver` SHALL return 200 only when the PG connection is established and the aggregated API is serving. `ark-controller` SHALL return 200 only when informer caches are fully synced and at least one reconciliation has completed on each registered CRD.
+Each Deployment SHALL expose a `/readyz` endpoint specific to its role. `ark-apiserver` SHALL return 200 only when the PG connection is established and the aggregated API is serving. `ark-controller` SHALL return 200 only when informer caches are fully synced and at least one reconciliation has completed on each registered CRD.
 
 #### Scenario: apiserver not ready while PG is reconnecting
 
@@ -69,23 +69,24 @@ Each Deployment SHALL expose a `/readyz` endpoint that reports readiness specifi
 - **THEN** `/readyz` returns non-200 until cache sync completes and one reconcile cycle has been observed on each CRD
 - **AND** the Deployment `Ready` condition remains `False` during this window
 
-### Requirement: CLI readiness checks collapse to per-Deployment waits when split is enabled
+### Requirement: CLI readiness checks rely on per-Deployment waits on PostgreSQL
 
-The `ark-cli` `readinessChecks.ts` module SHALL detect whether the cluster is running in split mode (by checking for a Deployment named `ark-apiserver` in the `ark-system` namespace) and SHALL skip the probe Model check (`waitForControllerReconciling`) in that case. The existing deployment readiness layer (layer 0) SHALL include `ark-apiserver` as a core service when split is detected.
+The `ark-cli` `readinessChecks.ts` module SHALL treat `ark-apiserver` as a core service when the PostgreSQL backend is detected (no `agents.ark.mckinsey.com` CRD present). Layer 0 (`waitForServicesReady`) SHALL cover both `ark-apiserver` and `ark-controller`. The probe Model code path (`waitForControllerReconciling`, `ark-readiness-probe` namespace, apply/delete logic) SHALL be removed.
 
-#### Scenario: CLI against a split-mode cluster skips the probe Model
+#### Scenario: CLI against a PostgreSQL cluster waits on both Deployments
 
-- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with both `ark-apiserver` and `ark-controller` Deployments present
-- **THEN** layers 0-4 run as today (deployments, APIServices, API group, aggregated API stable)
-- **AND** layer 5 (probe Model) is skipped
+- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with `storage.backend=postgresql`
+- **THEN** layer 0 waits for both `ark-apiserver` and `ark-controller` Deployment `Ready` conditions
+- **AND** layers for APIServices available and API group registered still run as integration sanity
 - **AND** no `ark-readiness-probe` namespace is created
-- **AND** the `ark status` output reports readiness as soon as both Deployments' `Ready` conditions are `True` and layers 1-4 pass
+- **AND** the command exits 0 as soon as both Deployments are Ready and the APIService is Available
 
-#### Scenario: CLI against a combined-mode cluster retains today's behaviour
+#### Scenario: CLI against an etcd cluster waits on controller only
 
-- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with only the `ark-controller` Deployment (no `ark-apiserver` Deployment)
-- **THEN** layer 5 (probe Model) runs as it does today
-- **AND** the `ark-readiness-probe` namespace is created and deleted as part of the check
+- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with `storage.backend=etcd`
+- **THEN** layer 0 waits for `ark-controller` Deployment `Ready` condition
+- **AND** no APIService / API-group / aggregated-API layers run
+- **AND** the command exits 0 as soon as the controller Deployment is Ready
 
 ### Requirement: WAL consumer remains singleton across apiserver replicas
 

--- a/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
+++ b/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Operator binary supports per-role startup
+
+The ark-controller binary SHALL accept a `--role={combined,apiserver,controller}` flag. In `combined` mode the process behaves exactly as the current implementation (embedded aggregated API server + reconcilers + webhooks). In `apiserver` mode the process starts only the aggregated API server and the WAL consumer. In `controller` mode the process starts only the controller-runtime Manager (reconcilers + webhooks) and communicates with the aggregated API via a standard Kubernetes client.
+
+#### Scenario: combined mode preserves current behaviour
+
+- **WHEN** the binary is started with `--role=combined` or no role flag
+- **THEN** both the aggregated API server and the reconcilers run in the same process, using the same leader-election Lease as today
+- **AND** no behaviour visible to Helm charts, CLI, or clients changes
+
+#### Scenario: apiserver role skips reconcilers
+
+- **WHEN** the binary is started with `--role=apiserver`
+- **THEN** `setupEmbeddedApiserver()` runs and the API server binds its port
+- **AND** the WAL consumer is started behind leader-election against `ark-apiserver-leader` Lease
+- **AND** no reconcilers, webhooks, or controller-runtime caches are started
+- **AND** non-leader replicas serve read traffic without running the WAL consumer
+
+#### Scenario: controller role skips apiserver
+
+- **WHEN** the binary is started with `--role=controller`
+- **THEN** controller-runtime Manager starts with reconcilers and webhooks
+- **AND** `setupEmbeddedApiserver()` does NOT run
+- **AND** the Manager's k8s client reaches the aggregated API via kube-apiserver → APIService proxy → `ark-apiserver` Service
+- **AND** leader election uses the `ark-controller-leader` Lease
+
+### Requirement: Helm chart renders two Deployments when split is enabled
+
+The `ark/dist/chart` chart SHALL accept a `deployment.split` boolean value (default `false`). When `deployment.split=true` and `storage.backend=postgresql`, the chart renders two Deployments: `ark-apiserver` and `ark-controller`. When `deployment.split=false` (or `storage.backend=etcd`), the chart renders a single `ark-controller` Deployment as today.
+
+#### Scenario: combined mode renders one Deployment
+
+- **WHEN** `helm install ark-controller ark/dist/chart --set deployment.split=false`
+- **THEN** a single `ark-controller` Deployment is rendered, running `--role=combined`
+- **AND** the `ark-apiserver` Service selector points to pods labelled `app.kubernetes.io/name=ark-controller`
+
+#### Scenario: split mode renders two Deployments with ordered startup
+
+- **WHEN** `helm install ark-controller ark/dist/chart --set deployment.split=true --set storage.backend=postgresql`
+- **THEN** an `ark-apiserver` Deployment is rendered running `--role=apiserver`
+- **AND** an `ark-controller` Deployment is rendered running `--role=controller`
+- **AND** the `ark-controller` Deployment includes an init container `wait-for-apiserver` that blocks on APIService `Available=True`
+- **AND** the `ark-apiserver` Service selector points to pods labelled `app.kubernetes.io/name=ark-apiserver`
+- **AND** a Helm post-install hook blocks chart completion until the APIService reports `Available=True`
+
+#### Scenario: upgrading from combined to split preserves cluster state
+
+- **WHEN** `helm upgrade` is run on a cluster currently running `deployment.split=false` with existing Agent/Model/Query resources, with `--set deployment.split=true`
+- **THEN** the upgrade succeeds without data loss
+- **AND** existing resources remain queryable via the aggregated API both during and after the upgrade
+- **AND** reconciliation of existing resources resumes without manual intervention
+
+### Requirement: Per-role readiness probes distinguish API serving from reconciler liveness
+
+Each Deployment SHALL expose a `/readyz` endpoint that reports readiness specific to its role. `ark-apiserver` SHALL return 200 only when the PG connection is established and the aggregated API is serving. `ark-controller` SHALL return 200 only when informer caches are fully synced and at least one reconciliation has completed on each registered CRD.
+
+#### Scenario: apiserver not ready while PG is reconnecting
+
+- **WHEN** the `ark-apiserver` pod loses its PG connection
+- **THEN** `/readyz` returns non-200 until reconnection completes
+- **AND** the Deployment `Ready` condition flips to `False`
+- **AND** clients see `APIService Available=False` until recovery
+
+#### Scenario: controller not ready while informers are syncing
+
+- **WHEN** the `ark-controller` pod starts and its informers are still synchronising
+- **THEN** `/readyz` returns non-200 until cache sync completes and one reconcile cycle has been observed on each CRD
+- **AND** the Deployment `Ready` condition remains `False` during this window
+
+### Requirement: CLI readiness checks collapse to per-Deployment waits when split is enabled
+
+The `ark-cli` `readinessChecks.ts` module SHALL detect whether the cluster is running in split mode (by checking for a Deployment named `ark-apiserver` in the `ark-system` namespace) and SHALL skip the probe Model check (`waitForControllerReconciling`) in that case. The existing deployment readiness layer (layer 0) SHALL include `ark-apiserver` as a core service when split is detected.
+
+#### Scenario: CLI against a split-mode cluster skips the probe Model
+
+- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with both `ark-apiserver` and `ark-controller` Deployments present
+- **THEN** layers 0-4 run as today (deployments, APIServices, API group, aggregated API stable)
+- **AND** layer 5 (probe Model) is skipped
+- **AND** no `ark-readiness-probe` namespace is created
+- **AND** the `ark status` output reports readiness as soon as both Deployments' `Ready` conditions are `True` and layers 1-4 pass
+
+#### Scenario: CLI against a combined-mode cluster retains today's behaviour
+
+- **WHEN** `ark status --wait-for-ready=60s` runs against a cluster with only the `ark-controller` Deployment (no `ark-apiserver` Deployment)
+- **THEN** layer 5 (probe Model) runs as it does today
+- **AND** the `ark-readiness-probe` namespace is created and deleted as part of the check
+
+### Requirement: WAL consumer remains singleton across apiserver replicas
+
+When the `ark-apiserver` Deployment has more than one replica, exactly one replica at a time SHALL run the WAL consumer. Leader election via the `ark-apiserver-leader` Lease determines the WAL-consumer replica. Non-leader replicas SHALL serve read traffic normally but SHALL NOT open a PG logical replication slot.
+
+#### Scenario: apiserver replica loses leader election
+
+- **WHEN** the replica currently running the WAL consumer loses the `ark-apiserver-leader` Lease (e.g., pod restart)
+- **THEN** the WAL consumer is shut down cleanly and the replication slot is released
+- **AND** another replica acquires the Lease and starts the WAL consumer on a fresh replication slot
+- **AND** no change events are lost or delivered twice across the switchover

--- a/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
+++ b/openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md
@@ -25,32 +25,35 @@ The ark-controller binary SHALL accept a required `--role={apiserver,controller}
 - **WHEN** the binary is started without `--role`
 - **THEN** the process exits with a non-zero status and a log message indicating the flag is required
 
-### Requirement: Helm chart renders topology per backend
+### Requirement: Two separate Helm charts own the two Deployments
 
-On `storage.backend=etcd`, the chart SHALL render a single `ark-controller` Deployment running `--role=controller` and no `ark-apiserver` Deployment, Service, or APIService. On `storage.backend=postgresql`, the chart SHALL additionally render an `ark-apiserver` Deployment, an `ark-apiserver` Service with selector `app.kubernetes.io/name=ark-apiserver`, and an `APIService` resource targeting that Service.
+The `ark/dist/chart` chart (`ark-controller`) SHALL render only the controller Deployment, CRDs, webhooks, and controller-side RBAC. The `ark/dist/chart-apiserver` chart (`ark-apiserver`) SHALL render the apiserver Deployment, the `ark-apiserver` Service, the `APIService` CR, and the apiserver-side RBAC. On etcd, only the `ark-controller` chart is installed. On PostgreSQL, both charts are installed, with `ark-apiserver` first.
 
-#### Scenario: etcd backend renders a single Deployment
+#### Scenario: etcd backend is a single-chart install
 
 - **WHEN** `helm install ark-controller ark/dist/chart --set storage.backend=etcd`
 - **THEN** one `ark-controller` Deployment is rendered, running `--role=controller`
-- **AND** no `ark-apiserver` Deployment, Service, or APIService is present
+- **AND** no `ark-apiserver` Deployment, Service, APIService, or chart installation is present
 - **AND** existing etcd-backend functionality is unchanged
 
-#### Scenario: postgresql backend renders two Deployments with ordered startup
+#### Scenario: postgresql backend is a two-chart install with ordered startup
 
-- **WHEN** `helm install ark-controller ark/dist/chart --set storage.backend=postgresql`
-- **THEN** an `ark-apiserver` Deployment is rendered running `--role=apiserver`
-- **AND** an `ark-controller` Deployment is rendered running `--role=controller`
+- **WHEN** `helm install ark-apiserver ark/dist/chart-apiserver --wait` completes
+- **AND** `helm install ark-controller ark/dist/chart --set storage.backend=postgresql` runs
+- **THEN** the `ark-apiserver` Deployment is running `--role=apiserver`
+- **AND** the `ark-controller` Deployment is running `--role=controller`
 - **AND** the `ark-apiserver` Service has selector `app.kubernetes.io/name=ark-apiserver`
-- **AND** the `ark-controller` Deployment includes an init container `wait-for-apiserver` that blocks on APIService `Available=True`
-- **AND** a Helm pre-upgrade hook ensures the APIService is `Available` before the controller rollout proceeds
+- **AND** the `APIService` CR targeting `ark-system/ark-apiserver` is present and `Available=True`
+- **AND** the `ark-controller` Deployment includes an init container `wait-for-apiserver` that blocks on APIService `Available=True` for any pod restart after install
 
 #### Scenario: upgrading from embedded topology to split preserves cluster state
 
-- **WHEN** `helm upgrade` runs on a cluster currently running the embedded topology (single `ark-controller` Deployment with `storage.backend=postgresql`) with existing Agent/Model/Query resources
-- **THEN** the upgrade succeeds without data loss
-- **AND** existing resources remain queryable via the aggregated API throughout the upgrade (no window where the APIService is unavailable)
-- **AND** reconciliation of existing resources resumes on the new `ark-controller` Deployment without manual intervention
+- **WHEN** `helm install ark-apiserver ark/dist/chart-apiserver --wait` runs on a cluster currently running the embedded topology (single `ark-controller` Deployment with `storage.backend=postgresql`), followed by `helm upgrade ark-controller ark/dist/chart` with the new chart version
+- **THEN** the two-step upgrade succeeds without data loss
+- **AND** the `APIService` endpoints flip from the old controller pods to the new apiserver pods during step 1, with no window where the APIService is unavailable
+- **AND** existing Agent/Model/Query resources remain queryable via the aggregated API throughout the upgrade
+- **AND** reconciliation of existing resources resumes on the new `ark-controller` Deployment after step 2 without manual intervention
+- **AND** `helm rollback` on either chart reverses its side of the migration independently
 
 ### Requirement: Per-role readiness probes distinguish API serving from reconciler liveness
 

--- a/openspec/changes/split-apiserver-deployment/tasks.md
+++ b/openspec/changes/split-apiserver-deployment/tasks.md
@@ -1,0 +1,53 @@
+## 1. Operator binary
+
+- [ ] 1.1 Add `--role={combined,apiserver,controller}` flag to `ark/cmd/main.go`, default `combined`
+- [ ] 1.2 Skip `setupEmbeddedApiserver()` when role is `controller`; skip reconciler/webhook setup when role is `apiserver`
+- [ ] 1.3 Scope leader-election Lease names per role (`ark-apiserver-leader`, `ark-controller-leader`)
+- [ ] 1.4 In `apiserver` role, leader-elect the WAL consumer within the apiserver replica set; non-leaders skip WAL setup but continue to serve reads
+- [ ] 1.5 Add health endpoints: `/readyz` on apiserver returns 200 when PG connected and API serving; on controller returns 200 when informers synced and at least one reconcile has completed
+- [ ] 1.6 Unit tests for role dispatch and leader-election scoping
+
+## 2. Helm chart
+
+- [ ] 2.1 Add `deployment.split` boolean to `ark/dist/chart/values.yaml` (default `false`) and schema
+- [ ] 2.2 Render `ark-apiserver` Deployment from `ark/dist/chart/templates/apiserver/deployment.yaml` when `deployment.split=true`
+- [ ] 2.3 Flip `ark-apiserver` Service selector to `app.kubernetes.io/name=ark-apiserver` when `deployment.split=true`; keep pointing to controller pods otherwise
+- [ ] 2.4 Omit apiserver args/ports from `ark-controller` Deployment when `deployment.split=true`
+- [ ] 2.5 Add init container `wait-for-apiserver` on `ark-controller` when `deployment.split=true`
+- [ ] 2.6 Add Helm post-install hook that blocks on `APIService v1alpha1.ark.mckinsey.com` condition `Available=True`
+- [ ] 2.7 Split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
+- [ ] 2.8 Chart template unit tests (`helm template` snapshot) for combined and split modes
+
+## 3. E2E setup
+
+- [ ] 3.1 Add `--deployment-split` arg to `.github/actions/setup-e2e/setup-local.sh`; pass through to Helm
+- [ ] 3.2 Add E2E matrix leg that runs PostgreSQL backend with `deployment-split=true`
+- [ ] 3.3 Once split-mode E2E is green across a release cycle, remove `setup-local.sh:184-220` (probe Model check) and rely on per-Deployment `kubectl wait`
+
+## 4. CLI readiness checks
+
+- [ ] 4.1 Add `ark-apiserver` to `tools/ark-cli/src/arkServices.ts` as a core service (gated on split detection)
+- [ ] 4.2 In `readinessChecks.ts`, detect split by checking for `deployment/ark-apiserver` in `ark-system`
+- [ ] 4.3 When split is detected, skip `waitForControllerReconciling` (probe Model) — layer 0 covers it
+- [ ] 4.4 Unit tests for split detection and probe-skip behaviour
+- [ ] 4.5 Remove probe Model code path entirely once combined mode is removed (tracked in §7)
+
+## 5. Migration and documentation
+
+- [ ] 5.1 Release notes section explaining split vs combined, when to use each, how to upgrade
+- [ ] 5.2 `helm upgrade` integration test: combined → split on a live cluster with existing Ark resources, assert zero data loss
+- [ ] 5.3 Document `--role` flag and `deployment.split` value in `docs/`
+- [ ] 5.4 Update `SIMPLE-ARCHITECTURE-GUIDE.md` and `ARK-ARCHITECTURE.md` to reflect the two-deployment topology
+
+## 6. Performance validation
+
+- [ ] 6.1 Benchmark write latency (reconciler → status) on combined vs split, same cluster, 100 and 1 000 Models reconciling in parallel
+- [ ] 6.2 Benchmark read latency for API consumers (e.g., `ark list agents` on a 10 k-resource cluster)
+- [ ] 6.3 If write latency regression exceeds a threshold (TBD, e.g. 50 ms p99), investigate in-cluster network / APIService proxy overhead before promoting split to default
+
+## 7. Promote split to default and remove combined
+
+- [ ] 7.1 After a release cycle of CI burn-in with `deployment.split=true`, flip the default in `values.yaml`
+- [ ] 7.2 Mark `--role=combined` as deprecated in release notes
+- [ ] 7.3 After one further release cycle, remove the `combined` role code path
+- [ ] 7.4 Remove the probe Model code path from `readinessChecks.ts` and `setup-local.sh` entirely

--- a/openspec/changes/split-apiserver-deployment/tasks.md
+++ b/openspec/changes/split-apiserver-deployment/tasks.md
@@ -1,53 +1,48 @@
 ## 1. Operator binary
 
-- [ ] 1.1 Add `--role={combined,apiserver,controller}` flag to `ark/cmd/main.go`, default `combined`
-- [ ] 1.2 Skip `setupEmbeddedApiserver()` when role is `controller`; skip reconciler/webhook setup when role is `apiserver`
-- [ ] 1.3 Scope leader-election Lease names per role (`ark-apiserver-leader`, `ark-controller-leader`)
-- [ ] 1.4 In `apiserver` role, leader-elect the WAL consumer within the apiserver replica set; non-leaders skip WAL setup but continue to serve reads
-- [ ] 1.5 Add health endpoints: `/readyz` on apiserver returns 200 when PG connected and API serving; on controller returns 200 when informers synced and at least one reconcile has completed
-- [ ] 1.6 Unit tests for role dispatch and leader-election scoping
+- [ ] 1.1 Add required `--role={apiserver,controller}` flag to `ark/cmd/main.go`; fail to start with a clear error if the flag is missing
+- [ ] 1.2 In `apiserver` role, run `setupEmbeddedApiserver` plus the WAL consumer (leader-elected); skip all reconciler, webhook, and non-apiserver Manager runnables
+- [ ] 1.3 In `controller` role, run reconcilers and webhooks; do not call `setupEmbeddedApiserver`; use a plain k8s client for aggregated API access
+- [ ] 1.4 Scope leader-election Lease names per role (`ark-apiserver-leader`, `ark-controller-leader`)
+- [ ] 1.5 Non-leader replicas in `apiserver` role serve read traffic without opening a PG replication slot
+- [ ] 1.6 Add health endpoints: `/readyz` on apiserver returns 200 when PG connected and API serving; on controller returns 200 when informers synced and at least one reconcile has completed
+- [ ] 1.7 Unit tests for role dispatch, leader-election scoping, and the non-leader-skips-WAL path
 
 ## 2. Helm chart
 
-- [ ] 2.1 Add `deployment.split` boolean to `ark/dist/chart/values.yaml` (default `false`) and schema
-- [ ] 2.2 Render `ark-apiserver` Deployment from `ark/dist/chart/templates/apiserver/deployment.yaml` when `deployment.split=true`
-- [ ] 2.3 Flip `ark-apiserver` Service selector to `app.kubernetes.io/name=ark-apiserver` when `deployment.split=true`; keep pointing to controller pods otherwise
-- [ ] 2.4 Omit apiserver args/ports from `ark-controller` Deployment when `deployment.split=true`
-- [ ] 2.5 Add init container `wait-for-apiserver` on `ark-controller` when `deployment.split=true`
-- [ ] 2.6 Add Helm post-install hook that blocks on `APIService v1alpha1.ark.mckinsey.com` condition `Available=True`
-- [ ] 2.7 Split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
-- [ ] 2.8 Chart template unit tests (`helm template` snapshot) for combined and split modes
+- [ ] 2.1 Rename the existing controller Deployment template to reflect its controller-only responsibility; drop apiserver args/ports from it; set `--role=controller`
+- [ ] 2.2 New `ark/dist/chart/templates/apiserver/deployment.yaml` rendered when `storage.backend=postgresql`; `--role=apiserver` arg; per-replica image and resources from values
+- [ ] 2.3 New `ark/dist/chart/templates/apiserver/service.yaml` with selector `app.kubernetes.io/name=ark-apiserver`, rendered when `storage.backend=postgresql`
+- [ ] 2.4 `apiservice.yaml` rendered when `storage.backend=postgresql`; target the apiserver Service
+- [ ] 2.5 Split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
+- [ ] 2.6 `templates/hooks/pre-upgrade-apiserver.yaml` — Helm pre-upgrade hook that applies the apiserver Deployment/Service, waits for `APIService v1alpha1.ark.mckinsey.com` condition `Available=True`, flips the APIService selector, then returns
+- [ ] 2.7 `ark-controller` Deployment init container `wait-for-apiserver` that blocks on the APIService condition (covers pod restarts after initial upgrade)
+- [ ] 2.8 Chart template unit tests (`helm template` snapshot) for etcd and postgresql backends
 
 ## 3. E2E setup
 
-- [ ] 3.1 Add `--deployment-split` arg to `.github/actions/setup-e2e/setup-local.sh`; pass through to Helm
-- [ ] 3.2 Add E2E matrix leg that runs PostgreSQL backend with `deployment-split=true`
-- [ ] 3.3 Once split-mode E2E is green across a release cycle, remove `setup-local.sh:184-220` (probe Model check) and rely on per-Deployment `kubectl wait`
+- [ ] 3.1 Strip `.github/actions/setup-e2e/setup-local.sh` lines 132-220 (API-group poll / aggregated-API warmup / probe Model); rely on `kubectl wait` on `ark-apiserver` and `ark-controller` Deployments
+- [ ] 3.2 Update the existing `postgresql` E2E matrix leg to use the split-mode chart values (no new matrix entry — the split becomes the only topology)
+- [ ] 3.3 Add an upgrade-in-place E2E job: seed a PostgreSQL cluster on the previous release, run `helm upgrade` to this release, assert Agent/Model/Query resources remain reachable and reconciling throughout
 
 ## 4. CLI readiness checks
 
-- [ ] 4.1 Add `ark-apiserver` to `tools/ark-cli/src/arkServices.ts` as a core service (gated on split detection)
-- [ ] 4.2 In `readinessChecks.ts`, detect split by checking for `deployment/ark-apiserver` in `ark-system`
-- [ ] 4.3 When split is detected, skip `waitForControllerReconciling` (probe Model) — layer 0 covers it
-- [ ] 4.4 Unit tests for split detection and probe-skip behaviour
-- [ ] 4.5 Remove probe Model code path entirely once combined mode is removed (tracked in §7)
+- [ ] 4.1 Add `ark-apiserver` to `tools/ark-cli/src/arkServices.ts` as a core service (PostgreSQL backend only)
+- [ ] 4.2 In `readinessChecks.ts`, delete `waitForControllerReconciling`, the probe Model manifest, and the `ark-readiness-probe` namespace handling
+- [ ] 4.3 In `readinessChecks.ts`, detect backend from CRD presence as today; on PostgreSQL, layer 0 covers both `ark-apiserver` and `ark-controller` via the existing `waitForServicesReady` path
+- [ ] 4.4 Update `readinessChecks.spec.ts` — remove probe-Model tests, add tests for `ark-apiserver` inclusion in core services
+- [ ] 4.5 Remove the `--readiness-stable-count` / N=10 aggregated-API probe — per-Deployment `Ready` is now sufficient. Keep the APIService and API-group checks as integration sanity
 
 ## 5. Migration and documentation
 
-- [ ] 5.1 Release notes section explaining split vs combined, when to use each, how to upgrade
-- [ ] 5.2 `helm upgrade` integration test: combined → split on a live cluster with existing Ark resources, assert zero data loss
-- [ ] 5.3 Document `--role` flag and `deployment.split` value in `docs/`
-- [ ] 5.4 Update `SIMPLE-ARCHITECTURE-GUIDE.md` and `ARK-ARCHITECTURE.md` to reflect the two-deployment topology
+- [ ] 5.1 Release notes section explaining the topology change, the automated Helm upgrade path, and how to verify post-upgrade
+- [ ] 5.2 Document `--role` flag and the new Deployment layout in `docs/`
+- [ ] 5.3 Update `SIMPLE-ARCHITECTURE-GUIDE.md` and `ARK-ARCHITECTURE.md` to reflect two Deployments on PostgreSQL / one on etcd
+- [ ] 5.4 Explicit callout in release notes that `ark-controller` logs no longer contain aggregated API server log lines on PostgreSQL — operators should check `ark-apiserver` pods
 
 ## 6. Performance validation
 
-- [ ] 6.1 Benchmark write latency (reconciler → status) on combined vs split, same cluster, 100 and 1 000 Models reconciling in parallel
+- [ ] 6.1 Benchmark write latency (reconciler → status) before and after the split, same cluster, 100 and 1 000 Models reconciling in parallel
 - [ ] 6.2 Benchmark read latency for API consumers (e.g., `ark list agents` on a 10 k-resource cluster)
-- [ ] 6.3 If write latency regression exceeds a threshold (TBD, e.g. 50 ms p99), investigate in-cluster network / APIService proxy overhead before promoting split to default
-
-## 7. Promote split to default and remove combined
-
-- [ ] 7.1 After a release cycle of CI burn-in with `deployment.split=true`, flip the default in `values.yaml`
-- [ ] 7.2 Mark `--role=combined` as deprecated in release notes
-- [ ] 7.3 After one further release cycle, remove the `combined` role code path
-- [ ] 7.4 Remove the probe Model code path from `readinessChecks.ts` and `setup-local.sh` entirely
+- [ ] 6.3 If write latency regression exceeds a threshold (TBD, e.g. 50 ms p99), investigate in-cluster network / APIService proxy overhead before releasing
+- [ ] 6.4 Record baseline numbers in the PR description so future regressions are detectable

--- a/openspec/changes/split-apiserver-deployment/tasks.md
+++ b/openspec/changes/split-apiserver-deployment/tasks.md
@@ -8,16 +8,31 @@
 - [ ] 1.6 Add health endpoints: `/readyz` on apiserver returns 200 when PG connected and API serving; on controller returns 200 when informers synced and at least one reconcile has completed
 - [ ] 1.7 Unit tests for role dispatch, leader-election scoping, and the non-leader-skips-WAL path
 
-## 2. Helm chart
+## 2. Helm charts
 
-- [ ] 2.1 Rename the existing controller Deployment template to reflect its controller-only responsibility; drop apiserver args/ports from it; set `--role=controller`
-- [ ] 2.2 New `ark/dist/chart/templates/apiserver/deployment.yaml` rendered when `storage.backend=postgresql`; `--role=apiserver` arg; per-replica image and resources from values
-- [ ] 2.3 New `ark/dist/chart/templates/apiserver/service.yaml` with selector `app.kubernetes.io/name=ark-apiserver`, rendered when `storage.backend=postgresql`
-- [ ] 2.4 `apiservice.yaml` rendered when `storage.backend=postgresql`; target the apiserver Service
-- [ ] 2.5 Split RBAC: apiserver ServiceAccount gets PG secret access; controller ServiceAccount drops it
-- [ ] 2.6 `templates/hooks/pre-upgrade-apiserver.yaml` — Helm pre-upgrade hook that applies the apiserver Deployment/Service, waits for `APIService v1alpha1.ark.mckinsey.com` condition `Available=True`, flips the APIService selector, then returns
-- [ ] 2.7 `ark-controller` Deployment init container `wait-for-apiserver` that blocks on the APIService condition (covers pod restarts after initial upgrade)
-- [ ] 2.8 Chart template unit tests (`helm template` snapshot) for etcd and postgresql backends
+### ark-controller chart (`ark/dist/chart`)
+
+- [ ] 2.1 Drop apiserver args/ports from the controller Deployment; add `--role=controller` arg
+- [ ] 2.2 Add init container `wait-for-apiserver` that runs `kubectl wait apiservice v1alpha1.ark.mckinsey.com --for=condition=Available --timeout=5m`
+- [ ] 2.3 Remove apiserver-related values from `values.yaml` and schema; the controller chart no longer knows about the apiserver
+- [ ] 2.4 Remove APIService CR, `ark-apiserver` Service, and apiserver RBAC from this chart — they move to the new chart
+- [ ] 2.5 Chart template unit tests (`helm template` snapshot) covering etcd and postgresql topologies
+
+### ark-apiserver chart (new, `ark/dist/chart-apiserver`)
+
+- [ ] 2.6 Scaffold `ark/dist/chart-apiserver/` with `Chart.yaml` (name `ark-apiserver`), `values.yaml`, `values.schema.json`, `templates/`
+- [ ] 2.7 `templates/deployment.yaml` — runs `--role=apiserver`; image, replicas, resources from values; leader-election enabled via `ark-apiserver-leader` Lease
+- [ ] 2.8 `templates/service.yaml` — name `ark-apiserver` (stable, matches today's Service name); selector `app.kubernetes.io/name=ark-apiserver`
+- [ ] 2.9 `templates/apiservice.yaml` — `APIService` `v1alpha1.ark.mckinsey.com` targeting the Service; ownership migrates from the controller chart via Helm annotation takeover (`helm.sh/resource-policy: keep` on the controller side during transition, or a one-time manual `kubectl apply` documented in the upgrade notes)
+- [ ] 2.10 `templates/rbac.yaml` — ServiceAccount, ClusterRole/Binding with PG secret access; no reconciler permissions
+- [ ] 2.11 Chart template unit tests (`helm template` snapshot)
+- [ ] 2.12 Release-process update: the apiserver chart is released on the same cadence as the controller chart, version-aligned per release
+
+### Install/upgrade integration
+
+- [ ] 2.13 Update `scripts/deploy/deploy-controller.sh` (and any other deploy scripts) to install `ark-apiserver` first, then `ark-controller`, on postgresql; install only `ark-controller` on etcd
+- [ ] 2.14 Update `devspace.yaml` to depend on / deploy both charts in the correct order for local development
+- [ ] 2.15 Document the APIService ownership handover for the transition release (existing installs have the APIService owned by the controller chart; first upgrade hands it to the apiserver chart)
 
 ## 3. E2E setup
 


### PR DESCRIPTION
## Summary

- Proposes splitting the aggregated API server out of `ark-controller` into its own `ark-apiserver` Deployment
- Motivated by repeated E2E flakiness (#1527, #1637, #1763, #1841) where the same pod being responsible for both API serving and reconcile loops makes Deployment readiness ambiguous
- Removes the need for the throwaway Model probe used in `setup-local.sh:132-220` and ported into #1914's `readinessChecks.ts`
- Keeps `combined` mode as the default for backward compatibility; `deployment.split=true` is opt-in until the next release cycle

## Artefacts

- `openspec/changes/split-apiserver-deployment/proposal.md` — why + what changes + impact
- `openspec/changes/split-apiserver-deployment/design.md` — decisions (`--role` flag, WAL consumer ownership, leader-election scoping, startup ordering, migration strategy, trade-offs)
- `openspec/changes/split-apiserver-deployment/tasks.md` — phased task list across operator, Helm, E2E, CLI, migration, perf validation
- `openspec/changes/split-apiserver-deployment/specs/split-apiserver-deployment/spec.md` — requirements + acceptance scenarios

## Relationship to #1914

#1914 ports `setup-local.sh:132-220` into `ark status --wait-for-ready`. The probe-Model part of that (layer 5) inherits the same limitations as the shell version: heavy, leaky on abnormal exit, race-prone across parallel clients. This proposal solves those limitations by making the two responsibilities visible as two Deployments, at which point per-Deployment readiness probes replace the probe Model.

Until this proposal lands, #1914 is a 1:1 port of what CI already does and does not introduce a regression. Once this proposal is implemented, #1914's `waitForControllerReconciling` can be removed (task §4.3 / §7.4).

## Not included

This is a spec-only PR. No operator code, Helm chart, or CLI changes land here. Implementation PRs follow the task list in `tasks.md`.