### PR TITLE
fix(cli): skip ark-apiserver install when storage backend is etcd

### DIFF
--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -260,15 +260,18 @@ export const arkServices: ServiceCollection =
   applyConfigOverrides(defaultArkServices);
 
 /**
- * Get services that can be installed via Helm charts (only enabled services)
+ * Get services that can be installed via Helm charts (only enabled services).
+ * When a backend is specified, services with a non-matching requiresBackend are excluded.
  */
-export function getInstallableServices(): ServiceCollection {
+export function getInstallableServices(
+  backend: 'etcd' | 'postgresql' = 'etcd'
+): ServiceCollection {
   const installable: ServiceCollection = {};
 
   for (const [key, service] of Object.entries(arkServices)) {
-    if (service.enabled && service.chartPath) {
-      installable[key] = service;
-    }
+    if (!service.enabled || !service.chartPath) continue;
+    if (service.requiresBackend && service.requiresBackend !== backend) continue;
+    installable[key] = service;
   }
 
   return installable;

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -19,6 +19,11 @@ vi.mock('../../lib/cluster.js', () => ({
   getClusterInfo: mockGetClusterInfo,
 }));
 
+const mockDetectStorageBackend = vi.fn().mockResolvedValue('etcd');
+vi.mock('../../lib/readinessChecks.js', () => ({
+  detectStorageBackend: mockDetectStorageBackend,
+}));
+
 const mockGetInstallableServices = vi.fn() as any;
 const mockArkServices = {};
 const mockArkDependencies = {};

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -25,6 +25,7 @@ import {
   type WaitProgress,
 } from '../../lib/waitForReady.js';
 import {parseTimeoutToSeconds} from '../../lib/timeout.js';
+import {detectStorageBackend} from '../../lib/readinessChecks.js';
 
 function isValidVersion(version: string): boolean {
   return /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version);
@@ -229,6 +230,8 @@ export async function installArk(
   output.success(`connected to cluster: ${chalk.bold(clusterInfo.context)}`);
   console.log(); // Add blank line after cluster info
 
+  const backend = await detectStorageBackend();
+
   // If specific services are requested, install only those services
   if (serviceNames.length > 0) {
     for (const serviceName of serviceNames) {
@@ -281,7 +284,7 @@ export async function installArk(
       }
 
       // Core ARK service
-      const services = getInstallableServices();
+      const services = getInstallableServices(backend);
       const service = Object.values(services).find((s) => s.name === serviceName);
 
       if (!service) {
@@ -313,12 +316,15 @@ export async function installArk(
 
   // If not using -y flag, show checklist interface
   if (!options.yes) {
+    const backendMatch = (s: ArkService) =>
+      !s.requiresBackend || s.requiresBackend === backend;
+
     const coreServices = Object.values(arkServices)
-      .filter((s) => s.category === 'core')
+      .filter((s) => s.category === 'core' && backendMatch(s))
       .sort((a, b) => a.name.localeCompare(b.name));
 
     const otherServices = Object.values(arkServices)
-      .filter((s) => s.category === 'service')
+      .filter((s) => s.category === 'service' && backendMatch(s))
       .sort((a, b) => a.name.localeCompare(b.name));
 
     const mandatoryServiceNames = [...coreServices, ...otherServices]
@@ -512,7 +518,7 @@ export async function installArk(
     }
 
     // Install all services
-    const services = getInstallableServices();
+    const services = getInstallableServices(backend);
     for (const service of Object.values(services)) {
       output.info(`installing ${service.name}...`);
 
@@ -549,7 +555,8 @@ export async function installArk(
           s.enabled &&
           s.category === 'core' &&
           s.k8sDeploymentName &&
-          s.namespace
+          s.namespace &&
+          (!s.requiresBackend || s.requiresBackend === backend)
       );
 
       const spinner = ora(


### PR DESCRIPTION
## Summary

- `getInstallableServices()` now accepts a backend parameter and filters out services whose `requiresBackend` doesn't match (defaults to `etcd`)
- The install command detects the active storage backend before installing, filtering all three code paths: named service lookup, interactive checklist, and `-y` auto-install
- The `--wait-for-ready` path also filters on backend, matching the existing behavior in the status command
- Prevents ark-apiserver from being deployed on default etcd clusters where it serves no purpose