### PR TITLE
feat(openspec): add executor status reporting change proposal

### DIFF
--- a/openspec/changes/executor-status-reporting/.openspec.yaml
+++ b/openspec/changes/executor-status-reporting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/executor-status-reporting/design.md
+++ b/openspec/changes/executor-status-reporting/design.md
@@ -1,0 +1,184 @@
+## Context
+
+Today the operator dispatches queries to external executors via A2A `SendMessage` with `blocking: true`. It blocks until the executor returns a complete response, then writes `Query.status.response`. No intermediate status is surfaced. The Query phase jumps from `pending` to `running` to `done/error` with nothing in between.
+
+Executors with scheduling capabilities (e.g., Claude Agent SDK with per-conversation pod isolation) can take ~30 seconds to provision infrastructure before agent execution begins. Users see "Running" during this entire window with no explanation.
+
+The existing Query Extension (`query/v1`) carries a `QueryRef` from operator to executor. It currently has no mechanism for the executor to report state back.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users see "Initializing session" (or equivalent) across all surfaces while executor infrastructure provisions
+- Status propagation is standardized via A2A using the existing Query Extension
+- The Ark SDK enforces a vocabulary of executor states so surfaces can render consistently
+- The operator remains unaware of executor infrastructure details — it relays status, doesn't interpret it
+- ExecutionEngine CRD stays simple (address resolver only)
+
+**Non-Goals:**
+- Sub-step progress within "initializing" (e.g., "pulling image", "mounting volume")
+- Streaming A2A — we use task polling, not SSE/streaming
+- Health checks or readiness probes for executors (separate concern)
+- Changes to the phase state machine (phases remain: pending, running, done, error, canceled)
+
+## Decisions
+
+### Decision: Extend the existing Query Extension, not a new extension
+
+The Query Extension already defines the A2A contract between operator and executors. Adding a `/status` metadata key alongside the existing `/ref` key keeps related concerns together and avoids extension proliferation.
+
+**Keys:**
+- `{URI}/ref` — operator → executor (QueryRef, unchanged)
+- `{URI}/status` — executor → operator (ExecutorStatus, new)
+
+**Alternative considered**: New `executor-status/v1` extension. Rejected — adds a separate extension for what is fundamentally part of query execution flow.
+
+### Decision: Task polling via non-blocking `SendMessage` + `GetTask`
+
+The operator sends `SendMessage` with `blocking: false`. The executor returns a Task immediately in `working` state with status metadata. The operator polls `GetTask` on requeue intervals (3-5 seconds) until the task reaches a terminal state.
+
+This fits the existing K8s reconciliation pattern (check state, update, requeue) and uses standard request/response HTTP semantics. No long-lived connections.
+
+**Alternative considered**: A2A streaming (`SendMessageStreaming`). Rejected — requires reworking the operator's dispatch model to handle event streams, introduces long-lived connection management, and adds complexity for a signal that changes at most a few times over 30 seconds.
+
+### Decision: `executorStatus` field on QueryStatus, not a new phase
+
+Adding `initializing` as a Query phase would change the phase state machine that all existing consumers depend on. Instead, `executorStatus` is a structured field within the existing `running` phase. Surfaces that understand it show contextual status; surfaces that don't still work (they see "Running").
+
+```go
+type ExecutorStatus struct {
+    State     string       `json:"state,omitempty"`
+    Message   string       `json:"message,omitempty"`
+    UpdatedAt *metav1.Time `json:"updatedAt,omitempty"`
+}
+```
+
+**Alternative considered**: Sub-condition (`SessionReady=False`). Rejected — conditions are for tracking lifecycle state transitions, not transient executor progress.
+
+**Alternative considered**: K8s Events only. Rejected — events are fire-and-forget with no structured field for surfaces to read. Dashboard and CLI would need to parse event messages.
+
+### Decision: Standardized state vocabulary in the SDK
+
+The Ark SDK defines an `ExecutorState` enum:
+
+```
+INITIALIZING = "initializing"   # Infrastructure provisioning
+WORKING      = "working"        # Agent is executing
+COMPLETED    = "completed"      # Execution finished
+FAILED       = "failed"         # Execution failed
+CANCELED     = "canceled"       # Execution canceled
+```
+
+The `state` field is the enum value (standardized, surfaces key on it). The `message` field is freeform (human-readable, for display). The SDK enforces the vocabulary; executors import it; the operator relays it without interpretation.
+
+**Alternative considered**: Freeform state strings with no enum. Rejected — surfaces need to map states to specific UX treatments (spinner text, icons, colors). A standardized vocabulary makes this deterministic.
+
+### Decision: All surfaces read from Query CR
+
+The CLI, Fark, dashboard, and REST API all consume `executorStatus` from the Query CR. No surface talks directly to executors. This ensures a single source of truth and uniform behavior.
+
+The CLI uses two paths today:
+- Polling: reads `Query.status` via REST API
+- Streaming: reads chunks from broker via SSE
+
+For executor status, both paths can read `executorStatus` from the query response — the API already exposes full query status.
+
+### Decision: No backward compatibility shim
+
+The SDK and executors are released together. When the SDK gains `report_status()`, all executor deployments pick it up. The operator switches to `blocking: false` for all external executors in the same release. No feature detection or fallback needed.
+
+## A2A Wire Format
+
+### Outbound (unchanged)
+
+```http
+POST /a2a HTTP/1.1
+
+{
+  "jsonrpc": "2.0",
+  "method": "message/send",
+  "params": {
+    "message": { "role": "user", "parts": [{ "text": "..." }] },
+    "configuration": { "blocking": false },
+    "metadata": {
+      ".../query/v1/ref": { "name": "my-query", "namespace": "default" }
+    }
+  }
+}
+```
+
+### Immediate Return (executor returns Task)
+
+```json
+{
+  "id": "t-abc123",
+  "status": {
+    "state": "working",
+    "message": { "role": "agent", "parts": [{ "text": "Initializing session" }] },
+    "metadata": {
+      ".../query/v1/status": {
+        "state": "initializing",
+        "message": "Initializing session"
+      }
+    }
+  }
+}
+```
+
+### Poll Response (GetTask, after provisioning)
+
+```json
+{
+  "id": "t-abc123",
+  "status": {
+    "state": "completed",
+    "metadata": {
+      ".../query/v1/status": {
+        "state": "working",
+        "message": "Processing"
+      }
+    }
+  },
+  "history": [
+    { "role": "user", "parts": [{ "text": "..." }] },
+    { "role": "agent", "parts": [{ "text": "response content" }] }
+  ]
+}
+```
+
+## Operator Poll Loop
+
+```
+1. SendMessage(blocking: false)
+2. Receive Task{state: working}
+3. Extract .../query/v1/status from task metadata
+4. Write Query.status.executorStatus
+5. Set Query.status.phase = running (if not already)
+6. Requeue after 3-5 seconds
+7. GetTask(taskId)
+8. If task.state != terminal → goto 3
+9. If task.state == completed → extract response, write Query.status.response, phase = done
+10. If task.state == failed → extract error, phase = error
+```
+
+## Surface Rendering
+
+| Surface | What changes |
+|---------|-------------|
+| Dashboard | Subtitle under phase badge: "Initializing session..." when `executorStatus.state == "initializing"` |
+| Ark CLI (polling) | Status line before response: "Initializing session..." |
+| Ark CLI (streaming) | Status line before chunks begin |
+| Fark CLI | Spinner text includes executor status message with elapsed timer |
+| REST API | `executorStatus` field included in query status response |
+
+## Risks / Trade-offs
+
+- **Poll interval latency**: 3-5 second requeue means status updates are delayed by up to one poll interval. For a ~30 second provisioning window this is acceptable. If sub-second updates become necessary, streaming can be revisited.
+- **Operator load**: Each running query with a non-blocking executor adds periodic `GetTask` HTTP calls. At moderate scale this is fine. At high concurrency, consider batching or backoff.
+- **Task support in A2A libraries**: The `trpc-a2a-go` client must support `GetTask`. If not already available, this needs implementation or contribution.
+
+## Open Questions
+
+- What should the poll interval be? Fixed 3-5s, or exponential backoff? (Likely fixed for simplicity — defer to implementation.)
+- Should `executorStatus` be cleared when the query reaches a terminal phase, or preserved for post-mortem inspection? (Leaning toward preserved.)
+- Does `trpc-a2a-go` already support `GetTask`/`tasks/get`? Needs verification before implementation.

--- a/openspec/changes/executor-status-reporting/proposal.md
+++ b/openspec/changes/executor-status-reporting/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+When executors with scheduling capabilities (e.g., Claude Agent SDK) receive a query, session infrastructure (pods, filesystems) can take ~30 seconds to provision. During this time users see "Running" with no indication that they're waiting for infrastructure, not intelligence. This erodes trust and makes the system feel broken.
+
+## What Changes
+
+- The A2A Query Extension (`query/v1`) gains a new metadata key (`/status`) for executors to report their state back to the operator
+- The operator switches from `blocking: true` to `blocking: false` A2A dispatch, then polls `GetTask` until completion — writing executor status to the Query CR on each poll
+- The Query CRD gains an `executorStatus` field (state + message) on `QueryStatus`
+- The Ark SDK defines a standardized `ExecutorState` enum and `report_status()` method on `BaseExecutor`
+- All four surfaces (dashboard, Ark CLI, Fark CLI, REST API) read `executorStatus` and display contextual status within the "running" phase
+
+## Capabilities
+
+### New Capabilities
+- `executor-status-reporting`: Executors report provisioning/execution state via A2A Query Extension; operator relays to Query CR; surfaces display contextual status to users
+
+### Modified Capabilities
+- `query-extension-v1`: Extended with a `/status` metadata key for executor → operator status flow (existing `/ref` key unchanged)
+
+## Impact
+
+- `ark/api/extensions/query/v1/` — New status schema, updated README documenting bidirectional flow
+- `ark/api/v1alpha1/query_types.go` — `ExecutorStatus` struct added to `QueryStatus`
+- `ark/internal/a2a/a2a.go` — New `QueryExtensionStatusKey` constant, status extraction from Task metadata
+- `ark/internal/controller/query_controller.go` — Switch to non-blocking A2A dispatch + `GetTask` poll loop, write `executorStatus` on each poll
+- `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py` — `ExecutorState` enum, `report_status()` on `BaseExecutor`
+- `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py` — Wire `report_status()` into A2A Task status metadata
+- `services/ark-dashboard/` — Contextual status subtitle under phase badge
+- `services/ark-api/` — Expose `executorStatus` in query response payloads
+- `tools/ark-cli/` — Show executor status in polling/streaming output
+- `tools/fark/` — Show executor status in query watcher spinner
+
+### Documentation
+- `docs/content/reference/resources/query.mdx` — New `executorStatus` field
+- `docs/content/reference/query-execution.mdx` — Updated lifecycle with intermediate status and polling
+- `docs/content/developer-guide/building-execution-engines.mdx` — `report_status()` contract for executor implementers
+- `ark/api/extensions/query/v1/README.md` — Bidirectional flow, status metadata key, status schema
+- `docs/content/developer-guide/queries/a2a-queries.mdx` — A2A queries now carry intermediate status
+- `docs/content/developer-guide/cli-tools.mdx` — Fark executor status display
+- `docs/content/user-guide/dashboard.mdx` — Dashboard provisioning indicator
+
+### Downstream (separate proposal in marketplace repo)
+- `executors/claude-agent-sdk/` — First executor to implement `report_status(INITIALIZING, "Initializing session")` during scheduler pod provisioning
+- `agents-at-scale-marketplace/docs/content/executors/claude-agent-sdk.mdx` — Document status reporting behavior

--- a/openspec/changes/executor-status-reporting/specs/executor-status-reporting/spec.md
+++ b/openspec/changes/executor-status-reporting/specs/executor-status-reporting/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Standardized executor state vocabulary
+The Ark SDK SHALL define an `ExecutorState` enum with the following values: `initializing`, `working`, `completed`, `failed`, `canceled`. All executors reporting status MUST use these enum values in the `state` field. The `message` field SHALL be freeform text for human-readable display.
+
+#### Scenario: Executor reports initializing state
+- **WHEN** an executor begins provisioning session infrastructure
+- **THEN** the executor SHALL call `report_status(ExecutorState.INITIALIZING, "Initializing session")` which sets the A2A Task status metadata with the standardized state value
+
+#### Scenario: Executor reports working state
+- **WHEN** session infrastructure is ready and agent execution begins
+- **THEN** the executor SHALL call `report_status(ExecutorState.WORKING, "Processing")` to update the A2A Task status metadata
+
+#### Scenario: Executor uses non-standard state value
+- **WHEN** an executor passes a string not in the `ExecutorState` enum to `report_status()`
+- **THEN** the SDK SHALL raise a `ValueError`
+
+### Requirement: BaseExecutor report_status method
+The Ark SDK `BaseExecutor` class SHALL expose a `report_status(state, message)` method. `ExecutorApp` SHALL inject the mechanism to propagate status into A2A Task metadata before calling `execute_agent()`. Executors call `report_status()` during execution to signal state transitions.
+
+#### Scenario: Executor calls report_status during execution
+- **WHEN** an executor calls `self.report_status(ExecutorState.INITIALIZING, "Initializing session")` inside `execute_agent()`
+- **THEN** the A2A Task status metadata at key `{QueryExtensionURI}/status` SHALL be updated with `{"state": "initializing", "message": "Initializing session"}`
+
+#### Scenario: Executor does not call report_status
+- **WHEN** an executor completes `execute_agent()` without calling `report_status()`
+- **THEN** no `{QueryExtensionURI}/status` metadata SHALL be set and the Query CR SHALL have no `executorStatus` field
+
+### Requirement: Query CRD executorStatus field
+The Query CRD `QueryStatus` SHALL include an `executorStatus` field with `state` (string), `message` (string), and `updatedAt` (timestamp). This field SHALL only be populated when the executor reports status via the A2A Query Extension.
+
+#### Scenario: Operator receives executor status from A2A Task
+- **WHEN** the operator polls `GetTask` and the Task metadata contains `{QueryExtensionURI}/status`
+- **THEN** the operator SHALL write the status to `Query.status.executorStatus` with the current timestamp in `updatedAt`
+
+#### Scenario: Query reaches terminal phase
+- **WHEN** a Query transitions to `done`, `error`, or `canceled`
+- **THEN** the last `executorStatus` SHALL be preserved on the Query CR for post-mortem inspection
+
+### Requirement: Non-blocking A2A dispatch with task polling
+The operator SHALL send `SendMessage` with `blocking: false` to external execution engines. The operator SHALL poll `GetTask` at regular intervals (3-5 seconds) until the Task reaches a terminal state (`completed` or `failed`). On each poll, the operator SHALL extract executor status from Task metadata and update the Query CR.
+
+#### Scenario: Executor returns non-terminal Task
+- **WHEN** `SendMessage(blocking: false)` returns a Task with `state: working`
+- **THEN** the operator SHALL extract executor status from Task metadata, write it to the Query CR, and requeue for polling after 3-5 seconds
+
+#### Scenario: Task reaches completed state
+- **WHEN** `GetTask` returns a Task with `state: completed`
+- **THEN** the operator SHALL extract the response from Task history, write `Query.status.response`, and set `Query.status.phase = done`
+
+#### Scenario: Task reaches failed state
+- **WHEN** `GetTask` returns a Task with `state: failed`
+- **THEN** the operator SHALL extract the error from Task status message, write it to `Query.status.response`, and set `Query.status.phase = error`
+
+#### Scenario: GetTask poll fails transiently
+- **WHEN** a `GetTask` HTTP call fails due to a transient error (timeout, connection reset)
+- **THEN** the operator SHALL retry on the next requeue interval without marking the Query as errored
+
+### Requirement: Dashboard displays executor status
+The dashboard SHALL display the executor status message as a subtitle under the phase badge when `executorStatus.state` is present and the Query phase is `running`.
+
+#### Scenario: Query is running with initializing executor status
+- **WHEN** a Query has `phase: running` and `executorStatus.state: initializing`
+- **THEN** the dashboard SHALL display "Initializing session..." (or the executor's message) below the "Running" phase badge
+
+#### Scenario: Query is running with no executor status
+- **WHEN** a Query has `phase: running` and no `executorStatus` field
+- **THEN** the dashboard SHALL display the "Running" phase badge with no subtitle (current behavior)
+
+### Requirement: Ark CLI displays executor status
+The Ark CLI SHALL display the executor status message as a status line during query polling, before the response is available.
+
+#### Scenario: CLI polls query with initializing executor status
+- **WHEN** the CLI polls a Query with `executorStatus.state: initializing`
+- **THEN** the CLI SHALL display the executor status message (e.g., "Initializing session...")
+
+### Requirement: Fark CLI displays executor status
+The Fark CLI query watcher SHALL include the executor status message in its spinner text, with an elapsed timer.
+
+#### Scenario: Fark watches query with initializing executor status
+- **WHEN** the Fark query watcher observes `executorStatus.state: initializing`
+- **THEN** the spinner text SHALL display the executor status message with elapsed time (e.g., "Initializing session... (12s)")
+
+### Requirement: REST API exposes executor status
+The REST API SHALL include `executorStatus` in query status responses when present.
+
+#### Scenario: API returns query with executor status
+- **WHEN** a client requests a Query that has `executorStatus` set
+- **THEN** the API response SHALL include `executorStatus` with `state`, `message`, and `updatedAt` fields in the query status object

--- a/openspec/changes/executor-status-reporting/specs/query-extension-v1/spec.md
+++ b/openspec/changes/executor-status-reporting/specs/query-extension-v1/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Status metadata key for executor-to-operator flow
+The Query Extension (`query/v1`) SHALL define a new metadata key `{QueryExtensionURI}/status` for executors to report state back to the operator via A2A Task metadata. The existing `{QueryExtensionURI}/ref` key SHALL remain unchanged.
+
+#### Scenario: Executor sets status metadata on Task
+- **WHEN** an executor calls `report_status()` during execution
+- **THEN** the A2A Task status metadata SHALL contain `{QueryExtensionURI}/status` with a JSON object containing `state` (string from ExecutorState enum) and `message` (freeform string)
+
+#### Scenario: Operator reads status metadata from Task
+- **WHEN** the operator receives a Task response (from `SendMessage` or `GetTask`) containing `{QueryExtensionURI}/status` in the Task status metadata
+- **THEN** the operator SHALL extract the status object and write it to `Query.status.executorStatus`
+
+#### Scenario: Task has no status metadata
+- **WHEN** the operator receives a Task response without `{QueryExtensionURI}/status` in metadata
+- **THEN** the operator SHALL not modify `Query.status.executorStatus`
+
+### Requirement: Status schema definition
+The Query Extension SHALL include a `status-schema.json` defining the status metadata structure: `state` (string, required) and `message` (string, optional).
+
+#### Scenario: Status metadata validates against schema
+- **WHEN** an executor sets `{QueryExtensionURI}/status` to `{"state": "initializing", "message": "Initializing session"}`
+- **THEN** the value SHALL validate against `status-schema.json`
+
+#### Scenario: Status metadata with missing state field
+- **WHEN** a status metadata object is missing the `state` field
+- **THEN** the value SHALL NOT validate against `status-schema.json`
+
+### Requirement: Extension README documents bidirectional flow
+The Query Extension README SHALL document both metadata keys (`/ref` for operator→executor, `/status` for executor→operator) and the bidirectional flow pattern including wire format examples for the status response.
+
+#### Scenario: Executor implementer reads extension docs
+- **WHEN** a developer reads `ark/api/extensions/query/v1/README.md`
+- **THEN** they SHALL find documentation for both the `/ref` metadata key (request direction) and the `/status` metadata key (response direction) with wire format examples

--- a/openspec/changes/executor-status-reporting/tasks.md
+++ b/openspec/changes/executor-status-reporting/tasks.md
@@ -1,0 +1,59 @@
+## 1. Query Extension Schema
+
+- [ ] 1.1 Create `ark/api/extensions/query/v1/status-schema.json` defining the status metadata structure (`state` required string, `message` optional string)
+- [ ] 1.2 Add `QueryExtensionStatusKey` constant to `ark/internal/a2a/a2a.go` (`{QueryExtensionURI}/status`)
+- [ ] 1.3 Update `ark/api/extensions/query/v1/README.md` to document bidirectional flow, the new `/status` metadata key, and wire format examples
+
+## 2. Query CRD
+
+- [ ] 2.1 Add `ExecutorStatus` struct (`State`, `Message`, `UpdatedAt`) to `ark/api/v1alpha1/query_types.go`
+- [ ] 2.2 Add `ExecutorStatus *ExecutorStatus` field to `QueryStatus`
+- [ ] 2.3 Run `make manifests` to regenerate CRDs from Go types
+
+## 3. Operator A2A Dispatch
+
+- [ ] 3.1 Verify `trpc-a2a-go` client supports `GetTask`/`tasks/get` — if not, implement or find alternative
+- [ ] 3.2 Add status extraction function to `ark/internal/a2a/a2a.go` that reads `{QueryExtensionURI}/status` from Task status metadata and returns an `ExecutorStatus`
+- [ ] 3.3 Modify `executeA2AAgentMessage` in `ark/internal/a2a/a2a.go` to send `SendMessage` with `blocking: false`
+- [ ] 3.4 Update `extractResponseFromMessageResult` to handle non-terminal Task states (currently only handles `completed` and `failed`)
+- [ ] 3.5 Implement `GetTask` poll loop in `ark/internal/controller/query_controller.go` — store task ID on first dispatch, poll on requeue, extract status and write to `Query.status.executorStatus`
+- [ ] 3.6 Write unit tests for status extraction, non-blocking dispatch, and poll loop
+
+## 4. Ark SDK
+
+- [ ] 4.1 Add `ExecutorState` enum to `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py` with values: `INITIALIZING`, `WORKING`, `COMPLETED`, `FAILED`, `CANCELED`
+- [ ] 4.2 Add `report_status(state, message)` method to `BaseExecutor` that validates state against enum
+- [ ] 4.3 Wire `report_status()` in `ExecutorApp` (`executor_app.py`) to set A2A Task status metadata at `{QueryExtensionURI}/status`
+- [ ] 4.4 Write unit tests for `report_status()` including enum validation and metadata propagation
+
+## 5. Dashboard
+
+- [ ] 5.1 Update `queries-section.tsx` to read `executorStatus` from query status and display contextual subtitle under the phase badge when phase is `running`
+- [ ] 5.2 Show executor status message (e.g., "Initializing session...") with appropriate styling
+- [ ] 5.3 Verify no subtitle is shown when `executorStatus` is absent (backward compatibility)
+
+## 6. Ark CLI
+
+- [ ] 6.1 Update `chatClient.ts` polling path to read `executorStatus` from query status and display status line
+- [ ] 6.2 Update streaming path to show executor status before chunks begin
+- [ ] 6.3 Verify CLI falls back gracefully when `executorStatus` is not present
+
+## 7. Fark CLI
+
+- [ ] 7.1 Update `query_watcher.go` to watch for `executorStatus` field changes on the Query CR
+- [ ] 7.2 Display executor status message in spinner text with elapsed timer (e.g., "Initializing session... (12s)")
+- [ ] 7.3 Verify watcher falls back gracefully when `executorStatus` is not present
+
+## 8. REST API
+
+- [ ] 8.1 Verify `executorStatus` is exposed in query status responses (may work automatically if the field is on the Query CR and the API serializes full status)
+- [ ] 8.2 Update OpenAI-compatible response format to include `executorStatus` in the `ark` extension object
+
+## 9. Documentation
+
+- [ ] 9.1 Update `docs/content/reference/resources/query.mdx` — document new `executorStatus` field in QueryStatus
+- [ ] 9.2 Update `docs/content/reference/query-execution.mdx` — add intermediate status and polling to lifecycle description
+- [ ] 9.3 Update `docs/content/developer-guide/building-execution-engines.mdx` — document `report_status()` contract and `ExecutorState` enum for executor implementers
+- [ ] 9.4 Update `docs/content/developer-guide/queries/a2a-queries.mdx` — document intermediate status flow in A2A queries
+- [ ] 9.5 Update `docs/content/developer-guide/cli-tools.mdx` — document executor status display in Fark
+- [ ] 9.6 Update `docs/content/user-guide/dashboard.mdx` — document provisioning indicator


### PR DESCRIPTION
## Summary

- Add OpenSpec change proposal for executor status reporting — bridging the UX gap when executor pods are being provisioned
- Extend the A2A Query Extension (`query/v1`) with a `/status` metadata key for executors to report state back to the operator
- Design non-blocking A2A dispatch with task polling so the operator can relay intermediate status to the Query CR
- Add `executorStatus` field to Query CRD with standardized state vocabulary enforced by the Ark SDK
- Define surface rendering for dashboard, Ark CLI, Fark CLI, and REST API to display contextual status (e.g., "Initializing session...") within the running phase

## Test plan

- [ ] Review proposal.md for completeness and alignment with Ark architecture
- [ ] Review design.md decisions and wire format examples
- [ ] Review specs for testable requirements and scenario coverage
- [ ] Review tasks.md for implementation completeness and ordering