### PR TITLE
test: migrate CLI tests to mock-llm

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -830,7 +830,6 @@ jobs:
   e2e-cli-tests:
     needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
-    if: ${{ needs.setup-container-cache-registry.outputs.is-fork-pr == 'false' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -883,6 +883,20 @@ jobs:
           kubectl wait --for=condition=ready pod -l app=ark-api -n default --timeout=120s
           kubectl wait --for=condition=ready pod -l app=ark-mcp -n default --timeout=120s
 
+      - name: Install mock-llm
+        run: |
+          for resource in deployment service serviceaccount configmap role rolebinding secret; do
+            kubectl delete $resource mock-llm -n default --ignore-not-found
+          done
+          for resource in clusterrole clusterrolebinding; do
+            kubectl delete $resource mock-llm --ignore-not-found
+          done
+          helm upgrade --install mock-llm oci://ghcr.io/dwmkerr/charts/mock-llm \
+            --version 0.1.28 \
+            --namespace default \
+            --values tests/pytest/cli-tests/mock-llm-values.yaml \
+            --wait --timeout=120s
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -895,12 +909,6 @@ jobs:
       - name: Run CLI tests
         env:
           PYTHONPATH: ${{ github.workspace }}/tests/pytest/cli-tests
-          CICD_OPENAI_API_KEY: ${{ secrets.CICD_OPENAI_API_KEY }}
-          CICD_OPENAI_BASE_URL: ${{ secrets.CICD_OPENAI_BASE_URL || 'https://api.openai.com/v1' }}
-          CICD_ANTHROPIC_API_KEY: ${{ secrets.CICD_ANTHROPIC_API_KEY }}
-          CICD_ANTHROPIC_BASE_URL: ${{ secrets.CICD_ANTHROPIC_BASE_URL }}
-          CICD_AZURE_API_KEY: ${{ secrets.CICD_AZURE_OPENAI_KEY }}
-          CICD_AZURE_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
         run: |
           cd tests/pytest/cli-tests/tests
           pytest . -n 3 --dist loadscope -v --tb=short --log-cli-level=INFO

--- a/tests/pytest/cli-tests/conftest.py
+++ b/tests/pytest/cli-tests/conftest.py
@@ -1,17 +1,36 @@
-def pytest_collection_modifyitems(items):
-    """Sort parametrized provider tests so all tests for a given provider run
-    together (openai → anthropic → azure). Without this, pytest interleaves
-    them by test name, causing create/delete races across providers when using
-    the module-scoped cleanup fixture."""
-    provider_order = {"openai": 0, "anthropic": 1, "azure": 2}
-    original_order = {item: i for i, item in enumerate(items)}
+import logging
+import subprocess
+from pathlib import Path
 
-    def sort_key(item):
-        node = item.nodeid
-        bracket = node.rfind("[")
-        if bracket != -1:
-            provider = node[bracket + 1:].rstrip("]")
-            return (provider_order.get(provider, 99), original_order[item])
-        return (99, original_order[item])
+import pytest
 
-    items.sort(key=sort_key)
+logger = logging.getLogger(__name__)
+
+MOCK_LLM_MODEL_YAML = Path(__file__).parent / "mock-llm-model.yaml"
+MOCK_LLM_MODEL_NAME = "test-model-mock"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_llm_model(request):
+    result = subprocess.run(
+        ["kubectl", "apply", "-f", str(MOCK_LLM_MODEL_YAML)],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        logger.warning("kubectl apply mock-llm-model failed (rc=%d): %s %s",
+                       result.returncode, result.stdout.strip(), result.stderr.strip())
+
+    subprocess.run(
+        ["kubectl", "wait", "--for=condition=ModelAvailable",
+         f"model/{MOCK_LLM_MODEL_NAME}", "-n", "default", "--timeout=60s"],
+        check=True
+    )
+
+    yield MOCK_LLM_MODEL_NAME
+
+    worker_id = getattr(request.config, "workerinput", {}).get("workerid", "master")
+    if worker_id == "master":
+        subprocess.run(
+            ["kubectl", "delete", "-f", str(MOCK_LLM_MODEL_YAML), "--ignore-not-found"],
+            capture_output=True
+        )

--- a/tests/pytest/cli-tests/helpers/models_helper.py
+++ b/tests/pytest/cli-tests/helpers/models_helper.py
@@ -7,8 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-DEFAULT_AZURE_API_VERSION = "2024-04-01-preview"
-
 
 class ModelsHelper:
     NAMESPACE = "default"
@@ -75,40 +73,20 @@ class ModelsHelper:
         }
         return self._apply_yaml(resource)
 
-    def create_anthropic_model(self, name: str, secret_name: str, model: str = "claude-3-haiku-20240307", base_url: str = "") -> Tuple[bool, str]:
+    def create_mock_model(self, name: str, model: str = "gpt-4.1-mini") -> Tuple[bool, str]:
         resource: Dict[str, Any] = {
             "apiVersion": "ark.mckinsey.com/v1alpha1",
             "kind": "Model",
             "metadata": {"name": name, "namespace": self.NAMESPACE},
             "spec": {
                 "config": {
-                    "anthropic": {
-                        "apiKey": {"valueFrom": {"secretKeyRef": {"key": "token", "name": secret_name}}},
-                        "baseUrl": {"value": base_url},
+                    "openai": {
+                        "apiKey": {"value": "mock-api-key"},
+                        "baseUrl": {"value": "http://mock-llm.default.svc.cluster.local:6556/v1"},
                     }
                 },
                 "model": {"value": model},
-                "provider": "anthropic",
-                "type": "completions",
-            },
-        }
-        return self._apply_yaml(resource)
-
-    def create_azure_model(self, name: str, secret_name: str, model: str = "gpt-35-turbo", base_url: str = "", api_version: str = DEFAULT_AZURE_API_VERSION) -> Tuple[bool, str]:
-        resource: Dict[str, Any] = {
-            "apiVersion": "ark.mckinsey.com/v1alpha1",
-            "kind": "Model",
-            "metadata": {"name": name, "namespace": self.NAMESPACE},
-            "spec": {
-                "config": {
-                    "azure": {
-                        "auth": {"apiKey": {"valueFrom": {"secretKeyRef": {"key": "token", "name": secret_name}}}},
-                        "baseUrl": {"value": base_url},
-                        "apiVersion": {"value": api_version},
-                    }
-                },
-                "model": {"value": model},
-                "provider": "azure",
+                "provider": "openai",
                 "type": "completions",
             },
         }
@@ -173,7 +151,3 @@ class ModelsHelper:
             ["kubectl", "delete", "secret", name, "-n", self.NAMESPACE, "--ignore-not-found=true"],
         )
         return success, stderr
-
-    def cleanup(self, model_name: str, secret_name: str) -> None:
-        self.delete_model(model_name)
-        self.delete_secret(secret_name)

--- a/tests/pytest/cli-tests/mock-llm-model.yaml
+++ b/tests/pytest/cli-tests/mock-llm-model.yaml
@@ -1,0 +1,17 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: test-model-mock
+  namespace: default
+spec:
+  type: completions
+  provider: openai
+  model:
+    value: gpt-4.1-mini
+  pollInterval: 3s
+  config:
+    openai:
+      baseUrl:
+        value: http://mock-llm.default.svc.cluster.local:6556/v1
+      apiKey:
+        value: mock-api-key

--- a/tests/pytest/cli-tests/mock-llm-values.yaml
+++ b/tests/pytest/cli-tests/mock-llm-values.yaml
@@ -1,0 +1,20 @@
+terminationGracePeriodSeconds: 1
+resources:
+  limits:
+    cpu: 50m
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: '{"object":"list","data":[{"id":"gpt-4.1-mini","object":"model","owned_by":"openai"}]}'
+
+  - path: "/v1/chat/completions"
+    response:
+      status: 200
+      content: '{"id":"mock-response","object":"chat.completion","model":"gpt-4.1-mini","choices":[{"message":{"role":"assistant","content":"Hello! I received your message."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":10,"total_tokens":20}}'

--- a/tests/pytest/cli-tests/tests/test_file_gateway.py
+++ b/tests/pytest/cli-tests/tests/test_file_gateway.py
@@ -1,5 +1,6 @@
 import pytest
 from helpers.file_gateway_helper import FileGatewayHelper
+from helpers.mcp_servers_helper import McpServersHelper
 
 
 @pytest.fixture(scope="session")
@@ -315,6 +316,26 @@ def test_file_api_image_repository(helper):
     pod_names = helper.get_pod_names()
     file_api_pods = [p for p in pod_names if 'file-api' in p]
     assert len(file_api_pods) > 0, "file-api pod not found"
-    
+
     image = helper.get_pod_image(file_api_pods[0])
     assert "ghcr.io/mckinsey" in image or "file-api" in image, f"file-api image repository unexpected: {image}"
+
+
+def test_file_gateway_mcp_server(helper):
+    """Test File Gateway MCP server is available with tools"""
+    mcp_helper = McpServersHelper()
+    server_name = "file-gateway"
+
+    success, server_data = mcp_helper.get_mcp_server(server_name)
+    assert success, f"Failed to get MCP server {server_name}"
+
+    status = server_data.get("status", {})
+    tool_count = status.get("toolCount", 0)
+    assert tool_count > 0, f"File Gateway should have tools, found {tool_count}"
+
+    conditions = status.get("conditions", [])
+    available = any(
+        c.get("type") == "Available" and c.get("status") == "True"
+        for c in conditions
+    )
+    assert available, "File Gateway MCP server should be Available"

--- a/tests/pytest/cli-tests/tests/test_mcp_servers.py
+++ b/tests/pytest/cli-tests/tests/test_mcp_servers.py
@@ -4,7 +4,7 @@ from helpers.mcp_servers_helper import McpServersHelper
 
 class TestMcpServersCLI:
     helper = None
-    test_server_name = "file-gateway-mcpserver"
+    test_server_name = "file-gateway"
     
     @classmethod
     def setup_class(cls):
@@ -83,28 +83,6 @@ class TestMcpServersCLI:
         
         assert success, f"Failed to verify MCP server endpoint: {endpoint}"
         assert len(endpoint) > 0, "Endpoint should not be empty"
-    
-    def test_file_gateway_mcp_server_specific(self):
-        success, servers = self.helper.list_mcp_servers()
-        if not success:
-            pytest.skip("Failed to list MCP servers")
-        
-        if self.test_server_name not in servers:
-            pytest.skip(f"MCP server {self.test_server_name} not found")
-        
-        success, server_data = self.helper.get_mcp_server(self.test_server_name)
-        assert success, f"Failed to get {self.test_server_name}"
-        
-        status = server_data.get("status", {})
-        tool_count = status.get("toolCount", 0)
-        assert tool_count > 0, f"File Gateway should have tools, found {tool_count}"
-        
-        conditions = status.get("conditions", [])
-        available = any(
-            c.get("type") == "Available" and c.get("status") == "True" 
-            for c in conditions
-        )
-        assert available, "File Gateway MCP server should be Available"
     
     def test_mcp_server_metadata(self):
         success, servers = self.helper.list_mcp_servers()

--- a/tests/pytest/cli-tests/tests/test_models.py
+++ b/tests/pytest/cli-tests/tests/test_models.py
@@ -1,41 +1,8 @@
-import os
 import pytest
-from helpers.models_helper import DEFAULT_AZURE_API_VERSION, ModelsHelper
+from helpers.models_helper import ModelsHelper
 
-PREFIX = "cli-model-test"
-
-PROVIDERS = [
-    pytest.param(
-        "openai",
-        {"api_key_env": "CICD_OPENAI_API_KEY", "base_url_env": "CICD_OPENAI_BASE_URL", "model": "gpt-4o-mini"},
-        id="openai",
-    ),
-    pytest.param(
-        "anthropic",
-        {"api_key_env": "CICD_ANTHROPIC_API_KEY", "base_url_env": "CICD_ANTHROPIC_BASE_URL", "model": "claude-3-haiku-20240307"},
-        id="anthropic",
-    ),
-    pytest.param(
-        "azure",
-        {"api_key_env": "CICD_AZURE_API_KEY", "base_url_env": "CICD_AZURE_BASE_URL", "model": "gpt-35-turbo", "api_version": DEFAULT_AZURE_API_VERSION},
-        id="azure",
-    ),
-]
-
-
-def _secret_name(provider: str) -> str:
-    return f"{PREFIX}-{provider}-secret"
-
-
-def _model_name(provider: str) -> str:
-    return f"{PREFIX}-{provider}"
-
-
-def _skip_if_missing(config: dict) -> None:
-    if not os.environ.get(config["api_key_env"]):
-        pytest.skip(f"{config['api_key_env']} not set")
-    if config.get("base_url_env") and not os.environ.get(config["base_url_env"]):
-        pytest.skip(f"{config['base_url_env']} not set")
+SECRET_MODEL_NAME = "cli-model-test-secret"
+SECRET_NAME = "cli-model-test-secret-token"
 
 
 @pytest.fixture(scope="module")
@@ -43,66 +10,86 @@ def helper():
     return ModelsHelper()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def cleanup(helper):
-    yield
-    for p in PROVIDERS:
-        helper.cleanup(_model_name(p.id), _secret_name(p.id))
+@pytest.mark.models
+class TestSecretModel:
+    """Tests secret creation and a model that uses secretKeyRef.
+    The model will not become available (no real LLM behind the URL),
+    but we verify the CRUD operations and spec are correct."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def cleanup(self, helper):
+        yield
+        helper.delete_model(SECRET_MODEL_NAME)
+        helper.delete_secret(SECRET_NAME)
+
+    def test_create_secret(self, helper):
+        success, msg = helper.create_secret(SECRET_NAME, "dummy-token")
+        assert success, f"Failed to create secret: {msg}"
+
+    def test_secret_exists(self, helper):
+        success, _, stderr = helper._run_cmd(
+            ["kubectl", "get", "secret", SECRET_NAME, "-n", helper.NAMESPACE],
+            check=False,
+        )
+        assert success, f"Secret not found: {stderr}"
+
+    def test_create_model(self, helper):
+        success, msg = helper.create_openai_model(
+            SECRET_MODEL_NAME, SECRET_NAME, "gpt-4o-mini",
+            "http://mock-llm.default.svc.cluster.local:6556/v1"
+        )
+        assert success, f"Failed to create model: {msg}"
+
+    def test_model_exists(self, helper):
+        assert helper.model_exists(SECRET_MODEL_NAME), "Model not found in cluster"
+
+    def test_model_provider_spec(self, helper):
+        actual = helper.get_model_provider(SECRET_MODEL_NAME)
+        assert actual == "openai", f"Expected provider 'openai', got '{actual}'"
+
+    def test_model_name_spec(self, helper):
+        actual = helper.get_model_name_value(SECRET_MODEL_NAME)
+        assert actual == "gpt-4o-mini", f"Expected model 'gpt-4o-mini', got '{actual}'"
+
+    def test_delete_model(self, helper):
+        success, msg = helper.delete_model(SECRET_MODEL_NAME)
+        assert success, f"Failed to delete model: {msg}"
+        assert not helper.model_exists(SECRET_MODEL_NAME), "Model still exists after deletion"
+
+    def test_delete_secret(self, helper):
+        success, msg = helper.delete_secret(SECRET_NAME)
+        assert success, f"Failed to delete secret: {msg}"
 
 
 @pytest.mark.models
-@pytest.mark.parametrize("provider,config", PROVIDERS)
-class TestProviderModels:
+class TestMockModel:
+    MODEL_NAME = "cli-model-test-mock"
 
-    def test_create_secret(self, helper, provider, config):
-        _skip_if_missing(config)
-        api_key = os.environ[config["api_key_env"]]
-        success, msg = helper.create_secret(_secret_name(provider), api_key)
-        assert success, f"Failed to create {provider} secret: {msg}"
+    @pytest.fixture(scope="class", autouse=True)
+    def cleanup(self, helper):
+        yield
+        helper.delete_model(self.MODEL_NAME)
 
-    def test_secret_exists(self, helper, provider, config):
-        _skip_if_missing(config)
-        success, _, stderr = helper._run_cmd(
-            ["kubectl", "get", "secret", _secret_name(provider), "-n", helper.NAMESPACE],
-            check=False,
-        )
-        assert success, f"{provider} secret not found: {stderr}"
+    def test_create_model(self, helper):
+        success, msg = helper.create_mock_model(self.MODEL_NAME)
+        assert success, f"Failed to create mock model: {msg}"
 
-    def test_create_model(self, helper, provider, config):
-        _skip_if_missing(config)
-        base_url = os.environ.get(config["base_url_env"], "") if config["base_url_env"] else ""
-        if provider == "openai":
-            success, msg = helper.create_openai_model(_model_name(provider), _secret_name(provider), config["model"], base_url)
-        elif provider == "anthropic":
-            success, msg = helper.create_anthropic_model(_model_name(provider), _secret_name(provider), config["model"], base_url)
-        else:
-            api_version = config.get("api_version", DEFAULT_AZURE_API_VERSION)
-            success, msg = helper.create_azure_model(_model_name(provider), _secret_name(provider), config["model"], base_url, api_version)
-        assert success, f"Failed to create {provider} model: {msg}"
+    def test_model_exists(self, helper):
+        assert helper.model_exists(self.MODEL_NAME), "Mock model not found in cluster"
 
-    def test_model_exists(self, helper, provider, config):
-        _skip_if_missing(config)
-        assert helper.model_exists(_model_name(provider)), f"{provider} model not found in cluster"
+    def test_model_provider_spec(self, helper):
+        actual = helper.get_model_provider(self.MODEL_NAME)
+        assert actual == "openai", f"Expected provider 'openai', got '{actual}'"
 
-    def test_model_provider_spec(self, helper, provider, config):
-        _skip_if_missing(config)
-        actual = helper.get_model_provider(_model_name(provider))
-        assert actual == provider, f"Expected provider '{provider}', got '{actual}'"
+    def test_model_name_spec(self, helper):
+        actual = helper.get_model_name_value(self.MODEL_NAME)
+        assert actual == "gpt-4.1-mini", f"Expected model 'gpt-4.1-mini', got '{actual}'"
 
-    def test_model_name_spec(self, helper, provider, config):
-        _skip_if_missing(config)
-        actual = helper.get_model_name_value(_model_name(provider))
-        assert actual == config["model"], f"Expected model '{config['model']}', got '{actual}'"
+    def test_model_available(self, helper):
+        available, message = helper.wait_for_availability(self.MODEL_NAME)
+        assert available, f"Mock model not available after timeout: {message}"
 
-    def test_model_available(self, helper, provider, config):
-        _skip_if_missing(config)
-        available, message = helper.wait_for_availability(_model_name(provider))
-        if not available and "unknown error" in message:
-            pytest.skip(f"{provider} model unreachable from cluster (network): {message}")
-        assert available, f"{provider} model not available after timeout: {message}"
-
-    def test_delete_model(self, helper, provider, config):
-        _skip_if_missing(config)
-        success, msg = helper.delete_model(_model_name(provider))
-        assert success, f"Failed to delete {provider} model: {msg}"
-        assert not helper.model_exists(_model_name(provider)), f"{provider} model still exists after deletion"
+    def test_delete_model(self, helper):
+        success, msg = helper.delete_model(self.MODEL_NAME)
+        assert success, f"Failed to delete mock model: {msg}"
+        assert not helper.model_exists(self.MODEL_NAME), "Mock model still exists after deletion"

--- a/tests/pytest/cli-tests/tests/test_queries.py
+++ b/tests/pytest/cli-tests/tests/test_queries.py
@@ -1,9 +1,7 @@
-import base64
 import json
-import os
 import subprocess
 import sys
-import time
+import os
 
 import pytest
 
@@ -16,310 +14,153 @@ class TestQueriesCLI:
     helper = None
     created_queries = []
     agent_name = "test-cli-agent"
-    model_name = "test-cli-model"
-    secret_name = "test-cli-model-token"
-    provider_config = None
-    
+    model_name = "test-model-mock"
+
     @classmethod
     def setup_class(cls):
         cls.helper = QueriesHelper()
+        cls.created_queries = []
 
-        if os.environ.get("CICD_AZURE_API_KEY") and os.environ.get("CICD_AZURE_BASE_URL"):
-            cls.provider_config = {
-                "type": "azure",
-                "model": "gpt-4.1-mini",
-                "token": os.environ["CICD_AZURE_API_KEY"],
-                "url": os.environ["CICD_AZURE_BASE_URL"],
-                "apiVersion": os.environ.get("CICD_AZURE_API_VERSION", "2024-12-01-preview"),
-            }
-        elif os.environ.get("CICD_OPENAI_API_KEY") and os.environ.get("CICD_OPENAI_BASE_URL"):
-            cls.provider_config = {
-                "type": "openai",
-                "model": os.environ.get("CICD_OPENAI_MODEL", "gpt-4o-mini"),
-                "token": os.environ["CICD_OPENAI_API_KEY"],
-                "url": os.environ["CICD_OPENAI_BASE_URL"],
-            }
-        else:
-            cls.provider_config = None
-    
-    @classmethod
-    def teardown_class(cls):
-        if cls.helper:
-            cls.helper.cleanup_queries("test-query-cli-")
-        
         subprocess.run(
             ["kubectl", "delete", "agent", cls.agent_name, "-n", "default", "--ignore-not-found=true"],
             capture_output=True
         )
-        subprocess.run(
-            ["kubectl", "delete", "model", cls.model_name, "-n", "default", "--ignore-not-found=true"],
-            capture_output=True
-        )
-        subprocess.run(
-            ["kubectl", "delete", "secret", cls.secret_name, "-n", "default", "--ignore-not-found=true"],
-            capture_output=True
-        )
-    
-    def test_setup_prerequisites(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
-        secret_yaml = f"""apiVersion: v1
-kind: Secret
-metadata:
-  name: {self.secret_name}
-  namespace: default
-type: Opaque
-data:
-  token: {base64.b64encode(self.provider_config['token'].encode()).decode()}
-"""
-        
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", "-"],
-            input=secret_yaml,
-            capture_output=True,
-            text=True
-        )
-        
-        assert result.returncode == 0 or "already exists" in result.stderr.lower(), f"Failed to create secret: {result.stderr}"
-        
-        provider_type = self.provider_config['type']
-        if provider_type == 'openai':
-            model_yaml = f"""apiVersion: ark.mckinsey.com/v1alpha1
-kind: Model
-metadata:
-  name: {self.model_name}
-  namespace: default
-spec:
-  type: openai
-  model:
-    value: {self.provider_config['model']}
-  config:
-    openai:
-      baseUrl:
-        value: {self.provider_config['url']}
-      apiKey:
-        valueFrom:
-          secretKeyRef:
-            name: {self.secret_name}
-            key: token
-"""
-        elif provider_type == 'azure':
-            model_yaml = f"""apiVersion: ark.mckinsey.com/v1alpha1
-kind: Model
-metadata:
-  name: {self.model_name}
-  namespace: default
-spec:
-  type: azure
-  model:
-    value: {self.provider_config['model']}
-  config:
-    azure:
-      baseUrl:
-        value: {self.provider_config['url']}
-      apiVersion:
-        value: {self.provider_config['apiVersion']}
-      apiKey:
-        valueFrom:
-          secretKeyRef:
-            name: {self.secret_name}
-            key: token
-"""
-        elif provider_type == 'bedrock':
-            endpoint_config = ""
-            if self.provider_config.get('endpoint'):
-                endpoint_config = f"""      endpoint:
-        value: {self.provider_config['endpoint']}
-"""
-            model_yaml = f"""apiVersion: ark.mckinsey.com/v1alpha1
-kind: Model
-metadata:
-  name: {self.model_name}
-  namespace: default
-spec:
-  type: bedrock
-  model:
-    value: {self.provider_config['model']}
-  config:
-    bedrock:
-      region:
-        value: {self.provider_config['region']}
-{endpoint_config}      bearerToken:
-        valueFrom:
-          secretKeyRef:
-            name: {self.secret_name}
-            key: token
-"""
-        else:
-            pytest.skip(f"Unknown provider type: {provider_type}")
-        
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", "-"],
-            input=model_yaml,
-            capture_output=True,
-            text=True
-        )
-        
-        assert result.returncode == 0 or "already exists" in result.stderr.lower(), f"Failed to create model: {result.stderr}"
 
-        deadline = time.time() + 30
-        available = False
-        while time.time() < deadline:
-            result = subprocess.run(
-                ["kubectl", "get", "model", self.model_name, "-n", "default", "-o", "json"],
-                capture_output=True,
-                text=True,
-                timeout=10
-            )
-            if result.returncode == 0:
-                model_data = json.loads(result.stdout)
-                conditions = model_data.get("status", {}).get("conditions", [])
-                available = any(
-                    c.get("type") == "ModelAvailable" and c.get("status") == "True"
-                    for c in conditions
-                )
-                if available:
-                    break
-            time.sleep(2)
-        assert available, f"Model {self.model_name} did not become available within 30s"
-        
         agent_yaml = f"""apiVersion: ark.mckinsey.com/v1alpha1
 kind: Agent
 metadata:
-  name: {self.agent_name}
+  name: {cls.agent_name}
   namespace: default
 spec:
   modelRef:
-    name: {self.model_name}
+    name: {cls.model_name}
   prompt: |
     You are a test agent used for CLI testing.
     Keep responses concise and indicate that you are a test agent.
 """
-        
         result = subprocess.run(
             ["kubectl", "apply", "-f", "-"],
             input=agent_yaml,
             capture_output=True,
             text=True
         )
-        
-        assert result.returncode == 0 or "already exists" in result.stderr.lower(), f"Failed to create agent: {result.stderr}"
-    
+        assert result.returncode == 0, f"Failed to create test agent: {result.stderr}"
+
+    @classmethod
+    def teardown_class(cls):
+        if cls.helper:
+            cls.helper.cleanup_queries("test-query-cli-")
+
+        subprocess.run(
+            ["kubectl", "delete", "agent", cls.agent_name, "-n", "default", "--ignore-not-found=true"],
+            capture_output=True
+        )
+
+    def test_setup_prerequisites(self):
+        result = subprocess.run(
+            ["kubectl", "get", "model", self.model_name, "-n", "default", "-o", "json"],
+            capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0, f"Mock model not found: {result.stderr}"
+
+        model_data = json.loads(result.stdout)
+        conditions = model_data.get("status", {}).get("conditions", [])
+        available = any(
+            c.get("type") == "ModelAvailable" and c.get("status") == "True"
+            for c in conditions
+        )
+        assert available, f"Model {self.model_name} is not available"
+
+        result = subprocess.run(
+            ["kubectl", "get", "agent", self.agent_name, "-n", "default"],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, f"Test agent not found: {result.stderr}"
+
     def test_create_query(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         query_name = "test-query-cli-create"
         success, message = self.helper.create_query(
             name=query_name,
             agent_name=self.agent_name,
             input_text="Say hello in one sentence",
-            timeout=180
+            timeout=60
         )
-        
         assert success, f"Query creation failed: {message}"
         self.created_queries.append(query_name)
-    
+
     def test_get_query(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         query_name = "test-query-cli-get"
         success, message = self.helper.create_query(
             name=query_name,
             agent_name=self.agent_name,
             input_text="What is 2+2? Answer in one short sentence.",
-            timeout=180
+            timeout=60
         )
-        
-        if not success:
-            pytest.skip(f"Query creation failed: {message}")
-        
+        assert success, f"Query creation failed: {message}"
         self.created_queries.append(query_name)
-        
+
         success, query_data = self.helper.get_query(query_name)
         assert success, "Failed to get query"
         assert query_data is not None
         assert query_data["metadata"]["name"] == query_name
-    
+
     def test_get_query_response(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         query_name = "test-query-cli-response"
         success, message = self.helper.create_query(
             name=query_name,
             agent_name=self.agent_name,
             input_text="Reply with OK in one sentence.",
-            timeout=180
+            timeout=60
         )
-        
-        if not success:
-            pytest.skip(f"Query creation failed: {message}")
-        
+        assert success, f"Query creation failed: {message}"
         self.created_queries.append(query_name)
-        
+
         success, response = self.helper.get_query_response(query_name)
         assert success, "Failed to get query response"
         assert response is not None
         assert len(response) > 0
         assert "Phase:" in response
-    
+
     def test_list_queries(self):
         success, queries = self.helper.list_queries()
         assert success, "Failed to list queries"
         assert isinstance(queries, list)
-        
+
         for query_name in self.created_queries:
             assert query_name in queries, f"Query {query_name} not found in list"
-    
+
     def test_verify_query_status(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         query_name = "test-query-cli-status"
         success, message = self.helper.create_query(
             name=query_name,
             agent_name=self.agent_name,
             input_text="Status check. Reply in one sentence.",
-            timeout=180
+            timeout=60
         )
-        
-        if not success:
-            pytest.skip(f"Query creation failed: {message}")
-        
+        assert success, f"Query creation failed: {message}"
         self.created_queries.append(query_name)
-        
+
         success, status = self.helper.verify_query_status(query_name)
         assert success, "Failed to verify query status"
         assert status in ["Completed", "Failed", "InProgress"]
-    
+
     def test_delete_query(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         query_name = "test-query-cli-delete"
         success, message = self.helper.create_query(
             name=query_name,
             agent_name=self.agent_name,
             input_text="Delete me. Reply in one sentence.",
-            timeout=180
+            timeout=60
         )
-        
-        if not success:
-            pytest.skip(f"Query creation failed: {message}")
-        
+        assert success, f"Query creation failed: {message}"
+
         success, message = self.helper.delete_query(query_name)
         assert success, f"Failed to delete query: {message}"
-        
+
         success, query_data = self.helper.get_query(query_name)
         assert not success or query_data is None, "Query should not exist after deletion"
-    
+
     def test_cleanup_queries(self):
-        if not self.provider_config:
-            pytest.skip("No model provider credentials configured")
-        
         created_count = 0
         for i in range(3):
             query_name = f"test-query-cli-cleanup-{i}"
@@ -327,14 +168,13 @@ spec:
                 name=query_name,
                 agent_name=self.agent_name,
                 input_text=f"Test {i}. Reply in one sentence.",
-                timeout=180
+                timeout=60
             )
             if success:
                 created_count += 1
-        
-        if created_count == 0:
-            pytest.skip("No queries could be created")
-        
+
+        assert created_count > 0, "No queries could be created"
+
         success, count = self.helper.cleanup_queries("test-query-cli-cleanup-")
         assert success, "Failed to cleanup queries"
         assert count >= 1, f"Expected at least 1 query deleted, got {count}"


### PR DESCRIPTION
- Replace real LLM provider tests with mock-llm in cli-tests
- Add mock-llm-values.yaml and mock-llm-model.yaml for CLI test suite
- Rewrite conftest.py with session-scoped mock_llm_model fixture (xdist-safe)
- Replace TestProviderModels with TestSecretModel (CRUD without real LLM) and TestMockModel (full lifecycle with mock-llm)
- Rewrite test_queries.py to use test-model-mock with delete-before-create guard
- Fix test_mcp_servers.py test_server_name from file-gateway-mcpserver to file-gateway
- Move test_file_gateway_mcp_server_specific into test_file_gateway.py (runs after installation)
- Add mock-llm install step to e2e-cli-tests CI job; remove real provider env vars

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 