### PR TITLE
ci: add OpenSpec Flow workflow

### DIFF
--- a/.github/actions/openspec-flow-flip-label/action.yml
+++ b/.github/actions/openspec-flow-flip-label/action.yml
@@ -1,0 +1,37 @@
+name: OpenSpec Flow — Flip Label
+description: >
+  Removes one label from an issue and adds another in a single gh issue edit
+  call. If the remove-label is not present, the call fails silently and the
+  add-label is still applied.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues write permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue number to edit labels on
+    required: true
+  remove-label:
+    description: Label to remove from the issue
+    required: true
+  add-label:
+    description: Label to add to the issue
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Flip label
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        REMOVE_LABEL: ${{ inputs.remove-label }}
+        ADD_LABEL: ${{ inputs.add-label }}
+      run: |
+        gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+          --remove-label "$REMOVE_LABEL" --add-label "$ADD_LABEL"

--- a/.github/actions/openspec-flow-handle-failure/action.yml
+++ b/.github/actions/openspec-flow-handle-failure/action.yml
@@ -1,0 +1,51 @@
+name: OpenSpec Flow — Handle Failure
+description: >
+  Posts a failure comment on an issue and flips the label to LABEL_FAILED.
+  Removes current-label (failure is best-effort), adds LABEL_FAILED, then
+  posts a comment with AGENT_COMMENT_MARKER header and REENGAGE_FOOTER.
+  LABEL_FAILED, AGENT_COMMENT_MARKER, and REENGAGE_FOOTER must be set in the
+  workflow-level env block.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues write permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue or PR number to post the failure comment on
+    required: true
+  run-url:
+    description: URL of the current Actions run (for the "View logs" link)
+    required: true
+  current-label:
+    description: The label currently on the issue that should be removed
+    required: true
+  message:
+    description: Failure message line to include in the comment body
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post failure comment and flip to failed label
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        RUN_URL: ${{ inputs.run-url }}
+        CURRENT_LABEL: ${{ inputs.current-label }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+          --remove-label "$CURRENT_LABEL" --add-label "$LABEL_FAILED" || true
+        {
+          echo "$AGENT_COMMENT_MARKER"
+          echo "> $MESSAGE"
+          echo ""
+          echo "---"
+          echo "$REENGAGE_FOOTER"
+        } > /tmp/comment.md
+        gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md

--- a/.github/actions/openspec-flow-inject-usage-table/action.yml
+++ b/.github/actions/openspec-flow-inject-usage-table/action.yml
@@ -1,0 +1,99 @@
+name: openspec-flow-inject-usage-table
+description: |
+  Scrape the Claude session log written by `claude-code-action` to
+  $RUNNER_TEMP/claude-execution-output.json, build a Markdown usage
+  table of Skill + Task (sub-agent) invocations, and inject the table
+  into the target PR body between the openspec-flow-usage-table
+  markers.
+
+  Extracted from the plan and implement jobs of openspec-flow.yaml so
+  the logic lives in one place. Caller picks the branch prefix
+  (`spec` or `impl`) to match the PR the run just opened.
+
+inputs:
+  branch_prefix:
+    description: "Branch prefix to search for the target PR — 'spec' or 'impl'."
+    required: true
+  issue_number:
+    description: "Issue number used in the branch name, e.g. 52 for impl/52-*"
+    required: true
+  github_token:
+    description: >
+      Token used for `gh pr list/view/edit`. Typically
+      `secrets.AGENT_GITHUB_TOKEN || github.token`.
+    required: true
+  repo:
+    description: "Repo (owner/name). Defaults to $GITHUB_REPOSITORY."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue_number }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+      run: |
+        : "${REPO:=$GITHUB_REPOSITORY}"
+        export REPO
+        python3 << 'PYEOF'
+        import json, os, re, subprocess, sys
+        repo = os.environ['REPO']
+        issue = os.environ['ISSUE_NUMBER']
+        prefix = os.environ['BRANCH_PREFIX']
+        if prefix not in ('spec', 'impl'):
+            print(f'::error::branch_prefix must be spec or impl, got {prefix!r}')
+            sys.exit(1)
+        session_log = os.path.join(os.environ.get('RUNNER_TEMP', '/tmp'), 'claude-execution-output.json')
+        open_m = '<!-- openspec-flow-usage-table -->'
+        close_m = '<!-- /openspec-flow-usage-table -->'
+        rows, step = [], 1
+        if os.path.exists(session_log):
+            with open(session_log) as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line.strip())
+                    except Exception:
+                        continue
+                    for item in obj.get('message', {}).get('content', []):
+                        if not isinstance(item, dict):
+                            continue
+                        n, inp = item.get('name', ''), item.get('input') or {}
+                        if n == 'Skill':
+                            skill = inp.get('skill', '?')
+                            detail = (inp.get('args') or '').strip() or 'Invoked'
+                            rows.append(f'| {step} | {skill} | {detail} |')
+                            step += 1
+                        elif n == 'Task':
+                            agent = inp.get('subagent_type') or '(agent)'
+                            desc = (inp.get('description') or '')[:80]
+                            rows.append(f'| {step} | {agent} | {desc} |')
+                            step += 1
+        else:
+            print(f'::warning::No session log at {session_log}')
+        table = '\n'.join(
+            ['| Step | Agent/Skill | Detail |', '|------|-------------|--------|']
+            + (rows or ['| — | — | No sub-agent or skill invocations found |']))
+        block = f'{open_m}\n{table}\n{close_m}'
+        pr_out = subprocess.check_output(
+            ['gh', 'pr', 'list', '--repo', repo, '--state', 'open',
+             '--search', f'head:{prefix}/{issue}-', '--json', 'number',
+             '--jq', '.[0].number // empty'], text=True).strip()
+        if not pr_out:
+            print(f'::warning::No open {prefix} PR for issue #{issue} — skipping usage table')
+            sys.exit(0)
+        body = subprocess.check_output(
+            ['gh', 'pr', 'view', pr_out, '--repo', repo, '--json', 'body', '--jq', '.body'],
+            text=True)
+        if open_m in body:
+            new_body = re.sub(re.escape(open_m) + r'.*?' + re.escape(close_m), block, body, flags=re.DOTALL)
+        else:
+            new_body = body.replace('\n---\n', f'\n{block}\n\n---\n', 1)
+            if new_body == body:
+                new_body = body.rstrip() + f'\n\n{block}\n'
+        subprocess.run(['gh', 'pr', 'edit', pr_out, '--repo', repo, '--body', new_body], check=True)
+        print(f'Injected usage table into {prefix} PR #{pr_out}')
+        PYEOF

--- a/.github/actions/openspec-flow-postflight/action.yml
+++ b/.github/actions/openspec-flow-postflight/action.yml
@@ -1,0 +1,87 @@
+name: OpenSpec Flow — Postflight
+description: >
+  Asserts that an agent step produced observable output: either new commits
+  were pushed (HEAD differs from base-sha) OR a comment containing
+  AGENT_COMMENT_MARKER was posted on the issue/PR. The marker-comment check
+  retries up to 3 times with a 5-second pause to absorb API lag. Sets a
+  `passed` output. Exits 1 on failure so the calling job's handle-failure
+  step can flip the label to openspec:failed. Does NOT post any comment
+  itself — commenting is the caller's responsibility.
+  AGENT_COMMENT_MARKER must be set in the workflow-level env block.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues read permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue or PR number to inspect for marker comments
+    required: true
+  job:
+    description: "Job being asserted: plan | implement | respond"
+    required: true
+  base-sha:
+    description: git rev-parse HEAD captured before the agent step ran
+    required: true
+  run-url:
+    description: URL of the current Actions run (for log messages)
+    required: true
+
+outputs:
+  passed:
+    description: "'true' if the assertion passed, 'false' otherwise"
+    value: ${{ steps.assert.outputs.passed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Assert observable agent output
+      id: assert
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        JOB: ${{ inputs.job }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        RUN_URL: ${{ inputs.run-url }}
+      run: |
+        current_sha=$(git rev-parse HEAD)
+        echo "Base SHA:    $BASE_SHA"
+        echo "Current SHA: $current_sha"
+
+        if [ "$current_sha" != "$BASE_SHA" ]; then
+          new_count=$(git rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo "?")
+          echo "Postflight passed: $new_count new commit(s) since base SHA."
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "No new commits. Checking for marker comment (up to 3 attempts)..."
+        found=false
+        for attempt in 1 2 3; do
+          echo "Attempt $attempt/3..."
+          marker_count=$(gh api --paginate "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            | jq -r --arg m "$AGENT_COMMENT_MARKER" \
+              '[.[] | select(.body | contains($m))] | length' 2>/dev/null || echo "0")
+          if [ "$marker_count" -gt 0 ]; then
+            found=true
+            echo "Postflight passed: found $marker_count marker comment(s) on #$ISSUE_NUMBER."
+            break
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "No marker comment yet — waiting 5s before retry..."
+            sleep 5
+          fi
+        done
+
+        if [ "$found" = "true" ]; then
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "::error::Postflight failed: no new commits and no marker comment found after 3 attempts. Silent no-op detected. Run: $RUN_URL"
+        echo "passed=false" >> "$GITHUB_OUTPUT"
+        exit 1

--- a/.github/actions/openspec-flow-preflight/action.yml
+++ b/.github/actions/openspec-flow-preflight/action.yml
@@ -1,0 +1,77 @@
+name: OpenSpec Flow — Preflight
+description: >
+  Validates pre-conditions before an agent step runs. For the plan job,
+  checks that the issue body meets a minimum length threshold; exits with
+  a skip comment when the condition is not met. For implement and respond
+  jobs, skips the body-length check and always passes. Sets a `skip`
+  output that callers can gate subsequent steps on.
+  AGENT_COMMENT_MARKER and REENGAGE_FOOTER must NOT appear in the skip
+  comment — it is informational only and is not pruned by prune-comments.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues write permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue or PR number to inspect and post on
+    required: true
+  job:
+    description: "Job being guarded: plan | implement | respond"
+    required: true
+  min-body-length:
+    description: Minimum issue body character count (plan job only)
+    required: false
+    default: "40"
+
+outputs:
+  skip:
+    description: "'true' if the agent step should be skipped, 'false' otherwise"
+    value: ${{ steps.check.outputs.skip }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run preflight checks
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        JOB: ${{ inputs.job }}
+        MIN_BODY_LENGTH: ${{ inputs.min-body-length }}
+        RUN_URL: ${{ github.server_url }}/${{ inputs.repo }}/actions/runs/${{ github.run_id }}
+      run: |
+        case "$JOB" in
+          plan)
+            body_length=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+              --json body --jq '.body | length' 2>/dev/null || echo "0")
+            echo "Issue body length: $body_length (min: $MIN_BODY_LENGTH)"
+            if [ "$body_length" -lt "$MIN_BODY_LENGTH" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              {
+                echo "> **OpenSpec Flow preflight skipped this run.**"
+                echo "> The issue body is too short ($body_length chars; minimum is $MIN_BODY_LENGTH)."
+                echo "> Please add more context to the issue description and re-trigger."
+                echo ">"
+                echo "> [View run]($RUN_URL)"
+              } > /tmp/preflight-skip.md
+              gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/preflight-skip.md
+              echo "Preflight: issue body too short — skip=true"
+              exit 0
+            fi
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Preflight: issue body length OK — skip=false"
+            ;;
+          implement|respond)
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Preflight: no body-length check for $JOB job — skip=false"
+            ;;
+          *)
+            echo "::warning::Unknown job '$JOB' passed to preflight — defaulting to skip=false"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            ;;
+        esac

--- a/.github/actions/openspec-flow-prune-comments/action.yml
+++ b/.github/actions/openspec-flow-prune-comments/action.yml
@@ -1,0 +1,38 @@
+name: OpenSpec Flow — Prune Comments
+description: >
+  Deletes all prior agent summary comments from an issue or PR whose body
+  contains the AGENT_COMMENT_MARKER environment variable value.
+  Callers must supply AGENT_COMMENT_MARKER in the workflow-level env block.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues write permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue or PR number to prune comments from
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Prune prior agent summary comments
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+      run: |
+        # Pipe to jq so --arg reaches jq. `gh api --jq` takes a single
+        # expression string and does not forward --arg.
+        ids=$(gh api --paginate "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+          | jq -r --arg m "$AGENT_COMMENT_MARKER" \
+            '.[] | select(.body | contains($m)) | .id')
+        [ -z "$ids" ] && { echo "No prior agent comments."; exit 0; }
+        while read -r id; do
+          [ -z "$id" ] && continue
+          gh api --method DELETE "repos/$REPO/issues/comments/$id" >/dev/null 2>&1 \
+            || echo "::warning::Failed to delete comment $id"
+        done <<< "$ids"

--- a/.github/actions/openspec-flow-raise-comment/action.yml
+++ b/.github/actions/openspec-flow-raise-comment/action.yml
@@ -1,0 +1,44 @@
+name: OpenSpec Flow — Raise Comment
+description: >
+  Posts a starting status comment on an issue or PR. The comment body starts
+  with AGENT_COMMENT_MARKER, includes the message text, and ends with ---
+  followed by REENGAGE_FOOTER. Both env vars must be set in the workflow-level
+  env block.
+
+inputs:
+  gh-token:
+    description: GitHub token with issues write permission
+    required: true
+  repo:
+    description: Repository in owner/name format
+    required: true
+  issue-number:
+    description: Issue or PR number to comment on
+    required: true
+  run-url:
+    description: URL of the current Actions run (for the "View run" link)
+    required: true
+  message:
+    description: Message body line to include in the comment (e.g. "OpenSpec Flow exploring this issue. [View run]($run-url)")
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post starting comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REPO: ${{ inputs.repo }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        RUN_URL: ${{ inputs.run-url }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        {
+          echo "$AGENT_COMMENT_MARKER"
+          echo "> $MESSAGE"
+          echo ""
+          echo "---"
+          echo "$REENGAGE_FOOTER"
+        } > /tmp/comment.md
+        gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md

--- a/.github/actions/openspec-flow-run-agent/action.yml
+++ b/.github/actions/openspec-flow-run-agent/action.yml
@@ -1,0 +1,105 @@
+name: openspec-flow-run-agent
+description: |
+  Thin wrapper around `anthropics/claude-code-action`'s entrypoint,
+  factored out of the plan/implement/respond jobs to stop triplicating
+  the ALL_INPUTS jq construction and env wiring.
+
+  The caller is responsible for:
+    - `actions/checkout` of the target repo
+    - cloning claude-code-action to `claude_code_action_path`
+    - installing bun on PATH
+
+inputs:
+  prompt:
+    description: Full agent prompt text.
+    required: true
+  anthropic_api_key:
+    description: >
+      Anthropic API key (from secrets.ANTHROPIC_API_KEY). Optional if
+      `claude_code_oauth_token` is set.
+    required: false
+    default: ""
+  claude_code_oauth_token:
+    description: >
+      Claude Code OAuth token (`claude setup-token` output). Alternative to
+      `anthropic_api_key` — when set, the agent runs against the user's
+      Claude subscription instead of API billing. At least one of the two
+      must be provided.
+    required: false
+    default: ""
+  github_token:
+    description: >
+      GitHub token the agent uses for API calls and git push. Typically
+      secrets.AGENT_GITHUB_TOKEN with a fallback to github.token — see
+      caller workflow.
+    required: true
+  override_github_token:
+    description: >
+      Optional PAT that overrides the OIDC-derived app token. Passed
+      through as OVERRIDE_GITHUB_TOKEN env var.
+    required: false
+    default: ""
+  additional_permissions:
+    description: >
+      Extra scopes to request on the OIDC-exchanged installation token.
+      Must match the env var name the action reads
+      (process.env.ADDITIONAL_PERMISSIONS in src/github/token.ts).
+      Example: `workflows: write` to let the agent push
+      .github/workflows/*.yaml edits.
+    required: false
+    default: ""
+  show_full_output:
+    description: >
+      If "true", agent tool-call output is visible in the run log.
+      Useful for debugging silent no-ops. Leak risk on public repos —
+      leave off unless investigating.
+    required: false
+    default: "false"
+  claude_code_action_path:
+    description: >
+      Filesystem path where the caller has cloned claude-code-action.
+    required: false
+    default: "/tmp/claude-code-action"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        PROMPT: ${{ inputs.prompt }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        OVERRIDE_GITHUB_TOKEN: ${{ inputs.override_github_token }}
+        ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
+        INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        ACTION_PATH: ${{ inputs.claude_code_action_path }}
+      run: |
+        # Override GITHUB_ACTION_PATH — GH sets it to *this* composite
+        # action's dir by default; claude-code-action's entrypoint needs
+        # its own source tree instead.
+        export GITHUB_ACTION_PATH="$ACTION_PATH"
+        export CLAUDE_ARGS="--permission-mode bypassPermissions"
+        # Require at least one of api_key / oauth_token. Fail fast with a
+        # clear message rather than letting the action silently degrade.
+        if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+          echo "::error::Neither anthropic_api_key nor claude_code_oauth_token was provided. Set one in the caller workflow."
+          exit 1
+        fi
+        # Both set: warn, do not intervene. Claude Agent SDK precedence is
+        # API-key-wins (matches the local `claude` CLI). Operator must
+        # pick: delete the ANTHROPIC_API_KEY secret on the repo if they
+        # want OAuth/subscription auth to route.
+        if [ -n "$ANTHROPIC_API_KEY" ] && [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+          echo "::warning::Both ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are set. The Claude Agent SDK uses the API key; OAuth is ignored. Delete the API key secret to route subscription auth."
+        fi
+        ALL_INPUTS="$(jq -nc \
+          --arg prompt "$PROMPT" \
+          --arg api_key "$ANTHROPIC_API_KEY" \
+          --arg oauth_token "$CLAUDE_CODE_OAUTH_TOKEN" \
+          --arg gh_token "$GITHUB_TOKEN" \
+          --arg claude_args "$CLAUDE_ARGS" \
+          --arg extra_perms "$ADDITIONAL_PERMISSIONS" \
+          '{prompt: $prompt, anthropic_api_key: $api_key, claude_code_oauth_token: $oauth_token, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
+        export ALL_INPUTS
+        bun run "$GITHUB_ACTION_PATH/src/entrypoints/run.ts"

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -1,0 +1,1104 @@
+# =============================================================================
+# OpenSpec Flow
+# =============================================================================
+# Single workflow driving the full OpenSpec lifecycle:
+#
+#   plan  ──►  implement  ──►  respond (any time)  ──►  cleanup
+#
+# - plan      fires on issue assignment / openspec:start label   -> spec PR
+# - implement fires on spec/** PR merge or issue relabel         -> code PR
+# - respond   fires on openspec:start label on a PR              -> refinement
+# - cleanup   fires on impl/** PR merge                          -> strips
+#             openspec:review from linked issue (GitHub itself
+#             auto-closes the issue via `Closes #<n>` in PR body)
+#
+# The respond job lets a human discuss the PR (comments + reviews) and then
+# hand control back to the agent by adding `openspec:start`. The agent reads
+# the conversation, refines the relevant artifacts, and posts a single
+# summary comment. Prior summary comments are deleted first (matched by an
+# HTML marker) so PRs don't accumulate status breadcrumbs.
+#
+# -----------------------------------------------------------------------------
+# Trigger matrix
+# -----------------------------------------------------------------------------
+#   Event                                     Job        Condition
+#   issue assigned to AGENT_ASSIGNEE          plan       no lifecycle label set
+#   issue labeled openspec:start              plan       no lifecycle label set
+#   issue labeled openspec:start              implement  issue in spec-ready
+#   spec/** PR closed with merge=true         implement  issue in spec-ready
+#   PR labeled openspec:start                 respond    branch matches spec/** or impl/**
+#   impl/** PR closed with merge=true         cleanup    (always — strips review label)
+#
+# -----------------------------------------------------------------------------
+# `openspec:start` on an issue — state dispatch
+# -----------------------------------------------------------------------------
+#   This label is the single manual trigger. Its effect depends on the
+#   issue's current lifecycle label:
+#
+#   +-------------------+-----------------------------------------------+
+#   | Current state     | openspec:start does                           |
+#   +-------------------+-----------------------------------------------+
+#   | none / cleared    | plan (open a spec PR)                         |
+#   | exploring         | silent skip — plan in flight                  |
+#   | spec-ready        | implement (open a code PR)                    |
+#   | implement         | silent skip — implement in flight             |
+#   | review            | nudge comment → direct the user to label the  |
+#   |                   | impl PR instead; respond job handles there    |
+#   | failed            | silent skip — clear label manually, then      |
+#   |                   | re-trigger (auto-retry is future work)        |
+#   +-------------------+-----------------------------------------------+
+#
+#   Dedupe: if implement fires from an issue-label event but an
+#   impl/<n>-* PR already exists (open or merged), the job posts a
+#   nudge pointing to the existing PR rather than starting duplicate
+#   work. `openspec:start` is always consumed at the start of a run
+#   (or when a nudge is posted) so it stays clickable.
+#
+# -----------------------------------------------------------------------------
+# Required secrets / labels / skills — same as before consolidation
+# -----------------------------------------------------------------------------
+#   ANTHROPIC_API_KEY    (required)
+#   AGENT_GITHUB_TOKEN   (optional — falls back to github.token)
+#
+#   Labels:
+#     openspec:start       — manual trigger (consumed when a job starts)
+#     openspec:exploring   — plan job running
+#     openspec:spec-ready  — proposal PR open
+#     openspec:implement   — implement job running
+#     openspec:review      — code PR open
+#     openspec:failed      — any job failed
+#
+#   Skills under .claude/skills/openspec-* must be present (run
+#   `openspec init --tools claude` locally and commit the output).
+
+name: OpenSpec Flow
+
+on:
+  issues:
+    types: [assigned, labeled]
+  pull_request:
+    types: [closed, labeled]
+
+env:
+  AGENT_ASSIGNEE: "dwmkerr-agent"
+  # Name of a sub-agent that the flow prompts tell Claude to delegate to.
+  # Sourced from the repo/org variable `OPENSPEC_FLOW_SUBAGENT_NAME` so
+  # each project decides in its own Settings → Actions → Variables.
+  # Unset / empty ⇒ no sub-agent delegation instruction is included in
+  # the prompts; Claude does the work directly (with access to project
+  # CLAUDE.md). When set, the operator is responsible for creating
+  # `.claude/agents/<name>.md` with the rules that sub-agent should
+  # follow — project-specific sub-agent configuration is not auto-
+  # inherited from CLAUDE.md because Task-spawned sub-agents get a
+  # fresh context.
+  SUBAGENT_NAME: ${{ vars.OPENSPEC_FLOW_SUBAGENT_NAME }}
+  CLAUDE_CODE_ACTION_REF: "v1.0.79"
+  OPENSPEC_CLI_VERSION: "latest"
+  LABEL_START: "openspec:start"
+  LABEL_EXPLORING: "openspec:exploring"
+  LABEL_SPEC_READY: "openspec:spec-ready"
+  LABEL_IMPLEMENT: "openspec:implement"
+  LABEL_REVIEW: "openspec:review"
+  LABEL_FAILED: "openspec:failed"
+  # Embedded as an HTML comment in every agent-authored summary comment so
+  # later runs can find and delete prior summaries without touching human
+  # comments. Do not change casually — stale markers will leak.
+  AGENT_COMMENT_MARKER: "<!-- openspec-flow-summary -->"
+  REENGAGE_FOOTER: "Add the `openspec:start` label to re-engage the agent with the latest discussion."
+  # Version of dwmkerr/claude-toolkit used for the session-log usage-table scraping
+  # approach. The grepsession pattern (grep JSONL for "name":"Skill" / "name":"Task")
+  # is adapted inline for the CI path ($RUNNER_TEMP/claude-execution-output.json).
+  # Update when the toolkit releases a new version that changes the session log format.
+  CLAUDE_TOOLKIT_REF: "v0.1.6"
+  # Extra scopes requested on the OIDC-exchanged installation token used by
+  # the agent step. Sourced from the repo/org variable
+  # `AGENT_ADDITIONAL_PERMISSIONS` so each project decides in its own
+  # Settings → Actions → Variables (not in source). Unset / empty =
+  # defaults (contents/pull_requests/issues: write). Set to
+  # `workflows: write` if implement tasks need to edit
+  # `.github/workflows/*.yaml` — also requires granting the Claude
+  # GitHub App `workflows: read and write` on the repo. See CLAUDE.md →
+  # "Agent workflow permissions".
+  AGENT_ADDITIONAL_PERMISSIONS: ${{ vars.AGENT_ADDITIONAL_PERMISSIONS }}
+  # Debug knob — if set to "true", the agent's tool-call output is
+  # streamed into the run log. Default off because it can leak prompts /
+  # repo content on public runs. Flip via the repo variable
+  # `OPENSPEC_FLOW_SHOW_FULL_OUTPUT` when investigating silent no-ops.
+  OPENSPEC_FLOW_SHOW_FULL_OUTPUT: ${{ vars.OPENSPEC_FLOW_SHOW_FULL_OUTPUT }}
+  # Comma-separated list of GitHub logins allowed to trigger the flow.
+  # Sourced from repo/org variable `OPENSPEC_FLOW_ALLOWED_USERS` so it can
+  # be widened without a code change. Defaults to the repo owner and agent
+  # identity. Set to empty string to disable the check (not recommended).
+  ALLOWED_USERS: ${{ vars.OPENSPEC_FLOW_ALLOWED_USERS || 'dwmkerr,dwmkerr-agent' }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # PLAN — issue -> proposal PR
+  # ---------------------------------------------------------------------------
+  plan:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: openspec-flow-plan-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check trigger (assignee or start label, plus idempotency)
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+          ADDED_LABEL: ${{ github.event.label.name }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          if [ -n "$ALLOWED_USERS" ] && ! echo ",$ALLOWED_USERS," | grep -q ",$SENDER,"; then
+            echo "Sender $SENDER not in ALLOWED_USERS — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          fired=""
+          case "$EVENT_ACTION" in
+            assigned)
+              if [ "$ASSIGNEE_LOGIN" = "$AGENT_ASSIGNEE" ]; then
+                fired="assignee=$ASSIGNEE_LOGIN"
+              fi
+              ;;
+            labeled)
+              if [ "$ADDED_LABEL" = "$LABEL_START" ]; then
+                fired="label=$ADDED_LABEL"
+              fi
+              ;;
+          esac
+
+          if [ -z "$fired" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # spec-ready: implement job handles this trigger. Skip plan.
+          # review: impl PR is already open; nudge user to comment there.
+          # exploring/implement: work in flight; silent skip.
+          # failed: leave for manual cleanup (future: auto-retry).
+          if echo ",$ISSUE_LABELS," | grep -q ",$LABEL_REVIEW,"; then
+            echo "Issue is in $LABEL_REVIEW — nudging to impl PR"
+            # Only open or merged PRs count — a closed-unmerged PR is not
+            # something the user should be directed to comment on.
+            impl_pr=$(gh pr list --repo "$REPO" \
+              --state all --search "head:impl/$ISSUE_NUMBER-" \
+              --json number,url,state,mergedAt \
+              --jq '[.[] | select(.state == "OPEN" or .mergedAt != null)] | .[0] // empty' 2>/dev/null || echo "")
+            pr_url=$(echo "$impl_pr" | jq -r '.url // empty' 2>/dev/null)
+            {
+              echo "$AGENT_COMMENT_MARKER"
+              if [ -n "$pr_url" ]; then
+                echo "> Implementation is already under review at $pr_url."
+                echo "> To refine the implementation, comment on that PR and add \`$LABEL_START\` **there** — the respond job will pick up the discussion."
+              else
+                echo "> Issue is marked \`$LABEL_REVIEW\` but no \`impl/$ISSUE_NUMBER-*\` PR was found. Clear the label to retry implement."
+              fi
+              echo ""
+              echo "---"
+              echo "$REENGAGE_FOOTER"
+            } > /tmp/nudge.md
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/nudge.md
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo ",$ISSUE_LABELS," | grep -qE ",(${LABEL_EXPLORING}|${LABEL_SPEC_READY}|${LABEL_IMPLEMENT}|${LABEL_FAILED}),"; then
+            echo "Issue already in an openspec:* lifecycle state — skipping plan"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Preflight: if a spec PR for this issue has already been merged,
+          # plan has nothing to do — running it would scaffold a change
+          # folder that already exists on main, producing an empty diff
+          # (see #52 / PR #64). Nudge the user instead.
+          merged_spec=$(gh pr list --repo "$REPO" --state merged \
+            --search "head:spec/$ISSUE_NUMBER-" \
+            --json url --jq '.[0].url // empty')
+          if [ -n "$merged_spec" ]; then
+            echo "Spec already merged at $merged_spec — skipping plan"
+            {
+              echo "$AGENT_COMMENT_MARKER"
+              echo "> Spec for this issue is already merged at $merged_spec."
+              echo "> If you want to implement, set this issue to \`$LABEL_SPEC_READY\` and add \`$LABEL_START\` — the implement job will pick it up."
+              echo "> If you want to re-open the spec for changes, comment on the merged PR and open a new change explicitly."
+              echo ""
+              echo "---"
+              echo "$REENGAGE_FOOTER"
+            } > /tmp/nudge.md
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/nudge.md
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Triggered by $fired"
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify required labels exist
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          missing=()
+          for label in "$LABEL_START" "$LABEL_EXPLORING" "$LABEL_SPEC_READY" "$LABEL_FAILED"; do
+            if ! gh label list --repo "$REPO" --search "$label" --json name \
+                --jq '.[].name' | grep -Fxq "$label"; then
+              missing+=("$label")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required labels: ${missing[*]}"
+            {
+              echo "> OpenSpec Flow could not start: missing labels \`${missing[*]}\`. Create them and re-trigger."
+              echo ">"
+              echo "> $REENGAGE_FOOTER"
+            } > /tmp/comment.md
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+            exit 1
+          fi
+
+      # Inlined rather than dispatched to a script file because this step
+      # runs before `actions/checkout`, so the repo isn't on disk yet.
+      # When we move to a reusable composite action (e.g.
+      # `./.github/actions/openspec-flow-prune-comments`) we can hoist this,
+      # but that requires the action code to be fetched separately.
+      - name: Prune prior agent summary comments
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Pipe to jq so --arg reaches jq. `gh api --jq` takes a single
+          # expression string and does not forward --arg.
+          ids=$(gh api --paginate "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            | jq -r --arg m "$AGENT_COMMENT_MARKER" \
+              '.[] | select(.body | contains($m)) | .id')
+          [ -z "$ids" ] && { echo "No prior agent comments."; exit 0; }
+          while read -r id; do
+            [ -z "$id" ] && continue
+            gh api --method DELETE "repos/$REPO/issues/comments/$id" >/dev/null 2>&1 \
+              || echo "::warning::Failed to delete comment $id"
+          done <<< "$ids"
+
+      - name: React, label, and post starting comment
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          gh api -X POST "repos/$REPO/issues/$ISSUE_NUMBER/reactions" -f content="eyes" >/dev/null || true
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABEL_EXPLORING"
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow exploring this issue. [View run]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+
+      - name: Checkout repository
+        if: steps.check.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+
+      - name: Verify OpenSpec skills present
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          if [ ! -f .claude/skills/openspec-explore/SKILL.md ]; then
+            echo "::error::OpenSpec not installed"
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+              --body "> OpenSpec not installed. Run \`openspec init --tools claude\` locally and commit \`.claude/\`."
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+              --remove-label "$LABEL_EXPLORING" --add-label "$LABEL_FAILED" || true
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        if: steps.check.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install OpenSpec CLI
+        if: steps.check.outputs.run == 'true'
+        run: |
+          npm install -g "@fission-ai/openspec@${OPENSPEC_CLI_VERSION}"
+          openspec --version
+
+      - name: Clone claude-code-action
+        if: steps.check.outputs.run == 'true'
+        run: |
+          git clone --depth 1 --branch "$CLAUDE_CODE_ACTION_REF" \
+            https://github.com/anthropics/claude-code-action.git /tmp/claude-code-action
+
+      - name: Install bun
+        if: steps.check.outputs.run == 'true'
+        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+      - name: Install claude-code-action dependencies
+        if: steps.check.outputs.run == 'true'
+        run: cd /tmp/claude-code-action && bun install --production
+
+      - name: Run plan agent
+        if: steps.check.outputs.run == 'true'
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          show_full_output: ${{ env.OPENSPEC_FLOW_SHOW_FULL_OUTPUT }}
+          prompt: |
+            Drive issue #${{ github.event.issue.number }} in
+            ${{ github.repository }} to a draft OpenSpec proposal PR.
+            Issue title: "${{ github.event.issue.title }}"
+            ${{ env.SUBAGENT_NAME && format('
+
+            Run the work in a sub-agent called `{0}`.', env.SUBAGENT_NAME) || '' }}
+
+            1. EXPLORE — invoke the `openspec-explore` skill
+               (installed at `.claude/skills/openspec-explore/SKILL.md`).
+
+               Explore has two jobs: (a) surface open questions, (b) get
+               grounded in real context. Do both.
+
+               Grounding — before speccing:
+
+               - If the issue references a GitHub repo, skill, plugin,
+                 action, library, or any other external code, clone it:
+                   `git clone --depth 1 <url> /tmp/<name>`
+                 Read the files that matter (README, action.yml, entry
+                 scripts, exported APIs). Cite specific paths in the
+                 spec when you rely on their behaviour.
+
+               - If the issue references an article, spec, or doc URL,
+                 fetch and read it. Quote the relevant passage in the
+                 spec's context section.
+
+               - If the expected interface does not exist in the cloned
+                 repo (no such script, no such export, no such flag),
+                 that is an open question, not a hand-wave — capture it.
+
+               Open questions:
+
+               - If explore surfaces questions that the issue body and
+                 the grounded content together do not answer, list them
+                 in the proposal's "Open Questions" section. Proceed to
+                 BUILD SPEC only if none of the questions are spec-
+                 blocking (i.e. the spec can still capture a coherent
+                 intent despite them).
+               - If any open question IS spec-blocking, stop. Do not
+                 guess. Post a comment on the issue listing the blocking
+                 questions and exit without opening a PR — the human
+                 will answer and re-trigger.
+               - If no open questions remain, proceed directly.
+
+            2. BUILD SPEC — invoke the `openspec-ff-change` skill, deriving
+               the change name from the issue title (kebab-case, <= 40 chars).
+            3. OPEN PR — after `openspec validate <name> --strict` passes:
+               - commit on `spec/${{ github.event.issue.number }}-<slug>`
+               - open PR titled
+                 `chore: propose specification for #${{ github.event.issue.number }} <short title>`
+               - PR body order: `Refs #${{ github.event.issue.number }}`, blank line,
+                 2-4 sentence recap, one line naming the skills used,
+                 `---`, full contents of proposal.md.
+               - Post one comment on the issue with a one-paragraph recap,
+                 a sentence naming the skills, a link to the PR, and ending
+                 with a `---` rule on its own line followed by:
+                 "${{ env.REENGAGE_FOOTER }}"
+                 The comment body MUST start with the literal line
+                 `${{ env.AGENT_COMMENT_MARKER }}` so later runs can prune it.
+
+            CONSTRAINTS
+            - Write nothing outside `openspec/changes/<name>/`.
+            - Conventional commit PR title (`chore:` prefix).
+
+      - name: Inject usage table into spec PR body
+        if: success() && steps.check.outputs.run == 'true'
+        uses: ./.github/actions/openspec-flow-inject-usage-table
+        with:
+          branch_prefix: spec
+          issue_number: ${{ github.event.issue.number }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+
+      # Postflight: plan agent must open a spec PR with at least one file
+      # change. Empty diffs can happen when the change folder already
+      # exists on main and ff-change silently no-ops (see #52 / PR #64).
+      # If no PR exists, or the PR is empty, fail the step so the failure
+      # handler flips openspec:failed rather than advertising a fake
+      # openspec:spec-ready.
+      - name: Postflight — assert spec PR exists + non-empty
+        if: success() && steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          pr=$(gh pr list --repo "$REPO" --state open \
+            --search "head:spec/$ISSUE_NUMBER-" \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "::error::Plan agent reported success but no open spec/$ISSUE_NUMBER-* PR exists."
+            exit 1
+          fi
+          files=$(gh pr view "$pr" --repo "$REPO" --json files --jq '.files | length')
+          if [ "$files" -eq 0 ]; then
+            echo "::error::Plan agent opened spec PR #$pr but it has zero file changes."
+            gh pr close "$pr" --repo "$REPO" --delete-branch \
+              --comment "Closed by plan postflight — empty diff." || true
+            exit 1
+          fi
+          echo "Postflight ok — spec PR #$pr with $files file(s)."
+
+      - name: Flip label to openspec:spec-ready
+        if: success() && steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_EXPLORING" --add-label "$LABEL_SPEC_READY"
+
+      - name: Handle failure
+        if: failure() && steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_EXPLORING" --add-label "$LABEL_FAILED" || true
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow plan failed. [View logs]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+
+  # ---------------------------------------------------------------------------
+  # IMPLEMENT — spec/** PR merged -> code PR
+  # ---------------------------------------------------------------------------
+  implement:
+    # Fires on two paths:
+    #   (a) proposal PR closed/merged — the original auto-forward trigger
+    #   (b) issue labeled openspec:start while in spec-ready — human asks to
+    #       kick off implementation (e.g. impl never ran, or spec was merged
+    #       before the flow existed). Dedupe against any existing impl PR.
+    if: |
+      (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'openspec:start')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: openspec-flow-implement-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check trigger (proposal PR merge or issue relabel)
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          ISSUE_NUMBER_EVT: ${{ github.event.issue.number }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          if [ -n "$ALLOWED_USERS" ] && ! echo ",$ALLOWED_USERS," | grep -q ",$SENDER,"; then
+            echo "Sender $SENDER not in ALLOWED_USERS — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          issue_number=""
+          change_slug=""
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$MERGED" != "true" ]; then
+              echo "PR not merged — skipping"; echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            if [[ ! "$HEAD_REF" =~ ^spec/([0-9]+)-(.+)$ ]]; then
+              echo "PR head '$HEAD_REF' not spec/<n>-* — skipping"; echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            issue_number="${BASH_REMATCH[1]}"
+            change_slug="${BASH_REMATCH[2]}"
+          else
+            # issues.labeled with openspec:start — only implement when the
+            # issue is in spec-ready (plan job handles the unstarted case;
+            # nudge handles review; exploring/implement/failed silent-skip).
+            if ! echo ",$ISSUE_LABELS," | grep -q ",$LABEL_SPEC_READY,"; then
+              echo "Issue #$ISSUE_NUMBER_EVT not in $LABEL_SPEC_READY — skipping"; echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            issue_number="$ISSUE_NUMBER_EVT"
+            # Derive slug from the merged spec PR for this issue.
+            change_slug=$(gh pr list --repo "$REPO" --state merged \
+              --search "head:spec/$issue_number-" \
+              --json headRefName --jq '.[0].headRefName // empty' \
+              | sed -E "s|^spec/$issue_number-||")
+            if [ -z "$change_slug" ]; then
+              echo "::error::No merged spec/$issue_number-* PR found — cannot derive change slug"
+              gh issue comment "$issue_number" --repo "$REPO" \
+                --body "> No merged \`spec/$issue_number-*\` PR found. Cannot derive the change slug automatically."
+              gh issue edit "$issue_number" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+              echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            # Dedupe: only open or merged impl PRs block retry. A closed-
+            # unmerged PR (e.g. abandoned by a reviewer) should NOT prevent
+            # the user from re-triggering implement — otherwise issue #52
+            # behaviour recurs.
+            existing=$(gh pr list --repo "$REPO" --state all \
+              --search "head:impl/$issue_number-" \
+              --json url,state,mergedAt \
+              --jq '[.[] | select(.state == "OPEN" or .mergedAt != null)] | .[0].url // empty')
+            if [ -n "$existing" ]; then
+              echo "Impl PR already exists at $existing — nudging"
+              {
+                echo "$AGENT_COMMENT_MARKER"
+                echo "> Implementation PR already exists at $existing."
+                echo "> Add \`$LABEL_START\` on that PR to refine it."
+                echo ""
+                echo "---"
+                echo "$REENGAGE_FOOTER"
+              } > /tmp/nudge.md
+              gh issue comment "$issue_number" --repo "$REPO" --body-file /tmp/nudge.md
+              gh issue edit "$issue_number" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+              echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            # Consume the start label — implement job now owns this run.
+            gh issue edit "$issue_number" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "change_slug=$change_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Verify issue is in spec-ready state
+        id: verify-issue
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+        run: |
+          labels="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")"
+          if ! echo ",$labels," | grep -q ",$LABEL_SPEC_READY,"; then
+            echo "Issue #$ISSUE_NUMBER not in $LABEL_SPEC_READY (has: $labels) — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Prune prior agent summary comments
+        if: steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+        run: |
+          # Pipe to jq so --arg reaches jq. `gh api --jq` takes a single
+          # expression string and does not forward --arg.
+          ids=$(gh api --paginate "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            | jq -r --arg m "$AGENT_COMMENT_MARKER" \
+              '.[] | select(.body | contains($m)) | .id')
+          [ -z "$ids" ] && { echo "No prior agent comments."; exit 0; }
+          while read -r id; do
+            [ -z "$id" ] && continue
+            gh api --method DELETE "repos/$REPO/issues/comments/$id" >/dev/null 2>&1 \
+              || echo "::warning::Failed to delete comment $id"
+          done <<< "$ids"
+
+      - name: React, flip label, post starting comment
+        if: steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          # Populated when implement fires from a spec PR merge event; empty
+          # when fired from an issue relabel. Used to drop a breadcrumb on
+          # the merged spec PR so it is visible there too.
+          SPEC_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          gh api -X POST "repos/$REPO/issues/$ISSUE_NUMBER/reactions" -f content="rocket" >/dev/null || true
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_SPEC_READY" --add-label "$LABEL_IMPLEMENT"
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow Implement running. [View run]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+          if [ -n "$SPEC_PR_NUMBER" ]; then
+            {
+              echo "$AGENT_COMMENT_MARKER"
+              echo "> Implement stage starting for issue #$ISSUE_NUMBER. [View run]($RUN_URL)"
+              echo ""
+              echo "---"
+              echo "$REENGAGE_FOOTER"
+            } > /tmp/pr-comment.md
+            gh pr comment "$SPEC_PR_NUMBER" --repo "$REPO" --body-file /tmp/pr-comment.md || true
+          fi
+
+      - name: Checkout repository
+        if: steps.verify-issue.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+
+      - name: Setup Node.js
+        if: steps.verify-issue.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install OpenSpec CLI
+        if: steps.verify-issue.outputs.run == 'true'
+        run: |
+          npm install -g "@fission-ai/openspec@${OPENSPEC_CLI_VERSION}"
+          openspec --version
+
+      - name: Verify OpenSpec skills present
+        if: steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+        run: |
+          if [ ! -f .claude/skills/openspec-apply-change/SKILL.md ]; then
+            echo "::error::Apply skill missing"
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+              --body "> Apply skill missing. Run \`openspec init --tools claude\` locally."
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+              --remove-label "$LABEL_IMPLEMENT" --add-label "$LABEL_FAILED" || true
+            exit 1
+          fi
+
+      - name: Clone claude-code-action
+        if: steps.verify-issue.outputs.run == 'true'
+        run: |
+          git clone --depth 1 --branch "$CLAUDE_CODE_ACTION_REF" \
+            https://github.com/anthropics/claude-code-action.git /tmp/claude-code-action
+
+      - name: Install bun
+        if: steps.verify-issue.outputs.run == 'true'
+        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+      - name: Install claude-code-action dependencies
+        if: steps.verify-issue.outputs.run == 'true'
+        run: cd /tmp/claude-code-action && bun install --production
+
+      - name: Run implement agent
+        if: steps.verify-issue.outputs.run == 'true'
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          show_full_output: ${{ env.OPENSPEC_FLOW_SHOW_FULL_OUTPUT }}
+          prompt: |
+            Drive issue #${{ steps.check.outputs.issue_number }} in
+            ${{ github.repository }} through the OpenSpec implement stage.
+            The proposal PR for `spec/${{ steps.check.outputs.issue_number }}-${{ steps.check.outputs.change_slug }}`
+            has been merged into main, so the change folder
+            `openspec/changes/${{ steps.check.outputs.change_slug }}/` is on main.
+            ${{ env.SUBAGENT_NAME && format('
+
+            Run the work in a sub-agent called `{0}`.', env.SUBAGENT_NAME) || '' }}
+
+            1. APPLY — `openspec-apply-change` skill.
+            2. VERIFY — `openspec-verify-change` skill (skip if nothing to verify).
+            3. ARCHIVE — `openspec-archive-change` skill.
+            4. OPEN CODE PR — commit on `impl/${{ steps.check.outputs.issue_number }}-<slug>`,
+               title `feat: implement spec for #${{ steps.check.outputs.issue_number }} <short title>`.
+               PR body: `Closes #${{ steps.check.outputs.issue_number }}` on its
+               own line (so merging the impl PR auto-closes the issue), then
+               a blank line, 2-4 sentence recap, a sentence naming the skills,
+               `---`, bulleted file-change list.
+               Post one comment on the issue: one-paragraph recap, skills
+               used, link to PR. Comment body MUST start with the literal
+               line `${{ env.AGENT_COMMENT_MARKER }}` and end with `---`
+               then `${{ env.REENGAGE_FOOTER }}` on its own line.
+
+            CONSTRAINTS
+            - Change folder ends under `openspec/changes/archive/<name>/`.
+            - Conventional commit PR title.
+
+      - name: Inject usage table into impl PR body
+        if: success() && steps.verify-issue.outputs.run == 'true'
+        uses: ./.github/actions/openspec-flow-inject-usage-table
+        with:
+          branch_prefix: impl
+          issue_number: ${{ steps.check.outputs.issue_number }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+
+      # Postflight: agent often reports success but produces no impl PR
+      # (silent no-op — #48). Assert the expected artifact exists;
+      # fail the step if it does not, so the failure handler flips the
+      # label to openspec:failed rather than the misleading
+      # openspec:review. Minimal inline check until #48 lands properly.
+      - name: Postflight — assert impl PR exists
+        if: success() && steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+        run: |
+          pr=$(gh pr list --repo "$REPO" --state open \
+            --search "head:impl/$ISSUE_NUMBER-" \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "::error::Implement agent reported success but no impl/$ISSUE_NUMBER-* PR was opened. Silent no-op (see #48)."
+            exit 1
+          fi
+          echo "Postflight ok — impl PR #$pr exists."
+
+      - name: Flip label to openspec:review + breadcrumb spec PR
+        if: success() && steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          SPEC_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_IMPLEMENT" --add-label "$LABEL_REVIEW"
+          if [ -n "$SPEC_PR_NUMBER" ]; then
+            # Find the impl PR we just opened to link it on the spec PR.
+            impl_url=$(gh pr list --repo "$REPO" --state open \
+              --search "head:impl/$ISSUE_NUMBER-" \
+              --json url --jq '.[0].url // empty')
+            {
+              echo "$AGENT_COMMENT_MARKER"
+              if [ -n "$impl_url" ]; then
+                echo "> Implement stage complete — impl PR opened at $impl_url."
+              else
+                echo "> Implement stage reported success but no impl PR was found (see #48)."
+              fi
+              echo ""
+              echo "---"
+              echo "$REENGAGE_FOOTER"
+            } > /tmp/pr-comment.md
+            gh pr comment "$SPEC_PR_NUMBER" --repo "$REPO" --body-file /tmp/pr-comment.md || true
+          fi
+
+      - name: Handle failure
+        if: failure() && steps.verify-issue.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          SPEC_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_IMPLEMENT" --add-label "$LABEL_FAILED" || true
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow Implement failed. [View logs]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+          if [ -n "$SPEC_PR_NUMBER" ]; then
+            gh pr comment "$SPEC_PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md || true
+          fi
+
+  # ---------------------------------------------------------------------------
+  # RESPOND — openspec:start on a PR -> refine based on discussion
+  # ---------------------------------------------------------------------------
+  respond:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'openspec:start'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: openspec-flow-respond-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check trigger (spec/** or impl/** branch)
+        id: check
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          if [ -n "$ALLOWED_USERS" ] && ! echo ",$ALLOWED_USERS," | grep -q ",$SENDER,"; then
+            echo "Sender $SENDER not in ALLOWED_USERS — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          if [[ ! "$HEAD_REF" =~ ^(spec|impl)/([0-9]+)-(.+)$ ]]; then
+            echo "Branch '$HEAD_REF' is not spec/** or impl/** — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "branch_kind=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          echo "issue_number=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+          echo "change_slug=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+
+      - name: Prune prior agent summary comments
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ids=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+            | jq -r --arg m "$AGENT_COMMENT_MARKER" \
+              '.[] | select(.body | contains($m)) | .id')
+          [ -z "$ids" ] && { echo "No prior agent comments."; exit 0; }
+          while read -r id; do
+            [ -z "$id" ] && continue
+            gh api --method DELETE "repos/$REPO/issues/comments/$id" >/dev/null 2>&1 \
+              || echo "::warning::Failed to delete comment $id"
+          done <<< "$ids"
+
+      - name: React and post starting comment
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/reactions" -f content="eyes" >/dev/null || true
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow respond — reading the discussion and refining artifacts. [View run]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+
+      - name: Setup Node.js
+        if: steps.check.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install OpenSpec CLI
+        if: steps.check.outputs.run == 'true'
+        run: |
+          npm install -g "@fission-ai/openspec@${OPENSPEC_CLI_VERSION}"
+          openspec --version
+
+      - name: Clone claude-code-action
+        if: steps.check.outputs.run == 'true'
+        run: |
+          git clone --depth 1 --branch "$CLAUDE_CODE_ACTION_REF" \
+            https://github.com/anthropics/claude-code-action.git /tmp/claude-code-action
+
+      - name: Install bun
+        if: steps.check.outputs.run == 'true'
+        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+      - name: Install claude-code-action dependencies
+        if: steps.check.outputs.run == 'true'
+        run: cd /tmp/claude-code-action && bun install --production
+
+      - name: Run respond agent
+        if: steps.check.outputs.run == 'true'
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          show_full_output: ${{ env.OPENSPEC_FLOW_SHOW_FULL_OUTPUT }}
+          prompt: |
+            Refine PR #${{ github.event.pull_request.number }} in
+            ${{ github.repository }} based on the conversation so far.
+
+            Branch: `${{ github.event.pull_request.head.ref }}`
+            Branch kind: `${{ steps.check.outputs.branch_kind }}` (spec = proposal PR,
+            impl = code PR).
+            Change folder: `openspec/changes/${{ steps.check.outputs.change_slug }}/`
+            (for impl branches, the folder may have been moved under
+            `openspec/changes/archive/` already — check both).
+            ${{ env.SUBAGENT_NAME && format('
+
+            Run the work in a sub-agent called `{0}`.', env.SUBAGENT_NAME) || '' }}
+
+            HOW
+            1. READ THE CONVERSATION — use `gh` to fetch:
+               - `gh pr view ${{ github.event.pull_request.number }} --comments`
+               - `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews`
+               - `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`
+               Focus on human comments; ignore prior agent comments (those
+               starting with the line `${{ env.AGENT_COMMENT_MARKER }}`).
+
+            2. REFINE ARTIFACTS — based on the discussion:
+               - For a `spec/**` PR: update proposal.md / design.md / tasks.md /
+                 specs/**/*.md in the change folder. Re-run
+                 `openspec validate <slug> --strict` until it passes.
+               - For an `impl/**` PR: update the implementation files and/or
+                 archived spec content as the discussion requires.
+               If the conversation asks for no change, do not force one.
+
+            3. COMMIT AND PUSH — commit to the PR branch with a
+               conventional-commit message like
+               `chore(openspec): refine per PR review`. Push with
+               `git push origin HEAD`.
+
+            4. POST SUMMARY COMMENT — post one comment on the PR. It MUST:
+               - start with the literal line `${{ env.AGENT_COMMENT_MARKER }}`
+               - list each artifact you modified and the nature of the change
+                 (or state clearly that nothing needed changing, and why)
+               - end with `---` on its own line, then
+                 `${{ env.REENGAGE_FOOTER }}`
+
+            CONSTRAINTS
+            - Stay within the change folder for spec PRs; stay within the
+              implementation paths for impl PRs. Do not invent new scope.
+            - If a reviewer's ask conflicts with the spec, flag the conflict
+              in the summary comment rather than silently resolving it.
+
+      - name: Remove openspec:start label
+        if: always() && steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL_START" 2>/dev/null || true
+
+      - name: Handle failure
+        if: failure() && steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          RUN_URL="${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }}"
+          {
+            echo "$AGENT_COMMENT_MARKER"
+            echo "> OpenSpec Flow respond failed. [View logs]($RUN_URL)"
+            echo ""
+            echo "---"
+            echo "$REENGAGE_FOOTER"
+          } > /tmp/comment.md
+          gh issue comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+
+  # ---------------------------------------------------------------------------
+  # CLEANUP — impl/** PR closed -> reset the linked issue's label state.
+  #
+  # Two cases:
+  #   1. Merged: strip openspec:review. GitHub auto-closes the issue via the
+  #      `Closes #<n>` link in the PR body; we only own the label.
+  #   2. Closed unmerged: strip openspec:review and restore openspec:spec-ready
+  #      so the user can retry implement without a fake `review` label lying
+  #      on the issue (see state-machine bug around #52 / PR #62).
+  # ---------------------------------------------------------------------------
+  cleanup:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: openspec-flow-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check branch matches impl/<n>-*
+        id: check
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGED: ${{ github.event.pull_request.merged }}
+        run: |
+          if [[ ! "$HEAD_REF" =~ ^impl/([0-9]+)-(.+)$ ]]; then
+            echo "Head '$HEAD_REF' is not impl/<n>-* — skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "merged=$MERGED" >> "$GITHUB_OUTPUT"
+          echo "issue_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Reset linked issue label state
+        if: steps.check.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          MERGED: ${{ steps.check.outputs.merged }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Always strip stale in-flight labels.
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "$LABEL_REVIEW" \
+            --remove-label "$LABEL_IMPLEMENT" 2>/dev/null || true
+
+          if [ "$MERGED" = "true" ]; then
+            # Merge path — issue is closed by GitHub via `Closes #<n>`; no
+            # further label action needed.
+            echo "Impl PR merged — labels cleared."
+          else
+            # Unmerged close — restore spec-ready so implement can be retried.
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+              --add-label "$LABEL_SPEC_READY" 2>/dev/null || true
+            {
+              echo "$AGENT_COMMENT_MARKER"
+              echo "> Impl PR #$PR_NUMBER was closed without merging."
+              echo "> Issue reset to \`$LABEL_SPEC_READY\`. Add \`$LABEL_START\` to retry implement."
+              echo ""
+              echo "---"
+              echo "$REENGAGE_FOOTER"
+            } > /tmp/nudge.md
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/nudge.md || true
+          fi

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -93,7 +93,7 @@ env:
   # fresh context.
   SUBAGENT_NAME: ${{ vars.OPENSPEC_FLOW_SUBAGENT_NAME }}
   CLAUDE_CODE_ACTION_REF: "v1.0.79"
-  OPENSPEC_CLI_VERSION: "latest"
+  OPENSPEC_CLI_VERSION: "1.3.1"
   LABEL_START: "openspec:start"
   LABEL_EXPLORING: "openspec:exploring"
   LABEL_SPEC_READY: "openspec:spec-ready"


### PR DESCRIPTION
## Summary
- Ports OpenSpec Flow from dwmkerr/livedown — full plan → implement → respond → cleanup lifecycle driven by issue labels
- Clones `claude-code-action` at runtime (no external action references, consistent with `ark_agent.yml`)
- Access-controlled via `ALLOWED_USERS` env var (defaults to `dwmkerr,dwmkerr-agent`; override via repo variable `OPENSPEC_FLOW_ALLOWED_USERS`)

## Setup required
- Secrets: `ANTHROPIC_API_KEY`, `AGENT_GITHUB_TOKEN` (PAT for dwmkerr-agent)
- Labels: `openspec:start`, `openspec:exploring`, `openspec:spec-ready`, `openspec:implement`, `openspec:review`, `openspec:failed`
- OpenSpec skills in `.claude/skills/openspec-*/` (run `openspec init --tools claude` locally and commit)