### PR TITLE
fix(openspec-flow): scraper format + drop skill-naming prompts

### DIFF
--- a/.github/actions/openspec-flow-inject-usage-table/action.yml
+++ b/.github/actions/openspec-flow-inject-usage-table/action.yml
@@ -53,36 +53,46 @@ runs:
             close_m = '<!-- /openspec-flow-usage-table -->'
             rows, step = [], 1
             if os.path.exists(session_log):
+                # claude-code-action writes a single pretty-printed JSON
+                # array of SDKMessage objects, not JSONL. Parse the whole
+                # file once and iterate items.
+                # See: anthropics/claude-code-action base-action/src/run-claude-sdk.ts
+                # `await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2))`
                 with open(session_log) as f:
-                    for line in f:
-                        try:
-                            obj = json.loads(line.strip())
-                        except Exception:
+                    raw = f.read()
+                try:
+                    messages = json.loads(raw)
+                except Exception as e:
+                    print(f'::warning::Could not parse session log as JSON ({e}) — table will be empty')
+                    messages = []
+                if not isinstance(messages, list):
+                    print(f'::warning::Session log root is {type(messages).__name__}, expected list — table will be empty')
+                    messages = []
+                for obj in messages:
+                    if not isinstance(obj, dict):
+                        continue
+                    msg = obj.get('message')
+                    if not isinstance(msg, dict):
+                        continue
+                    content = msg.get('content')
+                    if not isinstance(content, list):
+                        continue
+                    for item in content:
+                        if not isinstance(item, dict):
                             continue
-                        if not isinstance(obj, dict):
-                            continue
-                        msg = obj.get('message')
-                        if not isinstance(msg, dict):
-                            continue
-                        content = msg.get('content')
-                        if not isinstance(content, list):
-                            continue
-                        for item in content:
-                            if not isinstance(item, dict):
-                                continue
-                            n, inp = item.get('name', ''), item.get('input') or {}
-                            if not isinstance(inp, dict):
-                                inp = {}
-                            if n == 'Skill':
-                                skill = inp.get('skill', '?')
-                                detail = (inp.get('args') or '').strip() or 'Invoked'
-                                rows.append(f'| {step} | {skill} | {detail} |')
-                                step += 1
-                            elif n == 'Task':
-                                agent = inp.get('subagent_type') or '(agent)'
-                                desc = (inp.get('description') or '')[:80]
-                                rows.append(f'| {step} | {agent} | {desc} |')
-                                step += 1
+                        n, inp = item.get('name', ''), item.get('input') or {}
+                        if not isinstance(inp, dict):
+                            inp = {}
+                        if n == 'Skill':
+                            skill = inp.get('skill', '?')
+                            detail = (inp.get('args') or '').strip() or 'Invoked'
+                            rows.append(f'| {step} | {skill} | {detail} |')
+                            step += 1
+                        elif n == 'Task':
+                            agent = inp.get('subagent_type') or '(agent)'
+                            desc = (inp.get('description') or '')[:80]
+                            rows.append(f'| {step} | {agent} | {desc} |')
+                            step += 1
             else:
                 print(f'::warning::No session log at {session_log}')
             table = '\n'.join(

--- a/.github/actions/openspec-flow-inject-usage-table/action.yml
+++ b/.github/actions/openspec-flow-inject-usage-table/action.yml
@@ -53,20 +53,11 @@ runs:
             close_m = '<!-- /openspec-flow-usage-table -->'
             rows, step = [], 1
             if os.path.exists(session_log):
-                # claude-code-action writes a single pretty-printed JSON
-                # array of SDKMessage objects, not JSONL. Parse the whole
-                # file once and iterate items.
-                # See: anthropics/claude-code-action base-action/src/run-claude-sdk.ts
-                # `await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2))`
+                # Session log is a JSON array of SDKMessage objects.
                 with open(session_log) as f:
-                    raw = f.read()
-                try:
-                    messages = json.loads(raw)
-                except Exception as e:
-                    print(f'::warning::Could not parse session log as JSON ({e}) — table will be empty')
-                    messages = []
+                    messages = json.load(f)
                 if not isinstance(messages, list):
-                    print(f'::warning::Session log root is {type(messages).__name__}, expected list — table will be empty')
+                    print(f'::warning::Session log root is {type(messages).__name__}, expected list')
                     messages = []
                 for obj in messages:
                     if not isinstance(obj, dict):

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -432,10 +432,12 @@ jobs:
                - open PR titled
                  `chore: propose specification for #${{ github.event.issue.number }} <short title>`
                - PR body order: `Refs #${{ github.event.issue.number }}`, blank line,
-                 2-4 sentence recap, one line naming the skills used,
-                 `---`, full contents of proposal.md.
+                 2-4 sentence recap, `---`, full contents of proposal.md.
+                 (A usage table of any Skill/Task tool invocations is
+                 appended automatically by the workflow — do not write one
+                 yourself, and do not narrate which skills you used.)
                - Post one comment on the issue with a one-paragraph recap,
-                 a sentence naming the skills, a link to the PR, and ending
+                 a link to the PR, and ending
                  with a `---` rule on its own line followed by:
                  "${{ env.REENGAGE_FOOTER }}"
                  The comment body MUST start with the literal line
@@ -755,11 +757,14 @@ jobs:
                title `feat: implement spec for #${{ steps.check.outputs.issue_number }} <short title>`.
                PR body: `Closes #${{ steps.check.outputs.issue_number }}` on its
                own line (so merging the impl PR auto-closes the issue), then
-               a blank line, 2-4 sentence recap, a sentence naming the skills,
-               `---`, bulleted file-change list.
-               Post one comment on the issue: one-paragraph recap, skills
-               used, link to PR. Comment body MUST start with the literal
-               line `${{ env.AGENT_COMMENT_MARKER }}` and end with `---`
+               a blank line, 2-4 sentence recap, `---`, bulleted file-change
+               list.
+               (A usage table of any Skill/Task tool invocations is appended
+               automatically by the workflow — do not write one yourself,
+               and do not narrate which skills you used.)
+               Post one comment on the issue: one-paragraph recap, link to
+               PR. Comment body MUST start with the literal line
+               `${{ env.AGENT_COMMENT_MARKER }}` and end with `---`
                then `${{ env.REENGAGE_FOOTER }}` on its own line.
 
             CONSTRAINTS


### PR DESCRIPTION
## Summary
- **Scraper fix:** session log is a single pretty-printed JSON array (`JSON.stringify(messages, null, 2)`), not JSONL. Old loop `for line in f: json.loads(line)` failed on every line so the table always reported zero invocations even when skills were used. Verified against [base-action/src/run-claude-sdk.ts:184](https://github.com/anthropics/claude-code-action/blob/v1.0.79/base-action/src/run-claude-sdk.ts#L184).
- **Prompt fix:** dropped `naming the skills used` / `sentence naming the skills` instructions in plan and implement prompts. Agent was hallucinating skill names from prompt context, producing PRs that claimed "Skills used: openspec-explore, openspec-ff-change" right above a table that said "No sub-agent or skill invocations found." Usage table is now the single source of truth.
- Verified scraper logic against synthetic SDKMessage array — picks up Skill + Task invocations correctly.

Will report back to livedown once we confirm in the next test run.