### PR TITLE
feat: propose AWS EKS+RDS deployment flow

### DIFF
--- a/infrastructure/aws-spike/.gitignore
+++ b/infrastructure/aws-spike/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+crash.log
+.terraform.lock.hcl

--- a/infrastructure/aws-spike/README.md
+++ b/infrastructure/aws-spike/README.md
@@ -1,0 +1,84 @@
+# AWS spike: EKS + RDS Postgres for Ark
+
+This is the validated terraform that proves the deployment shape described in `openspec/changes/aws-eks-rds-deployment/`. It is named "spike" because it lives outside the current `infrastructure/providers/aws/` module while the OpenSpec change is under review. Once accepted, the modular layout here folds into `infrastructure/providers/aws/`.
+
+## What this provisions
+
+- VPC, 3 AZs, single NAT, public + private + intra subnets.
+- EKS auto-mode cluster with the `general-purpose` node pool.
+- RDS Postgres 15 (single-AZ by default, Multi-AZ as a variable). SSL enforced via `rds.force_ssl=1`. Logical replication enabled via `rds.logical_replication=1` so the aggregated apiserver can use Postgres CDC.
+- Password generated and stored in AWS Secrets Manager.
+- IRSA roles for `ark-controller` and `ark-apiserver`. The apiserver role has `secretsmanager:GetSecretValue` scoped to the DB password ARN.
+- ECR repositories for each Ark service image.
+
+The RDS security group allows ingress from both the AWS-managed cluster shared SG and the EKS module's node SG. This handles EKS auto-mode, which attaches the cluster shared SG to node ENIs rather than the module's node SG.
+
+## Apply
+
+```bash
+cd infrastructure/aws-spike
+
+# Provide AWS credentials via your usual mechanism (env vars, profile, etc.)
+
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars to set region, cluster name, RDS sizing, etc.
+
+terraform init
+terraform plan
+terraform apply
+```
+
+Apply takes about 15 minutes. EKS control plane creation is the slow step.
+
+## Point ark install at the cluster
+
+```bash
+$(terraform output -raw kubeconfig_command)
+
+SECRET_NAME=$(terraform output -raw rds_password_secret_name)
+PASSWORD=$(aws secretsmanager get-secret-value --secret-id "$SECRET_NAME" --query SecretString --output text)
+
+kubectl create namespace ark-system
+kubectl -n ark-system create secret generic ark-db-password --from-literal=password="$PASSWORD"
+
+cat > .arkrc.yaml <<EOF
+storage:
+  backend: postgresql
+  postgresql:
+    host: $(terraform output -raw rds_endpoint)
+    port: $(terraform output -raw rds_port)
+    database: $(terraform output -raw rds_database_name)
+    user: $(terraform output -raw rds_username)
+    passwordSecretName: ark-db-password
+    passwordSecretKey: password
+    sslMode: require
+EOF
+
+ark install -y --backend postgresql --ark-version 0.1.63-rc
+```
+
+The `--ark-version 0.1.63-rc` is needed today because `npm @agents-at-scale/ark` is still at `0.1.62` while the matching OCI charts have been published as `0.1.63-rc`. Once a release ships both artifacts together, the flag goes away.
+
+## Tear down
+
+```bash
+terraform destroy
+```
+
+## Outputs
+
+- `cluster_name`, `cluster_endpoint`, `oidc_provider_arn`: needed by `aws eks update-kubeconfig` and by anyone adding IRSA roles outside terraform.
+- `rds_endpoint`, `rds_port`, `rds_database_name`, `rds_username`, `rds_password_secret_name`, `rds_password_secret_arn`: needed by `ark install` and by `ExternalSecret` rendering.
+- `ark_controller_role_arn`, `ark_apiserver_role_arn`: needed by the SA annotation step (once chart `serviceAccountAnnotations` is wired, otherwise applied via `kubectl annotate`).
+- `ecr_repository_urls`: map of service name to ECR repo URL.
+- `kubeconfig_command`: convenience string for the `aws eks update-kubeconfig` invocation.
+
+## What is intentionally not here
+
+- AWS Load Balancer Controller, ExternalDNS, cert-manager wiring, KMS envelope encryption, VPC endpoints, Multi-AZ, log retention, OTel collector: all in Phase 3 of the OpenSpec change.
+- AgentCore A2A: covered separately.
+- Mirror of upstream container images into ECR: ECR repos are provisioned but not populated.
+
+## Costs
+
+Roughly $170 per month if left running (EKS control plane $73, NAT gateway $32, RDS db.t3.medium single-AZ $60, plus small Secrets Manager and storage costs). Destroy when not in use.

--- a/infrastructure/aws-spike/main.tf
+++ b/infrastructure/aws-spike/main.tf
@@ -1,0 +1,67 @@
+data "aws_availability_zones" "this" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.this.names, 0, 3)
+
+  tags = {
+    Environment = var.environment
+    Initiative  = "ark-aws-spike"
+    ManagedBy   = "terraform"
+  }
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  name = "${var.cluster_name}-vpc"
+  azs  = local.azs
+  tags = local.tags
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.private_subnets
+  tags            = local.tags
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  identifier     = "${var.cluster_name}-postgres"
+  engine_version = var.rds_engine_version
+  instance_class = var.rds_instance_class
+  multi_az       = var.rds_multi_az
+  vpc_id         = module.vpc.vpc_id
+  subnet_ids     = module.vpc.private_subnets
+  allowed_security_group_ids = [
+    module.eks.cluster_primary_security_group_id,
+    module.eks.node_security_group_id,
+  ]
+  tags = local.tags
+}
+
+module "irsa" {
+  source = "./modules/irsa"
+
+  cluster_name            = var.cluster_name
+  oidc_provider_arn       = module.eks.oidc_provider_arn
+  oidc_provider_url       = module.eks.oidc_provider_url
+  rds_password_secret_arn = module.rds.password_secret_arn
+  tags                    = local.tags
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  repositories = var.ecr_repositories
+  tags         = local.tags
+}

--- a/infrastructure/aws-spike/modules/ecr/main.tf
+++ b/infrastructure/aws-spike/modules/ecr/main.tf
@@ -1,0 +1,33 @@
+resource "aws_ecr_repository" "this" {
+  for_each             = toset(var.repositories)
+  name                 = each.value
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = aws_ecr_repository.this
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last ${var.keep_last_images} images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = var.keep_last_images
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/infrastructure/aws-spike/modules/ecr/outputs.tf
+++ b/infrastructure/aws-spike/modules/ecr/outputs.tf
@@ -1,0 +1,7 @@
+output "repository_urls" {
+  value = { for k, r in aws_ecr_repository.this : k => r.repository_url }
+}
+
+output "repository_arns" {
+  value = { for k, r in aws_ecr_repository.this : k => r.arn }
+}

--- a/infrastructure/aws-spike/modules/ecr/variables.tf
+++ b/infrastructure/aws-spike/modules/ecr/variables.tf
@@ -1,0 +1,22 @@
+variable "repositories" {
+  type = list(string)
+  default = [
+    "ark/ark-controller",
+    "ark/ark-api",
+    "ark/ark-apiserver",
+    "ark/ark-broker",
+    "ark/ark-dashboard",
+    "ark/ark-mcp",
+    "ark/localhost-gateway",
+  ]
+}
+
+variable "keep_last_images" {
+  type    = number
+  default = 20
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/aws-spike/modules/eks/main.tf
+++ b/infrastructure/aws-spike/modules/eks/main.tf
@@ -1,0 +1,21 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.0"
+
+  name               = var.cluster_name
+  kubernetes_version = var.cluster_version
+
+  endpoint_public_access                   = true
+  enable_cluster_creator_admin_permissions = true
+  deletion_protection                      = false
+
+  compute_config = {
+    enabled    = true
+    node_pools = ["general-purpose"]
+  }
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  tags = var.tags
+}

--- a/infrastructure/aws-spike/modules/eks/outputs.tf
+++ b/infrastructure/aws-spike/modules/eks/outputs.tf
@@ -1,0 +1,32 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider_url" {
+  value = module.eks.cluster_oidc_issuer_url
+}
+
+output "cluster_security_group_id" {
+  value = module.eks.cluster_security_group_id
+}
+
+output "node_security_group_id" {
+  value = module.eks.node_security_group_id
+}
+
+output "cluster_primary_security_group_id" {
+  value       = module.eks.cluster_primary_security_group_id
+  description = "AWS-managed shared SG attached to auto-mode node ENIs"
+}

--- a/infrastructure/aws-spike/modules/eks/variables.tf
+++ b/infrastructure/aws-spike/modules/eks/variables.tf
@@ -1,0 +1,22 @@
+variable "cluster_name" {
+  type    = string
+  default = "ark-cluster"
+}
+
+variable "cluster_version" {
+  type    = string
+  default = "1.33"
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/aws-spike/modules/irsa/main.tf
+++ b/infrastructure/aws-spike/modules/irsa/main.tf
@@ -1,0 +1,76 @@
+data "aws_iam_policy_document" "controller_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:${var.controller_namespace}:${var.controller_service_account}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "controller" {
+  name               = "${var.cluster_name}-ark-controller"
+  assume_role_policy = data.aws_iam_policy_document.controller_trust.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "apiserver_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:${var.apiserver_namespace}:${var.apiserver_service_account}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.oidc_provider_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "apiserver" {
+  name               = "${var.cluster_name}-ark-apiserver"
+  assume_role_policy = data.aws_iam_policy_document.apiserver_trust.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "apiserver_secrets" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    resources = [var.rds_password_secret_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "apiserver_secrets" {
+  name   = "read-rds-password"
+  role   = aws_iam_role.apiserver.id
+  policy = data.aws_iam_policy_document.apiserver_secrets.json
+}

--- a/infrastructure/aws-spike/modules/irsa/outputs.tf
+++ b/infrastructure/aws-spike/modules/irsa/outputs.tf
@@ -1,0 +1,7 @@
+output "controller_role_arn" {
+  value = aws_iam_role.controller.arn
+}
+
+output "apiserver_role_arn" {
+  value = aws_iam_role.apiserver.arn
+}

--- a/infrastructure/aws-spike/modules/irsa/variables.tf
+++ b/infrastructure/aws-spike/modules/irsa/variables.tf
@@ -1,0 +1,40 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "oidc_provider_arn" {
+  type = string
+}
+
+variable "oidc_provider_url" {
+  type = string
+}
+
+variable "controller_namespace" {
+  type    = string
+  default = "ark-system"
+}
+
+variable "controller_service_account" {
+  type    = string
+  default = "ark-controller"
+}
+
+variable "apiserver_namespace" {
+  type    = string
+  default = "ark-system"
+}
+
+variable "apiserver_service_account" {
+  type    = string
+  default = "ark-apiserver"
+}
+
+variable "rds_password_secret_arn" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/aws-spike/modules/rds/main.tf
+++ b/infrastructure/aws-spike/modules/rds/main.tf
@@ -1,0 +1,87 @@
+resource "random_password" "this" {
+  length           = 24
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_secretsmanager_secret" "this" {
+  name        = "${var.identifier}-password"
+  description = "Password for RDS Postgres user ${var.username}"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = random_password.this.result
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.identifier}-subnets"
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}
+
+resource "aws_security_group" "this" {
+  name        = "${var.identifier}-sg"
+  description = "Allow Postgres from EKS nodes"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_security_group_rule" "ingress_from_allowed_sgs" {
+  for_each                 = toset(var.allowed_security_group_ids)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.this.id
+  source_security_group_id = each.value
+  description              = "Postgres from ${each.value}"
+}
+
+resource "aws_db_parameter_group" "this" {
+  name        = "${var.identifier}-pg15"
+  family      = "postgres15"
+  description = "Logical replication + force_ssl for Ark"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "rds.force_ssl"
+    value        = "1"
+    apply_method = "immediate"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_db_instance" "this" {
+  identifier = var.identifier
+
+  engine            = "postgres"
+  engine_version    = var.engine_version
+  instance_class    = var.instance_class
+  allocated_storage = var.allocated_storage
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = var.database_name
+  username = var.username
+  password = random_password.this.result
+
+  multi_az                = var.multi_az
+  publicly_accessible     = false
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = [aws_security_group.this.id]
+  parameter_group_name    = aws_db_parameter_group.this.name
+  backup_retention_period = var.backup_retention_days
+  deletion_protection     = false
+  skip_final_snapshot     = true
+  apply_immediately       = true
+
+  tags = var.tags
+}

--- a/infrastructure/aws-spike/modules/rds/outputs.tf
+++ b/infrastructure/aws-spike/modules/rds/outputs.tf
@@ -1,0 +1,27 @@
+output "endpoint" {
+  value = aws_db_instance.this.address
+}
+
+output "port" {
+  value = aws_db_instance.this.port
+}
+
+output "database_name" {
+  value = aws_db_instance.this.db_name
+}
+
+output "username" {
+  value = aws_db_instance.this.username
+}
+
+output "password_secret_arn" {
+  value = aws_secretsmanager_secret.this.arn
+}
+
+output "password_secret_name" {
+  value = aws_secretsmanager_secret.this.name
+}
+
+output "security_group_id" {
+  value = aws_security_group.this.id
+}

--- a/infrastructure/aws-spike/modules/rds/variables.tf
+++ b/infrastructure/aws-spike/modules/rds/variables.tf
@@ -1,0 +1,58 @@
+variable "identifier" {
+  type    = string
+  default = "ark-postgres"
+}
+
+variable "engine_version" {
+  type    = string
+  default = "15.17"
+}
+
+variable "instance_class" {
+  type    = string
+  default = "db.t3.medium"
+}
+
+variable "allocated_storage" {
+  type    = number
+  default = 20
+}
+
+variable "multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "backup_retention_days" {
+  type    = number
+  default = 7
+}
+
+variable "database_name" {
+  type    = string
+  default = "ark"
+}
+
+variable "username" {
+  type    = string
+  default = "ark"
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the DB subnet group"
+}
+
+variable "allowed_security_group_ids" {
+  type        = list(string)
+  description = "Security group IDs allowed to reach Postgres on 5432. For EKS auto-mode you typically need the cluster primary SG (used by node ENIs), not the module's node_security_group_id."
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/aws-spike/modules/vpc/main.tf
+++ b/infrastructure/aws-spike/modules/vpc/main.tf
@@ -1,0 +1,26 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  name = var.name
+  cidr = var.cidr
+
+  azs             = var.azs
+  private_subnets = [for k, _ in var.azs : cidrsubnet(var.cidr, 4, k)]
+  public_subnets  = [for k, _ in var.azs : cidrsubnet(var.cidr, 8, k + 48)]
+  intra_subnets   = [for k, _ in var.azs : cidrsubnet(var.cidr, 8, k + 52)]
+
+  create_igw         = true
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  tags = var.tags
+}

--- a/infrastructure/aws-spike/modules/vpc/outputs.tf
+++ b/infrastructure/aws-spike/modules/vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "intra_subnets" {
+  value = module.vpc.intra_subnets
+}
+
+output "vpc_cidr" {
+  value = module.vpc.vpc_cidr_block
+}

--- a/infrastructure/aws-spike/modules/vpc/variables.tf
+++ b/infrastructure/aws-spike/modules/vpc/variables.tf
@@ -1,0 +1,18 @@
+variable "name" {
+  type    = string
+  default = "ark-vpc"
+}
+
+variable "cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "azs" {
+  type = list(string)
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/aws-spike/outputs.tf
+++ b/infrastructure/aws-spike/outputs.tf
@@ -1,0 +1,55 @@
+output "aws_region" {
+  value = var.aws_region
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "rds_endpoint" {
+  value = module.rds.endpoint
+}
+
+output "rds_port" {
+  value = module.rds.port
+}
+
+output "rds_database_name" {
+  value = module.rds.database_name
+}
+
+output "rds_username" {
+  value = module.rds.username
+}
+
+output "rds_password_secret_name" {
+  value = module.rds.password_secret_name
+}
+
+output "rds_password_secret_arn" {
+  value = module.rds.password_secret_arn
+}
+
+output "ark_controller_role_arn" {
+  value = module.irsa.controller_role_arn
+}
+
+output "ark_apiserver_role_arn" {
+  value = module.irsa.apiserver_role_arn
+}
+
+output "ecr_repository_urls" {
+  value = module.ecr.repository_urls
+}
+
+output "kubeconfig_command" {
+  value = "aws eks update-kubeconfig --region ${var.aws_region} --name ${module.eks.cluster_name}"
+}

--- a/infrastructure/aws-spike/providers.tf
+++ b/infrastructure/aws-spike/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/infrastructure/aws-spike/terraform.tfvars.example
+++ b/infrastructure/aws-spike/terraform.tfvars.example
@@ -1,0 +1,9 @@
+aws_region      = "eu-north-1"
+cluster_name    = "ark-cluster"
+cluster_version = "1.33"
+
+rds_multi_az       = false
+rds_instance_class = "db.t3.medium"
+rds_engine_version = "15.17"
+
+environment = "dev"

--- a/infrastructure/aws-spike/variables.tf
+++ b/infrastructure/aws-spike/variables.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  type    = string
+  default = "eu-north-1"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "ark-cluster"
+}
+
+variable "cluster_version" {
+  type    = string
+  default = "1.33"
+}
+
+variable "rds_multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "rds_instance_class" {
+  type    = string
+  default = "db.t3.medium"
+}
+
+variable "rds_engine_version" {
+  type    = string
+  default = "15.17"
+}
+
+variable "ecr_repositories" {
+  type = list(string)
+  default = [
+    "ark/ark-controller",
+    "ark/ark-api",
+    "ark/ark-apiserver",
+    "ark/ark-broker",
+    "ark/ark-dashboard",
+    "ark/ark-mcp",
+    "ark/localhost-gateway",
+  ]
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}

--- a/openspec/changes/aws-eks-rds-deployment/.openspec.yaml
+++ b/openspec/changes/aws-eks-rds-deployment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/aws-eks-rds-deployment/design.md
+++ b/openspec/changes/aws-eks-rds-deployment/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Ark's deployment story is GCP/GKE-first. The AWS terraform module under `infrastructure/providers/aws/` provisions a VPC and an EKS cluster and nothing else. Helm chart defaults match the local-development case (no SSL on Postgres, no annotations on ServiceAccounts, no namespace pins on half the services). The CLI assumes the kubectl context is already correct.
+
+A spike validated the full path on 2026-05-12 in account `029422951777`, region `eu-north-1`: VPC plus EKS 1.33 auto-mode plus RDS Postgres 15.17 with `rds.logical_replication=1` and `rds.force_ssl=1`, IRSA roles for the controller and the apiserver (Secrets Manager read scoped to the DB password ARN), and ECR repositories. A Model, an Agent, and a Query roundtrip through the aggregated apiserver into RDS in 2.16 seconds. The end-to-end path works, but only after roughly ten manual workarounds.
+
+The full strategic write-up, including phasing, ownership, and effort estimates, lives in `reference-plan.md` co-located with this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A clean AWS account can be provisioned and `ark install`-ed in two commands and under 25 minutes.
+- The terraform module produces every input the CLI needs (cluster name, RDS endpoint and secret refs, IRSA role ARNs). The CLI consumes those outputs without further manual wiring.
+- Chart defaults work on cloud-managed Postgres (SSL enforced) and cloud-managed Kubernetes (IRSA annotations through values).
+- IRSA role-ARN annotations on ServiceAccounts survive `helm upgrade`.
+- Release tags automatically publish charts, CLI, and container images.
+
+**Non-Goals:**
+- AgentCore A2A integration. Covered separately.
+- Multi-cloud abstraction inside a single chart or installer. Cloud-specific behaviour goes behind a `--target <cloud>` flag, not into the default code path.
+- AWS-native observability (CloudWatch, AMP, Grafana). Listed in the production add-ons phase but optional and separable.
+- Multi-tenancy posture (one cluster per tenant vs namespace isolation). Tracked as an open question that should be answered before Phase 1 IRSA scoping ships.
+
+## Decisions
+
+### Decision: terraform module structured as `modules/{vpc,eks,rds,irsa,ecr}/`
+
+The spike already sits in the modular shape. Each module owns its concern and exposes outputs the root composition wires together. The root `main.tf` is ~50 lines of module calls.
+
+**Alternative considered:** keep the existing flat `infrastructure/providers/aws/` layout and add files. Rejected because the existing layout is bare and the modular shape is the upstream-worthy contribution.
+
+### Decision: RDS module accepts a list of allowed security group IDs
+
+EKS auto-mode attaches the AWS-managed cluster shared SG (`cluster_primary_security_group_id`) to node ENIs, not the module-created `node_security_group_id`. Anything granting "ingress from EKS nodes" using just the module's node SG silently times out. The RDS module takes `allowed_security_group_ids` as a list; the root composition passes both `cluster_primary_security_group_id` and `node_security_group_id`.
+
+**Alternative considered:** open RDS to the full VPC CIDR. Rejected because it widens the blast radius unnecessarily; the list approach is the same SG-only model, just with the right SG inside it.
+
+### Decision: ESO for the Secrets Manager to Kubernetes Secret bridge
+
+Today the spike pulls the RDS password from Secrets Manager and applies a Kubernetes Secret by hand. ESO syncs the value continuously using IRSA-scoped Secrets Manager read. Password rotation in Secrets Manager flows into the cluster without operator intervention.
+
+**Alternative considered:** AWS Secrets and Config Provider for Secrets Store CSI Driver. Rejected for now because ESO is more general (any backend, any cloud), and its CRD model fits the rest of the Ark resource shape. ESO can be replaced later if needed.
+
+### Decision: `--target aws` profile rather than per-flag overrides
+
+The CLI accepts `--target aws --terraform-outputs <path>` and reads cloud-specific defaults from a profile. The terraform-outputs JSON is a documented contract.
+
+**Alternative considered:** add individual flags (`--ssl-mode`, `--postgres-host`, `--apiserver-role-arn`, etc.) and require the user to wire each one. Rejected because the surface grows quickly and the user has the same information in the terraform outputs already; the profile is the smaller surface.
+
+**Alternative considered:** make the AWS defaults the global defaults (apply to all installs). Rejected because it breaks the local-minikube case; cloud and local have legitimately different needs.
+
+### Decision: chart `serviceAccountAnnotations: {}` rendered in SA templates
+
+Single PR pattern applied to all nine Ark charts. ServiceAccount templates render an `annotations:` block from `.Values.serviceAccountAnnotations`. The pattern works for IRSA on EKS, Workload Identity on GKE, Workload Identity on AKS, and the older in-cluster KIAM and kube2iam tools.
+
+**Alternative considered:** ship the IRSA-annotated SA from terraform and have charts skip SA creation. Rejected because it splits ownership of the SA across two systems and breaks `helm uninstall` cleanup.
+
+### Decision: terraform module published as subpath of the main repo
+
+Reference as `git::https://github.com/mckinsey/agents-at-scale-ark.git//infrastructure/aws-stack?ref=v0.1.X`. Aligns with the Helm chart distribution model (versioned, downloadable, doesn't require cloning).
+
+**Alternative considered:** publish to the Terraform Registry as a separate module. Rejected because it requires a separate registry account, separate release cadence, and a separate maintenance lifecycle. Subpath stays with the rest of Ark.
+
+### Decision: auto-trigger Deploy workflow on release tag
+
+`.github/workflows/deploy.yml` becomes a tag-push trigger with `deploy_helm_chart=true`, `deploy_to_npm=true`, `deploy_containers=true` set. Today these flags require a human to remember; `v0.1.63-rc.1` shows the consequence (tag and release exist, but the Deploy run was cancelled and nothing was published).
+
+**Alternative considered:** keep manual dispatch and document the required flags. Rejected because manual is fragile and forgetting flags has already caused real artifact gaps.
+
+### Decision: default `sslMode` in apiserver chart values changes from `disable` to `require`
+
+Cloud-managed Postgres (RDS, Cloud SQL, Aiven, Azure) all require SSL. Local Postgres with SSL enabled works with `require`. Local Postgres without SSL set up can override to `disable`.
+
+**Alternative considered:** detect the backend host and pick the default automatically. Rejected because chart values do not have access to runtime hostname classification; an explicit default is simpler and predictable.
+
+## Risks / Trade-offs
+
+- **Chart-level changes need code-owner approval.** `serviceAccountAnnotations` and the namespace fixes are small patches but they are behaviour changes for any existing user whose context-default-namespace was the install target. Documentation and a release note are required.
+- **Terraform module versioning couples to the main repo cadence.** The subpath approach means a new Ark release also drops a new module version, even if the infrastructure side did not change. Acceptable trade-off for simpler maintenance.
+- **EKS auto-mode behaviour is opaque.** The spike used `cluster_primary_security_group_id` as the canonical "node SG", but this is AWS-managed and may change. The terraform module documents the reasoning in a comment so future maintainers know why both SGs are passed.
+- **The CLI `--target aws` profile is a new surface to maintain.** Each new cloud profile adds work. Mitigation: the profile is opt-in; the default install path is unchanged.
+- **External-contributor velocity on the upstream repo.** Some of these PRs need upstream-maintainer review even when small. The recommended order in `reference-plan.md` puts the contributor-landable items first.
+
+## Open Questions
+
+- Should `--target aws` produce a sample `ExternalSecret` manifest, or render it inline as part of the install? The latter is cleaner UX but couples the CLI more tightly to ESO. (Lean: inline render, with a flag to skip.)
+- Should the terraform module manage the `ark-system` namespace, or leave it to `ark install`? (Lean: leave to `ark install` so terraform stays cluster-shape-agnostic.)
+- Multi-tenancy posture: one Ark cluster per tenant, or one cluster with namespace isolation? Affects whether IRSA roles are one-per-tenant or one-per-service. Should be answered before Phase 1 IRSA scoping ships.
+- Image distribution: pull from `ghcr.io` directly (cross-region pull cost, ghcr egress dependency) or mirror to ECR (the spike provisions ECR but does not mirror)? Phase 1 acceptance should state which path ships.
+- Egress posture: assume NAT-out-to-Internet (the spike's default), or build for a locked-down VPC with PrivateLink and VPC endpoints to OpenAI and Anthropic? Affects Phase 3 scope.

--- a/openspec/changes/aws-eks-rds-deployment/proposal.md
+++ b/openspec/changes/aws-eks-rds-deployment/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Ark runs on AWS EKS + RDS Postgres today, but a spike on 2026-05-12 needed about ten manual workarounds to get the standard `ark install` path working. The upstream codebase grew up around minikube and GCP/GKE: Helm charts assume non-cloud defaults, the CLI does not know about IRSA, and the AWS terraform under `infrastructure/providers/aws/` is 92 lines and only provisions a VPC plus an EKS cluster. The proposal closes the gap so that any contributor can go from a clean AWS account to a working Ark cluster in two commands.
+
+The spike that validated the end-to-end path lives at `infrastructure/aws-spike/`. End-to-end smoke (Model + Agent + Query through the aggregated apiserver and RDS) completed in 2.16 seconds.
+
+## What Changes
+
+Ten changes, grouped by area. Two are already in `main` from prior PRs (#2117 postgres install flow, #2132 apiserver readiness wait). The remaining eight are tracked in `tasks.md`.
+
+- Infrastructure: extend `infrastructure/providers/aws/` with RDS, IRSA, and ECR modules. Fix the auto-mode security-group bug where `node_security_group_id` is not what auto-mode actually attaches to nodes.
+- Charts: add `serviceAccountAnnotations` values key to controller and apiserver charts so IRSA role-ARN annotations can flow through values. Change apiserver chart `sslMode` default from `disable` to `require`. Parameterise the controller chart's hardcoded SA name and namespace.
+- CLI: fix six services in `tools/ark-cli/src/arkServices.ts` that have no `namespace` key and land in whichever ns the kubectl context defaults to. Ship a default StorageClass option for PVC-using charts. Add an `--target aws` profile that consumes terraform outputs.
+- Secrets: adopt external-secrets-operator for the Secrets-Manager-to-Kubernetes-Secret bridge that is manual today.
+- Process: auto-trigger the Deploy workflow on `v*` release tags so chart, CLI, and container publishes do not depend on a human ticking three flags.
+- Samples: audit four `samples/queries/*.yaml` files that use plural `spec.targets` against the apiserver's strict-decoding behaviour.
+
+## Capabilities
+
+### New Capabilities
+
+- `aws-deployment-flow`: contributors can provision an EKS cluster, an RDS Postgres instance, IRSA roles, and ECR repositories with a single terraform module that produces every input `ark install` needs. The CLI consumes those outputs and installs the full Ark stack with IRSA annotations and SSL-enforced Postgres pre-wired.
+
+### Modified Capabilities
+
+- `helm-chart-deployment`: chart ServiceAccount templates support an `annotations` block configurable through values, so cloud-specific IAM bindings (EKS IRSA, GKE Workload Identity, AKS Workload Identity) work without `kubectl annotate` after install.
+- `cli-install-flow`: `ark install` gains a `--target <cloud>` profile mechanism that reads cloud-specific defaults and a `--terraform-outputs` flag that consumes a JSON contract produced by the AWS terraform module.
+
+## Impact
+
+- `infrastructure/providers/aws/`: extended from 92 lines to a modular layout adding RDS, IRSA, ECR modules and the security-group fix.
+- `infrastructure/aws-spike/`: the validated spike code, included for reviewer inspection. Slated to be folded into `infrastructure/providers/aws/` once the modular shape is agreed.
+- `ark/dist/chart-apiserver/`: `values.yaml` default for `sslMode`, `serviceAccountAnnotations` rendering in `templates/serviceaccount.yaml`.
+- `ark/dist/chart/`: same `serviceAccountAnnotations` work, plus parameterising the hardcoded SA name and namespace in `templates/rbac/service_account.yaml`.
+- `tools/ark-cli/src/arkServices.ts`: add `namespace: ark-system` to `ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `noah`.
+- `tools/ark-cli/src/commands/install/index.ts`: `--target aws` and `--terraform-outputs` flag handlers, ExternalSecret rendering option, default StorageClass option.
+- `docs/content/operations-guide/provisioning.mdx`: AWS tab gains RDS, IRSA, ECR sections.
+- `docs/content/operations-guide/postgres-storage-backend.mdx`: RDS minor-retirement caveat (spike hit `15.7 not found` in `eu-north-1`; check `aws rds describe-db-engine-versions` for the current floor).
+- `.github/workflows/deploy.yml`: auto-fire on `v*` tag push with chart, npm, and container flags set.
+- `samples/queries/`: audit `query-streaming.yaml`, `query-with-label-selectors.yaml`, `query-model.yaml`, `query-with-mcp-settings-in-annotations.yaml` against current Query schema (singular `target`).
+- New: ExternalSecret rendering path for the RDS password bridge.
+
+The full strategic plan including phasing, ownership, and effort estimates is in `reference-plan.md` in this change directory.

--- a/openspec/changes/aws-eks-rds-deployment/reference-plan.md
+++ b/openspec/changes/aws-eks-rds-deployment/reference-plan.md
@@ -1,0 +1,331 @@
+# Ark on AWS: deployment plan (EKS + RDS)
+
+Last updated: 2026-05-14. Companion files: `aws-spike/NOTES.md` (validation log) and `aws-spike/FOLLOWUP.md` (line-item backlog).
+
+## Glossary
+
+- **Ark**: the agents-at-scale platform, repo `mckinsey/agents-at-scale-ark`. "Upstream" in this document means that repo.
+- **EKS**: AWS managed Kubernetes service.
+- **EKS auto-mode**: a launch mode where AWS schedules nodes on demand. Pods receive secondary IPs on the node ENI and inherit the AWS-managed cluster shared SG.
+- **IRSA**: IAM Roles for Service Accounts. The EKS mechanism that binds an IAM role to a Kubernetes ServiceAccount via OIDC, so pods can call AWS APIs with scoped credentials.
+- **OIDC provider**: the IAM identity provider that EKS exposes for IRSA. Each cluster has one; its ARN is needed when creating IRSA roles.
+- **RDS**: AWS managed relational database. This plan uses Postgres 15.
+- **WAL CDC**: write-ahead-log change data capture. Ark's aggregated apiserver uses Postgres logical replication to watch resource changes and stream them to controllers.
+- **ACM**: AWS Certificate Manager, issues TLS certs for AWS load balancers.
+- **ECR**: AWS container registry.
+- **ESO**: external-secrets-operator. A Kubernetes operator that syncs values from AWS Secrets Manager (and other backends) into k8s Secrets.
+- **release-please**: GitHub bot that opens release PRs from conventional commits. Merging the release PR creates a tag; a separate Deploy workflow publishes artifacts.
+
+## 1. Overview
+
+Ark runs on AWS EKS + RDS Postgres today. A spike on 2026-05-12 validated the full path: Model and Agent CRs created via `kubectl`, a Query routed through the aggregated apiserver into RDS, picked up by the controller via Postgres logical replication, executed against OpenAI, response written back to RDS. Roundtrip 2.16 seconds.
+
+Getting there required about ten manual workarounds because the upstream codebase grew up around local minikube and GCP/GKE. Helm charts assume non-cloud defaults. The CLI does not know about IRSA. The AWS terraform under `infrastructure/providers/aws/` is 92 lines and only provisions a VPC and EKS cluster.
+
+The sections below list the gaps, the steps to close them, and the recommended order. Production-grade Ark on EKS+RDS is roughly six to eight weeks of work.
+
+## 2. Goals and success criteria
+
+| Goal | Success criterion |
+| --- | --- |
+| Low-friction install on EKS+RDS | No `kubectl annotate sa` after install. No local chart swaps. No manual `helm uninstall` retries on a fresh cluster. |
+| Reproducible AWS provisioning | `terraform apply` from a clean account produces every input `ark install` needs: cluster name, RDS endpoint, secret reference, IRSA role ARNs. |
+| Time from clean AWS account to working Model and Query | Under 25 minutes, in two commands. Today: about 30 minutes and ten manual steps. |
+| Production-grade ingress | Public hostnames for `ark-dashboard` and `ark-api`, ACM certs, Route53 records managed by ExternalDNS. |
+| Upstream-merged | All work lands as PRs against `mckinsey/agents-at-scale-ark`. |
+
+## 3. Recommended order
+
+Land in parallel: P-1, P-3, P-4, P-10. All small, independently mergeable, no blocking dependencies.
+
+Then sequence the upstream-bottleneck items P-2, P-5, P-6. These need chart and CLI code-owner approval and cannot be landed by an external contributor alone.
+
+Then P-7, P-8, P-9 as production polish. They compose on top of the foundation.
+
+If only one item lands in the next sprint, make it **P-2** (chart `serviceAccountAnnotations`). One PR covers IRSA on EKS, Workload Identity on GKE, and Workload Identity on AKS.
+
+## 4. Current state
+
+Verified on 2026-05-14:
+
+Working:
+- Spike terraform applies cleanly to a clean AWS account in `eu-north-1`. Tears down cleanly. Code under `aws-spike/`.
+- `ark install --backend postgresql --ark-version 0.1.63-rc` produces a running stack. The `v0.1.63-rc` OCI charts are real (the empty `0.1.62` placeholder was replaced on 2026-05-12).
+- PR #2117 (postgres install flow fix) and PR #2132 (apiserver readiness wait) are merged on `main`.
+- Aggregated apiserver to RDS to controller via WAL CDC, dispatching to the completions executor, hitting OpenAI, persisting status back to RDS. End-to-end validated.
+
+Not yet in published artifacts:
+- `v0.1.63-rc.1` tag was created on 2026-05-13, but the Deploy workflow run for it was cancelled. PR #2132's fix is on `main` and tagged, but is not in any chart or CLI build that npm or OCI serves. Today the way to get it is to build the CLI from a local checkout of `main`.
+- `npm @agents-at-scale/ark@0.1.63-rc` is not published. npm latest is still `0.1.62`.
+
+Still manual:
+- IRSA role ARNs must be annotated on ServiceAccounts after install. Charts do not expose annotations through values.
+- The RDS password lives in AWS Secrets Manager. There is no automatic bridge to a k8s Secret; it must be pulled and applied by hand.
+- Six services (`ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `noah`) have no `namespace` key in `arkServices.ts` and land in whichever ns the kubectl context points at (`default` on a fresh cluster).
+- The apiserver chart's `sslMode` defaults to `"disable"`. RDS rejects non-SSL connections.
+- The terraform-aws-modules/eks/aws module exposes `node_security_group_id`, but auto-mode attaches `cluster_primary_security_group_id` to node ENIs. RDS ingress that allows the former silently times out.
+- `file-gateway` PVCs stay Pending. EKS auto-mode includes the EBS CSI driver but does not mark any StorageClass as default.
+
+## 5. Target state
+
+```bash
+# One-time per account:
+git clone <repo> && cd terraform-aws-ark
+terraform apply -var region=eu-north-1
+# ~15 min. Produces: VPC, EKS, RDS, IRSA roles, ECR, LB Controller,
+# ExternalDNS, cert-manager. Writes terraform-output.json.
+
+# Per environment:
+ark install --target aws --terraform-outputs ./terraform-output.json
+# ~5 min. Pulls RDS endpoint, secret refs, IRSA role ARNs from terraform
+# output. Bridges Secrets Manager to k8s Secret (via ESO). Installs all
+# charts with namespaces and IRSA annotations pre-wired. Waits for
+# readiness. Exits non-zero on failure.
+
+# Verify:
+kubectl get models,agents,queries -A
+curl https://ark-api.<your-zone>/healthz
+```
+
+The terraform module owns infrastructure. `ark install` owns the application layer. The terraform-outputs JSON is the contract between them.
+
+## 6. Gap analysis
+
+Priorities reflect the cost of the workaround on a user trying to install today.
+
+### P0, blocks AWS users today
+
+| Gap | Where | Status |
+| --- | --- | --- |
+| Dummy `ark-apiserver:0.1.62` chart | OCI registry | Resolved by `v0.1.63-rc` |
+| Apiserver readiness race | `ark-cli` | Resolved by PR #2132 (in `main`, not yet published) |
+| Auto-mode SG mismatch (RDS times out) | upstream terraform | Open. Fix baked into spike, needs upstream PR |
+| Default `sslMode: "disable"` | apiserver chart | Open, single-value PR |
+
+### P1, install produces an ugly result without a workaround
+
+| Gap | Where | Effort |
+| --- | --- | --- |
+| Chart SAs have no `serviceAccountAnnotations` values key | controller and apiserver charts | M (about 2 days) |
+| 6 services missing `namespace` key in `arkServices.ts` | `tools/ark-cli` | S, config-only patch |
+| Controller SA name and namespace hardcoded in template | controller chart | S, parameterise |
+| Manual SM to k8s secret bridge | install flow | M, adopt ESO or AWS Secrets Provider |
+| No default StorageClass story | install or docs | S, ship a `gp3` StorageClass with `is-default-class: "true"` |
+| Stale `targets`-plural Query samples (4 sample files) | `samples/queries/` | S to M, depending on whether the apiserver still rejects plural |
+| Deploy workflow does not auto-publish on release tag | `.github/workflows/deploy.yml` | M, CI process change |
+
+### P2, production-grade
+
+| Gap | Where | Effort |
+| --- | --- | --- |
+| AWS Load Balancer Controller | terraform helm release | M |
+| ExternalDNS with IRSA | terraform helm release | M |
+| Route53 hosted zone and ACM cert | terraform | M |
+| Multi-AZ RDS option | terraform var (already plumbed) | S |
+| KMS envelope encryption (EKS and RDS) | terraform | M |
+| VPC endpoints (S3, SecretsManager, ECR) | terraform | M |
+| RDS backups, PITR, deletion protection, final snapshot | terraform module | S |
+| OTel collector and CloudWatch Logs | terraform and chart | L |
+| AMP and Grafana | terraform helm release | L |
+| Log retention policy | terraform | S |
+| Cross-region RDS replica for DR | terraform | M |
+| EKS upgrade path documentation | docs | S |
+
+### P3, strategic
+
+| Gap | Where | Effort |
+| --- | --- | --- |
+| Karpenter explicit (vs auto-mode default) | terraform | M |
+
+## 7. Phased plan
+
+```
+                   ┌──────────────────────────────┐
+                   │ Phase 0: spike validated     │
+                   │ (done 2026-05-12)            │
+                   └────────────┬─────────────────┘
+                                │
+   ┌────────────────────────────┼────────────────────────────┐
+   │                            │                            │
+┌──▼──────────────┐    ┌────────▼─────────┐    ┌─────────────▼─────┐
+│ Phase 1: infra  │    │ Phase 2: install │    │ Phase 3: prod     │
+│ upstream PR     │    │ smoothing        │    │ add-ons + obs.    │
+│ ~3-4 days       │    │ 1-2 sprints      │    │ 2-3 sprints       │
+└─────────────────┘    └──────────────────┘    └───────────────────┘
+```
+
+### Phase 1: infra upstream (3 to 4 days)
+
+Owner: external contributor (Stefano). Spike code is already in modular shape.
+
+Deliverables, as one PR to `mckinsey/agents-at-scale-ark`:
+- Add `modules/{rds,irsa,ecr}/` next to the current AWS provider, or refactor the existing `providers/aws/` into the modular layout.
+- RDS module: Postgres parameter group with `rds.logical_replication=1` and `rds.force_ssl=1`. Password in Secrets Manager. Multi-AZ as a variable. Backups, PITR window, deletion protection, final-snapshot identifier configurable.
+- IRSA module: OIDC provider plus roles for `ark-controller` and `ark-apiserver`. The apiserver role gets `secretsmanager:GetSecretValue` scoped to the DB password ARN.
+- ECR module: repos for each Ark service image, lifecycle policy.
+- Fix the auto-mode SG bug: RDS module accepts a list of allowed SG IDs, includes `cluster_primary_security_group_id`.
+- Outputs needed by `ark install`: cluster name, OIDC provider ARN, RDS endpoint, RDS secret name and ARN, role ARNs.
+- Docs: AWS tab of `provisioning.mdx` adds RDS, IRSA, ECR sections. `postgres-storage-backend.mdx` adds the RDS minor-retirement caveat (RDS retires Postgres minors quickly; check `aws rds describe-db-engine-versions --engine postgres` for what is offered in the target region).
+
+Acceptance: a contributor following the docs can `terraform apply` and get an EKS cluster plus RDS Postgres ready for `ark install`, in a region of their choice.
+
+### Phase 2: install smoothing (1 to 2 sprints)
+
+Owners split: external contributor for config and sample fixes; upstream maintainers for chart templates and the CLI loop.
+
+Mergeable independently:
+1. Chart values gain `serviceAccountAnnotations: {}` in `ark-controller` and `ark-apiserver` (and consistently in the other 7 charts). SA templates render the annotations. Unblocks IRSA role-ARN injection through values.
+2. `arkServices.ts`: add `namespace: 'ark-system'` to the 6 services that miss it. The list, verified against `tools/ark-cli/src/arkServices.ts:152-213`: `ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `noah`. Note: `file-gateway` already pins `namespace: 'default'` explicitly.
+3. `ark-controller` chart: parameterise the SA name and namespace (the apiserver chart already does this; match the pattern). The current template at `ark/dist/chart/templates/rbac/service_account.yaml` writes `name: ark-controller` and `namespace: ark-system` literally.
+4. `chart-apiserver/values.yaml:20`: change `sslMode` default to `"require"`. Document that local-dev users with a non-SSL postgres can override.
+5. Generalise the apiserver-readiness exit-non-zero pattern from PR #2132 to other per-service install failures, if not already covered. Recheck `tools/ark-cli/src/commands/install/index.ts:115-133` against current `main`; the swallowed-error path may already be addressed.
+6. Ship a default StorageClass option. Either an `ark install --create-default-storageclass=gp3` flag, or the `file-gateway` chart specifies one.
+7. Audit the four Query samples that use plural `targets` (`query-streaming.yaml`, `query-with-label-selectors.yaml`, `query-model.yaml`, `query-with-mcp-settings-in-annotations.yaml`). If the apiserver still rejects plural with strict decoding, fix all four. If it accepts plural via a webhook alias, document the alias and the canonical form.
+
+Acceptance: from a Phase-1 cluster, `ark install --backend postgresql --ark-version <published>` succeeds with no `kubectl` between install and first Query.
+
+### Phase 3: production add-ons and observability (2 to 3 sprints)
+
+Terraform module gains helm releases for:
+- AWS Load Balancer Controller, with IRSA for ALB and NLB management.
+- ExternalDNS, with IRSA scoped to the Route53 zone.
+- cert-manager ClusterIssuer wired to Let's Encrypt or ACM Private CA. cert-manager itself is already installed by `ark install` for webhook certs; this adds a public-cert path.
+- KMS keys plus envelope encryption on EKS and RDS.
+- ESO for the SM-to-Secret bridge.
+- VPC endpoints for S3, SecretsManager, ECR (reduces NAT egress cost and is required for any locked-down VPC).
+- RDS Multi-AZ flipped on for non-dev environments.
+
+Optional, separable:
+- OTel collector plus CloudWatch Logs exporter.
+- AMP workspace and Grafana.
+- Karpenter for explicit NodePool tuning.
+
+Acceptance: `ark-dashboard.<zone>` and `ark-api.<zone>` resolve, serve TLS, route correctly. Secrets rotate from SM automatically. Phase-3 acceptance does not include OTel and AMP; those are tracked separately so the phase can ship without them.
+
+## 8. Proposals
+
+Ten changes that together close the gap. Each proposal lists what to do, why it pays back, and what blocks it.
+
+### P-1. Upstream the spike's RDS, IRSA, ECR modules and SG fix
+
+Add `modules/{rds,irsa,ecr}/` and fix the auto-mode SG bug. RDS module accepts `allowed_security_group_ids` as a list; defaults include `cluster_primary_security_group_id`. Outputs cover everything `ark install` needs.
+
+The upstream AWS terraform today is 92 lines and only does VPC plus EKS. Anyone adding RDS hits the silent SG timeout that consumed half an afternoon on the spike. This PR turns AWS provisioning into a documented apply.
+
+Owner: external contributor. Effort: 3 to 4 days including docs. Blocks: none.
+
+### P-2. Add `serviceAccountAnnotations` to all Ark charts
+
+Single PR adding `serviceAccountAnnotations: {}` to every chart's `values.yaml` and rendering the annotations in the SA template. The same change to all nine charts, plus a values reference in the docs.
+
+IRSA is the canonical EKS pattern for binding IAM roles to pods. The same SA-annotation mechanism is used by Azure Workload Identity, GKE Workload Identity, and the older in-cluster auth tools like KIAM and kube2iam. One small PR covers all of them. Without it, every cloud user has to `kubectl annotate` after install, and `helm upgrade` undoes the annotation.
+
+Owner: upstream maintainer. Effort: about 2 days, because SA templates differ across charts (the controller chart hardcodes the SA name, the apiserver chart parameterises it, the others not inspected). Blocks: none.
+
+### P-3. Fix the missing `namespace` keys in `arkServices.ts`
+
+Config patch in `tools/ark-cli/src/arkServices.ts` adding `namespace: 'ark-system'` to `ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `noah`. `file-gateway` already pins `namespace: 'default'` and is not in scope.
+
+services landing in `default` is confusing on fresh clusters and breaks the cross-namespace service references inside Ark (e.g. `ark-completions` calling `ark-api`). The intent ("use current context namespace") only helps users who set their context first, and is the wrong default.
+
+Owner: needs upstream maintainer review even though the patch is small, because changing the default ns is a behaviour change for any existing user whose context-default-ns was the install target. Effort: 1 hour patch plus discussion. Blocks: nothing technical.
+
+### P-4. Change apiserver `sslMode` default to `require`
+
+Single-value change in `ark/dist/chart-apiserver/values.yaml:20`.
+
+every cloud-managed Postgres requires SSL. The current default forces every cloud user to override. `require` works against local postgres-with-SSL too; local users without SSL set up can override to `disable`.
+
+Owner: any contributor. Effort: 15 minutes plus a release note. Blocks: none.
+
+### P-5. Generalise the per-service install-failure exit pattern
+
+PR #2132 fixed the apiserver-readiness path: install now exits non-zero when readiness times out. The broader pattern of swallowing per-service errors in `installArk()` should match. Verify against `tools/ark-cli/src/commands/install/index.ts:115-133` on current `main`; if `handleInstallError` already exits non-zero for non-version-not-found errors, this is done.
+
+today, if a service fails to install in CI, the CI run succeeds. PR #2132 fixed the specific case. Closing the general case prevents the next regression.
+
+Owner: upstream maintainer. Effort: half a day if the work is needed, otherwise verification only. Blocks: none.
+
+### P-6. Ship a default StorageClass option
+
+Either a CLI flag `ark install --create-default-storageclass=gp3` that applies a StorageClass marked default, or the `file-gateway` chart specifies a StorageClass explicitly. The former helps any PVC-using component; the latter is narrower.
+
+EKS auto-mode bundles the EBS CSI driver but marks no StorageClass as default. `file-gateway` and any other PVC-using chart stays Pending until a user creates one by hand.
+
+Owner: upstream maintainer. Effort: 1 day including a decision on where the StorageClass lives. Blocks: none.
+
+### P-7. Adopt ESO for the RDS password bridge
+
+Install ESO via terraform helm release with IRSA-scoped Secrets Manager read. `ark install` learns to render an `ExternalSecret` CR (instead of expecting a pre-existing k8s Secret), parameterised on the secret ARN from terraform outputs.
+
+Concrete shape:
+- Terraform output: `rds_password_secret_name` (already produced by spike).
+- Apiserver chart already reads from `postgresql.passwordSecretName` and `postgresql.passwordSecretKey`.
+- New CR `ExternalSecret/ark-db-password` syncs the SM value into a k8s Secret named per `postgresql.passwordSecretName`, keyed per `postgresql.passwordSecretKey`.
+
+today's manual pull means RDS password rotation breaks the apiserver until someone re-syncs. ESO does it continuously and uses IRSA for SM read.
+
+Owner: external contributor for terraform plus the `ExternalSecret` manifest, upstream maintainer for the optional CLI render. Effort: 4 to 5 days end-to-end. Blocks: P-2 (the ESO ServiceAccount needs the IRSA annotation pattern that P-2 introduces).
+
+### P-8. Add `ark install --target aws` profile
+
+A CLI flag that activates AWS defaults. Accepts `--terraform-outputs <path>` and reads:
+- RDS endpoint, secret name, IRSA role ARNs.
+- Renders ExternalSecret for the RDS password.
+- Sets `serviceAccountAnnotations` on chart SAs from the role ARNs.
+- Defaults `sslMode` to `require` if P-4 is not in.
+- Skips `file-gateway` PVC creation unless a StorageClass is named.
+
+a single command from terraform output to running cluster. Targeted profiles let cloud-specific defaults exist without polluting local dev. Same pattern as `kubectl --context`.
+
+Split this into design and implementation:
+- Design (1 week): agree on the terraform-outputs JSON schema, the `--target <cloud>` interface, and which defaults a profile may override.
+- Implementation (1 to 2 weeks): build the loader, the chart-args mapper, and the tests.
+
+Owner: design needs upstream maintainer sign-off; implementation can be split. Effort: 2 to 3 weeks total. Blocks: P-1 (outputs schema), P-2 (chart annotation values), P-3 (namespace fixes), P-7 (ESO substrate).
+
+### P-9. Publish a versioned terraform-aws-ark module
+
+Pin the Phase 1 plus Phase 3 terraform to a release tag and reference it as `git::https://github.com/mckinsey/agents-at-scale-ark.git//infrastructure/aws-stack?ref=v0.1.X`. Subpath approach over Terraform Registry because it shares the release cadence of the Ark codebase and avoids a separate registry account. Future option to publish to the Registry remains open.
+
+lets downstream users pin a working Ark plus infrastructure combination instead of consuming from `main`.
+
+Owner: external contributor plus upstream maintainer for the tagging convention. Effort: 2 days after Phase 1 and Phase 3 are merged. Blocks: P-1 and the relevant Phase 3 items.
+
+### P-10. Auto-trigger Deploy workflow on release tag
+
+Change `.github/workflows/deploy.yml` so a `v*` tag push automatically dispatches with `deploy_helm_chart=true`, `deploy_to_npm=true`, `deploy_containers=true`. Today these flags require a human to remember to tick them. `v0.1.63-rc.1`'s Deploy was cancelled and the artifacts were never published.
+
+Releases that ship charts but not the CLI (or no artifacts at all) are a real problem. `v0.1.63-rc.1` is on the tag list but nothing is in any registry. Manual flags are easy to forget; auto-firing on the release tag matches how the rest of the org ships.
+
+Owner: upstream maintainer (CI ownership). Effort: 1 day. Blocks: nothing. Risk: low; the change is reversible.
+
+## 9. Risks and dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Upstream maintainers do not prioritise P-2, P-5, P-6 | External contributor can land P-1, P-4, P-9, P-10 independently. P-2 is the upstream-owned bottleneck and the highest payback. |
+| RDS Postgres minor versions get retired (spike hit `15.7 not found`) | Pin the terraform default to the latest minor offered. Document the `aws rds describe-db-engine-versions` check in `postgres-storage-backend.mdx`. |
+| Release pipeline keeps publishing incomplete releases (charts without CLI) | P-10 fixes this. Until then, `--ark-version` override plus local CLI build is the documented workaround. |
+| EKS auto-mode behaviour changes | Use `cluster_primary_security_group_id` as the canonical "node SG" reference. It is AWS-managed and stable across auto-mode and managed-node-group attachments. |
+| External-contributor velocity on the upstream repo | The recent PR history (PRs #1958, #2117) shows non-trivial PRs landing. P-3 in particular needs code-owner approval even though the patch is small, because it is a behaviour change. |
+| Phase 3 effort is aggressive if the external contributor is solo | KMS plus IAM key policies alone is typically a day of debugging. The 2 to 3 sprint estimate assumes maintainers also contribute on the chart side. |
+
+Open dependencies blocking specific phases:
+- Upstream release engineers re-dispatching Deploy for `v0.1.63-rc.1`, or implementing P-10. Workaround exists (build CLI locally, use `--ark-version`).
+- Security review of the IRSA role policies and KMS key policies before Phase 3 goes to non-dev environments.
+
+## 10. Open questions
+
+1. **Terraform module ownership**. Does Ark ship `terraform-aws-ark` itself (P-9 subpath approach), or should the upstream publish a consumer module in a separate repo? Affects who owns the lifecycle of the module.
+2. **Multi-tenancy posture**. One Ark cluster per tenant, or one cluster with namespace isolation? Affects how `ark-tenant` is wired and how IRSA roles are scoped. This is a design choice tracked here because it influences Phase 1 IRSA role definitions (one role per tenant vs one role per service); resolving it before Phase 1 ships is preferable.
+3. **Image distribution**. Pull from `ghcr.io/mckinsey/...` directly (cross-region pull cost, ghcr egress dependency) or mirror to ECR (the spike provisions ECR but does not mirror images)? Phase 1 acceptance should state which path is shipped.
+4. **Egress posture**. Assume NAT-out-to-Internet works (the spike's default), or build for a fully-locked-down VPC with PrivateLink and VPC endpoints to OpenAI and Anthropic? Affects Phase 3 scope.
+
+## 11. AgentCore
+
+AgentCore will be covered in the next days.
+
+## Appendix
+
+For the per-line backlog of every gap from the spike (including resolved items with strikethrough), see `aws-spike/FOLLOWUP.md`. For the chronological validation log, see `aws-spike/NOTES.md`. This file is the plan. The other two are the line-item backlog and the validation log.

--- a/openspec/changes/aws-eks-rds-deployment/tasks.md
+++ b/openspec/changes/aws-eks-rds-deployment/tasks.md
@@ -1,0 +1,50 @@
+Tasks are grouped into phases. Two items resolved before this change opened: dummy `ark-apiserver:0.1.62` chart (replaced by `v0.1.63-rc`) and the apiserver readiness race (PR #2132 merged on `main`).
+
+## 1. Phase 1 — infrastructure upstream PR
+
+- [ ] 1.1 Add `infrastructure/providers/aws/modules/rds/` (Postgres parameter group with `rds.logical_replication=1` and `rds.force_ssl=1`, password in Secrets Manager, `multi_az` variable, backups, PITR retention, deletion protection, final-snapshot identifier configurable)
+- [ ] 1.2 Add `infrastructure/providers/aws/modules/irsa/` (OIDC provider and roles for `ark-controller` and `ark-apiserver`; apiserver role gets `secretsmanager:GetSecretValue` scoped to the DB password ARN)
+- [ ] 1.3 Add `infrastructure/providers/aws/modules/ecr/` (repos for each Ark service image, lifecycle policy)
+- [ ] 1.4 Fix the auto-mode SG bug: RDS module accepts `allowed_security_group_ids` list; root passes both `cluster_primary_security_group_id` and `node_security_group_id`
+- [ ] 1.5 Outputs: cluster name, OIDC provider ARN, RDS endpoint, RDS secret name and ARN, IRSA role ARNs
+- [ ] 1.6 Update `docs/content/operations-guide/provisioning.mdx` AWS tab with RDS, IRSA, ECR sections
+- [ ] 1.7 Update `docs/content/operations-guide/postgres-storage-backend.mdx` with the RDS minor-retirement caveat
+- [ ] 1.8 Acceptance: a contributor following the docs can `terraform apply` and get an EKS cluster plus RDS Postgres ready for `ark install`, in a region of their choice
+
+## 2. Phase 2 — chart and CLI smoothing
+
+- [ ] 2.1 Add `serviceAccountAnnotations: {}` to `ark/dist/chart-apiserver/values.yaml` and render in `templates/serviceaccount.yaml`
+- [ ] 2.2 Add `serviceAccountAnnotations: {}` to `ark/dist/chart/values.yaml` and render in `templates/rbac/service_account.yaml`. Parameterise the hardcoded SA name and namespace (apiserver chart pattern)
+- [ ] 2.3 Repeat for the other seven charts (`ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `ark-completions`, `localhost-gateway`)
+- [ ] 2.4 Update `tools/ark-cli/src/arkServices.ts`: add `namespace: 'ark-system'` to `ark-api`, `ark-broker`, `ark-dashboard`, `ark-mcp`, `ark-tenant`, `noah`. Leave `file-gateway` at its explicit `namespace: 'default'`
+- [ ] 2.5 Change `ark/dist/chart-apiserver/values.yaml` default `sslMode` from `"disable"` to `"require"`
+- [ ] 2.6 Verify the per-service install-failure exit pattern in `tools/ark-cli/src/commands/install/index.ts`; generalise PR #2132's apiserver-readiness exit-non-zero pattern if not already covered
+- [ ] 2.7 Ship a default StorageClass option: either `ark install --create-default-storageclass=gp3` flag or `file-gateway` chart specifies one
+- [ ] 2.8 Audit four sample files (`samples/queries/query-streaming.yaml`, `query-with-label-selectors.yaml`, `query-model.yaml`, `query-with-mcp-settings-in-annotations.yaml`) against current Query schema; fix or document the plural-targets handling
+- [ ] 2.9 Acceptance: `ark install --backend postgresql --ark-version <published>` succeeds with no `kubectl` between install and first Query, on a Phase-1 cluster
+
+## 3. Phase 3 — production add-ons
+
+- [ ] 3.1 Terraform helm release for AWS Load Balancer Controller, with IRSA for ALB and NLB management
+- [ ] 3.2 Terraform helm release for ExternalDNS, with IRSA scoped to the Route53 zone
+- [ ] 3.3 Terraform helm release for ESO (external-secrets-operator), with IRSA for Secrets Manager read
+- [ ] 3.4 Terraform module gains Route53 hosted zone and ACM cert provisioning
+- [ ] 3.5 KMS keys plus envelope encryption on EKS and RDS
+- [ ] 3.6 VPC endpoints for S3, SecretsManager, ECR (cost reduction; required for locked-down VPC)
+- [ ] 3.7 RDS Multi-AZ flipped on for non-dev environments via a variable
+- [ ] 3.8 Add `--target aws` profile to `ark install`: design (terraform outputs schema agreed; `--target <cloud>` interface designed; defaults a profile may override agreed) then implementation (loader, chart-args mapper, tests)
+- [ ] 3.9 Render an `ExternalSecret` CR for the RDS password bridge from terraform outputs and chart values
+- [ ] 3.10 Optional, separable: OTel collector and CloudWatch Logs exporter, AMP workspace and Grafana, Karpenter for explicit NodePool tuning
+- [ ] 3.11 Acceptance: `ark-dashboard.<zone>` and `ark-api.<zone>` resolve, serve TLS, route correctly; secrets rotate from Secrets Manager automatically
+
+## 4. Process changes
+
+- [ ] 4.1 Change `.github/workflows/deploy.yml` so a `v*` tag push automatically dispatches with `deploy_helm_chart=true`, `deploy_to_npm=true`, `deploy_containers=true`
+- [ ] 4.2 Publish `terraform-aws-ark` as a versioned subpath: reference as `git::https://github.com/mckinsey/agents-at-scale-ark.git//infrastructure/aws-stack?ref=v0.1.X`. Tag at release time. Document the pinning convention
+- [ ] 4.3 Re-dispatch Deploy on `v0.1.63-rc.1` (or wait for 4.1 to land and re-tag) so PR #2132's apiserver-readiness fix exists in a published artifact
+
+## 5. Pre-flight (open questions to answer before Phase 1 ships)
+
+- [ ] 5.1 Multi-tenancy posture: one Ark cluster per tenant, or one cluster with namespace isolation? Decision affects whether IRSA roles in Phase 1 are one-per-tenant or one-per-service
+- [ ] 5.2 Image distribution: pull from `ghcr.io` directly, or mirror to ECR? Phase 1 acceptance states which path ships
+- [ ] 5.3 Egress posture: NAT-out-to-Internet, or PrivateLink and VPC endpoints? Affects Phase 3 scope


### PR DESCRIPTION
## Summary

OpenSpec change `aws-eks-rds-deployment` plus validated spike terraform at `infrastructure/aws-spike/`. Draft for review.

Covers the ten outstanding gaps a contributor hits today when installing Ark on AWS, grouped into Phase 1 (infra upstream PR), Phase 2 (chart + CLI smoothing), Phase 3 (production add-ons), and Phase 4 (process changes). Two prerequisite items already landed on main: #2117 (postgres install flow) and #2132 (apiserver readiness wait).

The spike validated the full path on 2026-05-12 in `eu-north-1`: VPC + EKS 1.33 auto-mode + RDS Postgres 15 + IRSA + ECR. End-to-end smoke (Model + Agent + Query through the aggregated apiserver and RDS) completed in 2.16 seconds. The cluster + RDS were torn down after validation.

## What is in this PR

- `openspec/changes/aws-eks-rds-deployment/`:
  - `proposal.md`: why, what changes, capabilities, impact.
  - `design.md`: context, goals/non-goals, decisions with alternatives, risks, open questions.
  - `tasks.md`: phased task list.
  - `reference-plan.md`: the full strategic plan with glossary, phasing, ownership, effort estimates.
- `infrastructure/aws-spike/`: terraform code in modular layout (`vpc`, `eks`, `rds`, `irsa`, `ecr`). Slated to fold into `infrastructure/providers/aws/` once direction is agreed.

## What this PR is not

- Not an implementation PR. No chart, CLI, or workflow changes here. Those are the tasks tracked in `tasks.md` for follow-up PRs.
- AgentCore A2A is intentionally out of scope; covered separately.

## Review focus

- Does the modular terraform shape match the direction the upstream wants for `infrastructure/providers/aws/`?
- Are the chart-level changes (`serviceAccountAnnotations`, `sslMode` default, the six missing `namespace` keys in `arkServices.ts`) acceptable as behaviour changes, or do they need a feature flag?
- Is `--target aws` a direction the CLI should grow, or should cloud-specific install logic live elsewhere?
- The auto-mode security-group fix (allow RDS ingress from `cluster_primary_security_group_id`, not just `node_security_group_id`): does this match other auto-mode patterns in the codebase?

The open questions at the end of `design.md` are the items I would like answered before Phase 1 lands.