### PR TITLE
feat: Add file_ids support to ark-sdk

### DIFF
--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor.py
@@ -52,6 +52,7 @@ class Message(BaseModel):
     role: str
     content: str
     name: str = ""
+    file_ids: list[str] = []
 
     class Config:
         extra = "allow"

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/executor_app.py
@@ -207,8 +207,11 @@ class A2AExecutorAdapter(AgentExecutor):
         if hasattr(context.message, "context_id") and context.message.context_id:
             conversation_id = context.message.context_id
 
+        metadata = getattr(context.message, "metadata", None) or {}
+        file_ids = metadata.get("file_ids", [])
+
         query_ref = extract_query_ref(context.message)
-        request = await resolve_query(query_ref, user_text, conversation_id=conversation_id)
+        request = await resolve_query(query_ref, user_text, conversation_id=conversation_id, file_ids=file_ids)
 
         broker_url = await discover_broker_url(query_ref.namespace)
         broker = BrokerClient(

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
@@ -66,6 +66,7 @@ async def resolve_query(
     query_ref: QueryRef,
     user_input: str,
     conversation_id: str = "",
+    file_ids: list[str] | None = None,
 ) -> ExecutionEngineRequest:
     """Resolve a QueryRef into a full ExecutionEngineRequest by fetching CRDs from the cluster.
 
@@ -77,10 +78,10 @@ async def resolve_query(
     await init_k8s()
     async with with_ark_client(query_ref.namespace, V1_ALPHA1) as ark:
         query = await ark.queries.a_get(query_ref.name, query_ref.namespace)
-        return await _resolve_from_query(ark, query, query_ref.namespace, user_input, conversation_id)
+        return await _resolve_from_query(ark, query, query_ref.namespace, user_input, conversation_id, file_ids=file_ids)
 
 
-async def _resolve_from_query(ark: Any, query: Any, namespace: str, user_input: str, conversation_id: str = "") -> ExecutionEngineRequest:
+async def _resolve_from_query(ark: Any, query: Any, namespace: str, user_input: str, conversation_id: str = "", file_ids: list[str] | None = None) -> ExecutionEngineRequest:
     target = query.spec.target
     if not target:
         raise ValueError(f"Query '{query.metadata['name']}' has no target")
@@ -99,7 +100,7 @@ async def _resolve_from_query(ark: Any, query: Any, namespace: str, user_input: 
 
     return ExecutionEngineRequest(
         agent=agent_config,
-        userInput=Message(role="user", content=user_input),
+        userInput=Message(role="user", content=user_input, file_ids=file_ids or []),
         mcpServers=mcp_servers,
         conversationId=conversation_id,
         query_annotations=query_annotations,


### PR DESCRIPTION
## Summary

- Add `file_ids: list[str]` field to `Message` model in ark-sdk
- Extract `file_ids` from A2A message metadata in `executor_app.py`
- Thread `file_ids` through `resolve_query()` → `_resolve_from_query()` → `ExecutionEngineRequest`

Enables executors to receive file references via the standard A2A pipeline. The UI adds `file_ids` to the A2A message metadata, and the executor receives them on `request.userInput.file_ids` for multimodal input (e.g. OpenAI `input_file` content parts).

Fully backward compatible — `file_ids` defaults to `[]`.

## Test plan

- [ ] Existing executor tests pass (no breaking changes)
- [ ] Send A2A message with `metadata.file_ids: ["file-abc"]`, verify executor receives them on `request.userInput.file_ids`
- [ ] Send A2A message without `file_ids` in metadata, verify `request.userInput.file_ids` is `[]`