### PR TITLE
docs(mcp-auth-dispatch-injection): openspec change for uniform Bearer injection + Secret watch

### DIFF
--- a/openspec/changes/mcp-auth-dispatch-injection/proposal.md
+++ b/openspec/changes/mcp-auth-dispatch-injection/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Stage 1 (`mcp-auth-token-injection`) injects `Authorization: Bearer <access_token>` only in the `MCPServerReconciler` path — used to discover tools and flip `status.authorization.state` to `Authorized`. The runtime tool-dispatch paths construct their own MCP clients elsewhere and never read `spec.authorization.tokenSecretRef`. Result: `Available=True`, `AUTH=Authorized`, 14 tools listed, every agent tool call gets `401 Unauthorized`.
+
+Two dispatch paths are affected:
+
+- `ark/executors/completions/agent_tools.go::createMCPExecutor` builds `MCPClientConfig.Headers` from `spec.headers` only.
+- `lib/ark-sdk/.../extensions/query.py::_resolve_mcp_server` builds `MCPServerConfig.headers` for named (external) execution engines from `spec.headers` only.
+
+The architecture intent (per `mcp-server-resolution`) is that the controller resolves all MCP config and ships fully-formed `headers` to executors. Executor authors must never touch Secrets themselves. Today both resolvers leak this responsibility back to the executor, and neither end picks it up.
+
+There is also a UX gap on the same Stage 2 "Secret as source of truth" story: peer MCP clients (Cursor, Claude Desktop) reload tokens immediately when their stored Secret changes, but Ark today only re-reads the token Secret on the periodic resync interval. An operator who patches a token Secret has no signal that anything is happening for tens of seconds. The `MCPServerReconciler` does not watch Secrets at all, so an out-of-band token rotation is invisible until the next resync tick — which makes the dashboard "authorize" affordance feel laggy and the kubectl edit experience feel broken.
+
+## What Changes
+
+- Add a shared helper `internal/resolution/mcp_auth.go::ResolveBearerToken(ctx, k8sClient, mcpServer)` returning the access token (empty string when `spec.authorization` is unset or the Secret/key is absent).
+- `ark/internal/controller/mcpserver_controller.go::resolveAuthorizationMaterial` SHALL use the new helper for the read; eventing stays in the controller.
+- `ark/executors/completions/agent_tools.go::createMCPExecutor` SHALL call the helper after resolving `spec.headers` and SHALL set `headers["Authorization"] = "Bearer <token>"` when a token is returned. `spec.headers` precedence rules are unchanged: a user-set `Authorization` in `spec.headers` takes priority and the helper-derived header is skipped.
+- `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py::_resolve_mcp_server` SHALL fetch the Secret named in `spec.authorization.tokenSecretRef` and SHALL set `MCPServerConfig.headers["Authorization"] = "Bearer <token>"` when present. Same precedence rule for a user-set `Authorization` in `spec.headers`.
+- `docs/content/developer-guide/building-execution-engines.mdx` SHALL state that `MCPServerConfig.headers` already carries the resolved `Authorization` header when the MCPServer has `spec.authorization.tokenSecretRef`. Executor authors construct MCP clients from `headers` opaquely.
+- `MCPServerReconciler` SHALL gain a label-driven Secret watch. Token Secrets carrying the convention label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. A field indexer on `spec.authorization.tokenSecretRef.name` resolves the reverse mapping. Helm charts that ship token Secrets stamp the label automatically; operators who hand-create Secrets stamp it manually for the real-time UX. Unlabelled Secrets keep working via the existing periodic resync — slower, but functionally equivalent. The cache SHALL NOT be filtered by the label, so reconciler reads of any token Secret continue to succeed regardless.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `mcp-auth-token-injection`: extends Bearer injection from the reconcile path to every MCP client construction path inside Ark (built-in completions executor + ark-sdk resolver for named executors). Reconcile-side behaviour unchanged.
+- `mcp-server-resolution`: `MCPServerConfig.headers` carries the resolved `Authorization` header for OAuth-protected MCPServers. Executor authors no longer need to know about `spec.authorization`.
+
+## Impact
+
+- **Scope:** `ark/internal/resolution/`, `ark/executors/completions/agent_tools.go`, `ark/internal/controller/mcpserver_controller.go` (refactor only), `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py`, `docs/content/developer-guide/building-execution-engines.mdx`.
+- **CRD / RBAC:** none. Stage 1 already grants `get/list/watch` on Secrets to the controller SA. The completions executor runs under the same SA today.
+- **Behavioural break:** an OAuth-protected MCPServer whose tool calls used to silently 401 will now succeed. No regression risk for non-OAuth MCPServers (`spec.authorization == nil` short-circuits before any Secret read).
+
+## Non-Goals
+
+- Token refresh — Stage 2 (`mcp-auth-token-refresh`).
+- Reacting to dispatch-path 401s by collapsing `status.authorization.state` back to `Required` — Stage 1's reconcile-side rollback already covers expired-token detection on the next reconcile; tool-call 401 surfaces as a query error to the user.
+- Per-executor SAs / fine-grained RBAC for non-controller executors — out of scope.

--- a/openspec/changes/mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
+++ b/openspec/changes/mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Bearer injection applies to all in-cluster MCP client construction paths
+
+When `spec.authorization.tokenSecretRef` is set on an MCPServer, every Ark code path that constructs an MCP client for that MCPServer SHALL inject `Authorization: Bearer <access_token>` derived from the referenced Secret. This applies at minimum to:
+
+- The `MCPServerReconciler` (already covered by the original Stage 1 requirement).
+- The built-in completions executor's tool dispatch path (`ark/executors/completions/agent_tools.go::createMCPExecutor`).
+- The ark-sdk Python resolver that builds `MCPServerConfig.headers` for named execution engines (`lib/ark-sdk/.../extensions/query.py::_resolve_mcp_server`).
+
+When `spec.authorization` is unset, no path SHALL attempt to read any Secret for token injection.
+
+#### Scenario: Built-in completions executor dispatches a tool against an Authorized MCPServer
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret carrying `access_token`
+- **WHEN** an agent without `executionEngine` invokes a tool backed by that MCPServer
+- **THEN** the built `MCPClientConfig.Headers` SHALL contain `Authorization: Bearer <access_token>` and the tool call SHALL NOT produce a 401 caused by missing credentials
+
+#### Scenario: Named execution engine receives MCPServerConfig for an Authorized MCPServer
+
+- **GIVEN** the same Authorized MCPServer
+- **WHEN** the controller dispatches a query to a named execution engine via A2A
+- **THEN** the resulting `ExecutionEngineRequest.mcpServers[*].headers` SHALL contain `Authorization: Bearer <access_token>` for that server
+
+#### Scenario: User has supplied Authorization in spec.headers
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef` set AND a `spec.headers` entry whose name is `Authorization`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** the explicit `spec.headers` value SHALL win and the helper-derived Bearer SHALL NOT overwrite it
+
+#### Scenario: spec.authorization is unset
+
+- **GIVEN** an MCPServer with `spec.authorization == nil`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no Secret read SHALL occur for token injection and no `Authorization` header SHALL be added beyond what `spec.headers` already supplies
+
+#### Scenario: Secret exists but the access-token key is empty
+
+- **GIVEN** the referenced Secret exists but the configured access-token key is missing or empty
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no `Authorization` header SHALL be injected and the call SHALL fall through to whatever `spec.headers` supplies
+
+### Requirement: Token resolution shares default key names across paths
+
+The reconciler and the executor dispatch paths SHALL share the same default access-token key name (`access_token`) and the same `accessTokenKey` override semantics, so an MCPServer that produces an `Authorized` state in reconcile is guaranteed to also yield a Bearer header at dispatch time. Implementations MAY share a helper or a constant; the binding requirement is that the two paths can never diverge on key resolution. Any shared helper SHALL be event-free — eventing for missing keys / Secrets stays in the reconciler.
+
+#### Scenario: Helper honours custom accessTokenKey override
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_TOKEN`
+- **WHEN** the helper is invoked against a Secret whose `MY_TOKEN` key carries a value
+- **THEN** the helper SHALL return that value
+
+#### Scenario: Helper short-circuits when authorization is unset
+
+- **GIVEN** `spec.authorization == nil`
+- **WHEN** the helper is invoked
+- **THEN** it SHALL return an empty string and SHALL NOT issue any API server reads
+
+### Requirement: Labelled token Secrets reconcile in real time
+
+Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval.
+
+#### Scenario: Operator patches a labelled token Secret
+
+- **GIVEN** an MCPServer in state `Authorized` whose `tokenSecretRef` points at a Secret carrying the label `ark.mckinsey.com/mcp-token-secret=true`
+- **WHEN** the operator patches the Secret to empty `access_token`
+- **THEN** the controller SHALL reconcile within seconds and SHALL transition `status.authorization.state` to `Required`
+
+#### Scenario: Multiple MCPServers reference the same labelled Secret
+
+- **GIVEN** two MCPServers in the same namespace whose `spec.authorization.tokenSecretRef.name` points at the same labelled Secret
+- **WHEN** the Secret is patched
+- **THEN** the controller SHALL enqueue a reconcile for each MCPServer
+
+### Requirement: Unlabelled token Secrets remain functional
+
+When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer on its periodic resync interval. The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
+
+#### Scenario: Operator patches an unlabelled token Secret
+
+- **GIVEN** an MCPServer whose `tokenSecretRef` points at a Secret with no `ark.mckinsey.com/mcp-token-secret` label
+- **WHEN** the operator patches the Secret
+- **THEN** the controller SHALL NOT immediately enqueue a reconcile based on the Secret event
+- **AND** on the next periodic resync the reconciler SHALL read the updated Secret and transition state accordingly

--- a/openspec/changes/mcp-auth-dispatch-injection/specs/mcp-server-resolution/spec.md
+++ b/openspec/changes/mcp-auth-dispatch-injection/specs/mcp-server-resolution/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Resolved MCPServerConfig.headers carries Authorization for OAuth-protected servers
+
+When an MCPServer has `spec.authorization.tokenSecretRef` set and the referenced Secret carries a non-empty access token, the resolver SHALL set `MCPServerConfig.headers["Authorization"] = "Bearer <access_token>"`. The Bearer header SHALL be derived inside the resolver from the cluster Secret — executors SHALL NOT receive `tokenSecretRef` or any other Secret-related field over the A2A wire.
+
+#### Scenario: Authorized MCPServer is resolved into MCPServerConfig
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret containing `access_token`
+- **WHEN** the controller resolves the agent's MCP servers
+- **THEN** the corresponding `MCPServerConfig.headers` SHALL contain `Authorization: Bearer <access_token>`
+
+#### Scenario: spec.headers Authorization wins over tokenSecretRef
+
+- **GIVEN** an MCPServer with both `spec.authorization.tokenSecretRef` set and a `spec.headers` entry named `Authorization`
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** the explicit `spec.headers` value SHALL be used and the helper-derived Bearer SHALL NOT replace it
+
+#### Scenario: MCPServer without authorization
+
+- **GIVEN** an MCPServer with `spec.authorization` unset
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** no `Authorization` header SHALL be added beyond `spec.headers`
+
+### Requirement: Executor authors do not handle MCPServer authorization
+
+`MCPServerConfig.headers` SHALL be the single contract executors consume for MCP authentication. Executor authors SHALL NOT need to read MCPServer CRDs, Secrets, or `spec.authorization` to call OAuth-protected MCP servers. Documentation describing how to build a new execution engine SHALL state this explicitly.
+
+#### Scenario: New execution engine consumes Authorization opaquely
+
+- **GIVEN** a custom execution engine receiving `ExecutionEngineRequest.mcpServers[i]`
+- **WHEN** it constructs an MCP client
+- **THEN** passing `MCPServerConfig.headers` to the client SHALL be sufficient for OAuth-protected servers — no extra resolution step SHALL be required

--- a/openspec/changes/mcp-auth-dispatch-injection/tasks.md
+++ b/openspec/changes/mcp-auth-dispatch-injection/tasks.md
@@ -1,0 +1,44 @@
+## 1. Shared helper
+
+- [ ] 1.1 Add `ark/internal/resolution/mcp_auth.go` with `ResolveBearerToken(ctx, k8sClient, mcpServer) (string, error)` returning `("", nil)` when `spec.authorization == nil`, the Secret is missing, or the access-token key is empty
+- [ ] 1.2 Unit tests: nil authorization, missing Secret, empty key, custom `accessTokenKey` override, populated token
+
+## 2. Reconciler alignment
+
+- [ ] 2.1 `ark/internal/controller/mcpserver_controller.go::resolveAuthorizationMaterial` reads access tokens via the same default key constant as the helper (`resolution.DefaultAccessTokenKey`) so the two paths cannot drift; no behaviour change
+- [ ] 2.2 All existing reconciler tests pass unchanged
+
+## 3. Built-in completions executor
+
+- [ ] 3.1 `ark/executors/completions/agent_tools.go::createMCPExecutor` calls `ResolveBearerToken` after the `spec.headers` loop
+- [ ] 3.2 Skip the helper-derived header when the user has already set `Authorization` in `spec.headers` (precedence rule)
+- [ ] 3.3 Unit test: MCPServer with `spec.authorization.tokenSecretRef` and a populated Secret → built `MCPClientConfig.Headers` contains `Authorization: Bearer <token>`
+
+## 4. ark-sdk Python resolver
+
+- [ ] 4.1 `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py::_resolve_mcp_server` reads the Secret named in `spec.authorization.tokenSecretRef` (with the same default + override key names as the controller)
+- [ ] 4.2 Set `headers["Authorization"] = f"Bearer {token}"` when present, skip when `spec.headers` already supplied an `Authorization` header
+- [ ] 4.3 Test in `lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py` covering: no authorization, populated Secret, header precedence
+
+## 5. Docs
+
+- [ ] 5.1 `docs/content/developer-guide/building-execution-engines.mdx`: note that `MCPServerConfig.headers` already carries the resolved `Authorization` header when `spec.authorization.tokenSecretRef` is set; executor authors construct clients from `headers` opaquely
+
+## 6. End-to-end verification
+
+- [ ] 6.1 Local: agent referencing an OAuth-protected MCPServer with a populated `tokenSecretRef` Secret completes a tool call without 401
+- [ ] 6.2 Local: same agent with `spec.authorization` cleared still works against an unprotected MCPServer
+
+## 7. Secret watch for real-time reconciliation
+
+- [ ] 7.1 Add `MCPTokenSecretLabel = "ark.mckinsey.com/mcp-token-secret"` constant in `ark/internal/labels/labels.go`, mirroring the existing constant style
+- [ ] 7.2 In `MCPServerReconciler.SetupWithManager`, register a field indexer on `&arkv1alpha1.MCPServer{}` for `spec.authorization.tokenSecretRef.name` (use a package-level constant `mcpTokenSecretRefField` for the field path string). Indexer returns `nil` when `spec.Authorization == nil`, otherwise `[]string{ref.Name}`
+- [ ] 7.3 Extend the controller builder with `Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.findMCPServersForSecret), builder.WithPredicates(predicate.NewPredicateFuncs(hasMCPTokenSecretLabel)))`. The predicate filters at event-handler level only — the cache is left unfiltered so reconciler reads of any token Secret continue to succeed
+- [ ] 7.4 Implement `findMCPServersForSecret` on `*MCPServerReconciler`: list MCPServers via the field index in the Secret's namespace and return one `reconcile.Request` per match. On list error, log and return `nil` so event delivery is not blocked
+- [ ] 7.5 Implement `hasMCPTokenSecretLabel(obj client.Object) bool` returning true when `obj.GetLabels()[labels.MCPTokenSecretLabel] == "true"`
+- [ ] 7.6 Envtest in `ark/internal/controller/mcpserver_secret_watch_test.go`:
+  - Labelled Secret patch enqueues a reconcile for the referencing MCPServer within seconds (use `Eventually` against a counting reconciler hook)
+  - Unlabelled Secret patch does NOT enqueue an event-driven reconcile within the same window (`Consistently` asserts the counter does not increment)
+  - Two MCPServers referencing the same labelled Secret both get enqueued on a single Secret patch
+- [ ] 7.7 Note in the marketplace chart authoring guide that token-Secret-bearing charts SHOULD stamp `ark.mckinsey.com/mcp-token-secret: "true"` on the Secret to opt in to real-time reconciliation. Unlabelled Secrets remain functional via the periodic resync.
+- [ ] 7.8 RBAC unchanged — Stage 1 already grants `get/list/watch` on Secrets to the controller SA


### PR DESCRIPTION
## Summary
- Extend `mcp-auth-token-injection` to require Bearer injection at every in-cluster MCP client construction path (reconcile, built-in completions executor, ark-sdk Python resolver)
- Extend `mcp-server-resolution` so `MCPServerConfig.headers` carries the resolved `Authorization` header — executor authors consume headers opaquely, never read `spec.authorization` or Secrets
- Add a label-driven Secret watch: Secrets carrying `ark.mckinsey.com/mcp-token-secret=true` trigger immediate reconcile; unlabelled Secrets remain functional via the existing periodic resync

Closes the gap exposed by note-taker / mcp-notion 401s after Stage 1 landed: state was `Authorized` but every tool call returned 401 because the dispatch-time MCP client never read `tokenSecretRef`.

Implementation lives on a separate branch and will land as a follow-up PR.