### PR TITLE
fix(install): make PostgreSQL backend installable end-to-end

### DIFF
--- a/ark/dist/chart-apiserver/templates/deployment.yaml
+++ b/ark/dist/chart-apiserver/templates/deployment.yaml
@@ -36,17 +36,17 @@ spec:
             - name: ARK_APISERVER_PORT
               value: {{ .Values.apiserver.port | quote }}
             - name: ARK_POSTGRES_HOST
-              value: {{ .Values.postgresql.host | quote }}
+              value: {{ required "postgresql.host is required" .Values.postgresql.host | quote }}
             - name: ARK_POSTGRES_PORT
               value: {{ .Values.postgresql.port | quote }}
             - name: ARK_POSTGRES_DATABASE
               value: {{ .Values.postgresql.database | quote }}
             - name: ARK_POSTGRES_USER
-              value: {{ .Values.postgresql.user | quote }}
+              value: {{ required "postgresql.user is required" .Values.postgresql.user | quote }}
             - name: ARK_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.passwordSecretName }}
+                  name: {{ required "postgresql.passwordSecretName is required" .Values.postgresql.passwordSecretName }}
                   key: {{ .Values.postgresql.passwordSecretKey }}
             - name: ARK_POSTGRES_SSL_MODE
               value: {{ .Values.postgresql.sslMode | quote }}

--- a/docs/content/operations-guide/_meta.js
+++ b/docs/content/operations-guide/_meta.js
@@ -2,6 +2,7 @@ export default {
   '---platform-ops': { type: 'separator', title: 'Platform operations' },
   provisioning: 'Cloud Infrastructure Provisioning',
   'deploying-ark': 'Deploying Ark',
+  'postgres-storage-backend': 'PostgreSQL Storage Backend',
   'tenant-namespace-management': 'Tenant and Namespace Management',
   monitoring: 'Monitoring',
 

--- a/docs/content/operations-guide/deploying-ark.mdx
+++ b/docs/content/operations-guide/deploying-ark.mdx
@@ -17,6 +17,18 @@ ark install
 
 This will run an interactive install of the core Ark controller, dependencies, and optional additional services.
 
+### Storage backend
+
+`ark install` accepts `--backend etcd` (default) or `--backend postgresql`. The etcd path stores resources as CRDs and is the simplest option. The PostgreSQL path uses an aggregated API server backed by Postgres and is suited for larger fleets, oversize resources, or shared-DB strategies.
+
+For PostgreSQL mode, supply a values file with the connection details:
+
+```bash
+ark install --backend postgresql --values pg-values.yaml
+```
+
+See [PostgreSQL Storage Backend](./postgres-storage-backend) for the full setup, database requirements, and operational notes.
+
 ## Local Development
 
 To run in local development mode with live-reload, install [Devspace](https://devspace.sh), clone and run:

--- a/docs/content/operations-guide/deploying-ark.mdx
+++ b/docs/content/operations-guide/deploying-ark.mdx
@@ -19,15 +19,20 @@ This will run an interactive install of the core Ark controller, dependencies, a
 
 ### Storage backend
 
-`ark install` accepts `--backend etcd` (default) or `--backend postgresql`. The etcd path stores resources as CRDs and is the simplest option. The PostgreSQL path uses an aggregated API server backed by Postgres and is suited for larger fleets, oversize resources, or shared-DB strategies.
+`ark install` reads the storage backend from `.arkrc.yaml`. The default is `etcd`, which stores resources as CRDs. The PostgreSQL path uses an aggregated API server backed by Postgres and is suited for larger fleets, oversize resources, or shared-DB strategies.
 
-For PostgreSQL mode, supply a values file with the connection details:
+To use PostgreSQL, add a `storage` block to `.arkrc.yaml`:
 
-```bash
-ark install --backend postgresql --values pg-values.yaml
+```yaml
+storage:
+  backend: postgresql
+  postgresql:
+    host: db.example.com
+    user: ark
+    passwordSecretName: ark-db-password
 ```
 
-See [PostgreSQL Storage Backend](./postgres-storage-backend) for the full setup, database requirements, and operational notes.
+Then run `ark install` as usual. The `--backend` CLI flag overrides the config value (e.g., `--backend etcd` for a temporary switch). See [PostgreSQL Storage Backend](./postgres-storage-backend) for the full setup, database requirements, and operational notes.
 
 ## Local Development
 

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -1,0 +1,220 @@
+# PostgreSQL Storage Backend
+
+By default Ark stores resources as Kubernetes CRDs in etcd. Ark also supports a PostgreSQL-backed mode where resources live in a Postgres database and are served via a [Kubernetes aggregated API server](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/). This page covers when to choose it, the database requirements, how to install it, and how to operate it.
+
+For the architectural background, see [Core Architecture](../reference/core-architecture).
+
+## When to use PostgreSQL mode
+
+Prefer PostgreSQL when any of these apply:
+
+- **Resource scale beyond etcd's comfort zone.** Large fleets of Agents, Models, Queries, MCPServers can push etcd object-count limits and slow the API server.
+- **Resource-size pressure.** etcd's 1.5 MiB per-object limit is a hard ceiling; Postgres rows are not.
+- **Persistence and operational tooling.** Standard SQL backups, point-in-time recovery, CDC, and BI tooling become available.
+- **Multi-region or external DB strategy.** Managed Postgres (RDS, Cloud SQL, Aiven) is easier to share across clusters than etcd.
+
+Stay on etcd if:
+
+- You want zero database operational burden.
+- You don't need the scale above and prefer the simpler single-binary controller.
+
+## Architecture in PostgreSQL mode
+
+Two Helm releases work together:
+
+- **`ark-controller`** — runs the reconciler. CRDs for `ark.mckinsey.com/*` are **not** installed in this mode.
+- **`ark-apiserver`** — registers as an aggregated API server. The Kubernetes API server proxies all `ark.mckinsey.com` requests to it; it persists resources to Postgres.
+
+When a user runs `kubectl apply -f agent.yaml`, the request flow is:
+
+```
+kubectl → kube-apiserver → APIService (v1alpha1.ark.mckinsey.com)
+       → ark-apiserver → PostgreSQL (resources table)
+```
+
+The controller observes resources through the same K8s API path; it doesn't talk to Postgres directly.
+
+## PostgreSQL requirements
+
+The apiserver creates a logical replication slot to drive its watch stream, so the database **must** allow logical replication:
+
+```
+wal_level             = logical
+max_replication_slots >= 1
+max_wal_senders       >= 1
+```
+
+A user/role with permission to:
+
+- `CREATE TABLE`, `CREATE INDEX`, `CREATE PUBLICATION` on the target database
+- `pg_replication_slots` access (typically the `REPLICATION` attribute or a member of `pg_create_logical_replication_slots`)
+
+For managed services:
+
+| Provider | How to enable logical replication |
+|---|---|
+| AWS RDS | Set `rds.logical_replication = 1` in the parameter group, reboot. |
+| Google Cloud SQL | Set `cloudsql.logical_decoding = on` flag, reboot. |
+| Azure Database for PostgreSQL | Set `wal_level = logical` server parameter, restart. |
+| Aiven / Neon | Logical replication is on by default. |
+
+The connection settings the chart accepts are listed in [`ark/dist/chart-apiserver/values.yaml`](https://github.com/mckinsey/agents-at-scale-ark/blob/main/ark/dist/chart-apiserver/values.yaml).
+
+## Schema and replication slot
+
+On first start, `ark-apiserver` creates:
+
+- A single table, `resources`, with one row per Ark resource (Agent, Model, Query, Team, …). Columns include `kind`, `namespace`, `name`, `uid`, `resource_version`, JSONB columns for `spec`, `status`, `labels`, `annotations`, `finalizers`, `owner_references`, plus timestamps and a soft-delete flag (`deleted_at`).
+- Indexes on `(kind, namespace)`, `(kind, namespace, name)`, a GIN index on `labels`, and a unique partial index on active (non-deleted) rows.
+- A publication and a logical replication slot, both named `ark_cdc`. The slot is what powers `kubectl get -w` and controller informers.
+
+The slot is **persistent**: it survives apiserver restarts and is not removed by `helm uninstall`. See [Uninstall and cleanup](#uninstall-and-cleanup) below.
+
+## Installing PostgreSQL mode
+
+### 1. Prepare PostgreSQL
+
+Provision a database with logical replication enabled, create the Ark database and user, and obtain the password.
+
+### 2. Create the Kubernetes password secret
+
+The chart references the password by secret name; you create it once:
+
+```bash
+kubectl create namespace ark-system
+kubectl create secret generic ark-db-password \
+  -n ark-system \
+  --from-literal=password='<your-password>'
+```
+
+### 3. Write a values file
+
+Create a YAML file (anywhere on your machine) describing the connection:
+
+```yaml
+# pg-values.yaml
+postgresql:
+  host: ark-storage.example.com
+  port: 5432
+  database: ark
+  user: ark
+  passwordSecretName: ark-db-password
+  passwordSecretKey: password
+  sslMode: require
+```
+
+`sslMode` accepts the standard libpq values: `disable`, `require`, `verify-ca`, `verify-full`.
+
+### 4. Install via the CLI
+
+```bash
+ark install \
+  --backend postgresql \
+  --values pg-values.yaml
+```
+
+The CLI installs `ark-controller` with `storage.backend=postgresql` (which disables CRD installation) and `ark-apiserver` with the connection values from your file. cert-manager and Gateway API CRDs are installed as dependencies just as in etcd mode.
+
+### Install via raw Helm
+
+If you prefer to skip the CLI, install the two charts directly:
+
+```bash
+helm upgrade --install ark-controller \
+  oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-controller \
+  --namespace ark-system --create-namespace \
+  --set rbac.enable=true \
+  --set storage.backend=postgresql
+
+helm upgrade --install ark-apiserver \
+  oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-apiserver \
+  --namespace ark-system \
+  --values pg-values.yaml
+```
+
+The apiserver chart's `postgresql.host`, `postgresql.user`, and `postgresql.passwordSecretName` are **required** values — `helm install` will fail at template time if they are missing.
+
+## Verifying the install
+
+```bash
+# No Ark CRDs in postgresql mode.
+kubectl get crd | grep ark.mckinsey.com
+# (no output)
+
+# Both APIServices should report Available=True.
+kubectl get apiservice v1alpha1.ark.mckinsey.com v1prealpha1.ark.mckinsey.com
+
+# kubectl operates on Ark resources transparently.
+kubectl get agents,models,queries -A
+```
+
+Create a smoke-test Agent to confirm the round trip lands in Postgres:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: smoke
+  namespace: default
+spec:
+  description: smoke test
+  prompt: "You are a helpful assistant."
+EOF
+```
+
+Then connect to Postgres and confirm the row exists:
+
+```sql
+SELECT kind, namespace, name, uid FROM resources WHERE kind = 'Agent';
+```
+
+## Multi-replica behaviour
+
+The `ark-apiserver` chart defaults to a single replica. The chart wires the RBAC needed for controller-runtime leader election on a `Lease` named `ark-apiserver-leader`.
+
+If you scale to multiple replicas:
+
+- Only one instance acquires the lease and runs the WAL consumer.
+- The replication slot's `active` flag is a second backstop — even without leader election, Postgres only lets one connection hold the slot at a time.
+
+Multi-replica mainly improves API request throughput; the WAL stream is still single-consumer by design.
+
+## Backups and restore
+
+Treat the `resources` table like any other application table:
+
+- Use your provider's automated backups or `pg_dump` for ad-hoc snapshots.
+- A point-in-time restore restores Ark state to that moment. Take care to also drop and recreate the `ark_cdc` replication slot after a restore so the apiserver starts a fresh watch stream.
+- Cluster-side state (Pods, Deployments owned by Ark) is **not** restored by a Postgres restore — only the declarative resources are.
+
+## Uninstall and cleanup
+
+`helm uninstall` removes the apiserver Deployment and APIService but does **not** drop the publication or the replication slot. An orphaned slot will pin WAL retention and can fill the disk.
+
+After uninstalling, drop the slot manually:
+
+```sql
+SELECT pg_drop_replication_slot('ark_cdc');
+DROP PUBLICATION IF EXISTS ark_cdc;
+```
+
+If the slot was invalidated (`wal_status = 'lost'`, typically after `max_slot_wal_keep_size` was exceeded), the apiserver drops and recreates it automatically on startup.
+
+The `resources` table itself is yours — drop it manually if you are decommissioning the database, or keep it for forensic queries.
+
+## Troubleshooting
+
+**`helm install` fails with `postgresql.host is required`.** You ran the apiserver chart without supplying connection details. Use `--values pg-values.yaml` or `--set postgresql.host=… --set postgresql.user=… --set postgresql.passwordSecretName=…`.
+
+**Apiserver pod is `CreateContainerConfigError`.** The pod is referencing a secret that doesn't exist. Confirm the secret named in `postgresql.passwordSecretName` exists in the same namespace as the release.
+
+**Apiserver crashes with `failed to connect to database: dial tcp … connect: connection refused`.** The host/port is wrong, the database isn't up yet, or a NetworkPolicy is blocking egress. The pod will restart and retry.
+
+**Apiserver logs `error retrieving resource lock`.** Leader election can't reach the Kubernetes API. Usually a transient startup issue; if it persists, check the ServiceAccount, RBAC bindings, and any egress restrictions.
+
+**APIService stuck at `False (FailedDiscoveryCheck)`.** The aggregator can't reach the apiserver Service. Check `kubectl get svc -n ark-system ark-apiserver`, verify pods are 1/1, and confirm no NetworkPolicy blocks port 6443 from the kube-apiserver.
+
+**`kubectl get agents` returns "the server doesn't have a resource type ...".** The APIService is not registered or not Available. Look at `kubectl get apiservice v1alpha1.ark.mckinsey.com -o yaml`.
+
+**Resources don't appear after `kubectl apply`, but no error.** Check `kubectl get events -A`. Confirm the apiserver pod is running and the replication slot exists in Postgres (`SELECT slot_name, active, wal_status FROM pg_replication_slots`).

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -87,37 +87,42 @@ kubectl create secret generic ark-db-password \
   --from-literal=password='<your-password>'
 ```
 
-### 3. Write a values file
+### 3. Configure `.arkrc.yaml`
 
-Create a YAML file (anywhere on your machine) describing the connection:
+The CLI reads the backend choice and connection details from `.arkrc.yaml`. You can place this file in either:
+
+- `~/.arkrc.yaml` (user-level, applies to all projects)
+- `./.arkrc.yaml` (project-level, takes precedence)
 
 ```yaml
-# pg-values.yaml
-postgresql:
-  host: ark-storage.example.com
-  port: 5432
-  database: ark
-  user: ark
-  passwordSecretName: ark-db-password
-  passwordSecretKey: password
-  sslMode: require
+# .arkrc.yaml
+storage:
+  backend: postgresql
+  postgresql:
+    host: ark-storage.example.com
+    port: 5432
+    database: ark
+    user: ark
+    passwordSecretName: ark-db-password
+    passwordSecretKey: password
+    sslMode: require
 ```
 
 `sslMode` accepts the standard libpq values: `disable`, `require`, `verify-ca`, `verify-full`.
 
+The `--backend` CLI flag and `ARK_STORAGE_BACKEND` env var override the config value, useful for testing the same code against a different backend without editing the file.
+
 ### 4. Install via the CLI
 
 ```bash
-ark install \
-  --backend postgresql \
-  --values pg-values.yaml
+ark install
 ```
 
-The CLI installs `ark-controller` with `storage.backend=postgresql` (which disables CRD installation) and `ark-apiserver` with the connection values from your file. cert-manager and Gateway API CRDs are installed as dependencies just as in etcd mode.
+The CLI installs `ark-controller` with `storage.backend=postgresql` (which disables CRD installation) and `ark-apiserver` with the connection values from the config. cert-manager and Gateway API CRDs are installed as dependencies just as in etcd mode.
 
 ### Install via raw Helm
 
-If you prefer to skip the CLI, install the two charts directly:
+If you prefer to skip the CLI, install the two charts directly with `--set` flags from the values you would have put in `.arkrc.yaml`:
 
 ```bash
 helm upgrade --install ark-controller \
@@ -129,7 +134,10 @@ helm upgrade --install ark-controller \
 helm upgrade --install ark-apiserver \
   oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-apiserver \
   --namespace ark-system \
-  --values pg-values.yaml
+  --set postgresql.host=ark-storage.example.com \
+  --set postgresql.user=ark \
+  --set postgresql.passwordSecretName=ark-db-password \
+  --set postgresql.sslMode=require
 ```
 
 The apiserver chart's `postgresql.host`, `postgresql.user`, and `postgresql.passwordSecretName` are **required** values — `helm install` will fail at template time if they are missing.
@@ -205,7 +213,9 @@ The `resources` table itself is yours — drop it manually if you are decommissi
 
 ## Troubleshooting
 
-**`helm install` fails with `postgresql.host is required`.** You ran the apiserver chart without supplying connection details. Use `--values pg-values.yaml` or `--set postgresql.host=… --set postgresql.user=… --set postgresql.passwordSecretName=…`.
+**`helm install` fails with `postgresql.host is required`.** You ran the apiserver chart without supplying connection details. Set `storage.postgresql` in `.arkrc.yaml` (the CLI passes these through) or use `--set postgresql.host=… --set postgresql.user=… --set postgresql.passwordSecretName=…` for raw helm.
+
+**`ark install` fails with `missing 'storage.postgresql' block`.** You set `storage.backend: postgresql` in `.arkrc.yaml` but didn't add the `storage.postgresql` block, or it's missing `host`/`user`/`passwordSecretName`. Fill in the required fields.
 
 **Apiserver pod is `CreateContainerConfigError`.** The pod is referencing a secret that doesn't exist. Confirm the secret named in `postgresql.passwordSecretName` exists in the same namespace as the release.
 

--- a/tools/ark-cli/.arkrc.yaml.sample
+++ b/tools/ark-cli/.arkrc.yaml.sample
@@ -18,6 +18,23 @@ chat:
   # Environment variable: ARK_CHAT_OUTPUT_FORMAT
   outputFormat: text
 
+# Storage backend for ark install
+# 'etcd' (default) stores resources as CRDs in etcd.
+# 'postgresql' uses the aggregated ark-apiserver, backed by PostgreSQL.
+# Can be overridden with the --backend CLI flag or ARK_STORAGE_BACKEND env var.
+storage:
+  backend: etcd
+  # Connection details required when backend is 'postgresql'.
+  # The password lives in a Kubernetes Secret; only the secret name is referenced here.
+  # postgresql:
+  #   host: db.example.com
+  #   port: 5432
+  #   database: ark
+  #   user: ark
+  #   passwordSecretName: ark-db-password
+  #   passwordSecretKey: password
+  #   sslMode: require
+
 # Service overrides for ark install
 services:
   # Enable localhost-gateway for local development

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -1,5 +1,8 @@
 import {vi} from 'vitest';
 import {Command} from 'commander';
+import {writeFileSync} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
 
 const mockExeca = vi.fn(() => Promise.resolve()) as any;
 vi.mock('execa', () => ({
@@ -17,11 +20,6 @@ vi.mock('inquirer', () => ({
 const mockGetClusterInfo = vi.fn() as any;
 vi.mock('../../lib/cluster.js', () => ({
   getClusterInfo: mockGetClusterInfo,
-}));
-
-const mockDetectStorageBackend = vi.fn().mockResolvedValue('etcd');
-vi.mock('../../lib/readinessChecks.js', () => ({
-  detectStorageBackend: mockDetectStorageBackend,
 }));
 
 const mockGetInstallableServices = vi.fn() as any;
@@ -1082,6 +1080,180 @@ describe('install command', () => {
       expect(helmInstallCalls[1][1]).toContain('ark-api');
       expect(helmInstallCalls[2][1]).toContain('ark-broker');
       expect(helmInstallCalls[3][1]).toContain('ark-dashboard');
+    });
+  });
+
+  describe('--backend flag', () => {
+    const writeTempValues = (content: string) => {
+      const file = join(
+        tmpdir(),
+        `ark-values-${Date.now()}-${Math.random()}.yaml`
+      );
+      writeFileSync(file, content);
+      return file;
+    };
+
+    it('rejects unknown backend value', async () => {
+      const command = createInstallCommand(mockConfig);
+
+      await expect(
+        command.parseAsync(['node', 'test', '--backend', 'mysql'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        "Invalid --backend value: mysql. Expected 'etcd' or 'postgresql'."
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('errors when --backend postgresql is used without --values', async () => {
+      const command = createInstallCommand(mockConfig);
+
+      await expect(
+        command.parseAsync(['node', 'test', '--backend', 'postgresql'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '--backend postgresql requires --values <path>'
+        )
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('errors when values file is missing required fields', async () => {
+      const file = writeTempValues('postgresql:\n  host: db\n');
+
+      const command = createInstallCommand(mockConfig);
+
+      await expect(
+        command.parseAsync([
+          'node',
+          'test',
+          '--backend',
+          'postgresql',
+          '--values',
+          file,
+        ])
+      ).rejects.toThrow('process.exit called');
+
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field postgresql.user')
+      );
+    });
+
+    it('passes storage.backend=postgresql to ark-controller (postgres connection details go only to ark-apiserver)', async () => {
+      const file = writeTempValues(
+        [
+          'postgresql:',
+          '  host: db.example.com',
+          '  user: ark_user',
+          '  passwordSecretName: my-secret',
+        ].join('\n')
+      );
+      const mockService = {
+        name: 'ark-controller',
+        helmReleaseName: 'ark-controller',
+        chartPath: './charts/ark-controller',
+        namespace: 'ark-system',
+        installArgs: ['--create-namespace', '--set', 'rbac.enable=true'],
+      };
+      mockGetInstallableServices.mockReturnValue({
+        'ark-controller': mockService,
+      });
+      mockExeca.mockResolvedValue({stdout: ''});
+
+      const command = createInstallCommand(mockConfig);
+      await command.parseAsync([
+        'node',
+        'test',
+        'ark-controller',
+        '--backend',
+        'postgresql',
+        '--values',
+        file,
+      ]);
+
+      const installCall = mockExeca.mock.calls.find(
+        (call: any) =>
+          call[0] === 'helm' &&
+          call[1][0] === 'upgrade' &&
+          call[1].includes('ark-controller')
+      );
+      expect(installCall).toBeDefined();
+      const args = installCall![1];
+      expect(args).toContain('storage.backend=postgresql');
+      expect(args.join(' ')).not.toContain('storage.postgresql.host');
+    });
+
+    it('passes --values to ark-apiserver in postgresql mode', async () => {
+      const file = writeTempValues(
+        [
+          'postgresql:',
+          '  host: db.example.com',
+          '  user: ark_user',
+          '  passwordSecretName: my-secret',
+        ].join('\n')
+      );
+      const mockService = {
+        name: 'ark-apiserver',
+        helmReleaseName: 'ark-apiserver',
+        chartPath: './charts/ark-apiserver',
+        namespace: 'ark-system',
+        requiresBackend: 'postgresql',
+      };
+      mockGetInstallableServices.mockReturnValue({
+        'ark-apiserver': mockService,
+      });
+      mockExeca.mockResolvedValue({stdout: ''});
+
+      const command = createInstallCommand(mockConfig);
+      await command.parseAsync([
+        'node',
+        'test',
+        'ark-apiserver',
+        '--backend',
+        'postgresql',
+        '--values',
+        file,
+      ]);
+
+      const installCall = mockExeca.mock.calls.find(
+        (call: any) =>
+          call[0] === 'helm' &&
+          call[1][0] === 'upgrade' &&
+          call[1].includes('ark-apiserver')
+      );
+      expect(installCall).toBeDefined();
+      const args = installCall![1];
+      expect(args).toContain('--values');
+      expect(args).toContain(file);
+      expect(args).not.toContain('storage.backend=postgresql');
+    });
+
+    it('does not append backend args in etcd mode (default)', async () => {
+      const mockService = {
+        name: 'ark-controller',
+        helmReleaseName: 'ark-controller',
+        chartPath: './charts/ark-controller',
+        namespace: 'ark-system',
+        installArgs: ['--create-namespace', '--set', 'rbac.enable=true'],
+      };
+      mockGetInstallableServices.mockReturnValue({
+        'ark-controller': mockService,
+      });
+      mockExeca.mockResolvedValue({stdout: ''});
+
+      const command = createInstallCommand(mockConfig);
+      await command.parseAsync(['node', 'test', 'ark-controller']);
+
+      const installCall = mockExeca.mock.calls.find(
+        (call: any) => call[0] === 'helm' && call[1][0] === 'upgrade'
+      );
+      expect(installCall).toBeDefined();
+      const args = installCall![1];
+      expect(args.join(' ')).not.toContain('storage.backend');
+      expect(args.join(' ')).not.toContain('storage.postgresql');
     });
   });
 

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -1,8 +1,5 @@
 import {vi} from 'vitest';
 import {Command} from 'commander';
-import {writeFileSync} from 'fs';
-import {tmpdir} from 'os';
-import {join} from 'path';
 
 const mockExeca = vi.fn(() => Promise.resolve()) as any;
 vi.mock('execa', () => ({
@@ -1083,17 +1080,28 @@ describe('install command', () => {
     });
   });
 
-  describe('--backend flag', () => {
-    const writeTempValues = (content: string) => {
-      const file = join(
-        tmpdir(),
-        `ark-values-${Date.now()}-${Math.random()}.yaml`
-      );
-      writeFileSync(file, content);
-      return file;
-    };
+  describe('storage backend', () => {
+    const pgConfig = {
+      clusterInfo: {
+        context: 'test-cluster',
+        type: 'minikube',
+        namespace: 'default',
+      },
+      storage: {
+        backend: 'postgresql',
+        postgresql: {
+          host: 'db.example.com',
+          port: 5432,
+          database: 'ark',
+          user: 'ark_user',
+          passwordSecretName: 'my-secret',
+          passwordSecretKey: 'password',
+          sslMode: 'require',
+        },
+      },
+    } as any;
 
-    it('rejects unknown backend value', async () => {
+    it('rejects unknown backend value from CLI flag', async () => {
       const command = createInstallCommand(mockConfig);
 
       await expect(
@@ -1101,56 +1109,48 @@ describe('install command', () => {
       ).rejects.toThrow('process.exit called');
 
       expect(mockOutput.error).toHaveBeenCalledWith(
-        "Invalid --backend value: mysql. Expected 'etcd' or 'postgresql'."
+        "Invalid backend value: mysql. Expected 'etcd' or 'postgresql'."
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('errors when --backend postgresql is used without --values', async () => {
-      const command = createInstallCommand(mockConfig);
+    it('errors when storage.backend is postgresql but storage.postgresql block is missing', async () => {
+      const brokenConfig = {
+        ...mockConfig,
+        storage: {backend: 'postgresql'},
+      };
+      const command = createInstallCommand(brokenConfig);
 
       await expect(
-        command.parseAsync(['node', 'test', '--backend', 'postgresql'])
+        command.parseAsync(['node', 'test'])
       ).rejects.toThrow('process.exit called');
 
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          '--backend postgresql requires --values <path>'
-        )
+        expect.stringContaining("missing 'storage.postgresql' block")
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('errors when values file is missing required fields', async () => {
-      const file = writeTempValues('postgresql:\n  host: db\n');
-
-      const command = createInstallCommand(mockConfig);
+    it('errors when storage.postgresql is missing required fields', async () => {
+      const brokenConfig = {
+        ...mockConfig,
+        storage: {
+          backend: 'postgresql',
+          postgresql: {host: 'db.example.com'},
+        },
+      };
+      const command = createInstallCommand(brokenConfig);
 
       await expect(
-        command.parseAsync([
-          'node',
-          'test',
-          '--backend',
-          'postgresql',
-          '--values',
-          file,
-        ])
+        command.parseAsync(['node', 'test'])
       ).rejects.toThrow('process.exit called');
 
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('missing required field postgresql.user')
+        expect.stringContaining('storage.postgresql.user')
       );
     });
 
-    it('passes storage.backend=postgresql to ark-controller (postgres connection details go only to ark-apiserver)', async () => {
-      const file = writeTempValues(
-        [
-          'postgresql:',
-          '  host: db.example.com',
-          '  user: ark_user',
-          '  passwordSecretName: my-secret',
-        ].join('\n')
-      );
+    it('reads backend from config.storage.backend by default', async () => {
       const mockService = {
         name: 'ark-controller',
         helmReleaseName: 'ark-controller',
@@ -1163,16 +1163,8 @@ describe('install command', () => {
       });
       mockExeca.mockResolvedValue({stdout: ''});
 
-      const command = createInstallCommand(mockConfig);
-      await command.parseAsync([
-        'node',
-        'test',
-        'ark-controller',
-        '--backend',
-        'postgresql',
-        '--values',
-        file,
-      ]);
+      const command = createInstallCommand(pgConfig);
+      await command.parseAsync(['node', 'test', 'ark-controller']);
 
       const installCall = mockExeca.mock.calls.find(
         (call: any) =>
@@ -1183,18 +1175,67 @@ describe('install command', () => {
       expect(installCall).toBeDefined();
       const args = installCall![1];
       expect(args).toContain('storage.backend=postgresql');
-      expect(args.join(' ')).not.toContain('storage.postgresql.host');
     });
 
-    it('passes --values to ark-apiserver in postgresql mode', async () => {
-      const file = writeTempValues(
-        [
-          'postgresql:',
-          '  host: db.example.com',
-          '  user: ark_user',
-          '  passwordSecretName: my-secret',
-        ].join('\n')
+    it('CLI --backend overrides config.storage.backend', async () => {
+      const mockService = {
+        name: 'ark-controller',
+        helmReleaseName: 'ark-controller',
+        chartPath: './charts/ark-controller',
+        namespace: 'ark-system',
+        installArgs: ['--create-namespace', '--set', 'rbac.enable=true'],
+      };
+      mockGetInstallableServices.mockReturnValue({
+        'ark-controller': mockService,
+      });
+      mockExeca.mockResolvedValue({stdout: ''});
+
+      const command = createInstallCommand(pgConfig);
+      await command.parseAsync([
+        'node',
+        'test',
+        'ark-controller',
+        '--backend',
+        'etcd',
+      ]);
+
+      const installCall = mockExeca.mock.calls.find(
+        (call: any) => call[0] === 'helm' && call[1][0] === 'upgrade'
       );
+      expect(installCall).toBeDefined();
+      const args = installCall![1];
+      expect(args.join(' ')).not.toContain('storage.backend=postgresql');
+    });
+
+    it('passes only storage.backend=postgresql to ark-controller (no connection details)', async () => {
+      const mockService = {
+        name: 'ark-controller',
+        helmReleaseName: 'ark-controller',
+        chartPath: './charts/ark-controller',
+        namespace: 'ark-system',
+        installArgs: ['--create-namespace', '--set', 'rbac.enable=true'],
+      };
+      mockGetInstallableServices.mockReturnValue({
+        'ark-controller': mockService,
+      });
+      mockExeca.mockResolvedValue({stdout: ''});
+
+      const command = createInstallCommand(pgConfig);
+      await command.parseAsync(['node', 'test', 'ark-controller']);
+
+      const installCall = mockExeca.mock.calls.find(
+        (call: any) =>
+          call[0] === 'helm' &&
+          call[1][0] === 'upgrade' &&
+          call[1].includes('ark-controller')
+      );
+      expect(installCall).toBeDefined();
+      const args = installCall![1];
+      expect(args).toContain('storage.backend=postgresql');
+      expect(args.join(' ')).not.toContain('postgresql.host');
+    });
+
+    it('passes translated --set keys to ark-apiserver in postgresql mode', async () => {
       const mockService = {
         name: 'ark-apiserver',
         helmReleaseName: 'ark-apiserver',
@@ -1207,16 +1248,8 @@ describe('install command', () => {
       });
       mockExeca.mockResolvedValue({stdout: ''});
 
-      const command = createInstallCommand(mockConfig);
-      await command.parseAsync([
-        'node',
-        'test',
-        'ark-apiserver',
-        '--backend',
-        'postgresql',
-        '--values',
-        file,
-      ]);
+      const command = createInstallCommand(pgConfig);
+      await command.parseAsync(['node', 'test', 'ark-apiserver']);
 
       const installCall = mockExeca.mock.calls.find(
         (call: any) =>
@@ -1226,9 +1259,11 @@ describe('install command', () => {
       );
       expect(installCall).toBeDefined();
       const args = installCall![1];
-      expect(args).toContain('--values');
-      expect(args).toContain(file);
-      expect(args).not.toContain('storage.backend=postgresql');
+      expect(args).toContain('postgresql.host=db.example.com');
+      expect(args).toContain('postgresql.user=ark_user');
+      expect(args).toContain('postgresql.passwordSecretName=my-secret');
+      expect(args).toContain('postgresql.sslMode=require');
+      expect(args.join(' ')).not.toContain('storage.backend=postgresql');
     });
 
     it('does not append backend args in etcd mode (default)', async () => {
@@ -1253,7 +1288,7 @@ describe('install command', () => {
       expect(installCall).toBeDefined();
       const args = installCall![1];
       expect(args.join(' ')).not.toContain('storage.backend');
-      expect(args.join(' ')).not.toContain('storage.postgresql');
+      expect(args.join(' ')).not.toContain('postgresql.host');
     });
   });
 

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -25,7 +25,53 @@ import {
   type WaitProgress,
 } from '../../lib/waitForReady.js';
 import {parseTimeoutToSeconds} from '../../lib/timeout.js';
-import {detectStorageBackend} from '../../lib/readinessChecks.js';
+import {readFileSync} from 'fs';
+import {parse as parseYaml} from 'yaml';
+
+type Backend = 'etcd' | 'postgresql';
+
+interface PostgresValues {
+  host: string;
+  port?: number | string;
+  database?: string;
+  user: string;
+  passwordSecretName: string;
+  passwordSecretKey?: string;
+  sslMode?: string;
+}
+
+function loadPostgresValues(path: string): PostgresValues {
+  const content = readFileSync(path, 'utf8');
+  const parsed = parseYaml(content) as {postgresql?: PostgresValues} | null;
+  const pg = parsed?.postgresql;
+  if (!pg) {
+    throw new Error(`values file ${path} missing 'postgresql' block`);
+  }
+  for (const key of ['host', 'user', 'passwordSecretName'] as const) {
+    if (!pg[key]) {
+      throw new Error(
+        `values file ${path} missing required field postgresql.${key}`
+      );
+    }
+  }
+  return pg;
+}
+
+function backendInstallArgs(
+  service: ArkService,
+  backend: Backend,
+  valuesPath?: string,
+  values?: PostgresValues
+): string[] {
+  if (backend === 'etcd') return [];
+  if (service.helmReleaseName === 'ark-apiserver' && valuesPath) {
+    return ['--values', valuesPath];
+  }
+  if (service.helmReleaseName === 'ark-controller' && values) {
+    return ['--set', 'storage.backend=postgresql'];
+  }
+  return [];
+}
 
 function isValidVersion(version: string): boolean {
   return /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version);
@@ -129,7 +175,7 @@ async function installService(
   verbose: boolean = false,
   arkVersionOverride?: string,
   marketplaceVersionOverride?: string,
-  backend?: 'etcd' | 'postgresql'
+  extraArgs?: string[]
 ) {
   await uninstallPrerequisites(service, verbose);
   await checkAndCleanFailedRelease(
@@ -180,6 +226,8 @@ async function installService(
   // Add any additional install args
   helmArgs.push(...(service.installArgs || []));
 
+  if (extraArgs) helmArgs.push(...extraArgs);
+
   await execute(
     'helm',
     helmArgs,
@@ -200,6 +248,8 @@ export async function installArk(
     verbose?: boolean;
     arkVersion?: string;
     marketplaceVersion?: string;
+    backend?: string;
+    values?: string;
   } = {}
 ) {
   // Validate version strings
@@ -231,7 +281,31 @@ export async function installArk(
   output.success(`connected to cluster: ${chalk.bold(clusterInfo.context)}`);
   console.log(); // Add blank line after cluster info
 
-  const backend = await detectStorageBackend();
+  const backend: Backend = (options.backend ?? 'etcd') as Backend;
+  if (backend !== 'etcd' && backend !== 'postgresql') {
+    output.error(
+      `Invalid --backend value: ${options.backend}. Expected 'etcd' or 'postgresql'.`
+    );
+    process.exit(1);
+  }
+
+  let postgresValues: PostgresValues | undefined;
+  if (backend === 'postgresql') {
+    if (!options.values) {
+      output.error(
+        `--backend postgresql requires --values <path> pointing at a YAML file with a 'postgresql' block`
+      );
+      process.exit(1);
+    }
+    try {
+      postgresValues = loadPostgresValues(options.values);
+    } catch (err) {
+      output.error(
+        `Failed to load values file: ${err instanceof Error ? err.message : String(err)}`
+      );
+      process.exit(1);
+    }
+  }
 
   // If specific services are requested, install only those services
   if (serviceNames.length > 0) {
@@ -273,7 +347,8 @@ export async function installArk(
             service,
             options.verbose,
             options.arkVersion,
-            options.marketplaceVersion
+            options.marketplaceVersion,
+            []
           );
           output.success(`${service.name} installed successfully`);
         } catch (error) {
@@ -303,7 +378,8 @@ export async function installArk(
           service,
           options.verbose,
           options.arkVersion,
-          options.marketplaceVersion
+          options.marketplaceVersion,
+          backendInstallArgs(service, backend, options.values, postgresValues)
         );
         output.success(`${service.name} installed successfully`);
       } catch (error) {
@@ -488,7 +564,8 @@ export async function installArk(
           service,
           options.verbose,
           options.arkVersion,
-          options.marketplaceVersion
+          options.marketplaceVersion,
+          backendInstallArgs(service, backend, options.values, postgresValues)
         );
 
         console.log(); // Add blank line after command output
@@ -539,7 +616,8 @@ export async function installArk(
           service,
           options.verbose,
           options.arkVersion,
-          options.marketplaceVersion
+          options.marketplaceVersion,
+          backendInstallArgs(service, backend, options.values, postgresValues)
         );
         console.log(); // Add blank line after command output
       } catch (error) {
@@ -633,6 +711,14 @@ export function createInstallCommand(config: ArkConfig) {
     .option(
       '--wait-for-ready <timeout>',
       'wait for Ark to be ready after installation (e.g., 30s, 2m)'
+    )
+    .option(
+      '--backend <type>',
+      "storage backend: 'etcd' (default) or 'postgresql'"
+    )
+    .option(
+      '--values <path>',
+      "path to YAML values file with a 'postgresql' block (required when --backend postgresql)"
     )
     .option('-v, --verbose', 'show commands being executed')
     .action(async (services, options) => {

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -2,7 +2,7 @@ import {Command} from 'commander';
 import chalk from 'chalk';
 import {execute} from '../../lib/commands.js';
 import inquirer from 'inquirer';
-import type {ArkConfig} from '../../lib/config.js';
+import type {ArkConfig, PostgresStorageConfig} from '../../lib/config.js';
 import {showNoClusterError} from '../../lib/startup.js';
 import output from '../../lib/output.js';
 import {
@@ -25,32 +25,21 @@ import {
   type WaitProgress,
 } from '../../lib/waitForReady.js';
 import {parseTimeoutToSeconds} from '../../lib/timeout.js';
-import {readFileSync} from 'fs';
-import {parse as parseYaml} from 'yaml';
 
 type Backend = 'etcd' | 'postgresql';
 
-interface PostgresValues {
-  host: string;
-  port?: number | string;
-  database?: string;
-  user: string;
-  passwordSecretName: string;
-  passwordSecretKey?: string;
-  sslMode?: string;
-}
-
-function loadPostgresValues(path: string): PostgresValues {
-  const content = readFileSync(path, 'utf8');
-  const parsed = parseYaml(content) as {postgresql?: PostgresValues} | null;
-  const pg = parsed?.postgresql;
+function validatePostgresConfig(
+  pg: PostgresStorageConfig | undefined
+): PostgresStorageConfig {
   if (!pg) {
-    throw new Error(`values file ${path} missing 'postgresql' block`);
+    throw new Error(
+      "missing 'storage.postgresql' block in .arkrc.yaml"
+    );
   }
   for (const key of ['host', 'user', 'passwordSecretName'] as const) {
     if (!pg[key]) {
       throw new Error(
-        `values file ${path} missing required field postgresql.${key}`
+        `missing required field storage.postgresql.${key} in .arkrc.yaml`
       );
     }
   }
@@ -60,15 +49,33 @@ function loadPostgresValues(path: string): PostgresValues {
 function backendInstallArgs(
   service: ArkService,
   backend: Backend,
-  valuesPath?: string,
-  values?: PostgresValues
+  values?: PostgresStorageConfig
 ): string[] {
   if (backend === 'etcd') return [];
-  if (service.helmReleaseName === 'ark-apiserver' && valuesPath) {
-    return ['--values', valuesPath];
-  }
-  if (service.helmReleaseName === 'ark-controller' && values) {
+  if (!values) return [];
+  if (service.helmReleaseName === 'ark-controller') {
     return ['--set', 'storage.backend=postgresql'];
+  }
+  if (service.helmReleaseName === 'ark-apiserver') {
+    const args: string[] = [];
+    args.push('--set', `postgresql.host=${values.host}`);
+    if (values.port !== undefined)
+      args.push('--set', `postgresql.port=${values.port}`);
+    if (values.database)
+      args.push('--set', `postgresql.database=${values.database}`);
+    args.push('--set', `postgresql.user=${values.user}`);
+    args.push(
+      '--set',
+      `postgresql.passwordSecretName=${values.passwordSecretName}`
+    );
+    if (values.passwordSecretKey)
+      args.push(
+        '--set',
+        `postgresql.passwordSecretKey=${values.passwordSecretKey}`
+      );
+    if (values.sslMode)
+      args.push('--set', `postgresql.sslMode=${values.sslMode}`);
+    return args;
   }
   return [];
 }
@@ -249,7 +256,6 @@ export async function installArk(
     arkVersion?: string;
     marketplaceVersion?: string;
     backend?: string;
-    values?: string;
   } = {}
 ) {
   // Validate version strings
@@ -281,27 +287,22 @@ export async function installArk(
   output.success(`connected to cluster: ${chalk.bold(clusterInfo.context)}`);
   console.log(); // Add blank line after cluster info
 
-  const backend: Backend = (options.backend ?? 'etcd') as Backend;
-  if (backend !== 'etcd' && backend !== 'postgresql') {
+  const requestedBackend = options.backend ?? config.storage?.backend ?? 'etcd';
+  if (requestedBackend !== 'etcd' && requestedBackend !== 'postgresql') {
     output.error(
-      `Invalid --backend value: ${options.backend}. Expected 'etcd' or 'postgresql'.`
+      `Invalid backend value: ${requestedBackend}. Expected 'etcd' or 'postgresql'.`
     );
     process.exit(1);
   }
+  const backend: Backend = requestedBackend;
 
-  let postgresValues: PostgresValues | undefined;
+  let postgresValues: PostgresStorageConfig | undefined;
   if (backend === 'postgresql') {
-    if (!options.values) {
-      output.error(
-        `--backend postgresql requires --values <path> pointing at a YAML file with a 'postgresql' block`
-      );
-      process.exit(1);
-    }
     try {
-      postgresValues = loadPostgresValues(options.values);
+      postgresValues = validatePostgresConfig(config.storage?.postgresql);
     } catch (err) {
       output.error(
-        `Failed to load values file: ${err instanceof Error ? err.message : String(err)}`
+        `${err instanceof Error ? err.message : String(err)}`
       );
       process.exit(1);
     }
@@ -379,7 +380,7 @@ export async function installArk(
           options.verbose,
           options.arkVersion,
           options.marketplaceVersion,
-          backendInstallArgs(service, backend, options.values, postgresValues)
+          backendInstallArgs(service, backend, postgresValues)
         );
         output.success(`${service.name} installed successfully`);
       } catch (error) {
@@ -565,7 +566,7 @@ export async function installArk(
           options.verbose,
           options.arkVersion,
           options.marketplaceVersion,
-          backendInstallArgs(service, backend, options.values, postgresValues)
+          backendInstallArgs(service, backend, postgresValues)
         );
 
         console.log(); // Add blank line after command output
@@ -617,7 +618,7 @@ export async function installArk(
           options.verbose,
           options.arkVersion,
           options.marketplaceVersion,
-          backendInstallArgs(service, backend, options.values, postgresValues)
+          backendInstallArgs(service, backend, postgresValues)
         );
         console.log(); // Add blank line after command output
       } catch (error) {
@@ -714,11 +715,7 @@ export function createInstallCommand(config: ArkConfig) {
     )
     .option(
       '--backend <type>',
-      "storage backend: 'etcd' (default) or 'postgresql'"
-    )
-    .option(
-      '--values <path>',
-      "path to YAML values file with a 'postgresql' block (required when --backend postgresql)"
+      "storage backend: 'etcd' (default) or 'postgresql' (overrides storage.backend in .arkrc.yaml)"
     )
     .option('-v, --verbose', 'show commands being executed')
     .action(async (services, options) => {

--- a/tools/ark-cli/src/lib/config.ts
+++ b/tools/ark-cli/src/lib/config.ts
@@ -15,6 +15,21 @@ export interface MarketplaceConfig {
   registry?: string;
 }
 
+export interface PostgresStorageConfig {
+  host: string;
+  port?: number | string;
+  database?: string;
+  user: string;
+  passwordSecretName: string;
+  passwordSecretKey?: string;
+  sslMode?: string;
+}
+
+export interface StorageConfig {
+  backend?: 'etcd' | 'postgresql';
+  postgresql?: PostgresStorageConfig;
+}
+
 export interface ArkConfig {
   chat?: ChatConfig;
   marketplace?: MarketplaceConfig;
@@ -22,6 +37,7 @@ export interface ArkConfig {
     reusePortForwards?: boolean;
     [serviceName: string]: Partial<ArkService> | boolean | undefined;
   };
+  storage?: StorageConfig;
   queryTimeout?: string;
   defaultExportTypes?: string[];
   // Cluster info - populated during startup if context exists
@@ -115,6 +131,14 @@ export function loadConfig(): ArkConfig {
       process.env.ARK_SERVICES_REUSE_PORT_FORWARDS === '1';
   }
 
+  if (process.env.ARK_STORAGE_BACKEND !== undefined) {
+    const backend = process.env.ARK_STORAGE_BACKEND;
+    if (backend === 'etcd' || backend === 'postgresql') {
+      config.storage = config.storage || {};
+      config.storage.backend = backend;
+    }
+  }
+
   return config;
 }
 
@@ -157,6 +181,19 @@ function mergeConfig(target: ArkConfig, source: ArkConfig): void {
           ...overrides,
         };
       }
+    }
+  }
+
+  if (source.storage) {
+    target.storage = target.storage || {};
+    if (source.storage.backend !== undefined) {
+      target.storage.backend = source.storage.backend;
+    }
+    if (source.storage.postgresql) {
+      target.storage.postgresql = {
+        ...(target.storage.postgresql as PostgresStorageConfig),
+        ...source.storage.postgresql,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes three bugs that together prevented a working install of the PostgreSQL storage backend via `ark install`, all reported by @Nab-0 and @Aman:

- **`chart-apiserver` rendered an invalid Deployment with default values.** Empty `postgresql.host`, `postgresql.user`, and `postgresql.passwordSecretName` produced `secretKeyRef.name: ""`, which the Kubernetes API server rejected. Added `required` template guards so the chart fails at template time with an actionable message.
- **`ark install` auto-detected `postgresql` on a fresh cluster.** Detection was based on CRD presence; on a greenfield cluster no CRD exists yet, so the CLI defaulted to postgres and tried to install `ark-apiserver`. Replaced detection with an explicit `--backend etcd|postgresql` flag (default `etcd`).
- **The selected backend was never propagated to the `ark-controller` chart.** Even when the CLI thought it was installing postgres mode, the controller release ran with chart defaults (`storage.backend=etcd`), so CRDs got created and the controller ran in etcd mode while the apiserver tried to run in postgres mode. The CLI now passes `--set storage.backend=postgresql` to the controller release in postgres mode.

Etcd-mode helm invocations are unchanged — backward compatible.

The PR also adds a `--values <path>` flag that points at a YAML file with the postgres connection details, which the CLI forwards to the apiserver release. New ops-guide page documents the full flow, database requirements (`wal_level=logical` etc.), schema, replication-slot lifecycle, and troubleshooting.

Supersedes and closes #1153 (which only patched the interactive controller path against pre-refactor CLI code).

## End-to-end validation

Tested on a fresh `kind` cluster with in-cluster Postgres:

- `helm install chart-apiserver` with defaults → fails fast: `postgresql.host is required`
- `ark install --backend mariadb` / `--backend postgresql` (no `--values`) → clear CLI errors
- `ark install ark-controller ark-apiserver --backend postgresql --values pg.yaml` → both releases deploy, 0 CRDs created, both APIServices `Available=True`, `kubectl apply` on an Agent round-trips through `kubectl get agents` and the `resources` table in postgres
- `ark install` (no flags) → emits the same helm command as `origin/main`

## Known follow-ups (out of scope for this PR)

- The OCI artifact `oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-apiserver:0.1.62` is currently the dummy stub published from `temp/publish-dummy-apiserver-chart`. The real chart is attached to the GitHub release; running **Actions → Deploy → `ark_version=v0.1.62`, `deploy_helm_chart=true`** will overwrite the dummy. Until that happens, end users testing the CLI flag against the published chart will get zero rendered resources.
- The `ark status` command still uses CRD-presence detection; should be aligned to the same `--backend` model in a follow-up.