### PR TITLE
fix: CVE-2026-42264 and CVE-2026-6321 in ark-cli dependencies

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@kubernetes/client-node": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "axios": "^1.15.1",
+        "axios": "^1.16.0",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "debug": "^4.4.1",
@@ -2589,12 +2589,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -3950,9 +3950,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "axios": "^1.15.1",
+    "axios": "^1.16.0",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "debug": "^4.4.1",
@@ -91,6 +91,7 @@
     "@hono/node-server": "^1.19.13",
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
-    "express-rate-limit": "^8.3.0"
+    "express-rate-limit": "^8.3.0",
+    "fast-uri": "^3.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Update axios from 1.15.1 to 1.16.0 to fix CVE-2026-42264 (prototype pollution in HTTP adapter)
- Add fast-uri override ^3.1.1 to fix CVE-2026-6321 (path traversal via percent-encoded dot segments)

Closes #2053

## Vulnerability Details

| Field | Value |
|-------|-------|
| **CVE** | CVE-2026-42264 |
| **Severity** | High |
| **Component** | axios |
| **Vulnerable Version** | 1.15.1 |
| **Patched Version** | 1.16.0 |

Prototype pollution read-side gadgets in the axios HTTP adapter (`lib/adapters/http.js`) allow an attacker with a separate prototype pollution primitive in the dependency chain to inject arbitrary HTTP headers into outgoing requests, enabling credential injection and request hijacking.

| Field | Value |
|-------|-------|
| **CVE** | CVE-2026-6321 |
| **Severity** | High |
| **CVSS Score** | 7.5 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N) |
| **Component** | fast-uri (transitive via ajv) |
| **Vulnerable Version** | <=3.1.0 |
| **Patched Version** | 3.1.1+ |

`fast-uri` decoded percent-encoded path separators (`%2F`) and dot segments (`%2E`) before applying dot-segment removal, causing encoded paths to be treated as real slashes and parent-directory references. Distinct URIs could collapse onto the same normalized path, allowing path-based policy bypass.

## Changes

- `tools/ark-cli/package.json`: Updated axios to `^1.16.0`; added `"fast-uri": "^3.1.1"` to overrides
- `tools/ark-cli/package-lock.json`: Lockfile updated; axios resolves to 1.16.0, fast-uri resolves to 3.1.2

## Testing

- All 497 unit tests pass

## References

- CVE-2026-42264: https://github.com/axios/axios/releases/tag/v1.16.0
- CVE-2026-6321: https://cve.circl.lu/cve/CVE-2026-6321
- fast-uri advisory: https://github.com/fastify/fast-uri/security/advisories/GHSA-q3j6-qgpj-74h6
- JFrog XRAY-975956: https://github.com/mckinsey/agents-at-scale-ark/issues/2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)