### PR TITLE
ci: add ark-apiserver chart to CI/CD pipelines

### DIFF
--- a/.github/release-please-config-rc.json
+++ b/.github/release-please-config-rc.json
@@ -99,6 +99,16 @@
         },
         {
           "type": "yaml",
+          "path": "ark/dist/chart-apiserver/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "ark/dist/chart-apiserver/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
           "path": "samples/agent-hosting/hosted-langchain-agents/chart/Chart.yaml",
           "jsonpath": "$.appVersion"
         },

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -96,6 +96,16 @@
         },
         {
           "type": "yaml",
+          "path": "ark/dist/chart-apiserver/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "ark/dist/chart-apiserver/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
           "path": "samples/agent-hosting/hosted-langchain-agents/chart/Chart.yaml",
           "jsonpath": "$.appVersion"
         },

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -938,6 +938,7 @@ jobs:
         chart:
           # Package only the essential charts.
           - { name: ark-controller, path: ark/dist/chart }
+          - { name: ark-apiserver, path: ark/dist/chart-apiserver }
           - { name: ark-completions, path: ark/executors/completions/chart }
           - { name: ark-api, path: services/ark-api/chart }
           - { name: ark-dashboard, path: services/ark-dashboard/chart }
@@ -1207,6 +1208,7 @@ jobs:
       matrix:
         chart:
           - ark-controller
+          - ark-apiserver
           - ark-completions
           - ark-api
           - ark-dashboard

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,6 +208,7 @@ jobs:
       matrix:
         chart:
           - ark-controller
+          - ark-apiserver
           - ark-completions
           - ark-api
           - ark-dashboard


### PR DESCRIPTION
## Summary

- PR #1958 split the aggregated API server into its own Helm chart at `ark/dist/chart-apiserver/`, but the CI/CD pipelines were not updated to build and publish it
- Add `ark-apiserver` to the `build-charts` matrix so the chart is linted, packaged, and uploaded as an artifact
- Add `ark-apiserver` to the `release-charts` matrix so it gets attached to GitHub releases
- Add `ark-apiserver` to the `deploy-helm-charts` matrix so it gets pushed to the GHCR OCI registry
- Add version/appVersion entries in both release-please configs so the chart version is bumped automatically on releases