### PR TITLE
fix: use npm instead of pnpm in ark-dashboard devspace dev command

### DIFF
--- a/services/ark-dashboard/devspace.yaml
+++ b/services/ark-dashboard/devspace.yaml
@@ -65,7 +65,7 @@ dev:
       [
         "sh",
         "-c",
-        "cd /app/ark-dashboard && npm install -g pnpm && pnpm install && pnpm run dev",
+        "cd /app/ark-dashboard && npm install && npm run dev",
       ]
     namespace: default
     # Stream logs instead of terminal


### PR DESCRIPTION
The devspace dev command was installing and using pnpm, but the project uses npm (package-lock.json, Dockerfile uses npm ci). There is no committed pnpm-lock.yaml, so pnpm was generating a fresh lockfile on every container restart.

This became a problem when pnpm v9+ introduced ERR_PNPM_IGNORED_BUILDS, requiring explicit approval for packages with build scripts (esbuild, sharp, unrs-resolver). Since the lockfile was regenerated each time with no approvals recorded, the container would crash-loop on every restart.

Switching to npm aligns devspace with the Dockerfile and package-lock.json, and avoids the pnpm build script approval requirement entirely.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 