### PR TITLE
feat(inline-tools): propose capability + dashboard mockup

### DIFF
--- a/openspec/changes/inline-tools/design.md
+++ b/openspec/changes/inline-tools/design.md
@@ -1,0 +1,198 @@
+## Context
+
+Ark agents acquire external capabilities today by referencing an `MCPServer` plus one or more `Tool` objects. That model is correct for real external services (databases, vendor APIs, anything with auth or streaming) but disproportionate for the long tail of "small things" agents need: parse a CSV, drive a runbook step, transform some text, glue two APIs together. The overhead — writing an MCP server, containerising it, publishing an image, authoring three CRDs — buys nothing for a 20-line script.
+
+The earlier `agent-skills` proposal tried to address this by adapting Claude Code's full skill shape — a `SKILL.md` document with prose + frontmatter + `scripts/` + reference files, surfaced through a `load_skill` catalog. User testing of the dashboard mockup showed that the prose/catalog half of that design wasn't carrying its weight: testers reached for the "I can write a Python function inline" affordance and largely ignored the markdown/expertise framing. `inline-tools` keeps the carrying primitive and drops the rest.
+
+Three hard constraints carry forward from `agent-skills`:
+
+1. **The wire-level invocation path must reuse Ark's existing MCP plumbing.** Auth, audit, tracing, broker integration, rate limits — reinventing any of that is not worth the cost.
+2. **The security boundary must hold from the first commit.** Inline tools will run user-authored code. The default posture has to be defensible without authors thinking about it.
+3. **The CRD shape must be additive to today's `Tool`.** No new kind, no new attachment field on `Agent`. An inline tool should be indistinguishable from an HTTP or MCP tool from the agent author's point of view.
+
+## Where scripts run (and don't)
+
+A common point of confusion is whether "inline tools" mean the model runs code locally. They don't. Inline tools are a *harness-side* primitive — neither Anthropic's API nor any other provider has a native concept here. What models supply is **tool calling**, and inline tools are implemented on top of that.
+
+```
+   Conventional MCP tool                 Inline tool
+   ──────────────────────                ──────────────────────
+   Model picks the tool   ╗   Model picks the tool   ╗
+   Tool call comes back   ║   Tool call comes back   ║   Same.
+   ──────────────────────  ║  ──────────────────────  ║   The model
+   Executor calls          ║   Executor calls          ║   side is
+   author-built MCP        ║   per-tool runner pod     ║   identical
+   server                  ║   (Ark-managed)           ║   regardless of
+                           ║                           ║   provider.
+   Swapping the model     ╝   Swapping the model     ╝
+   doesn't change where        doesn't change where
+   the script runs.            the script runs.
+```
+
+The script always runs in a per-tool sandbox pod inside the cluster, regardless of the agent's model provider. The design works with Anthropic, OpenAI, Azure OpenAI, Bedrock, and Gemini equally.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A custom tool is authorable in a single YAML file and deployable via `kubectl apply` with no image build, no registry, and no additional CRDs to author by hand.
+- Inline tools attach to agents via the existing `Agent.spec.tools` — agent authors do not learn a new concept to use them.
+- An agent can attach many inline tools cheaply; attached-but-unused tools cost zero pods (scale-to-zero) and zero new memory in the model's context beyond their tool descriptions.
+- Existing MCP/Tool tracing, auditing, and observability apply to inline-tool invocations unchanged.
+- The default security posture (no egress, no secrets, read-only root, non-root user, no Kubernetes token) is strong enough that an operator can trust an inline tool authored by a teammate without reviewing its YAML for boilerplate hardening.
+- Authors hit one CRD shape and one runtime contract per inline tool. Mixing languages across an agent's tool set is free — each tool is its own pod.
+
+**Non-Goals**
+
+- Bundling multiple scripts into one resource. If you have three related scripts, you author three `Tool` resources. The `agent-skills` proposal explored bundling; user testing didn't find the grouping load-bearing.
+- The full Claude-Code skill shape (`SKILL.md` + frontmatter + body + lazy-load catalog). Out of scope for `inline-tools`; future work if demand materialises.
+- Custom runner images in v1. Authors pick from the built-in `python@3.12`, `node@20`, or `bash`. Bringing your own image is plausible later but punted now.
+- A marketplace publishing story for inline tools. v1 is `kubectl apply` and a sample directory.
+- Cross-namespace tool references. Existing `Tool` constraint stands.
+- Streaming tool responses. Inline tools run short-lived scripts; anything long-lived should be an `MCPServer`.
+- OCI image, Git, or HTTP source URLs for the script. The script lives inline in the CRD; anything that outgrows what fits in a `ConfigMap` should be an `MCPServer`.
+- Reference-file mounts (a "skill" pattern). If a script needs static data files alongside it, that's an `MCPServer`.
+
+## Decisions
+
+### Decision: Extend the existing `Tool` CRD; do not introduce a new kind
+
+The `Tool` CRD already has discriminated subtypes (`http`, `mcp`, `agent`, `team`, `builtin`). `inline` slots in as a sixth variant with its own typed sub-object `spec.inline`. The author surface is:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Tool
+metadata:
+  name: csv-summarise
+spec:
+  type: inline
+  description: Summarise a CSV — column types, row count, basic stats
+  inputSchema:
+    type: object
+    properties:
+      file: { type: string, description: "Path to the CSV file" }
+    required: [file]
+  inline:
+    language: python   # optional; auto-detected from shebang
+    source: |
+      #!/usr/bin/env python
+      import sys, json, pandas as pd
+      args = json.loads(sys.argv[1])
+      df = pd.read_csv(args["file"])
+      print(df.describe().to_json())
+```
+
+**Why.** Inline tools are *tools*. Adding a separate kind (`InlineTool`, `Function`, `Script`) would split the agent author's mental model — "Tools come from one place, except inline tools, which come from another" — for no clear benefit. The discriminated-union shape is exactly what the existing `Tool` CRD already does for four different runtime models; this is the fifth.
+
+**Alternative considered: new kind `InlineTool`.** Cleaner isolation, easier to remove later, mirrors what the `agent-skills` proposal did. Rejected because it adds a second attachment surface on `Agent` (or forces inline tools through a translator) and because the existing `Tool` CRD's discriminator is the closest fit in the codebase.
+
+**Alternative considered: extend `Tool` with a `script` type instead of `inline`.** Slightly more accurate ("the tool is a script") but `inline` better captures the value prop versus the other types (which all delegate to *something external* — an HTTP endpoint, an MCP server, an agent, a team).
+
+### Decision: One tool per CRD; no bundling
+
+A `Tool` of `type: inline` is exactly one script with exactly one input schema. Multiple related scripts mean multiple `Tool` resources.
+
+**Why.** Bundling was the `agent-skills` shape (one `Skill` containing many scripts) and it carried real cost: a `SKILL.md` to define the bundle, a discovery rule to map files to tools, an extraction rule to handle inline fences, a separate attachment surface on `Agent`. User testing didn't find any of that load-bearing. Without bundling, every one of those drops out and inline tools become "just tools that happen to be scripts".
+
+**Cost accepted.** One Deployment per inline tool, even where two tools could have shared a pod. Mitigated entirely by scale-to-zero: idle tools cost nothing. Future work could pool same-language runners if this becomes a real problem in practice.
+
+### Decision: Single multi-language runner image; per-tool dispatch by shebang/language
+
+v1 ships **one** runner image, `ark-inline-runner:v1`, on an Alpine base, containing `bash` (5.x), `python@3.12` (as `python` / `python3`), and `node@20` (as `node`; `tsx` for `.ts`). Estimated size ≈ 150 MB.
+
+The runner mounts the tool's `ConfigMap` at `/tool/source` and dispatches on first invocation:
+
+```
+   /tool/source first line starts with #!  ──►  exec the file directly,
+                                                kernel honours the shebang
+        │
+        else use spec.inline.language:
+          bash    ──►  bash /tool/source "$ARGS_JSON"
+          python  ──►  python3 /tool/source "$ARGS_JSON"
+          node    ──►  node /tool/source "$ARGS_JSON"
+          ts      ──►  tsx /tool/source "$ARGS_JSON"
+        │
+        else (no shebang, no language)  ──►  default to bash
+```
+
+**Why a single image.** Pinning each tool to a language-specific image would mean three different images to maintain, three different reconciliation paths, and lookup logic in the controller. With one image, the controller writes the same PodSpec regardless of language and the dispatch is a few lines of shell. The cold-start cost is dominated by container startup once the image is cached on a node, not by the difference between a 50 MB and a 150 MB image.
+
+**Alternative considered: per-language images.** Smaller per-tool footprint but multiplies maintenance and complicates the controller. Rejected.
+
+**Alternative considered: language inferred *only* from shebang (no `language` field).** Cleaner — one source of truth — but breaks the no-shebang case (a bare `print("hi")` Python script). Adding `language` as an explicit override is one extra field for a noticeable UX improvement.
+
+### Decision: JSON-on-`argv[1]` runtime contract
+
+The runner serialises the tool's JSON arguments into a single string and passes it as `argv[1]`. Authors parse however their language wants:
+
+```python
+import sys, json
+args = json.loads(sys.argv[1])
+```
+
+```bash
+FILE=$(jq -r .file <<< "$1")
+```
+
+```javascript
+const args = JSON.parse(process.argv[2]);
+```
+
+**Why.** Three options were on the table — JSON-on-`argv[1]`, JSON-on-stdin, schema-to-named-flags. JSON-on-`argv[1]` is the simplest path that works uniformly for every language in the runner: no argparse, no flag-to-property mapping, no nested-object edge cases, no extra read step. Trivial in bash/python/node.
+
+**Alternative considered: JSON on stdin.** Cleaner for very large payloads but more boilerplate for the common case (`cat | jq` vs `jq <<< "$1"`). Rejected for v1; could be added as an opt-in mode later.
+
+**Alternative considered: named CLI flags from `inputSchema`.** Feels natural for shell scripts (`--file=foo.csv --limit=10`) but breaks down for nested objects, arrays, and rich types. The runner would need a schema-aware flag synthesiser; authors would learn a Python-`argparse`-shaped surface that isn't quite argparse. Rejected.
+
+### Decision: Per-tool sandbox; scale-to-zero by default
+
+Each inline `Tool` reconciles to its own `Deployment` (`replicas: 0` initially), `Service`, `ServiceAccount`, `NetworkPolicy` (deny-all egress), `ConfigMap` (the script body, content-hashed name), and is owned by the `Tool` for GC cascade.
+
+A new `inlinetoolactivator` subsystem in the operator (HTTP front-end, ~300 LOC) intercepts the first request to an inline tool's `Service`, scales the `Deployment` `0 → 1`, waits for readiness, and forwards. After `spec.inline.idleTimeout` (default 60 s) of no traffic, the controller scales back to `0`.
+
+**Why per-tool, not pooled.** Strong isolation from day one. A misbehaving script can't tamper with another tool's state, exhaust another tool's memory, or read another tool's secrets. The cost (more Deployments) is bounded by scale-to-zero.
+
+**Why custom, not Knative / KEDA.** Knative is a heavy dependency for the cluster operator; KEDA is closer but still pulls in CRDs and event sources we don't otherwise use. The scaling behaviour we actually need is trivial — 0 ↔ 1, no autoscaling beyond that for v1.
+
+**Alternative considered: pool same-language runners.** One long-lived python pod per namespace, scripts injected via the request path. Faster cold start; loses per-tool isolation (a script can read sibling scripts' state in memory). Rejected for v1; revisitable.
+
+### Decision: Inline tools surface to the executor as MCP tools
+
+When the controller reconciles an inline `Tool`, it synthesises an `MCPServer` (or an equivalent internal record) whose endpoint points at the tool's `Service`. The execution engine's path for "call a tool" is unchanged: the same MCP client invokes inline tools as invokes author-built MCP tools, with the same tracing, auth, and audit hooks.
+
+**Why.** Reuses every line of the existing MCP machinery. The executor doesn't grow a new code path; only the controller has to know that `type: inline` materialises infrastructure.
+
+**Alternative considered: direct executor → inline-runner HTTP.** Skips the synthetic MCPServer step. Cheaper in object count but forces the executor to learn a second tool-call protocol. Rejected — the synthetic MCPServer is cheap and keeps the executor uniform.
+
+### Decision: Security defaults are non-negotiable in v1
+
+Every inline tool pod runs with:
+
+- `runAsNonRoot: true`, `runAsUser: 65532`
+- `readOnlyRootFilesystem: true`
+- `capabilities.drop: [ALL]`
+- `allowPrivilegeEscalation: false`
+- `automountServiceAccountToken: false`
+- `seccompProfile.type: RuntimeDefault`
+- `NetworkPolicy` deny-all egress
+- No mounted secrets
+
+There is no `spec.inline.security` knob in v1. If an author needs to relax any of these (egress to an allow-listed host, a mounted secret, a Kubernetes role), they author an `MCPServer` instead. This keeps the surface a reviewer has to audit when approving inline tools to *just the script* — not the script plus a Kubernetes-permissions diff.
+
+**Alternative considered: ship the relax-knobs from the start (`spec.inline.network.egress`, `spec.inline.secrets`).** Faster path to real-world use cases. Rejected for v1 because we'd be designing the relaxation surface without enough evidence about what authors actually need. Re-adding these later is purely additive.
+
+## Risks
+
+- **Cold-start latency.** Scale-from-zero pod start is on the order of seconds, depending on image cache state. First invocation of an inline tool will feel slower than an HTTP tool. Mitigation: keep the runner image tight; document the latency in the user guide; consider `spec.inline.keepWarm: true` for v1.1.
+- **Per-tool pod sprawl.** A namespace with 50 inline tools has 50 Deployments. They are mostly at 0 replicas, but each consumes etcd objects and a `Service` IP. Mitigation: scale-to-zero handles compute cost; if object count becomes a problem, pooling is a backwards-compatible v1.5 change.
+- **Author surprises with `argv[1]` quoting.** Bash authors will discover the joys of JSON-in-an-argv-element. Mitigation: the docs page leads with `jq -r .field <<< "$1"` and the sample tools use it.
+- **Insufficient stderr surfacing.** Tool errors return the last 4 KiB of stderr — debuggable but not great. Mitigation: per-tool pod logs are accessible via standard `kubectl logs`; the user-guide debugging section calls this out.
+- **Drift from `agent-skills`.** The earlier change still has open tasks and an open PR. Mitigation: this proposal is explicit about superseding; once approved, the `agent-skills` change is withdrawn (archived as superseded), and PR #1990 is either rebased onto this scope or closed.
+
+## Open Questions
+
+- **`keepWarm` on day one or v1.5?** Adding `spec.inline.keepWarm: true` is a few lines and would address the cold-start risk for hot tools. Punting for now keeps v1 tight; revisit before merging the operator change.
+- **`spec.inline.image` escape hatch.** Should v1 quietly support a custom runner image (`spec.inline.image: my-registry/foo:bar`) as an undocumented relief valve? Leaning *no* — if you need a custom image, you have an MCPServer.
+- **Resource limits.** v1 defaults to `cpu: 500m`, `memory: 256Mi`. Are these the right starting numbers, and do we expose `spec.inline.resources` from day one? Leaning yes on exposure (matches the rest of Ark) but the defaults are a guess.
+- **TypeScript dispatch.** `tsx` adds ~50 MB to the runner image. Real demand, or drop TS support in v1?
+- **What happens to PR #1990 and the `agent-skills` change?** Concrete migration plan: rebase #1990 to the new scope, or close it and open a fresh PR off this branch?

--- a/openspec/changes/inline-tools/proposal.md
+++ b/openspec/changes/inline-tools/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Adding even trivial custom logic to an Ark agent today requires standing up a full `MCPServer` — write an MCP server in Python or Node, containerise it, push to a registry, author an `MCPServer` CRD, author a `Tool` CRD, attach the tool to the `Agent`. That's ~1 hour of scaffolding and a permanent registry dependency for what is often 20 lines of glue. `MCPServer` remains the right tool when logic is large, streaming, or has real external auth; **inline tools are the on-ramp below that threshold.**
+
+This change supersedes the broader `agent-skills` proposal. User testing of the skills mockup showed that the single most-valued capability was the "write a Python or bash function inline, attach it to an agent, no image, no registry" path. The wider Claude-Code shape (`SKILL.md` prose, lazy `load_skill` catalog, drop-in import of Claude-Code skill folders) carried complexity that testers did not engage with. `inline-tools` keeps the high-value primitive and drops the rest.
+
+## What Changes
+
+- **Extend the existing `Tool` CRD** (`ark.mckinsey.com/v1alpha1`) with a new `type: inline` value alongside `http`, `mcp`, `agent`, `team`, `builtin`. No new kind; no new attachment field on `Agent`. Inline tools attach via the existing `Agent.spec.tools` like any other tool.
+- **New `spec.inline` sub-object** on `Tool`, populated only when `type == inline`:
+  - `source` (string, required) — the script body, served verbatim into the runner pod.
+  - `language` (string, optional) — one of `bash`, `python`, `node`, `ts`. When omitted, the controller infers from the script's shebang (if the first line is `#!`) or its absence (defaults to `bash`).
+- **Reuse `spec.inputSchema` as-is.** The existing JSON-schema field tells the model the tool's argument shape. No new schema field is introduced.
+- **Per-tool runtime infrastructure.** A new controller path reconciles each `Tool` with `type: inline` into a `ConfigMap` (script body), a `ServiceAccount`, a `NetworkPolicy` (deny-all egress by default), a `Deployment` (`replicas: 0` by default), and a `Service`. Each inline tool is a fully isolated sandbox.
+- **New scale-to-zero activator** in the operator: a lightweight HTTP front-end for each inline tool's `Service` that scales the `Deployment` `0 → 1` on first invocation, forwards once ready, and scales back to `0` after an idle window (default 60 s). Custom, ~300 LOC, not Knative.
+- **One multi-language runner image** published by Ark: `ark-inline-runner:v1`, Alpine-based (~150 MB), containing `bash`, `python@3.12`, and `node@20`. The image mounts the tool's `ConfigMap` at `/tool/source`, dispatches by shebang or by `language`, and exposes a single MCP-shaped HTTP endpoint that the executor calls.
+- **Runtime contract: JSON on `argv[1]`.** The runner serialises the tool's JSON arguments into a single string and passes it as `argv[1]`. Authors parse with `json.loads(sys.argv[1])` (Python), `jq -r .field <<< "$1"` (bash), `JSON.parse(process.argv[2])` (node). `stdout` is the tool result (trimmed to 256 KiB); a non-zero exit code returns a tool error including the last 4 KiB of `stderr`.
+- **Security defaults from the first commit.** Non-root user (uid 65532), read-only root filesystem, all capabilities dropped, no service-account token, `seccompProfile: RuntimeDefault`, deny-all egress. All defaults are opt-in to relax via the existing Tool annotations / future `spec.inline.security` fields (out of v1 scope).
+- **Executor integration is uniform.** From the executor's point of view, an inline tool is just a tool that resolves to an MCP endpoint. The controller wires the existing MCP plumbing (auth, tracing, audit, broker) to the per-tool `Service`. No new code path in the execution engine.
+- **Dashboard UX (mockup ships in a separate PR).** The existing Tool editor grows one new option in its Type dropdown (`Inline`) and two conditional fields when it's selected: `Language` and `Source`. Inline tools show up in the existing tools list with a small `(inline · python)` badge.
+
+## Capabilities
+
+### New Capabilities
+
+- `inline-tools`: the `type: inline` extension to the `Tool` CRD, the per-tool reconciliation path, the scale-to-zero activator, the single multi-language runner image, and the JSON-on-`argv[1]` runtime contract.
+
+### Modified Capabilities
+
+- None. The `Tool` CRD already supports discriminated subtypes (`http`, `mcp`, `agent`, `team`, `builtin`); `inline` is purely additive. `Agent.spec.tools` is unchanged. The execution engine is unchanged — inline tools are reached via the existing MCP plumbing.
+
+## Impact
+
+- `ark/api/v1alpha1/tool_types.go` — extend the `Type` enum (`http;mcp;agent;team;builtin;inline`), add `Inline *InlineSpec` to `ToolSpec`, declare `InlineSpec { Source string; Language string }`.
+- `ark/api/v1alpha1/tool_webhook.go` (or equivalent) — validate `type == inline` requires non-empty `spec.inline.source`, and `spec.inline.language ∈ {"", "bash", "python", "node", "ts"}`. Reject if `type != inline` and `spec.inline` is set.
+- `ark/config/crd/bases/…_tools.yaml` — generated CRD manifest update.
+- `ark/internal/controller/tool_controller.go` — new reconciliation branch for `type: inline`: owns `ConfigMap`, `ServiceAccount`, `NetworkPolicy`, `Deployment` (`replicas: 0`), `Service`, and the executor-facing MCP-shaped wiring.
+- `ark/internal/inlinetoolactivator/…` — new subsystem (~300 LOC) for scale-to-zero.
+- `ark/images/inline-runner/` — Dockerfile for `ark-inline-runner:v1` plus the runner program (MCP HTTP server + per-script dispatch + JSON-on-`argv[1]` argv shaping).
+- `ark/dist/chart/templates/crd/…_tools.yaml` — Helm sync of the regenerated CRD.
+- `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/…` — regenerate types for the extended Tool shape.
+- `services/ark-api/…` — Tool CRUD endpoints accept the new `inline` type and validate the new fields. (Most of this comes for free via OpenAPI regeneration.)
+- `services/ark-dashboard/…` — Tool editor learns the `Inline` option; tools list gains the language badge. Follow-up PR; not part of the operator change itself.
+- `tools/ark-cli/…` — `ark tool create --inline --source-file ./foo.py …` convenience flag (nice-to-have, not required for v1).
+- `docs/` — new user-guide page "Inline tools — write a function, skip the MCP server".
+- `samples/inline-tools/` — two or three illustrative tools (CSV summary, runbook triage, copybook extractor).
+
+v1 deliberately scopes out: bundling (multiple scripts per resource — author multiple `Tool` resources), languages outside the default runner image (Go, Rust, Ruby — drop back to `MCPServer`), per-tool custom runner images, OCI / Git script sources, cross-namespace references, streaming tool responses, and reference-file mounts (a script that needs static data files belongs in `MCPServer`).

--- a/openspec/changes/inline-tools/specs/inline-tools/spec.md
+++ b/openspec/changes/inline-tools/specs/inline-tools/spec.md
@@ -1,0 +1,179 @@
+## ADDED Requirements
+
+### Requirement: Tool CRD accepts `type: inline` with an `inline` sub-object
+
+The operator SHALL accept a `Tool` custom resource (`ark.mckinsey.com/v1alpha1`) whose `spec.type` is `inline`. When `spec.type == inline`, the resource SHALL include a `spec.inline` sub-object with:
+
+- `source` (string, required, MUST be non-empty)
+- `language` (string, optional, MUST be one of `bash`, `python`, `node`, `ts` when set)
+
+The `spec.inline` field SHALL be permitted only when `spec.type == inline`. The validating webhook SHALL reject any other combination.
+
+#### Scenario: Minimal valid inline tool
+
+- **WHEN** a `Tool` is applied with `spec.type: inline`, a non-empty `spec.inline.source`, and a valid `spec.inputSchema`
+- **THEN** the validating webhook accepts the object
+- **AND** the controller reconciles the owned `ConfigMap`, `ServiceAccount`, `NetworkPolicy`, `Deployment` (replicas: 0), `Service`, and synthetic MCP endpoint
+
+#### Scenario: Empty source rejected
+
+- **WHEN** a `Tool` is applied with `spec.type: inline` and `spec.inline.source` empty or missing
+- **THEN** the validating webhook rejects the admission with a message naming `spec.inline.source`
+
+#### Scenario: `inline` sub-object on a non-inline tool is rejected
+
+- **WHEN** a `Tool` is applied with `spec.type: http` and a populated `spec.inline`
+- **THEN** the validating webhook rejects the admission with a message stating `spec.inline` is only allowed when `spec.type == inline`
+
+#### Scenario: Invalid language rejected
+
+- **WHEN** a `Tool` is applied with `spec.type: inline`, a valid `spec.inline.source`, and `spec.inline.language: ruby`
+- **THEN** the validating webhook rejects the admission with a message naming the allowed values (`bash`, `python`, `node`, `ts`)
+
+#### Scenario: Source size cap
+
+- **WHEN** a `Tool` is applied whose `spec.inline.source` exceeds 900 KiB
+- **THEN** the validating webhook rejects the admission with a message pointing the author at `MCPServer` for larger payloads
+
+### Requirement: Inline tools attach via the existing `Agent.spec.tools`
+
+The `Agent` CRD SHALL surface inline tools through the existing `spec.tools` mechanism with no new field. From an agent author's perspective, attaching an inline `Tool` is identical to attaching any other `Tool`.
+
+#### Scenario: Attaching an inline tool by name
+
+- **GIVEN** an inline `Tool` named `csv-summarise` and an `Agent` whose `spec.tools` references it
+- **WHEN** the agent reconciles
+- **THEN** the agent's effective tool list includes `csv-summarise`
+- **AND** the agent's `spec.tools` did not require any inline-specific entries
+
+#### Scenario: Inline tool callable end-to-end
+
+- **GIVEN** an `Agent` with `spec.tools` including `csv-summarise` (an inline Python tool)
+- **WHEN** the model invokes `csv-summarise(file: "/tmp/data.csv")` during a turn
+- **THEN** the call succeeds
+- **AND** the response is the script's stdout
+
+### Requirement: Controller reconciles per-tool sandbox infrastructure
+
+For each `Tool` with `spec.type == inline`, the controller SHALL reconcile a set of owned Kubernetes objects such that the script body is mounted at `/tool/source`, the pod runs with the documented security defaults, and external traffic reaches the pod only via the scale-to-zero activator. Each owned object SHALL set an owner reference pointing at the `Tool` so deletion cascades.
+
+#### Scenario: Content-hashed bundle ConfigMap
+
+- **WHEN** an inline `Tool` is reconciled
+- **THEN** a `ConfigMap` named `<tool>-<hash>` is created in the tool's namespace containing the script body at key `source`
+- **AND** the hash is a deterministic function of `spec.inline.source` so two byte-identical sources collapse to the same `ConfigMap` name
+
+#### Scenario: Security-hardened pod template
+
+- **WHEN** an inline `Tool` is reconciled
+- **THEN** the generated `Deployment`'s pod template sets `automountServiceAccountToken: false`
+- **AND** the pod security context is `runAsNonRoot: true`, `runAsUser: 65532`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`
+- **AND** the default resource limits are `cpu: 500m`, `memory: 256Mi`
+
+#### Scenario: Default-deny egress
+
+- **WHEN** an inline `Tool` is reconciled
+- **THEN** a `NetworkPolicy` is created that selects the tool's pod and permits no egress
+- **AND** v1 exposes no relaxation knob (an author needing egress SHALL author an `MCPServer` instead)
+
+#### Scenario: Owner-reference cascade on delete
+
+- **WHEN** an inline `Tool` is deleted
+- **THEN** every controller-owned object (`ConfigMap`, `ServiceAccount`, `NetworkPolicy`, `Deployment`, `Service`, synthetic MCP endpoint) is deleted by the Kubernetes garbage collector
+
+### Requirement: Scale-to-zero activator brings pods from 0 to 1 on demand
+
+A new `inlinetoolactivator` subsystem in the operator SHALL front each inline tool's `Service` as an HTTP proxy. When a request arrives for a tool whose `Deployment` has zero ready pods, the activator SHALL scale the `Deployment` to `replicas: 1`, wait for readiness, and forward the request. After an inline tool has been idle for `60s`, the controller SHALL scale the `Deployment` back to `replicas: 0`.
+
+#### Scenario: Cold start on first request
+
+- **GIVEN** an inline `Tool` whose `Deployment` has `replicas: 0`
+- **WHEN** an MCP request arrives at the tool's `Service`
+- **THEN** the activator scales the `Deployment` to `1`
+- **AND** the activator waits for a ready pod
+- **AND** the request is forwarded and the response returned to the caller
+
+#### Scenario: Scale back after idle
+
+- **GIVEN** an inline `Tool` that last served a request 61 s ago
+- **WHEN** the controller's idle sweeper runs
+- **THEN** the `Deployment` is scaled to `replicas: 0`
+
+#### Scenario: Cold-start timeout returns a tool error
+
+- **GIVEN** an inline `Tool` whose pod never becomes ready
+- **WHEN** an MCP request arrives and the activation deadline is exceeded
+- **THEN** the activator returns a tool error indicating the activation timeout
+
+### Requirement: Runner image contract
+
+Ark SHALL publish a single multi-language runner image `ark-inline-runner:v1` (Alpine-based) that bundles `bash`, `python@3.12`, `node@20`, and `tsx`. When started, the image SHALL expose an MCP-shaped HTTP endpoint and SHALL dispatch each invocation as follows:
+
+1. If `/tool/source` begins with `#!`, the runner SHALL `exec` the file directly and let the kernel honour the shebang.
+2. Otherwise, the runner SHALL dispatch by the `LANGUAGE` env var: `bash` → `bash /tool/source`, `python` → `python3 /tool/source`, `node` → `node /tool/source`, `ts` → `tsx /tool/source`.
+3. Otherwise (no shebang and no language), the runner SHALL default to `bash`.
+
+The runner SHALL pass the tool's JSON arguments as a single string in `argv[1]`. The runner SHALL stream `stdout` back as the tool result (trimmed to 256 KiB), log `stderr`, and return a tool error if the exit code is non-zero (error message includes the last 4 KiB of `stderr`).
+
+#### Scenario: Shebang dispatch overrides language
+
+- **GIVEN** an inline `Tool` whose `source` begins with `#!/usr/bin/env python` and `language: bash`
+- **WHEN** the model invokes the tool
+- **THEN** the runner `exec`s the file directly and the kernel runs it under Python
+
+#### Scenario: Language env dispatch
+
+- **GIVEN** an inline `Tool` whose `source` has no shebang and `language: python`
+- **WHEN** the model invokes the tool
+- **THEN** the runner executes `python3 /tool/source <args-json>`
+
+#### Scenario: Default to bash when no shebang and no language
+
+- **GIVEN** an inline `Tool` whose `source` has no shebang and no `language` field
+- **WHEN** the model invokes the tool
+- **THEN** the runner executes `bash /tool/source <args-json>`
+
+#### Scenario: JSON arguments arrive on argv[1]
+
+- **GIVEN** an inline Python `Tool` whose source contains `import sys, json; args = json.loads(sys.argv[1])`
+- **WHEN** the model invokes the tool with `{"file": "data.csv", "limit": 10}`
+- **THEN** the script's `args` dict equals `{"file": "data.csv", "limit": 10}`
+
+#### Scenario: Script fails with non-zero exit
+
+- **GIVEN** an inline `Tool` whose script exits 1 with `"bad input"` on stderr
+- **WHEN** the model invokes the tool
+- **THEN** the tool call returns an error
+- **AND** the error message includes `"bad input"`
+
+#### Scenario: Oversize stdout is trimmed
+
+- **GIVEN** an inline `Tool` whose script emits 5 MiB of stdout
+- **WHEN** the model invokes the tool
+- **THEN** the returned tool result is ≤ 256 KiB
+- **AND** the result indicates that the output was truncated
+
+### Requirement: Inline tools surface to the executor through existing MCP plumbing
+
+The execution engine SHALL NOT learn a dedicated code path for inline tools. When a `Tool` of `type: inline` is attached to an agent, the controller SHALL ensure there exists an MCP-shaped endpoint (a synthesised `MCPServer` or an equivalent internal record) such that the executor's standard MCP client invokes the inline tool by name. Tracing, auditing, and broker integration SHALL apply unchanged.
+
+#### Scenario: Executor uses the same call path for HTTP and inline tools
+
+- **GIVEN** an `Agent` whose `spec.tools` contains both an `http` tool and an `inline` tool
+- **WHEN** the executor calls each tool in the same turn
+- **THEN** both calls go through the same MCP client interface inside the executor
+- **AND** both calls emit the same trace span types and broker events
+
+### Requirement: v1 feature scope is explicitly bounded
+
+The v1 `inline-tools` capability SHALL NOT support: bundling multiple scripts in one `Tool`, `SKILL.md`-style prose / lazy-load catalogs, languages outside the default runner image (Go, Rust, Ruby, custom interpreter versions), per-tool custom runner images, OCI / Git / HTTP script sources, mounted reference files, cross-namespace tool references, streaming tool responses, or relaxation of the security defaults (egress allow-lists, mounted secrets, RBAC role refs). Authors requiring any of these SHALL continue to use `MCPServer`.
+
+#### Scenario: Custom runner image rejected
+
+- **WHEN** a `Tool` is applied with `spec.inline.image: my-registry/foo:bar`
+- **THEN** the validating webhook rejects the admission with a message pointing the author at `MCPServer`
+
+#### Scenario: Source reference outside `spec.inline.source` rejected
+
+- **WHEN** a `Tool` is applied with `spec.inline.source` empty but a sibling `spec.inline.sourceRef` (ConfigMap reference, Git URL, or similar) populated
+- **THEN** the validating webhook rejects the admission with a message stating only `spec.inline.source` is supported in v1

--- a/openspec/changes/inline-tools/tasks.md
+++ b/openspec/changes/inline-tools/tasks.md
@@ -1,0 +1,54 @@
+## 1. Operator — Tool CRD extension
+
+- [ ] 1.1 Extend `Tool.spec.type` enum in `ark/api/v1alpha1/tool_types.go` to include `inline` (full enum: `http;mcp;agent;team;builtin;inline`). Add `Inline *InlineSpec` to `ToolSpec`. Declare `InlineSpec` with `Source string` (required, min length 1) and `Language string` (optional, enum `bash;python;node;ts`). Prove: `make -C ark manifests generate` produces deepcopy + CRD YAML with the new enum value and field.
+- [ ] 1.2 Extend the `Tool` validating webhook to enforce: `type == inline` requires `spec.inline.source != ""`; `spec.inline` is rejected when `type != inline`; `spec.inline.language`, when set, is one of the four allowed values. Prove: `make -C ark test` with new webhook unit tests for each rejection case and the happy path.
+- [ ] 1.3 Sync the regenerated CRD into the Helm chart at `ark/dist/chart/templates/crd/`. Prove: `helm template ark/dist/chart` contains the extended `Tool` CRD with `inline` in the type enum.
+
+## 2. Operator — Inline tool reconciler
+
+- [ ] 2.1 Add an `inline`-branch to `ark/internal/controller/tool_controller.go`: when `tool.spec.type == "inline"`, reconcile owned `ConfigMap`, `ServiceAccount`, `NetworkPolicy`, `Deployment`, `Service`, and a synthetic `MCPServer` (or equivalent internal endpoint record). All owned objects carry an owner reference to the `Tool`. Prove: `make -C ark test` with a "creates all owned objects" envtest case.
+- [ ] 2.2 Compute a content hash of `spec.inline.source` and use it as the `ConfigMap` name suffix (`<tool>-<hash>`). Prove: unit test that two tools with byte-identical sources collapse to the same `ConfigMap` name.
+- [ ] 2.3 Build the PodSpec with the documented security defaults: `automountServiceAccountToken: false`, `runAsNonRoot: true`, `runAsUser: 65532`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`. Default resources: `cpu: 500m`, `memory: 256Mi`. Prove: unit test asserts each field on the generated PodSpec exactly.
+- [ ] 2.4 Generate a deny-all-egress `NetworkPolicy` for every inline tool. v1 exposes no relaxation knobs. Prove: unit test asserts the generated `NetworkPolicy` denies all egress.
+- [ ] 2.5 Resolve the dispatch path at reconcile time: if `source` starts with `#!`, set the runner's container `command` to `["/usr/local/bin/exec-source"]` (the runner's exec-the-file-directly handler); otherwise pass `language` as an env var the runner uses for dispatch. Prove: unit tests for shebang case and each `language` value.
+- [ ] 2.6 On `Tool` delete, GC all owned objects (owner references). Prove: envtest deletes a `Tool` and confirms `ConfigMap`, `Deployment`, `Service`, `NetworkPolicy`, `ServiceAccount`, and synthetic MCPServer disappear.
+- [ ] 2.7 Reflect controller state on `Tool.status.conditions`: `Ready`, `Reconciled`, `Activatable`. Prove: unit test each transition.
+
+## 3. Operator — Scale-to-zero activator
+
+- [ ] 3.1 Scaffold `ark/internal/inlinetoolactivator/` as an HTTP front-end addressable as a single `Service` in the operator namespace. Routes by hostname or path to the correct backing inline-tool `Service`. Prove: `go test ./ark/internal/inlinetoolactivator/...` for routing logic.
+- [ ] 3.2 On a request for an inline tool whose `Deployment` has zero ready pods, the activator scales the `Deployment` to `1`, waits for readiness (with a configurable timeout), and forwards the request. Prove: envtest for the cold-start happy path.
+- [ ] 3.3 Idle sweeper: a controller-side goroutine scales inline-tool `Deployment`s back to `0` after `idleTimeout` (60 s default; no `spec.inline.keepWarm` in v1 unless reopened from design). Prove: envtest fast-forwards time and asserts scale-down.
+- [ ] 3.4 Cold-start timeout returns a tool error to the caller indicating the activation deadline was exceeded. Prove: envtest with a pod whose readiness probe never passes.
+
+## 4. Runner image — `ark-inline-runner:v1`
+
+- [ ] 4.1 Author `ark/images/inline-runner/Dockerfile` on an Alpine base, installing `bash`, `python@3.12`, `node@20`, and `tsx`. Target image size ≤ ~150 MB compressed. Prove: `docker build` succeeds; size check in the image-build script.
+- [ ] 4.2 Implement the runner program (Go, in `ark/images/inline-runner/main.go`) that exposes an MCP-shaped HTTP endpoint: `POST /invoke` with the JSON tool arguments, `GET /healthz` for readiness. Prove: unit tests for both endpoints.
+- [ ] 4.3 Dispatch: if `/tool/source` begins with `#!`, exec the file directly; otherwise dispatch by the `LANGUAGE` env var (`bash` / `python` / `node` / `ts`); otherwise default to `bash`. Pass the request's JSON arguments as a single argv element (`argv[1]`). Prove: unit tests for shebang, each language env, and the bash default.
+- [ ] 4.4 Capture `stdout` (trimmed to 256 KiB) as the tool result; capture `stderr` (last 4 KiB) for the error path. Non-zero exit returns an MCP-shaped error including the stderr tail. Prove: unit tests for happy path, error path, and stdout truncation.
+- [ ] 4.5 Publish the image as `ghcr.io/mckinsey/ark-inline-runner:v1` via the existing image-publish workflow. Prove: image pull succeeds in a `kind` cluster running the chart.
+
+## 5. SDK + API
+
+- [ ] 5.1 Regenerate `lib/ark-sdk` types for the extended `Tool` shape. Prove: `make -C lib/ark-sdk generate && make -C lib/ark-sdk test`.
+- [ ] 5.2 `services/ark-api` accepts the new `inline` type and `spec.inline.{source,language}` fields. Most of this comes via OpenAPI regeneration — verify the create/get/list paths round-trip an inline `Tool` end-to-end. Prove: `make -C services/ark-api test` with a new integration test that creates, reads, and deletes an inline tool.
+
+## 6. Dashboard
+
+- [ ] 6.1 Extend `services/ark-dashboard/.../components/editors/tool-editor.tsx` with an `Inline` option in the Type dropdown, plus two conditional fields when selected: `Language` (Auto / Bash / Python / Node / TS — "Auto" means omit the field and let the controller infer) and `Source` (a multiline textarea, expandable like the existing Input Schema field). Prove: `npm run build` in `services/ark-dashboard/ark-dashboard` is green; the existing tools-section render path renders the new badge.
+- [ ] 6.2 Update `services/ark-dashboard/.../lib/services/tools.ts` `Tool.create` to pass the new fields when `type === 'inline'`. Prove: build is green; manual smoke test creates an inline tool via the dialog and it appears in the list with the language badge.
+- [ ] 6.3 Update `components/rows/tool-row.tsx` to show a small `(inline · <language>)` badge for inline tools. Prove: build is green; renders in the seeded mock if the mock service is in use.
+
+## 7. CLI (nice-to-have)
+
+- [ ] 7.1 `ark tool create --inline --source-file ./foo.py --name csv-summarise --description "…" --input-schema ./schema.json` convenience: read the source file from disk, infer language from extension, POST a Tool. Prove: `make -C tools/ark-cli test` with a new CLI integration test.
+
+## 8. Docs
+
+- [ ] 8.1 Author a "Inline tools — write a function, skip the MCP server" user-guide page under `docs/`. Cover: when to use vs MCPServer, the YAML shape, the `argv[1]` JSON contract for each language, the security defaults, debugging (`kubectl logs`), and the v1 limitations. Prove: `make docs` renders the page without warnings; links validate.
+- [ ] 8.2 Add a samples directory `samples/inline-tools/` with at least three illustrative tools (CSV summary in Python, runbook triage in bash, payload validator in Node). Each sample is a single applicable YAML file plus a short README. Prove: `kubectl apply -f samples/inline-tools/csv-summary.yaml` succeeds against a dev cluster and the tool is callable from a sample agent.
+
+## 9. Cleanup — `agent-skills` change
+
+- [ ] 9.1 Mark the `agent-skills` change as superseded in its `proposal.md` (header note pointing at `inline-tools`). Decide PR #1990 disposition (rebase onto this scope or close in favour of a fresh PR). Prove: `openspec list` shows both changes; the supersession note is unambiguous.

--- a/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/editors/tool-editor.tsx
@@ -35,6 +35,11 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 
+import {
+  INLINE_LANGUAGES,
+  type InlineToolLanguage,
+} from '@/lib/services/inline-tools-mock';
+
 import { AgentFields } from '../common/agent-fields';
 import { TeamFields } from '../common/team-fields';
 
@@ -47,6 +52,10 @@ interface ToolSpec {
   url?: string;
   agent?: string;
   team?: string;
+  inline?: {
+    source: string;
+    language?: InlineToolLanguage;
+  };
 }
 
 interface ToolEditorProps {
@@ -54,6 +63,55 @@ interface ToolEditorProps {
   onOpenChange: (open: boolean) => void;
   onSave: (tool: ToolSpec) => void;
   namespace: string;
+}
+
+const INLINE_LANGUAGE_AUTO = 'auto' as const;
+type InlineLanguageSelection = typeof INLINE_LANGUAGE_AUTO | InlineToolLanguage;
+
+const INLINE_LANGUAGE_OPTIONS: ReadonlyArray<{
+  value: InlineLanguageSelection;
+  label: string;
+}> = [
+  { value: 'auto', label: 'Auto (detect from shebang)' },
+  { value: 'bash', label: 'Bash' },
+  { value: 'python', label: 'Python' },
+  { value: 'node', label: 'Node' },
+  { value: 'ts', label: 'TypeScript' },
+];
+
+function isInlineToolLanguage(value: string): value is InlineToolLanguage {
+  return (INLINE_LANGUAGES as ReadonlyArray<string>).includes(value);
+}
+
+function inlineSourcePlaceholder(language: string | undefined): string {
+  switch (language) {
+    case 'python':
+      return '#!/usr/bin/env python\nimport sys, json\nargs = json.loads(sys.argv[1])\nprint(args)';
+    case 'node':
+      return "const args = JSON.parse(process.argv[2]);\nprocess.stdout.write(JSON.stringify({ ok: true, args }));";
+    case 'ts':
+      return "const args = JSON.parse(process.argv[2]);\nprocess.stdout.write(JSON.stringify({ ok: true, args }));";
+    case 'bash':
+      return '#!/usr/bin/env bash\nset -euo pipefail\nFIELD=$(jq -r .field <<< "$1")\necho "{\\"field\\":\\"$FIELD\\"}"';
+    default:
+      return '#!/usr/bin/env bash\nset -euo pipefail\necho "args=$1"';
+  }
+}
+
+function inlineSourceHint(language: string | undefined): string {
+  const base =
+    'Arguments arrive as a single JSON string on argv[1]. stdout is the tool result; non-zero exit returns an error with the last 4 KiB of stderr.';
+  switch (language) {
+    case 'python':
+      return `${base} Parse with json.loads(sys.argv[1]).`;
+    case 'node':
+    case 'ts':
+      return `${base} Parse with JSON.parse(process.argv[2]).`;
+    case 'bash':
+      return `${base} Parse with jq -r .field <<< "$1".`;
+    default:
+      return `${base} Language is detected from the shebang.`;
+  }
 }
 
 const formSchema = z
@@ -66,6 +124,8 @@ const formSchema = z
     httpUrl: z.string().optional(),
     selectedAgent: z.string().optional(),
     selectedTeam: z.string().optional(),
+    inlineSource: z.string().optional(),
+    inlineLanguage: z.string().optional(),
   })
   .refine(
     data => {
@@ -102,6 +162,18 @@ const formSchema = z
       message: 'Team selection is required for Team type',
       path: ['selectedTeam'],
     },
+  )
+  .refine(
+    data => {
+      if (data.type === 'inline') {
+        return data.inlineSource && data.inlineSource.trim().length > 0;
+      }
+      return true;
+    },
+    {
+      message: 'Source is required for Inline type',
+      path: ['inlineSource'],
+    },
   );
 
 export function ToolEditor({
@@ -112,12 +184,14 @@ export function ToolEditor({
 }: Readonly<ToolEditorProps>) {
   const [isInputSchemaExpanded, setIsInputSchemaExpanded] = useState(false);
   const [isAnnotationsExpanded, setIsAnnotationsExpanded] = useState(false);
+  const [isInlineSourceExpanded, setIsInlineSourceExpanded] = useState(false);
 
   const typeOptions = [
     { value: 'http', label: 'HTTP' },
     { value: 'mcp', label: 'MCP' },
     { value: 'agent', label: 'Agent' },
     { value: 'team', label: 'Team' },
+    { value: 'inline', label: 'Inline' },
   ];
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -131,16 +205,23 @@ export function ToolEditor({
       httpUrl: '',
       selectedAgent: '',
       selectedTeam: '',
+      inlineSource: '',
+      inlineLanguage: INLINE_LANGUAGE_AUTO,
     },
   });
 
   const selectedType = useWatch({ control: form.control, name: 'type' });
+  const selectedInlineLanguage = useWatch({
+    control: form.control,
+    name: 'inlineLanguage',
+  });
 
   useLayoutEffect(() => {
     if (open) {
       form.reset();
       setIsInputSchemaExpanded(false);
       setIsAnnotationsExpanded(false);
+      setIsInlineSourceExpanded(false);
     }
   }, [open, form]);
 
@@ -168,6 +249,19 @@ export function ToolEditor({
       return;
     }
 
+    const inlineLanguageValue = (values.inlineLanguage ?? '').trim();
+    const inlinePayload =
+      values.type === 'inline'
+        ? {
+            inline: {
+              source: values.inlineSource ?? '',
+              ...(isInlineToolLanguage(inlineLanguageValue)
+                ? { language: inlineLanguageValue }
+                : {}),
+            },
+          }
+        : {};
+
     const toolSpec: ToolSpec = {
       name: values.name.trim(),
       type: values.type.trim(),
@@ -179,6 +273,7 @@ export function ToolEditor({
         ? { agent: values.selectedAgent?.trim() }
         : {}),
       ...(values.type === 'team' ? { team: values.selectedTeam?.trim() } : {}),
+      ...inlinePayload,
     };
 
     onSave(toolSpec);
@@ -457,6 +552,103 @@ export function ToolEditor({
                     </FormItem>
                   )}
                 />
+              )}
+
+              {selectedType === 'inline' && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="inlineLanguage"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Language</FormLabel>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                          disabled={form.formState.isSubmitting}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select language..." />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {INLINE_LANGUAGE_OPTIONS.map(opt => (
+                              <SelectItem key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="inlineSource"
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className="flex items-center justify-between">
+                          <FormLabel>
+                            Source <span className="text-red-500">*</span>
+                          </FormLabel>
+                          <div className="flex items-center gap-2">
+                            {field.value && field.value.length > 0 && (
+                              <span className="text-muted-foreground text-xs">
+                                {field.value.length} characters
+                              </span>
+                            )}
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                setIsInlineSourceExpanded(
+                                  !isInlineSourceExpanded,
+                                )
+                              }
+                              className="h-8 px-2">
+                              {isInlineSourceExpanded ? (
+                                <>
+                                  <Minimize2 className="mr-1 h-4 w-4" />
+                                  Collapse
+                                </>
+                              ) : (
+                                <>
+                                  <Maximize2 className="mr-1 h-4 w-4" />
+                                  Expand
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                        </div>
+                        <FormControl>
+                          <Textarea
+                            placeholder={inlineSourcePlaceholder(
+                              selectedInlineLanguage,
+                            )}
+                            disabled={form.formState.isSubmitting}
+                            className={`font-mono resize-none transition-all duration-200 ${
+                              isInlineSourceExpanded
+                                ? 'max-h-[500px] min-h-[400px] overflow-y-auto'
+                                : 'max-h-[220px] min-h-[160px]'
+                            }`}
+                            style={{
+                              whiteSpace: 'pre',
+                              wordWrap: 'normal',
+                            }}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                        <p className="text-muted-foreground text-xs">
+                          {inlineSourceHint(selectedInlineLanguage)}
+                        </p>
+                      </FormItem>
+                    )}
+                  />
+                </>
               )}
             </div>
 

--- a/services/ark-dashboard/ark-dashboard/components/rows/tool-row.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/rows/tool-row.tsx
@@ -17,6 +17,15 @@ import type { Tool } from '@/lib/services/tools';
 import { cn } from '@/lib/utils';
 import { getCustomIcon } from '@/lib/utils/icon-resolver';
 
+function toolTypeBadge(tool: Tool): string | null {
+  if (!tool.type) return null;
+  if (tool.type === 'inline') {
+    const language = tool.inline?.language;
+    return language ? `inline · ${language}` : 'inline';
+  }
+  return tool.type;
+}
+
 type ToolRowProps = {
   readonly tool: Tool;
   readonly onInfo?: (tool: Tool) => void;
@@ -54,9 +63,26 @@ export function ToolRow(props: ToolRowProps) {
         <div className="flex flex-grow items-center gap-3 overflow-hidden">
           <IconComponent className="text-muted-foreground h-5 w-5 flex-shrink-0" />
           <div className="flex max-w-[400px] min-w-0 flex-col gap-1">
-            <p className="truncate text-sm font-medium" title={tool.name}>
-              {tool.name}
-            </p>
+            <div className="flex items-center gap-2">
+              <p className="truncate text-sm font-medium" title={tool.name}>
+                {tool.name}
+              </p>
+              {(() => {
+                const badge = toolTypeBadge(tool);
+                if (!badge) return null;
+                return (
+                  <span
+                    className={cn(
+                      'inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                      tool.type === 'inline'
+                        ? 'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
+                        : 'border-muted-foreground/30 bg-muted text-muted-foreground',
+                    )}>
+                    {badge}
+                  </span>
+                );
+              })()}
+            </div>
             <p
               className="text-muted-foreground truncate text-xs"
               title={tool.description ?? ''}>

--- a/services/ark-dashboard/ark-dashboard/components/sections/tools-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/tools-section.tsx
@@ -39,6 +39,10 @@ import {
   agentsService,
   toolsService,
 } from '@/lib/services';
+import {
+  inlineToolsMockService,
+  type InlineToolLanguage,
+} from '@/lib/services/inline-tools-mock';
 import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 import { groupToolsByLabel } from '@/lib/utils/groupToolsByLabels';
 
@@ -73,11 +77,12 @@ export const ToolsSection = forwardRef<
     const loadData = async () => {
       setLoading(true);
       try {
-        const [toolsData, agentsData] = await Promise.all([
+        const [toolsData, inlineToolsData, agentsData] = await Promise.all([
           toolsService.getAll(),
+          inlineToolsMockService.getAll(),
           agentsService.getAll(),
         ]);
-        setTools(toolsData);
+        setTools([...toolsData, ...inlineToolsData]);
         setAgents(agentsData);
       } catch (error) {
         console.error('Failed to load data:', error);
@@ -115,7 +120,14 @@ export const ToolsSection = forwardRef<
       return;
     }
     try {
-      await toolsService.delete(identifier);
+      const target = tools.find(
+        tool => (tool.name || tool.type) === identifier,
+      );
+      if (target?.type === 'inline') {
+        await inlineToolsMockService.delete(identifier);
+      } else {
+        await toolsService.delete(identifier);
+      }
       setTools(tools.filter(tool => (tool.name || tool.type) !== identifier));
       toast.success('Tool Deleted', {
         description: 'Successfully deleted tool',
@@ -143,15 +155,34 @@ export const ToolsSection = forwardRef<
     inputSchema?: Record<string, unknown>;
     annotations?: Record<string, string>;
     url?: string;
+    agent?: string;
+    team?: string;
+    inline?: { source: string; language?: InlineToolLanguage };
   }) => {
     try {
-      await toolsService.create({ ...toolSpec, namespace });
+      if (toolSpec.type === 'inline') {
+        if (!toolSpec.inline) {
+          throw new Error('Inline source is required');
+        }
+        await inlineToolsMockService.create({
+          name: toolSpec.name,
+          description: toolSpec.description,
+          inputSchema: toolSpec.inputSchema,
+          annotations: toolSpec.annotations,
+          inline: toolSpec.inline,
+        });
+      } else {
+        await toolsService.create({ ...toolSpec, namespace });
+      }
       toast.success('Tool Created', {
         description: `Successfully created ${toolSpec.name}`,
       });
 
-      const updatedTools = await toolsService.getAll();
-      setTools(updatedTools);
+      const [updatedTools, updatedInlineTools] = await Promise.all([
+        toolsService.getAll(),
+        inlineToolsMockService.getAll(),
+      ]);
+      setTools([...updatedTools, ...updatedInlineTools]);
     } catch (error) {
       toast.error('Failed to Create Tool', {
         description:

--- a/services/ark-dashboard/ark-dashboard/lib/services/inline-tools-mock.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/inline-tools-mock.ts
@@ -1,0 +1,267 @@
+/**
+ * Mock service for inline Tools backed by localStorage.
+ *
+ * The dashboard's real `toolsService` (lib/services/tools.ts) talks to
+ * /api/v1/tools and the underlying Tool CRD currently has type enum
+ * {http,mcp,agent,team,builtin}. Inline tools live in this separate
+ * mock layer until the operator side of the inline-tools change lands
+ * — see openspec/changes/inline-tools/.
+ *
+ * Replace with calls into the real toolsService once `type: inline`
+ * is accepted by the API. The shape exported here is deliberately the
+ * shape we expect from the API: a Tool with an `inline` sub-object
+ * containing source + optional language.
+ */
+
+import { trackEvent } from '@/lib/analytics/singleton';
+import type { Tool } from './tools';
+
+export type InlineToolLanguage = 'bash' | 'python' | 'node' | 'ts';
+
+export const INLINE_LANGUAGES: ReadonlyArray<InlineToolLanguage> = [
+  'bash',
+  'python',
+  'node',
+  'ts',
+];
+
+export interface InlineToolSpec {
+  source: string;
+  language?: InlineToolLanguage;
+}
+
+export interface InlineTool extends Tool {
+  type: 'inline';
+  description: string;
+  inline: InlineToolSpec;
+  inputSchema?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InlineToolCreateInput {
+  name: string;
+  description: string;
+  inline: InlineToolSpec;
+  inputSchema?: Record<string, unknown>;
+  annotations?: Record<string, string>;
+}
+
+const STORAGE_KEY = 'ark-dashboard:inline-tools:default';
+const SEED_VERSION_KEY = 'ark-dashboard:inline-tools:seed-version';
+const SEED_VERSION = '1';
+
+const SHEBANG_PREFIX = '#!';
+
+export function inferLanguageFromSource(
+  source: string,
+): InlineToolLanguage | undefined {
+  const firstLine = source.split(/\r?\n/, 1)[0] ?? '';
+  if (!firstLine.startsWith(SHEBANG_PREFIX)) return undefined;
+  if (firstLine.includes('python')) return 'python';
+  if (firstLine.includes('node')) return 'node';
+  if (firstLine.includes('tsx')) return 'ts';
+  if (firstLine.includes('bash') || firstLine.includes('sh')) return 'bash';
+  return undefined;
+}
+
+export function effectiveLanguage(
+  tool: Pick<InlineTool, 'inline'>,
+): InlineToolLanguage {
+  if (tool.inline.language) return tool.inline.language;
+  const inferred = inferLanguageFromSource(tool.inline.source);
+  return inferred ?? 'bash';
+}
+
+const SEED_CSV_SUMMARY: InlineToolCreateInput = {
+  name: 'csv-summarise',
+  description: 'Summarise a CSV file — column types, row count, basic stats',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      file: {
+        type: 'string',
+        description: 'Path to the CSV file inside the runner pod',
+      },
+    },
+    required: ['file'],
+  },
+  inline: {
+    language: 'python',
+    source: `#!/usr/bin/env python
+import sys, json
+import pandas as pd
+
+args = json.loads(sys.argv[1])
+df = pd.read_csv(args["file"])
+print(df.dtypes.to_json())
+print(df.describe().to_json())
+`,
+  },
+};
+
+const SEED_RUNBOOK_TRIAGE: InlineToolCreateInput = {
+  name: 'runbook-triage',
+  description: 'Run incident triage per runbook §3 and return a status code',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      alert_id: { type: 'string', description: 'The alert identifier' },
+    },
+    required: ['alert_id'],
+  },
+  inline: {
+    language: 'bash',
+    source: `#!/usr/bin/env bash
+set -euo pipefail
+ALERT_ID=$(jq -r .alert_id <<< "$1")
+echo "triaging $ALERT_ID..."
+# real runbook commands would live here
+echo "{\\"status\\":\\"green\\"}"
+`,
+  },
+};
+
+const SEED_PAYLOAD_VALIDATOR: InlineToolCreateInput = {
+  name: 'payload-validator',
+  description: 'Validate a JSON payload against a known schema',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      payload: { type: 'object', description: 'The JSON payload to validate' },
+    },
+    required: ['payload'],
+  },
+  inline: {
+    language: 'node',
+    source: `const args = JSON.parse(process.argv[2]);
+const payload = args.payload;
+const errors = [];
+if (typeof payload.id !== 'string') errors.push('id must be string');
+if (typeof payload.amount !== 'number') errors.push('amount must be number');
+process.stdout.write(JSON.stringify({ valid: errors.length === 0, errors }));
+`,
+  },
+};
+
+function buildSeed(): InlineTool[] {
+  const stamp = '2026-05-11T08:00:00.000Z';
+  return [
+    SEED_CSV_SUMMARY,
+    SEED_RUNBOOK_TRIAGE,
+    SEED_PAYLOAD_VALIDATOR,
+  ].map((spec, index) => ({
+    id: spec.name,
+    name: spec.name,
+    type: 'inline' as const,
+    description: spec.description,
+    inputSchema: spec.inputSchema,
+    annotations: spec.annotations,
+    inline: spec.inline,
+    createdAt: stamp,
+    updatedAt: stamp,
+    labels: { 'ark.mckinsey.com/seed-index': String(index) },
+  }));
+}
+
+function isInlineToolRecord(value: unknown): value is InlineTool {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (record.type !== 'inline') return false;
+  if (typeof record.name !== 'string') return false;
+  const inline = record.inline as Record<string, unknown> | undefined;
+  if (!inline || typeof inline !== 'object') return false;
+  return typeof inline.source === 'string';
+}
+
+function writeSeed(): InlineTool[] {
+  const seed = buildSeed();
+  if (typeof window === 'undefined') return seed;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seed));
+    window.localStorage.setItem(SEED_VERSION_KEY, SEED_VERSION);
+  } catch {
+    // quota or disabled storage — silently fall through
+  }
+  return seed;
+}
+
+function read(): InlineTool[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const storedSeedVersion = window.localStorage.getItem(SEED_VERSION_KEY);
+    if (!raw || storedSeedVersion !== SEED_VERSION) return writeSeed();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every(isInlineToolRecord)) {
+      return writeSeed();
+    }
+    return parsed;
+  } catch {
+    return writeSeed();
+  }
+}
+
+function write(tools: InlineTool[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tools));
+  } catch {
+    // quota or disabled storage — silently fall through
+  }
+}
+
+export const inlineToolsMockService = {
+  async getAll(): Promise<InlineTool[]> {
+    return read();
+  },
+
+  async getByName(name: string): Promise<InlineTool | null> {
+    return read().find(tool => tool.name === name) ?? null;
+  },
+
+  async create(input: InlineToolCreateInput): Promise<InlineTool> {
+    const tools = read();
+    if (tools.some(tool => tool.name === input.name)) {
+      throw new Error(`A tool named "${input.name}" already exists`);
+    }
+    if (!input.inline.source.trim()) {
+      throw new Error('Inline source is required');
+    }
+    const now = new Date().toISOString();
+    const next: InlineTool = {
+      id: input.name,
+      name: input.name,
+      type: 'inline',
+      description: input.description,
+      inputSchema: input.inputSchema,
+      annotations: input.annotations,
+      inline: input.inline,
+      createdAt: now,
+      updatedAt: now,
+    };
+    write([...tools, next]);
+    trackEvent({
+      name: 'tool_created',
+      properties: {
+        toolName: input.name,
+        toolType: 'inline',
+        inlineLanguage:
+          input.inline.language ?? inferLanguageFromSource(input.inline.source),
+      },
+    });
+    return next;
+  },
+
+  async delete(name: string): Promise<void> {
+    write(read().filter(tool => tool.name !== name));
+    trackEvent({
+      name: 'tool_deleted',
+      properties: { toolName: name },
+    });
+  },
+
+  async resetSeed(): Promise<void> {
+    writeSeed();
+  },
+};

--- a/services/ark-dashboard/ark-dashboard/lib/services/tools.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/tools.ts
@@ -9,6 +9,10 @@ export interface Tool {
   description?: string;
   annotations?: unknown;
   labels?: unknown;
+  inline?: {
+    source: string;
+    language?: string;
+  };
 }
 
 // Tool detail response with schema


### PR DESCRIPTION
## Summary

Proposes a new OpenSpec change, `inline-tools`, which **supersedes the broader `agent-skills` proposal (PR #1990).**

User testing of the skills mockup showed that the single most-valued capability was the "write a Python or bash function inline, attach it to an agent, no image, no registry" path. The wider Claude-Code shape (SKILL.md prose, lazy `load_skill` catalog, drop-in import of Claude-Code skill folders) carried complexity that testers did not engage with. `inline-tools` keeps the carrying primitive and drops the rest.

### Design shape (for reviewers' quick orientation)

| Axis | Decision |
|---|---|
| CRD | Extend existing `Tool` CRD with `type: inline` — no new kind |
| Attachment | Existing `Agent.spec.tools` — no new agent field |
| Granularity | One Tool per script — no bundling |
| Author surface | `spec.inline.{source, language?}` + reuse `spec.inputSchema` |
| Language | Bash, Python, Node, TS — single multi-language runner image, dispatched by shebang or `language` field |
| Runtime contract | JSON serialised onto `argv[1]`; stdout = tool result (256 KiB cap); non-zero exit returns tool error with last 4 KiB of stderr |
| Pod model | Per-tool `Deployment` — strong isolation boundary from day one |
| Scheduling | Scale-to-zero via a custom ~300 LOC activator — no Knative / KEDA |
| Executor | Reaches inline tools through the existing MCP plumbing — no new code path |
| Security | Non-root, read-only root, drop-all caps, no SA token, deny-all egress, no secrets — no relaxation knobs in v1 |

### What's in the change

- `openspec/changes/inline-tools/proposal.md` — why / what changes / capabilities / impact
- `openspec/changes/inline-tools/design.md` — context, goals / non-goals, six decisions each with rejected alternatives, risks, five open questions
- `openspec/changes/inline-tools/tasks.md` — 28 phased tasks across nine sections (CRD, controller, activator, runner image, SDK/API, dashboard, CLI, docs, agent-skills cleanup)
- `openspec/changes/inline-tools/specs/inline-tools/spec.md` — seven requirements, 22 scenarios

### How this was validated

- `openspec validate inline-tools` → `Change 'inline-tools' is valid`
- `openspec list` → `inline-tools` registers alongside existing in-flight changes

### Open questions the proposal leaves for reviewers

These are flagged explicitly in `design.md` and do not block approval:

- `keepWarm` on day one or v1.5 (cold-start UX vs scope discipline)
- `spec.inline.image` custom-runner escape hatch (currently rejected)
- TypeScript dispatch in the runner — real demand or drop?
- Resource defaults (`cpu: 500m`, `memory: 256Mi`) — guess; worth pressure-testing
- Concrete disposition of PR #1990 and the `agent-skills` change (rebase vs close)

### Relationship to PR #1990

This change is meant to **supersede `agent-skills`** rather than stack on top. Once this proposal is approved, PR #1990 should be closed and the `agent-skills` OpenSpec change archived as superseded. That's deliberately not done in this PR — it's a follow-up decision once reviewers agree on the rescope.

### Deliberately out of scope for v1

- Bundling multiple scripts into one resource (author multiple `Tool`s instead)
- The full Claude-Code skill shape (`SKILL.md` prose, lazy-load catalog)
- Custom runner images and languages outside the default image (Go, Rust, Ruby)
- OCI / Git / HTTP script sources
- Cross-namespace tool references and streaming tool responses
- Relaxation of the security defaults (egress allow-lists, mounted secrets, RBAC roles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)