### PR TITLE
fix: update axios to 1.15.1 to resolve CVE-2026-42039

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.59",
+  "version": "0.1.61-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.59",
+      "version": "0.1.61-rc.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "debug": "^4.4.1",
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "debug": "^4.4.1",


### PR DESCRIPTION
## Summary

- Updates axios from 1.15.0 to 1.15.1 in `tools/ark-cli/` to patch CVE-2026-42039

Closes #2008