### PR TITLE
fix: Redirect to default namespace when incorrect namespace provided

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
@@ -114,11 +114,11 @@ async def get_context_endpoint(namespace: str = None) -> ContextResponse:
                     "default_namespace": default_namespace
                 }
             )
-        logger.warning(f"Could not check namespace labels for {target_namespace}: {e}")
+        logger.warning("Could not check namespace labels: %s", e)
         # Fall back to environment variable for other errors
         read_only_mode = os.getenv("READ_ONLY_MODE", "false").lower() == "true"
     except Exception as e:
-        logger.warning(f"Could not check namespace labels for {target_namespace}: {e}")
+        logger.warning("Could not check namespace labels: %s", e)
         # Fall back to environment variable if we can't check the namespace
         read_only_mode = os.getenv("READ_ONLY_MODE", "false").lower() == "true"
 

--- a/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
@@ -2,9 +2,10 @@
 import logging
 import os
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client.api_client import ApiClient
+from kubernetes_asyncio.client.exceptions import ApiException
 
 from ark_sdk.models.kubernetes import NamespaceResponse, NamespaceListResponse, NamespaceCreateRequest
 from ...core.namespace import get_current_context
@@ -92,16 +93,30 @@ async def get_context_endpoint(namespace: str = None) -> ContextResponse:
     # Use provided namespace or fall back to current context namespace
     target_namespace = namespace or current_context["namespace"]
     
-    # Check if this specific namespace has demo label
+    # Check if namespace exists and has demo label
     read_only_mode = False
     try:
         async with ApiClient() as api:
             v1 = client.CoreV1Api(api)
             ns = await v1.read_namespace(name=target_namespace)
-            
+
             # Check if namespace has demo label
             if ns.metadata.labels and ns.metadata.labels.get("ark.mckinsey.com/demo") == "true":
                 read_only_mode = True
+    except ApiException as e:
+        if e.status == 404:
+            # Namespace doesn't exist - return 404 with default namespace for redirect
+            default_namespace = current_context["namespace"]
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "message": f"Namespace '{target_namespace}' not found",
+                    "default_namespace": default_namespace
+                }
+            )
+        logger.warning(f"Could not check namespace labels for {target_namespace}: {e}")
+        # Fall back to environment variable for other errors
+        read_only_mode = os.getenv("READ_ONLY_MODE", "false").lower() == "true"
     except Exception as e:
         logger.warning(f"Could not check namespace labels for {target_namespace}: {e}")
         # Fall back to environment variable if we can't check the namespace

--- a/services/ark-api/ark-api/tests/api/test_routes.py
+++ b/services/ark-api/ark-api/tests/api/test_routes.py
@@ -51,9 +51,107 @@ class TestNamespacesEndpoint(unittest.TestCase):
         self.assertEqual(data["items"][1]["name"], "kube-system")
 
 
+class TestContextEndpoint(unittest.TestCase):
+    """Test cases for the /context endpoint."""
+
+    def setUp(self):
+        """Set up test client."""
+        from ark_api.main import app
+        self.client = TestClient(app)
+
+    @patch('ark_api.api.v1.namespaces.get_current_context')
+    @patch('ark_api.api.v1.namespaces.ApiClient')
+    @patch('ark_api.api.v1.namespaces.client.CoreV1Api')
+    def test_get_context_success(self, mock_v1_api, mock_api_client, mock_get_current_context):
+        """Test successful context retrieval."""
+        # Setup mocks
+        mock_get_current_context.return_value = {
+            "namespace": "default",
+            "cluster": "test-cluster"
+        }
+
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_namespace = Mock()
+        mock_namespace.metadata.labels = None
+
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespace = AsyncMock(return_value=mock_namespace)
+
+        # Make the request
+        response = self.client.get("/v1/context")
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["namespace"], "default")
+        self.assertEqual(data["cluster"], "test-cluster")
+        self.assertEqual(data["read_only_mode"], False)
+
+    @patch('ark_api.api.v1.namespaces.get_current_context')
+    @patch('ark_api.api.v1.namespaces.ApiClient')
+    @patch('ark_api.api.v1.namespaces.client.CoreV1Api')
+    def test_get_context_with_valid_namespace(self, mock_v1_api, mock_api_client, mock_get_current_context):
+        """Test context with valid namespace parameter."""
+        mock_get_current_context.return_value = {
+            "namespace": "default",
+            "cluster": "test-cluster"
+        }
+
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_namespace = Mock()
+        mock_namespace.metadata.labels = {"ark.mckinsey.com/demo": "true"}
+
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespace = AsyncMock(return_value=mock_namespace)
+
+        # Make the request with namespace parameter
+        response = self.client.get("/v1/context?namespace=kyc-demo")
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["namespace"], "kyc-demo")
+        self.assertEqual(data["read_only_mode"], True)  # Demo namespace has read_only
+
+    @patch('ark_api.api.v1.namespaces.get_current_context')
+    @patch('ark_api.api.v1.namespaces.ApiClient')
+    @patch('ark_api.api.v1.namespaces.client.CoreV1Api')
+    def test_get_context_namespace_not_found(self, mock_v1_api, mock_api_client, mock_get_current_context):
+        """Test context returns 404 with default_namespace when namespace doesn't exist."""
+        from kubernetes_asyncio.client.exceptions import ApiException
+
+        mock_get_current_context.return_value = {
+            "namespace": "kyc-demo",
+            "cluster": "test-cluster"
+        }
+
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        # Mock 404 error from Kubernetes API
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespace = AsyncMock(
+            side_effect=ApiException(status=404, reason="Not Found")
+        )
+
+        # Make the request with invalid namespace
+        response = self.client.get("/v1/context?namespace=invalid-ns")
+
+        # Assert 404 response with default_namespace
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertIn("detail", data)
+        self.assertEqual(data["detail"]["message"], "Namespace 'invalid-ns' not found")
+        self.assertEqual(data["detail"]["default_namespace"], "kyc-demo")
+
+
 class TestDeleteEndpoints(unittest.TestCase):
     """Test cases for delete endpoints."""
-    
+
     def setUp(self):
         """Set up test client."""
         from ark_api.main import app

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/providers/namespace-provider.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/providers/namespace-provider.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { useSearchParams } from 'next/navigation';
 import type { PropsWithChildren } from 'react';
@@ -14,13 +14,15 @@ vi.mock('next/navigation', () => ({
   ),
 }));
 
+const mockUseGetContext = vi.fn(() => ({
+  data: { namespace: 'test-ns', read_only_mode: false },
+  isPending: false,
+  error: null,
+}));
+
 vi.mock('@/lib/services/namespaces-hooks', () => ({
   useCreateNamespace: vi.fn(() => ({ mutate: vi.fn() })),
-  useGetContext: vi.fn(() => ({
-    data: { namespace: 'test-ns', read_only_mode: false },
-    isPending: false,
-    error: null,
-  })),
+  useGetContext: () => mockUseGetContext(),
   useGetAllNamespaces: vi.fn(() => ({
     data: [{ name: 'test-ns' }, { name: 'default' }],
     isPending: false,
@@ -40,6 +42,11 @@ describe('NamespaceProvider', () => {
     vi.mocked(useSearchParams).mockReturnValue(
       new URLSearchParams('namespace=test-ns&filter=active') as any,
     );
+    mockUseGetContext.mockReturnValue({
+      data: { namespace: 'test-ns', read_only_mode: false },
+      isPending: false,
+      error: null,
+    });
   });
 
   it('preserves existing query params when setNamespace is called', () => {
@@ -52,5 +59,78 @@ describe('NamespaceProvider', () => {
     expect(mockPush).toHaveBeenCalledWith(
       '/agents?namespace=production&filter=active',
     );
+  });
+
+  describe('error handling', () => {
+    it('redirects to default_namespace from error when namespace not found', async () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('namespace=invalid-ns') as any,
+      );
+
+      // Simulate API error with default_namespace in the response
+      const apiError = {
+        message: "Namespace 'invalid-ns' not found",
+        data: {
+          detail: {
+            message: "Namespace 'invalid-ns' not found",
+            default_namespace: 'kyc-demo',
+          },
+        },
+      };
+
+      mockUseGetContext.mockReturnValue({
+        data: null,
+        isPending: false,
+        error: apiError,
+      });
+
+      renderHook(() => useNamespace(), { wrapper });
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/agents?namespace=kyc-demo');
+      });
+    });
+
+    it('redirects to default when error has no default_namespace', async () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('namespace=invalid-ns') as any,
+      );
+
+      // Simulate API error without default_namespace
+      const apiError = new Error('Network error');
+
+      mockUseGetContext.mockReturnValue({
+        data: null,
+        isPending: false,
+        error: apiError,
+      });
+
+      renderHook(() => useNamespace(), { wrapper });
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/agents?namespace=default');
+      });
+    });
+
+    it('does not redirect when already on default namespace and error occurs', async () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('namespace=default') as any,
+      );
+
+      const apiError = new Error('Network error');
+
+      mockUseGetContext.mockReturnValue({
+        data: null,
+        isPending: false,
+        error: apiError,
+      });
+
+      renderHook(() => useNamespace(), { wrapper });
+
+      // Should not redirect since we're already on default
+      await waitFor(() => {
+        expect(mockPush).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/providers/NamespaceProvider.tsx
+++ b/services/ark-dashboard/ark-dashboard/providers/NamespaceProvider.tsx
@@ -83,22 +83,44 @@ function NamespaceProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     if (error) {
-      toast.error('Failed to get namespace', {
-        description:
-          error instanceof Error
-            ? error.message
-            : 'An unexpected error occurred',
-      });
+      // Try to extract default_namespace from the 404 error response
+      // APIError has: { message, status, data: { detail: { default_namespace } } }
+      let defaultNamespace: string | null = null;
+
+      if (error && typeof error === 'object' && 'data' in error) {
+        const errorData = (error as { data?: { detail?: { default_namespace?: string } } }).data;
+        defaultNamespace = errorData?.detail?.default_namespace || null;
+      }
+
+      if (defaultNamespace && namespaceFromQueryParams !== defaultNamespace) {
+        toast.error(`Namespace "${namespaceFromQueryParams}" not found`, {
+          description: `Redirecting to ${defaultNamespace}...`,
+        });
+        setNamespace(defaultNamespace);
+      } else if (!defaultNamespace && namespaceFromQueryParams !== 'default') {
+        // Fallback to 'default' if we couldn't parse the default namespace
+        toast.error(`Namespace "${namespaceFromQueryParams}" not found`, {
+          description: 'Redirecting to default namespace...',
+        });
+        setNamespace('default');
+      } else {
+        toast.error('Failed to get namespace', {
+          description:
+            error instanceof Error
+              ? error.message
+              : 'An unexpected error occurred',
+        });
+      }
     }
-  }, [error]);
+  }, [error, namespaceFromQueryParams, setNamespace]);
 
   useEffect(() => {
-    if (!data && !isPending) {
+    if (!data && !isPending && !error) {
       toast.error('Failed to get namespace', {
         description: 'An unexpected error occurred',
       });
     }
-  }, [data, isPending]);
+  }, [data, isPending, error]);
 
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 