### PR TITLE
DO NOT MERGE: reference mcp oauth

### DIFF
--- a/ark/executors/completions/agent_tools.go
+++ b/ark/executors/completions/agent_tools.go
@@ -13,6 +13,7 @@ import (
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"mckinsey.com/ark/internal/eventing"
 	arkmcp "mckinsey.com/ark/internal/mcp"
+	"mckinsey.com/ark/internal/resolution"
 	"mckinsey.com/ark/internal/telemetry"
 )
 
@@ -144,6 +145,19 @@ func createMCPExecutor(ctx context.Context, k8sClient client.Client, tool *arkv1
 			return nil, fmt.Errorf("failed to resolve header %s: %w", header.Name, err)
 		}
 		headers[header.Name] = value
+	}
+
+	// spec.headers is the user's escape hatch — if they have already set
+	// Authorization explicitly, leave it alone and skip the tokenSecretRef
+	// read entirely.
+	if _, hasExplicit := headers["Authorization"]; !hasExplicit {
+		token, err := resolution.ResolveBearerToken(ctx, k8sClient, &mcpServerCRD)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve authorization token for MCPServer %s: %w", mcpServerCRD.Name, err)
+		}
+		if token != "" {
+			headers["Authorization"] = "Bearer " + token
+		}
 	}
 
 	// Parse timeout from MCPServer spec (default to 30s if not specified)

--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -17,9 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"mckinsey.com/ark/internal/annotations"
@@ -54,6 +58,12 @@ const (
 	// listed tools using a Bearer token resolved from
 	// spec.authorization.tokenSecretRef.
 	MCPServerReasonAuthorized = "Authorized"
+
+	// mcpTokenSecretRefField is the field-index path on MCPServer that
+	// points at the referenced token Secret. Used by the Secret watch to
+	// resolve "which MCPServers reference this Secret" without scanning
+	// the whole list every event.
+	mcpTokenSecretRefField = "spec.authorization.tokenSecretRef.name"
 )
 
 type MCPServerReconciler struct {
@@ -208,7 +218,7 @@ func (r *MCPServerReconciler) resolveAuthorizationMaterial(ctx context.Context, 
 
 	accessKey := ref.AccessTokenKey
 	if accessKey == "" {
-		accessKey = "access_token"
+		accessKey = resolution.DefaultAccessTokenKey
 	}
 	if raw, ok := secret.Data[accessKey]; ok {
 		material.accessToken = string(raw)
@@ -738,10 +748,70 @@ func (r *MCPServerReconciler) convertInputSchemaToRawExtension(schema any) *runt
 }
 
 func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &arkv1alpha1.MCPServer{}, mcpTokenSecretRefField, mcpTokenSecretRefIndexer); err != nil {
+		return fmt.Errorf("failed to register field indexer %s: %w", mcpTokenSecretRefField, err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arkv1alpha1.MCPServer{}).
+		// Token Secrets carrying MCPTokenSecretLabel trigger immediate
+		// reconcile of every MCPServer referencing them. The predicate
+		// filters at event-handler level only — the cache is left
+		// unfiltered so reconciler reads of any Secret keep working.
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForSecret),
+			builder.WithPredicates(predicate.NewPredicateFuncs(hasMCPTokenSecretLabel)),
+		).
 		Named("mcpserver").
 		Complete(r)
+}
+
+func mcpTokenSecretRefIndexer(obj client.Object) []string {
+	mcpServer, ok := obj.(*arkv1alpha1.MCPServer)
+	if !ok || mcpServer.Spec.Authorization == nil {
+		return nil
+	}
+	name := mcpServer.Spec.Authorization.TokenSecretRef.Name
+	if name == "" {
+		return nil
+	}
+	return []string{name}
+}
+
+// hasMCPTokenSecretLabel filters Secret events down to those carrying
+// the opt-in real-time-reconcile label. Helm charts shipping token
+// Secrets stamp this label automatically; hand-created Secrets stamp it
+// manually. Unlabelled Secrets fall through to the periodic resync.
+func hasMCPTokenSecretLabel(obj client.Object) bool {
+	return obj.GetLabels()[labels.MCPTokenSecretLabel] == "true"
+}
+
+// findMCPServersForSecret resolves the reverse mapping from a Secret
+// event to the MCPServers that reference it via
+// spec.authorization.tokenSecretRef. Uses the field index registered
+// above so the lookup is O(1) per match instead of a full list scan.
+func (r *MCPServerReconciler) findMCPServersForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := logf.FromContext(ctx)
+	var mcpServers arkv1alpha1.MCPServerList
+	if err := r.List(ctx, &mcpServers,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{mcpTokenSecretRefField: obj.GetName()},
+	); err != nil {
+		log.Error(err, "failed to list MCPServers for token Secret event", "secret", obj.GetName(), "namespace", obj.GetNamespace())
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(mcpServers.Items))
+	for i := range mcpServers.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      mcpServers.Items[i].Name,
+				Namespace: mcpServers.Items[i].Namespace,
+			},
+		})
+	}
+	return requests
 }
 
 // parseTimeout returns the MCPServer spec timeout as a duration,

--- a/ark/internal/controller/mcpserver_secret_watch_test.go
+++ b/ark/internal/controller/mcpserver_secret_watch_test.go
@@ -124,7 +124,7 @@ var _ = Describe("MCPServer Controller — token Secret watch", func() {
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
 
-		mgrCtx, mgrCancel = context.WithCancel(context.Background())
+		mgrCtx, mgrCancel = context.WithCancel(context.Background()) //nolint:fatcontext // BeforeEach rebinds outer-scope ctx so AfterEach can cancel this spec's manager.
 		go func() {
 			defer GinkgoRecover()
 			Expect(mgr.Start(mgrCtx)).To(Succeed())

--- a/ark/internal/controller/mcpserver_secret_watch_test.go
+++ b/ark/internal/controller/mcpserver_secret_watch_test.go
@@ -1,0 +1,278 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/labels"
+)
+
+// countingReconciler exposes the production label-driven Secret watch
+// wiring against an MCPServer reconciler whose Reconcile only counts
+// invocations. Lets the envtest assert "labelled Secret patch enqueues
+// reconcile / unlabelled does not" without tying the test to the full
+// MCP discovery path.
+type countingReconciler struct {
+	client.Client
+	requests atomic.Int32
+	seen     chan reconcile.Request
+	name     string
+}
+
+func (r *countingReconciler) Reconcile(_ context.Context, req reconcile.Request) (reconcile.Result, error) {
+	r.requests.Add(1)
+	select {
+	case r.seen <- req:
+	default:
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *countingReconciler) findMCPServersForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	var mcpServers arkv1alpha1.MCPServerList
+	if err := r.List(ctx, &mcpServers,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{mcpTokenSecretRefField: obj.GetName()},
+	); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(mcpServers.Items))
+	for i := range mcpServers.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      mcpServers.Items[i].Name,
+				Namespace: mcpServers.Items[i].Namespace,
+			},
+		})
+	}
+	return out
+}
+
+func (r *countingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &arkv1alpha1.MCPServer{}, mcpTokenSecretRefField, mcpTokenSecretRefIndexer); err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arkv1alpha1.MCPServer{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForSecret),
+			builder.WithPredicates(predicate.NewPredicateFuncs(hasMCPTokenSecretLabel)),
+		).
+		Named(r.name).
+		Complete(r)
+}
+
+// drainSeen reads all currently-buffered Reconcile requests so a
+// follow-up assertion only counts new events.
+func drainSeen(ch chan reconcile.Request) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+var watchTestCounter atomic.Int32
+
+var _ = Describe("MCPServer Controller — token Secret watch", func() {
+	var (
+		mgr        manager.Manager
+		mgrCtx     context.Context
+		mgrCancel  context.CancelFunc
+		reconciler *countingReconciler
+		ns         = "default"
+	)
+
+	BeforeEach(func() {
+		var err error
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme: scheme.Scheme,
+			// Disable metrics + health endpoints so parallel test
+			// invocations do not collide on default ports.
+			Metrics:                metricsserver.Options{BindAddress: "0"},
+			HealthProbeBindAddress: "0",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler = &countingReconciler{
+			Client: mgr.GetClient(),
+			seen:   make(chan reconcile.Request, 32),
+			name:   fmt.Sprintf("mcpserver-secret-watch-test-%d", watchTestCounter.Add(1)),
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+
+		mgrCtx, mgrCancel = context.WithCancel(context.Background())
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+
+		Expect(mgr.GetCache().WaitForCacheSync(mgrCtx)).To(BeTrue())
+	})
+
+	AfterEach(func() {
+		mgrCancel()
+	})
+
+	It("enqueues a reconcile when a labelled token Secret is patched", func() {
+		const mcpName = "mcp-watch-labelled"
+		const secretName = "mcp-watch-labelled-secret"
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+				Labels:    map[string]string{labels.MCPTokenSecretLabel: "true"},
+			},
+			Data: map[string][]byte{"access_token": []byte("v1")},
+		}
+		Expect(k8sClient.Create(mgrCtx, secret)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), secret) })
+
+		mcp := &arkv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: mcpName, Namespace: ns},
+			Spec: arkv1alpha1.MCPServerSpec{
+				Address:   arkv1alpha1.ValueSource{Value: "http://example.invalid/mcp"},
+				Transport: "http",
+				Authorization: &arkv1alpha1.MCPServerAuthorizationSpec{
+					TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: secretName},
+				},
+			},
+		}
+		Expect(k8sClient.Create(mgrCtx, mcp)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), mcp) })
+
+		// Wait for the create-driven reconcile to flush, then snapshot.
+		Eventually(func() int32 { return reconciler.requests.Load() }, 5*time.Second, 50*time.Millisecond).Should(BeNumerically(">=", 1))
+		drainSeen(reconciler.seen)
+		baseline := reconciler.requests.Load()
+
+		// Patch the Secret — labelled, so the watch must fire.
+		patch := client.MergeFrom(secret.DeepCopy())
+		secret.Data["access_token"] = []byte("v2")
+		Expect(k8sClient.Patch(mgrCtx, secret, patch)).To(Succeed())
+
+		Eventually(func() int32 { return reconciler.requests.Load() }, 5*time.Second, 50*time.Millisecond).Should(BeNumerically(">", baseline))
+
+		// Confirm one of the new reconciles targets our MCPServer.
+		Eventually(reconciler.seen, 5*time.Second, 50*time.Millisecond).Should(Receive(Equal(reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: mcpName, Namespace: ns},
+		})))
+	})
+
+	It("does NOT enqueue an event-driven reconcile when an unlabelled token Secret is patched", func() {
+		const mcpName = "mcp-watch-unlabelled"
+		const secretName = "mcp-watch-unlabelled-secret"
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+			Data:       map[string][]byte{"access_token": []byte("v1")},
+		}
+		Expect(k8sClient.Create(mgrCtx, secret)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), secret) })
+
+		mcp := &arkv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: mcpName, Namespace: ns},
+			Spec: arkv1alpha1.MCPServerSpec{
+				Address:   arkv1alpha1.ValueSource{Value: "http://example.invalid/mcp"},
+				Transport: "http",
+				Authorization: &arkv1alpha1.MCPServerAuthorizationSpec{
+					TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: secretName},
+				},
+			},
+		}
+		Expect(k8sClient.Create(mgrCtx, mcp)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), mcp) })
+
+		Eventually(func() int32 { return reconciler.requests.Load() }, 5*time.Second, 50*time.Millisecond).Should(BeNumerically(">=", 1))
+		drainSeen(reconciler.seen)
+		baseline := reconciler.requests.Load()
+
+		patch := client.MergeFrom(secret.DeepCopy())
+		secret.Data["access_token"] = []byte("v2")
+		Expect(k8sClient.Patch(mgrCtx, secret, patch)).To(Succeed())
+
+		// No label → predicate filters the event before the map func
+		// runs, so the counter must NOT increase within the window.
+		Consistently(func() int32 { return reconciler.requests.Load() }, 2*time.Second, 50*time.Millisecond).Should(Equal(baseline))
+	})
+
+	It("enqueues a reconcile for every MCPServer referencing the same labelled Secret", func() {
+		const secretName = "mcp-watch-shared-secret"
+		const mcpA = "mcp-watch-shared-a"
+		const mcpB = "mcp-watch-shared-b"
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+				Labels:    map[string]string{labels.MCPTokenSecretLabel: "true"},
+			},
+			Data: map[string][]byte{"access_token": []byte("v1")},
+		}
+		Expect(k8sClient.Create(mgrCtx, secret)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), secret) })
+
+		for _, name := range []string{mcpA, mcpB} {
+			mcp := &arkv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: arkv1alpha1.MCPServerSpec{
+					Address:   arkv1alpha1.ValueSource{Value: "http://example.invalid/mcp"},
+					Transport: "http",
+					Authorization: &arkv1alpha1.MCPServerAuthorizationSpec{
+						TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: secretName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(mgrCtx, mcp)).To(Succeed())
+			n := name
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(context.Background(), &arkv1alpha1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: ns},
+				})
+			})
+		}
+
+		Eventually(func() int32 { return reconciler.requests.Load() }, 5*time.Second, 50*time.Millisecond).Should(BeNumerically(">=", 2))
+		drainSeen(reconciler.seen)
+
+		patch := client.MergeFrom(secret.DeepCopy())
+		secret.Data["access_token"] = []byte("v2")
+		Expect(k8sClient.Patch(mgrCtx, secret, patch)).To(Succeed())
+
+		seenNames := map[string]bool{}
+		Eventually(func() map[string]bool {
+			for {
+				select {
+				case req := <-reconciler.seen:
+					seenNames[req.Name] = true
+				default:
+					return seenNames
+				}
+			}
+		}, 5*time.Second, 50*time.Millisecond).Should(And(HaveKey(mcpA), HaveKey(mcpB)))
+	})
+})

--- a/ark/internal/labels/labels.go
+++ b/ark/internal/labels/labels.go
@@ -5,4 +5,6 @@ package labels
 const (
 	MCPServerLabel = "mcp/server"
 	A2AServerLabel = "a2a/server"
+
+	MCPTokenSecretLabel = "ark.mckinsey.com/mcp-token-secret"
 )

--- a/ark/internal/resolution/mcp_auth.go
+++ b/ark/internal/resolution/mcp_auth.go
@@ -1,0 +1,65 @@
+/* Copyright 2025. McKinsey & Company */
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+// DefaultAccessTokenKey is the Secret key the controller and dispatch
+// paths read for the OAuth access token when the user has not overridden
+// spec.authorization.tokenSecretRef.accessTokenKey. It must stay aligned
+// with the same default in the controller and the ark-sdk Python resolver
+// so an MCPServer authored against any one of them works with all three.
+const DefaultAccessTokenKey = "access_token"
+
+// ResolveBearerToken returns the OAuth access token referenced by
+// mcpServer.Spec.Authorization.TokenSecretRef, or "" when authorization
+// is unset, the Secret is missing, or the configured key has no value.
+//
+// It is intentionally event-free — the MCPServerReconciler owns the
+// "Secret missing / key absent" Warning surface for human-facing
+// observability. This helper exists so dispatch-time MCP client
+// construction in the built-in completions executor (and any future
+// in-cluster path) shares the same Secret-read semantics as reconcile.
+//
+// Returns a non-nil error only for genuine API server failures; a
+// missing Secret is treated as "no token yet, fall through to the
+// existing 401 / discovery path".
+func ResolveBearerToken(ctx context.Context, k8sClient client.Client, mcpServer *arkv1alpha1.MCPServer) (string, error) {
+	if mcpServer == nil || mcpServer.Spec.Authorization == nil {
+		return "", nil
+	}
+
+	ref := mcpServer.Spec.Authorization.TokenSecretRef
+	if ref.Name == "" {
+		return "", nil
+	}
+
+	secret := &corev1.Secret{}
+	nn := types.NamespacedName{Name: ref.Name, Namespace: mcpServer.Namespace}
+	if err := k8sClient.Get(ctx, nn, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read authorization secret %s: %w", ref.Name, err)
+	}
+
+	key := ref.AccessTokenKey
+	if key == "" {
+		key = DefaultAccessTokenKey
+	}
+	raw, ok := secret.Data[key]
+	if !ok || len(raw) == 0 {
+		return "", nil
+	}
+	return string(raw), nil
+}

--- a/ark/internal/resolution/mcp_auth_test.go
+++ b/ark/internal/resolution/mcp_auth_test.go
@@ -1,0 +1,102 @@
+/* Copyright 2025. McKinsey & Company */
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func newAuthScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, arkv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestResolveBearerToken(t *testing.T) {
+	ctx := context.Background()
+
+	// Helper to build an MCPServer with the given Authorization spec.
+	mkServer := func(auth *arkv1alpha1.MCPServerAuthorizationSpec) *arkv1alpha1.MCPServer {
+		return &arkv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "srv", Namespace: "default"},
+			Spec: arkv1alpha1.MCPServerSpec{
+				Address:       arkv1alpha1.ValueSource{Value: "http://example/mcp"},
+				Authorization: auth,
+			},
+		}
+	}
+
+	t.Run("nil authorization returns empty without API call", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(newAuthScheme(t)).Build()
+		token, err := ResolveBearerToken(ctx, c, mkServer(nil))
+		require.NoError(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("missing secret returns empty for fall-through to 401 path", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(newAuthScheme(t)).Build()
+		srv := mkServer(&arkv1alpha1.MCPServerAuthorizationSpec{
+			TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: "missing"},
+		})
+		token, err := ResolveBearerToken(ctx, c, srv)
+		require.NoError(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("default access_token key is read", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+			Data:       map[string][]byte{"access_token": []byte("abc123")},
+		}
+		c := fake.NewClientBuilder().WithScheme(newAuthScheme(t)).WithObjects(secret).Build()
+		srv := mkServer(&arkv1alpha1.MCPServerAuthorizationSpec{
+			TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: "s"},
+		})
+		token, err := ResolveBearerToken(ctx, c, srv)
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", token)
+	})
+
+	t.Run("custom accessTokenKey override is honoured", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+			Data:       map[string][]byte{"MY_TOKEN": []byte("override-value")},
+		}
+		c := fake.NewClientBuilder().WithScheme(newAuthScheme(t)).WithObjects(secret).Build()
+		srv := mkServer(&arkv1alpha1.MCPServerAuthorizationSpec{
+			TokenSecretRef: arkv1alpha1.TokenSecretReference{
+				Name:           "s",
+				AccessTokenKey: "MY_TOKEN",
+			},
+		})
+		token, err := ResolveBearerToken(ctx, c, srv)
+		require.NoError(t, err)
+		assert.Equal(t, "override-value", token)
+	})
+
+	t.Run("empty access_token value returns empty (shell secret state)", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+			Data:       map[string][]byte{"access_token": {}},
+		}
+		c := fake.NewClientBuilder().WithScheme(newAuthScheme(t)).WithObjects(secret).Build()
+		srv := mkServer(&arkv1alpha1.MCPServerAuthorizationSpec{
+			TokenSecretRef: arkv1alpha1.TokenSecretReference{Name: "s"},
+		})
+		token, err := ResolveBearerToken(ctx, c, srv)
+		require.NoError(t, err)
+		assert.Empty(t, token)
+	})
+}

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py
@@ -299,6 +299,49 @@ def _resolve_parameters(
     return resolved
 
 
+DEFAULT_ACCESS_TOKEN_KEY = "access_token"
+
+
+async def _resolve_bearer_token(spec: Any, namespace: str) -> str:
+    """Read spec.authorization.tokenSecretRef and return the access token.
+
+    Mirrors the Go helper in ark/internal/resolution/mcp_auth.go so the
+    reconciler, the built-in completions executor, and named execution
+    engines all derive the same Bearer header from the same Secret keys.
+    Returns "" when spec.authorization is unset, the Secret is missing,
+    or the configured key has no value — the caller treats this as
+    "no Bearer to inject; let the existing 401 / discovery path run".
+    """
+    auth = getattr(spec, "authorization", None)
+    if auth is None:
+        return ""
+    ref = getattr(auth, "token_secret_ref", None) or getattr(auth, "tokenSecretRef", None)
+    if ref is None:
+        return ""
+    secret_name = _get_attr_or_key(ref, "name")
+    if not secret_name:
+        return ""
+    key = (
+        _get_attr_or_key(ref, "accessTokenKey")
+        or _get_attr_or_key(ref, "access_token_key")
+        or DEFAULT_ACCESS_TOKEN_KEY
+    )
+    try:
+        sc = SecretClient(namespace=namespace)
+        result = await sc.get_secret_value(secret_name, key)
+    except Exception as e:
+        logger.warning(f"Failed to resolve authorization secret {secret_name}/{key}: {e}")
+        return ""
+    raw = result.get("value") if isinstance(result, dict) else None
+    if not raw:
+        return ""
+    try:
+        return base64.b64decode(raw).decode("utf-8")
+    except Exception as e:
+        logger.warning(f"Failed to decode authorization secret {secret_name}/{key}: {e}")
+        return ""
+
+
 async def _resolve_mcp_server(ark: Any, server_name: str, namespace: str) -> Optional[MCPServerConfig]:
     server_namespace = namespace
     try:
@@ -322,6 +365,14 @@ async def _resolve_mcp_server(ark: Any, server_name: str, namespace: str) -> Opt
                 resolved = await _resolve_value_source(header_value_source, server_namespace)
                 if resolved:
                     headers[header_name] = resolved
+
+    # spec.headers is the user's escape hatch; if they have already
+    # set Authorization explicitly, leave it alone and skip the
+    # tokenSecretRef read entirely.
+    if "Authorization" not in headers:
+        token = await _resolve_bearer_token(spec, server_namespace)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
 
     transport = getattr(spec, "transport", "http") or "http"
     timeout = getattr(spec, "timeout", "30s") or "30s"

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py
@@ -11,6 +11,8 @@ from ark_sdk.extensions.query import (
     QueryRef,
     extract_query_ref,
     resolve_query,
+    _resolve_bearer_token,
+    _resolve_mcp_server,
     _resolve_value_source,
 )
 
@@ -736,6 +738,163 @@ class TestExtensionConstants(unittest.TestCase):
     def test_metadata_key_derived_from_uri(self):
         self.assertTrue(QUERY_EXTENSION_METADATA_KEY.startswith(QUERY_EXTENSION_URI))
         self.assertTrue(QUERY_EXTENSION_METADATA_KEY.endswith("/ref"))
+
+
+class TestResolveBearerToken(unittest.IsolatedAsyncioTestCase):
+    """Mirrors ark/internal/resolution/mcp_auth_test.go scenarios so the Go
+    reconciler and the Python resolver stay in lock-step on key resolution."""
+
+    async def test_returns_empty_when_authorization_unset(self):
+        spec = SimpleNamespace(authorization=None)
+        # Should not touch SecretClient at all.
+        with patch("ark_sdk.extensions.query.SecretClient") as mock_secret_cls:
+            result = await _resolve_bearer_token(spec, "default")
+        self.assertEqual(result, "")
+        mock_secret_cls.assert_not_called()
+
+    async def test_returns_empty_when_token_secret_ref_missing(self):
+        auth = SimpleNamespace(token_secret_ref=None, tokenSecretRef=None)
+        spec = SimpleNamespace(authorization=auth)
+        with patch("ark_sdk.extensions.query.SecretClient") as mock_secret_cls:
+            result = await _resolve_bearer_token(spec, "default")
+        self.assertEqual(result, "")
+        mock_secret_cls.assert_not_called()
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_returns_token_for_default_access_token_key(self, mock_secret_cls):
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(
+            return_value={"value": base64.b64encode(b"oauth-token-1").decode()}
+        )
+        mock_secret_cls.return_value = mock_sc
+
+        token_ref = SimpleNamespace(name="notion-oauth", accessTokenKey=None)
+        auth = SimpleNamespace(token_secret_ref=token_ref)
+        spec = SimpleNamespace(authorization=auth)
+
+        token = await _resolve_bearer_token(spec, "default")
+
+        self.assertEqual(token, "oauth-token-1")
+        mock_secret_cls.assert_called_with(namespace="default")
+        mock_sc.get_secret_value.assert_awaited_with("notion-oauth", "access_token")
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_honours_custom_access_token_key(self, mock_secret_cls):
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(
+            return_value={"value": base64.b64encode(b"custom-token").decode()}
+        )
+        mock_secret_cls.return_value = mock_sc
+
+        token_ref = SimpleNamespace(name="my-secret", accessTokenKey="MY_TOKEN")
+        auth = SimpleNamespace(token_secret_ref=token_ref)
+        spec = SimpleNamespace(authorization=auth)
+
+        token = await _resolve_bearer_token(spec, "ns1")
+
+        self.assertEqual(token, "custom-token")
+        mock_sc.get_secret_value.assert_awaited_with("my-secret", "MY_TOKEN")
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_returns_empty_when_secret_missing(self, mock_secret_cls):
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(side_effect=Exception("not found"))
+        mock_secret_cls.return_value = mock_sc
+
+        token_ref = SimpleNamespace(name="missing", accessTokenKey=None)
+        auth = SimpleNamespace(token_secret_ref=token_ref)
+        spec = SimpleNamespace(authorization=auth)
+
+        token = await _resolve_bearer_token(spec, "default")
+        self.assertEqual(token, "")
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_returns_empty_when_access_token_value_empty(self, mock_secret_cls):
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(return_value={"value": ""})
+        mock_secret_cls.return_value = mock_sc
+
+        token_ref = SimpleNamespace(name="empty", accessTokenKey=None)
+        auth = SimpleNamespace(token_secret_ref=token_ref)
+        spec = SimpleNamespace(authorization=auth)
+
+        token = await _resolve_bearer_token(spec, "default")
+        self.assertEqual(token, "")
+
+
+class TestResolveMcpServerBearerInjection(unittest.IsolatedAsyncioTestCase):
+    """The resolver-side counterpart to the Go controller bearer injection
+    in ark/internal/controller/mcpserver_controller.go — the resolved
+    MCPServerConfig.headers must carry Authorization when the MCPServer is
+    Authorized, and must defer to spec.headers Authorization when the
+    operator pinned a literal value."""
+
+    def _mcp_crd(self, *, with_auth=True, headers=None):
+        spec = SimpleNamespace()
+        spec.address = SimpleNamespace(value="http://example.invalid/mcp", value_from=None, valueFrom=None)
+        spec.transport = "http"
+        spec.timeout = "30s"
+        spec.headers = headers
+        if with_auth:
+            spec.authorization = SimpleNamespace(
+                token_secret_ref=SimpleNamespace(name="notion-oauth", accessTokenKey=None),
+            )
+        else:
+            spec.authorization = None
+        crd = MagicMock()
+        crd.spec = spec
+        return crd
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_authorized_mcp_server_injects_bearer(self, mock_secret_cls):
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(
+            return_value={"value": base64.b64encode(b"abc123").decode()}
+        )
+        mock_secret_cls.return_value = mock_sc
+
+        mock_ark = AsyncMock()
+        mock_ark.mcpservers.a_get = AsyncMock(return_value=self._mcp_crd())
+
+        cfg = await _resolve_mcp_server(mock_ark, "notion", "default")
+
+        self.assertIsNotNone(cfg)
+        self.assertEqual(cfg.headers.get("Authorization"), "Bearer abc123")
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_spec_headers_authorization_wins_over_token_secret_ref(self, mock_secret_cls):
+        # If the secret read happens at all the test silently fails;
+        # use a side_effect that would corrupt the result so we'd notice.
+        mock_sc = AsyncMock()
+        mock_sc.get_secret_value = AsyncMock(
+            return_value={"value": base64.b64encode(b"should-not-win").decode()}
+        )
+        mock_secret_cls.return_value = mock_sc
+
+        explicit_header = SimpleNamespace(
+            name="Authorization",
+            value=SimpleNamespace(value="Bearer pinned-by-operator", value_from=None, valueFrom=None),
+        )
+
+        mock_ark = AsyncMock()
+        mock_ark.mcpservers.a_get = AsyncMock(
+            return_value=self._mcp_crd(headers=[explicit_header])
+        )
+
+        cfg = await _resolve_mcp_server(mock_ark, "notion", "default")
+
+        self.assertEqual(cfg.headers.get("Authorization"), "Bearer pinned-by-operator")
+
+    @patch("ark_sdk.extensions.query.SecretClient")
+    async def test_no_authorization_means_no_bearer(self, mock_secret_cls):
+        mock_ark = AsyncMock()
+        mock_ark.mcpservers.a_get = AsyncMock(return_value=self._mcp_crd(with_auth=False))
+
+        cfg = await _resolve_mcp_server(mock_ark, "notion", "default")
+
+        self.assertIsNotNone(cfg)
+        self.assertNotIn("Authorization", cfg.headers)
+        mock_secret_cls.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/proposal.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Stage 1 (`mcp-auth-token-injection`) reads tokens from a Secret and reaches `Authorized`, but leaves token *production* to the operator. Today that means: discover OAuth metadata, register a dynamic client, drive PKCE through a browser, exchange the code, then `kubectl create secret` with the right keys. Miss a step and the controller stays in `Required` with no useful surface.
+
+This change adds `ark mcp auth login <server-name>` — one command that reads the discovered endpoints from `status.authorization`, runs RFC 7591 + RFC 7636 (DCR + PKCE on a loopback redirect), and writes the resulting tokens to the exact Secret the controller is polling. The controller transitions `Required → Authorized` on its next reconcile.
+
+It also adds `ark mcp auth logout <server-name>`. Today operators recover from connecting to the wrong server or upstream token revocation by hand-editing the Secret with `kubectl edit secret`; `logout` makes that a one-liner.
+
+The CLI is a UX layer over the existing Stage 1 contract. No CRD, controller, or RBAC changes.
+
+## What Changes
+
+- Add `ark mcp auth login <server-name>` to `ark-cli`. Behaviour:
+  - Reads the target `MCPServer` via `kubectl`. Refuses to run unless `status.authorization.state == Required`. Override with `--force`.
+  - Reads `status.authorization.{registrationEndpoint, authorizationEndpoint, tokenEndpoint, resource, scopesSupported}` populated by detection.
+  - Picks a free loopback port (or `--port <n>`) and starts an `http://127.0.0.1:<port>/callback` listener. Auto-opens the browser unless `--no-open`. The authorization URL is always printed to stdout so headless / SSH operators can paste it manually.
+  - Performs RFC 7591 Dynamic Client Registration with `redirect_uris=[<loopback>]`, `grant_types=[authorization_code, refresh_token]`, `response_types=[code]`, `token_endpoint_auth_method=client_secret_basic`. Rejects responses whose `redirect_uris` exclude the loopback URL.
+  - Builds the authorization URL with PKCE S256, random `state`, and `resource=<MCP URL>` (RFC 8707). Waits up to `--timeout <ms>` (default 5 minutes).
+  - Exchanges the code at `tokenEndpoint` using HTTP Basic with the registered `client_id` / `client_secret` plus the PKCE verifier.
+  - Patches the Secret named in `spec.authorization.tokenSecretRef.name` using the configured key names (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). Creates the Secret if absent.
+  - Computes `expires_at = now + expires_in - 30s` (RFC 3339 UTC) — the 30s margin absorbs clock skew between the CLI host, the IdP, and the controller, plus typical network round-trip on the next reconcile.
+  - Prints the resource URL, `expires_at`, and the expected `Required → Authorized` next transition. Exits non-zero on failure with one `output.error("mcp auth failed:", <message>)` line.
+- Add `ark mcp auth logout <server-name>` to `ark-cli`. Behaviour:
+  - Default: kubectl-patches the Secret named in `spec.authorization.tokenSecretRef.name`, setting `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret` to empty strings. Honours `*Key` overrides on `tokenSecretRef`.
+  - `--keep-client`: only empties `access_token`, `refresh_token`, `expires_at`. Preserves `client_id` / `client_secret` so a subsequent `login` re-uses the registered OAuth client without a fresh DCR.
+  - `--delete-secret`: deletes the Secret resource entirely instead of patching empties.
+  - `--keep-client` and `--delete-secret` are mutually exclusive.
+  - Idempotent on missing Secret (no-op, exit zero). Missing MCPServer → exit non-zero.
+  - On the controller's next reconcile, the empty `access_token` falls through the existing 401 path and `status.authorization.state` collapses to `Required` — ready for `ark mcp auth login`.
+- Wire the commands into `tools/ark-cli/src/index.tsx`.
+- Ship `pkce.ts` (S256 verifier/challenge + state) plus unit tests and an end-to-end `runAuth` test mocking the OAuth endpoints and `kubectl`.
+
+## Capabilities
+
+### New Capabilities
+
+- `ark-cli-mcp-auth`: `ark mcp auth login <server-name>` drives DCR + PKCE + loopback callback against an `MCPServer`'s discovered endpoints and patches the controller-referenced Secret. `ark mcp auth logout <server-name>` empties (or deletes) the same Secret to return the server to `Required`.
+
+### Modified Capabilities
+
+None. Consumes `mcp-auth-detection` (`status.authorization.*`) and `mcp-auth-token-injection` (`spec.authorization.tokenSecretRef`) unchanged (see `openspec/specs/mcp-auth-detection/` and `openspec/specs/mcp-auth-token-injection/`).
+
+## Impact
+
+- **Scope:** `tools/ark-cli/` only. No controller, CRD, RBAC, or Helm changes.
+- **New runtime deps:** none. `execa` and `open` already in `tools/ark-cli/package.json`.
+- **User-facing:** new command replaces the operator runbook. Stage 1 manual path still works.
+- **Security:** tokens written via the user's kubeconfig RBAC. CLI never persists tokens to disk, never logs them.
+
+## Non-Goals
+
+- Token refresh — Stage 2 (`mcp-auth-token-refresh`). Re-run `ark mcp auth login` until then.
+- Validating webhook for `spec.headers[Authorization]` vs `spec.authorization` clash — Stage 2.
+- Chainsaw e2e — blocked on TLS-capable in-cluster mock MCP.
+- Non-loopback / device-code flows — loopback covers every interactive MCP host today.

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/proposal.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/proposal.md
@@ -15,7 +15,7 @@ The CLI is a UX layer over the existing Stage 1 contract. No CRD, controller, or
   - Reads `status.authorization.{registrationEndpoint, authorizationEndpoint, tokenEndpoint, resource, scopesSupported}` populated by detection.
   - Picks a free loopback port (or `--port <n>`) and starts an `http://127.0.0.1:<port>/callback` listener. Auto-opens the browser unless `--no-open`. The authorization URL is always printed to stdout so headless / SSH operators can paste it manually.
   - Performs RFC 7591 Dynamic Client Registration with `redirect_uris=[<loopback>]`, `grant_types=[authorization_code, refresh_token]`, `response_types=[code]`, `token_endpoint_auth_method=client_secret_basic`. Rejects responses whose `redirect_uris` exclude the loopback URL.
-  - Builds the authorization URL with PKCE S256, random `state`, and `resource=<MCP URL>` (RFC 8707). Waits up to `--timeout <ms>` (default 5 minutes).
+  - Builds the authorization URL with PKCE S256, random `state`, and `resource=<MCP URL>` (RFC 8707). Waits up to `--timeout <duration>` (default 5 minutes).
   - Exchanges the code at `tokenEndpoint` using HTTP Basic with the registered `client_id` / `client_secret` plus the PKCE verifier.
   - Patches the Secret named in `spec.authorization.tokenSecretRef.name` using the configured key names (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). Creates the Secret if absent.
   - Computes `expires_at = now + expires_in - 30s` (RFC 3339 UTC) — the 30s margin absorbs clock skew between the CLI host, the IdP, and the controller, plus typical network round-trip on the next reconcile.
@@ -29,6 +29,19 @@ The CLI is a UX layer over the existing Stage 1 contract. No CRD, controller, or
   - On the controller's next reconcile, the empty `access_token` falls through the existing 401 path and `status.authorization.state` collapses to `Required` — ready for `ark mcp auth login`.
 - Wire the commands into `tools/ark-cli/src/index.tsx`.
 - Ship `pkce.ts` (S256 verifier/challenge + state) plus unit tests and an end-to-end `runAuth` test mocking the OAuth endpoints and `kubectl`.
+
+### Headless / SSH operators
+
+OAuth 2.1 loopback redirect (RFC 8252 §7.3) requires `127.0.0.1` / `[::1]` — authorization servers reject other hostnames. For a CLI session on a remote host:
+
+```sh
+# on the laptop
+ssh -L 8080:localhost:8080 jumphost
+# on the jumphost
+ark mcp auth login notion --port 8080 --no-open
+```
+
+The CLI prints the authorization URL with `http://127.0.0.1:8080/callback`. Paste it into the browser on the laptop — SSH forwards the loopback callback back to the jumphost. Loopback stays loopback. The proper headless flow (RFC 8628 device authorization grant) is out of scope; most MCP authorization servers do not support it yet.
 
 ## Capabilities
 

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/specs/ark-cli-mcp-auth/spec.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/specs/ark-cli-mcp-auth/spec.md
@@ -1,0 +1,243 @@
+## ADDED Requirements
+
+### Requirement: ark-cli exposes `mcp auth login` and `mcp auth logout` subcommands
+
+The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <ms>`; `--port` and `--timeout` SHALL reject non-integer or negative values.
+
+#### Scenario: User runs ark mcp auth login against a Required MCPServer
+
+- **GIVEN** an `MCPServer` named `notion` whose `status.authorization.state` is `Required`
+- **WHEN** the user runs `ark mcp auth login notion`
+- **THEN** the CLI SHALL drive DCR + PKCE + loopback callback + token exchange and patch the Secret named in `spec.authorization.tokenSecretRef`
+
+#### Scenario: User passes an unparseable port
+
+- **WHEN** the user runs `ark mcp auth login notion --port abc`
+- **THEN** the CLI SHALL exit non-zero with a message naming `--port` and the offending value
+
+### Requirement: Pre-flight refuses non-Required state without --force
+
+The command SHALL refuse to run unless `status.authorization.state` is `Required`. The user MAY override with `--force`.
+
+#### Scenario: MCPServer is already Authorized
+
+- **GIVEN** an `MCPServer` whose `status.authorization.state` is `Authorized`
+- **WHEN** the user runs `ark mcp auth login <name>` without `--force`
+- **THEN** the CLI SHALL exit non-zero and explain that the server is already authorized
+
+#### Scenario: User passes --force on an Authorized MCPServer
+
+- **WHEN** the user runs `ark mcp auth login <name> --force`
+- **THEN** the CLI SHALL run the full flow regardless of state
+
+### Requirement: Namespace resolution prefers explicit flag, then context, then default
+
+The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl` context namespace, else `default`.
+
+#### Scenario: User passes --namespace explicitly
+
+- **WHEN** the user runs `ark mcp auth login <name> --namespace tenant-a`
+- **THEN** the CLI SHALL use `tenant-a` for every kubectl call
+
+#### Scenario: kubectl context has no namespace
+
+- **GIVEN** the active `kubectl` context has no namespace configured
+- **WHEN** the user omits `--namespace`
+- **THEN** the CLI SHALL use `default`
+
+### Requirement: PKCE primitives meet RFC 7636 S256
+
+The CLI SHALL generate a PKCE code verifier of 43-128 unreserved characters and an S256-derived challenge, plus a cryptographically random opaque `state`.
+
+#### Scenario: Verifier and challenge are derived correctly
+
+- **WHEN** `generatePkcePair()` is invoked
+- **THEN** the verifier SHALL contain only `[A-Za-z0-9-._~]`, SHALL be 43-128 chars, and the challenge SHALL equal `BASE64URL(SHA-256(verifier))`
+
+#### Scenario: Default lengths balance entropy and compatibility
+
+- **WHEN** `generatePkcePair()` and `generateState()` are invoked with no overrides
+- **THEN** the verifier SHALL be 64 characters from the unreserved set
+- **AND** the `state` SHALL be at least 128 bits (16 bytes) of cryptographically secure random data, base64url-encoded
+
+### Requirement: Loopback callback listener handles success and error cases
+
+The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`.
+
+#### Scenario: Authorization server redirects with code and state
+
+- **WHEN** the browser is redirected to `/callback?code=abc&state=<our-state>`
+- **THEN** the listener SHALL respond 200 and surface `(code, state)` to the flow
+
+#### Scenario: Authorization server redirects with error
+
+- **WHEN** the browser is redirected to `/callback?error=access_denied`
+- **THEN** the listener SHALL respond 400 and the CLI SHALL exit non-zero with the OAuth `error` value in the message
+
+#### Scenario: Callback never arrives within --timeout
+
+- **GIVEN** `--timeout 60000`
+- **WHEN** no callback is received within 60 seconds
+- **THEN** the CLI SHALL exit non-zero with a timeout message naming the elapsed budget
+
+#### Scenario: User-supplied --port is already bound
+
+- **GIVEN** the user runs `ark mcp auth login <name> --port 8080`
+- **AND** port 8080 is already in use on the loopback interface
+- **THEN** the CLI SHALL exit non-zero with an error message naming the port and suggesting the user omit `--port` to let the OS pick a free port
+- **AND** SHALL NOT silently fall back to auto-selection
+
+### Requirement: Dynamic Client Registration enforces the loopback redirect URI
+
+The CLI SHALL POST to `status.authorization.registrationEndpoint` with `client_name=ark mcp auth`, `redirect_uris=[<loopback>]`, `grant_types=["authorization_code","refresh_token"]`, `response_types=["code"]`, and `token_endpoint_auth_method=client_secret_basic`. If the registration response includes `redirect_uris` and the loopback URI is absent, the CLI SHALL reject the registration and exit non-zero before continuing.
+
+#### Scenario: Registration endpoint omits the loopback URI
+
+- **GIVEN** the registration endpoint returns a `redirect_uris` array that does not include the loopback URL
+- **THEN** the CLI SHALL exit non-zero with an error naming the offending response
+
+#### Scenario: Registration response omits redirect_uris entirely
+
+- **GIVEN** the registration response does not include `redirect_uris` at all
+- **THEN** the CLI SHALL exit non-zero with the same loopback-enforcement error — fail-closed since we cannot confirm the loopback URL was registered
+
+### Requirement: DCR response uses a supported token_endpoint_auth_method
+
+The CLI registers with `token_endpoint_auth_method: client_secret_basic`. If the registration response advertises a different `token_endpoint_auth_method` that is neither `client_secret_basic` nor `none`, the CLI SHALL exit non-zero with an error naming the unsupported method.
+
+#### Scenario: Registration endpoint returns token_endpoint_auth_method=client_secret_post
+
+- **GIVEN** the registration response sets `token_endpoint_auth_method: "client_secret_post"`
+- **THEN** the CLI SHALL exit non-zero with an error naming the unsupported method
+
+### Requirement: Authorization request includes PKCE S256 and resource indicator
+
+The CLI SHALL build the authorization URL with `response_type=code`, `client_id`, `redirect_uri=<loopback>`, generated `state`, S256 `code_challenge` and `code_challenge_method=S256`, and `resource=<MCP URL>` per RFC 8707. `scope` SHALL be included only when supplied.
+
+#### Scenario: Authorization URL is constructed for an MCP at https://mcp.example/mcp
+
+- **WHEN** the CLI builds the authorization URL for an MCP whose discovered resource is `https://mcp.example/mcp`
+- **THEN** the URL SHALL include `code_challenge_method=S256`, the matching `code_challenge`, and `resource=https%3A%2F%2Fmcp.example%2Fmcp`
+
+### Requirement: State parameter is verified before token exchange
+
+The CLI SHALL refuse to exchange a code unless the returned `state` exactly matches the value the CLI generated.
+
+#### Scenario: Callback returns a tampered state
+
+- **WHEN** `/callback` arrives with a `state` value the CLI did not generate
+- **THEN** the CLI SHALL exit non-zero before posting to the token endpoint
+
+### Requirement: Token exchange uses HTTP Basic auth and PKCE verifier
+
+The CLI SHALL POST to `status.authorization.tokenEndpoint` with `grant_type=authorization_code`, `code`, `redirect_uri=<loopback>`, `code_verifier`, and `resource=<MCP URL>`, authenticating via HTTP Basic with the registered `client_id` / `client_secret`. On non-2xx the CLI SHALL surface the OAuth error verbatim.
+
+#### Scenario: Token endpoint returns 400 invalid_grant
+
+- **WHEN** the token endpoint returns `{"error":"invalid_grant"}` with HTTP 400
+- **THEN** the CLI SHALL exit non-zero and the error message SHALL include `invalid_grant`
+
+### Requirement: Tokens are written to the Secret using the configured key names
+
+The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch.
+
+#### Scenario: Token response carries access, refresh, and expires_in
+
+- **GIVEN** the token endpoint returns `{access_token, refresh_token, expires_in: 3600}`
+- **THEN** the patched Secret SHALL contain `access_token`, `refresh_token`, `expires_at` set to `now + 3600s - 30s` (RFC 3339 UTC), `client_id`, and `client_secret`
+
+#### Scenario: Token response omits refresh_token
+
+- **GIVEN** the token endpoint returns no `refresh_token`
+- **THEN** the patched Secret SHALL NOT contain a `refresh_token` key
+
+#### Scenario: User has overridden accessTokenKey on tokenSecretRef
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_ACCESS_TOKEN`
+- **WHEN** tokens are written
+- **THEN** the patched Secret SHALL store the access token under `MY_ACCESS_TOKEN`
+
+#### Scenario: Token response omits expires_in or sets it ≤ 0
+
+- **GIVEN** the token endpoint returns no `expires_in` (or `expires_in <= 0`)
+- **THEN** the patched Secret SHALL NOT contain an `expires_at` key
+- **AND** the CLI SHALL emit a single warning line indicating the token has no advertised lifetime
+
+### Requirement: Secrets and tokens never appear in logs
+
+The CLI SHALL never log access tokens, refresh tokens, client secrets, or `Authorization` headers. Diagnostic output SHALL be limited to: resource URL, chosen loopback port, registered `client_id`, computed `expires_at`, and high-level state transitions.
+
+#### Scenario: Successful run
+
+- **WHEN** `ark mcp auth login` succeeds
+- **THEN** stdout/stderr SHALL contain the resource URL and `expires_at` but SHALL NOT contain access or refresh token values
+
+### Requirement: Failures exit non-zero with a single error line
+
+Every failure path SHALL exit non-zero with one `output.error("mcp auth failed:", <message>)` line — never a raw stack trace.
+
+#### Scenario: Token exchange fails
+
+- **WHEN** the token endpoint returns 400
+- **THEN** the process SHALL exit non-zero and stderr SHALL contain exactly one `mcp auth failed:` line
+
+### Requirement: ark-cli exposes an `mcp auth logout` subcommand
+
+The CLI SHALL expose `ark mcp auth logout <server-name>` that empties (or deletes) the Secret named on `spec.authorization.tokenSecretRef`, returning the MCPServer to a state where `ark mcp auth login <server-name>` can run cleanly. The command SHALL accept `--namespace`, `--keep-client`, and `--delete-secret`. By default the CLI SHALL `kubectl patch` the Secret so `access_token`, `refresh_token`, `expires_at`, `client_id`, and `client_secret` (or their `*Key`-overridden names) all hold empty strings, leaving the Secret resource itself in place. `--keep-client` SHALL empty only `access_token`, `refresh_token`, and `expires_at`, preserving `client_id` and `client_secret` so a follow-up `login` re-uses the registered DCR client. `--delete-secret` SHALL `kubectl delete secret <name>` instead of patching. `--keep-client` and `--delete-secret` SHALL be mutually exclusive.
+
+#### Scenario: User logs out of an Authorized MCPServer
+
+- **GIVEN** an MCPServer whose state is `Authorized` and whose Secret carries all five token+client keys
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the patched Secret SHALL contain empty values for `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`
+
+#### Scenario: User passes --keep-client
+
+- **GIVEN** an Authorized MCPServer with all five keys populated
+- **WHEN** the user runs `ark mcp auth logout <name> --keep-client`
+- **THEN** the patched Secret SHALL contain empty `access_token`, `refresh_token`, `expires_at`
+- **AND** the patched Secret SHALL still contain the original `client_id` and `client_secret` values
+
+#### Scenario: User passes --delete-secret
+
+- **WHEN** the user runs `ark mcp auth logout <name> --delete-secret`
+- **THEN** the CLI SHALL `kubectl delete secret <referenced-name>` and exit zero
+
+#### Scenario: User passes both --keep-client and --delete-secret
+
+- **WHEN** the user runs `ark mcp auth logout <name> --keep-client --delete-secret`
+- **THEN** the CLI SHALL exit non-zero before contacting the cluster, naming the conflict between the two flags
+
+### Requirement: Logout honours overridden key names
+
+The CLI SHALL operate on the overridden key names from `spec.authorization.tokenSecretRef` rather than the defaults whenever any of `accessTokenKey`, `refreshTokenKey`, `expiresAtKey`, `clientIDKey`, or `clientSecretKey` is set. With `--keep-client`, the CLI SHALL empty only the overridden access-token, refresh-token, and expires-at keys.
+
+#### Scenario: tokenSecretRef has accessTokenKey override
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_ACCESS_TOKEN`
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the patched Secret SHALL have `MY_ACCESS_TOKEN` set to empty (and SHALL NOT add an `access_token` key)
+
+### Requirement: Logout is idempotent against a missing Secret
+
+When the referenced Secret does not exist, the CLI SHALL exit zero with a no-op message. When the MCPServer itself does not exist, the CLI SHALL exit non-zero.
+
+#### Scenario: Secret named in tokenSecretRef does not exist
+
+- **GIVEN** the MCPServer's Secret has been deleted out of band
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the CLI SHALL exit zero with a one-line message indicating no-op
+
+#### Scenario: MCPServer does not exist
+
+- **WHEN** the user runs `ark mcp auth logout does-not-exist`
+- **THEN** the CLI SHALL exit non-zero with an error
+
+### Requirement: Logout never logs token material
+
+The CLI SHALL never log access tokens, refresh tokens, client secrets, or `Authorization` headers during a logout run. Logout reads the Secret only to construct the patch payload; diagnostic output SHALL be limited to the Secret name, the keys cleared (or that the Secret was deleted), and a hint to re-run `ark mcp auth login <server-name>`.
+
+#### Scenario: Successful logout
+
+- **WHEN** `ark mcp auth logout <name>` succeeds against a populated Secret
+- **THEN** stdout/stderr SHALL name the cleared keys but SHALL NOT contain any token, refresh-token, or client-secret value

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/specs/ark-cli-mcp-auth/spec.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/specs/ark-cli-mcp-auth/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: ark-cli exposes `mcp auth login` and `mcp auth logout` subcommands
 
-The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <ms>`; `--port` and `--timeout` SHALL reject non-integer or negative values.
+The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <duration>`. `--port` SHALL reject non-integer or negative values. `--timeout` SHALL be a Go-duration string (e.g. `60s`, `5m`) and SHALL reject non-parseable or non-positive values. The default `--timeout` is `5m`.
 
 #### Scenario: User runs ark mcp auth login against a Required MCPServer
 
@@ -30,6 +30,14 @@ The command SHALL refuse to run unless `status.authorization.state` is `Required
 - **WHEN** the user runs `ark mcp auth login <name> --force`
 - **THEN** the CLI SHALL run the full flow regardless of state
 
+#### Scenario: --force fails mid-flow
+
+- **GIVEN** an MCPServer in state `Authorized` whose Secret carries valid tokens
+- **AND** the user runs `ark mcp auth login <name> --force`
+- **WHEN** any step of the OAuth flow fails (DCR rejected, callback timeout, token exchange 4xx, etc.)
+- **THEN** the CLI SHALL exit non-zero
+- **AND** the existing Secret SHALL be left unchanged — `--force` only bypasses the pre-flight `Required` guard, it never weakens the "Secret untouched on flow failure" invariant
+
 ### Requirement: Namespace resolution prefers explicit flag, then context, then default
 
 The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl` context namespace, else `default`.
@@ -37,6 +45,12 @@ The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl`
 #### Scenario: User passes --namespace explicitly
 
 - **WHEN** the user runs `ark mcp auth login <name> --namespace tenant-a`
+- **THEN** the CLI SHALL use `tenant-a` for every kubectl call
+
+#### Scenario: --namespace omitted, kubectl context has a namespace
+
+- **GIVEN** the active `kubectl` context has `namespace: tenant-a` configured
+- **WHEN** the user runs `ark mcp auth login <name>` with no `--namespace` flag
 - **THEN** the CLI SHALL use `tenant-a` for every kubectl call
 
 #### Scenario: kubectl context has no namespace
@@ -62,7 +76,7 @@ The CLI SHALL generate a PKCE code verifier of 43-128 unreserved characters and 
 
 ### Requirement: Loopback callback listener handles success and error cases
 
-The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`.
+The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`. The listener SHALL bind dual-stack so both `127.0.0.1:<port>` and `[::1]:<port>` accept callbacks. The authorization URL the CLI prints SHALL use `http://127.0.0.1:<port>/callback` (IPv4 form, broader AS compatibility); requests arriving via `[::1]` on the same port SHALL be handled identically.
 
 #### Scenario: Authorization server redirects with code and state
 
@@ -76,7 +90,7 @@ The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port
 
 #### Scenario: Callback never arrives within --timeout
 
-- **GIVEN** `--timeout 60000`
+- **GIVEN** `--timeout 60s`
 - **WHEN** no callback is received within 60 seconds
 - **THEN** the CLI SHALL exit non-zero with a timeout message naming the elapsed budget
 
@@ -86,6 +100,21 @@ The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port
 - **AND** port 8080 is already in use on the loopback interface
 - **THEN** the CLI SHALL exit non-zero with an error message naming the port and suggesting the user omit `--port` to let the OS pick a free port
 - **AND** SHALL NOT silently fall back to auto-selection
+
+#### Scenario: --no-open suppresses browser launch
+
+- **GIVEN** the user runs `ark mcp auth login <name> --no-open`
+- **THEN** the CLI SHALL print the full authorization URL to stdout
+- **AND** SHALL NOT spawn a browser process
+- **AND** SHALL continue waiting for the loopback callback in the normal way
+
+Note: this follows the CLI's `--no-X` convention — every boolean flag whose default is "yes, do X" supports a corresponding `--no-X` to opt out.
+
+#### Scenario: Callback arrives via the IPv6 loopback
+
+- **GIVEN** the listener is bound dual-stack
+- **WHEN** the browser is redirected and resolves loopback to `[::1]`
+- **THEN** the listener SHALL respond 200 and surface `(code, state)` to the flow identically to the IPv4 path
 
 ### Requirement: Dynamic Client Registration enforces the loopback redirect URI
 
@@ -139,7 +168,7 @@ The CLI SHALL POST to `status.authorization.tokenEndpoint` with `grant_type=auth
 
 ### Requirement: Tokens are written to the Secret using the configured key names
 
-The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch.
+The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch. When the CLI creates or patches the Secret, it SHALL also set the label `ark.mckinsey.com/mcp-token-secret: "true"` on the Secret. The label enables the controller's real-time Secret watch (see `mcp-auth-token-injection` capability); absence does not affect authentication correctness, only reconcile latency.
 
 #### Scenario: Token response carries access, refresh, and expires_in
 
@@ -162,6 +191,12 @@ The CLI SHALL write the token endpoint response into the Secret named in `spec.a
 - **GIVEN** the token endpoint returns no `expires_in` (or `expires_in <= 0`)
 - **THEN** the patched Secret SHALL NOT contain an `expires_at` key
 - **AND** the CLI SHALL emit a single warning line indicating the token has no advertised lifetime
+
+#### Scenario: Login stamps the mcp-token-secret label
+
+- **WHEN** `ark mcp auth login` writes tokens to the Secret (create or patch path)
+- **THEN** the resulting Secret SHALL carry the label `ark.mckinsey.com/mcp-token-secret: "true"`
+- **AND** removing or omitting the label SHALL NOT break authentication — only delays controller reconcile to the next `pollInterval` tick
 
 ### Requirement: Secrets and tokens never appear in logs
 

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/tasks.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/tasks.md
@@ -1,0 +1,60 @@
+## 1. CLI command surface
+
+- [ ] 1.1 Register `ark mcp` parent command in `tools/ark-cli/src/index.tsx`
+- [ ] 1.2 Register `ark mcp auth` parent command with `login` and `logout` subcommands
+- [ ] 1.3 Add `ark mcp auth login <server-name>` subcommand with `--namespace`, `--force`, `--port`, `--no-open`, `--timeout`
+- [ ] 1.4 Validate `--port` and `--timeout` parse as non-negative integers; clear error otherwise
+
+## 2. Resource resolution
+
+- [ ] 2.1 Resolve namespace: `--namespace` → current `kubectl` context → `default`
+- [ ] 2.2 `kubectl get mcpserver <name> -o json`; refuse if `status.authorization.state != Required` unless `--force`
+- [ ] 2.3 Read `spec.authorization.tokenSecretRef.name` and optional `*Key` overrides
+
+## 3. PKCE primitive
+
+- [ ] 3.1 `generatePkcePair()` — verifier 43-128 unreserved chars, S256 challenge (`tools/ark-cli/src/commands/mcp/pkce.ts`)
+- [ ] 3.2 `generateState()` — cryptographically random opaque string
+- [ ] 3.3 Unit tests: verifier alphabet, length bounds, challenge derivation
+
+## 4. OAuth flow
+
+- [ ] 4.1 Loopback HTTP listener on `--port` (or free port) handling `GET /callback`; reject missing `code`/`state` or `error=*`
+- [ ] 4.2 RFC 7591 DCR against `registrationEndpoint`; reject responses whose `redirect_uris` exclude the loopback URL
+- [ ] 4.3 Build authorization URL: `response_type=code`, `client_id`, `redirect_uri`, `state`, S256 challenge, `resource=<MCP URL>` (RFC 8707); `scope` only when supplied
+- [ ] 4.4 Open URL in default browser unless `--no-open`; always print URL
+- [ ] 4.5 Wait up to `--timeout` (default 5 minutes); single actionable error on timeout
+- [ ] 4.6 Verify returned `state` matches generated value before continuing
+- [ ] 4.7 Exchange code at `tokenEndpoint` with HTTP Basic + PKCE verifier; surface OAuth error verbatim on non-2xx
+
+## 5. Secret persistence
+
+- [ ] 5.1 Resolve key names from `tokenSecretRef` with documented defaults
+- [ ] 5.2 Compute `expires_at = now + expires_in - 30s` (RFC 3339 UTC) when `expires_in` present
+- [ ] 5.3 `kubectl create secret generic` if absent, else `kubectl patch secret` with base64 `data`
+- [ ] 5.4 Omit keys whose value is empty or absent
+
+## 6. Output and errors
+
+- [ ] 6.1 Print resource URL, `expires_at`, expected `Required → Authorized` transition on success
+- [ ] 6.2 Failure → exit non-zero with one `output.error("mcp auth failed:", <message>)` line
+- [ ] 6.3 Never log access tokens, refresh tokens, client secrets, or `Authorization` headers
+
+## 7. Tests
+
+- [ ] 7.1 PKCE unit tests (`pkce.spec.ts`)
+- [ ] 7.2 End-to-end `runAuth` spec (`auth.spec.ts`) with mock OAuth endpoints + fake `kubectl`; assert patched Secret payload for `ark mcp auth login`
+- [ ] 7.3 Negative paths: state mismatch, callback timeout, missing `tokenEndpoint`, bad `redirect_uris`
+- [ ] 7.4 Namespace resolution unit tests: explicit `--namespace` flag, `kubectl` context fallback, `default` fallback when both absent
+
+## 8. Auth logout subcommand
+
+- [ ] 8.1 Add `ark mcp auth logout <server-name>` subcommand with `--namespace`, `--keep-client`, `--delete-secret`
+- [ ] 8.2 Resolve target MCPServer + Secret name + `*Key` overrides via the same code path as `login`
+- [ ] 8.3 Default behaviour: `kubectl patch secret` to set `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret` (or their overridden key names) to empty strings
+- [ ] 8.4 `--keep-client`: only empty `access_token`, `refresh_token`, `expires_at`; preserve `client_id` / `client_secret`
+- [ ] 8.5 `--delete-secret`: `kubectl delete secret <referenced-name>` instead of patching
+- [ ] 8.6 Reject `--keep-client` + `--delete-secret` combination before contacting the cluster; exit non-zero with a clear error
+- [ ] 8.7 Output a one-line summary of the cleared keys plus a next-step hint pointing at `ark mcp auth login`
+- [ ] 8.8 Idempotent on missing Secret (no-op, exit zero); missing MCPServer → exit non-zero
+- [ ] 8.9 Tests covering: default clear, `--keep-client`, `--delete-secret`, missing Secret, missing MCPServer, mutual exclusion error

--- a/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/tasks.md
+++ b/openspec/changes/archive/2026-05-08-ark-cli-mcp-auth/tasks.md
@@ -2,8 +2,8 @@
 
 - [ ] 1.1 Register `ark mcp` parent command in `tools/ark-cli/src/index.tsx`
 - [ ] 1.2 Register `ark mcp auth` parent command with `login` and `logout` subcommands
-- [ ] 1.3 Add `ark mcp auth login <server-name>` subcommand with `--namespace`, `--force`, `--port`, `--no-open`, `--timeout`
-- [ ] 1.4 Validate `--port` and `--timeout` parse as non-negative integers; clear error otherwise
+- [ ] 1.3 Add `ark mcp auth login <server-name>` subcommand with `--namespace`, `--force`, `--port`, `--no-open`, `--timeout <duration>`
+- [ ] 1.4 Validate `--port` parses as a non-negative integer; validate `--timeout` parses as a Go-duration string (`60s`, `5m`, etc.) accepting positive durations only; clear error on either
 
 ## 2. Resource resolution
 
@@ -19,7 +19,7 @@
 
 ## 4. OAuth flow
 
-- [ ] 4.1 Loopback HTTP listener on `--port` (or free port) handling `GET /callback`; reject missing `code`/`state` or `error=*`
+- [ ] 4.1 Start a dual-stack loopback HTTP listener on `--port` (or a free port) bound on both `127.0.0.1` and `[::1]`; handle `GET /callback`; reject missing `code`/`state` or `error=*`
 - [ ] 4.2 RFC 7591 DCR against `registrationEndpoint`; reject responses whose `redirect_uris` exclude the loopback URL
 - [ ] 4.3 Build authorization URL: `response_type=code`, `client_id`, `redirect_uri`, `state`, S256 challenge, `resource=<MCP URL>` (RFC 8707); `scope` only when supplied
 - [ ] 4.4 Open URL in default browser unless `--no-open`; always print URL
@@ -33,6 +33,7 @@
 - [ ] 5.2 Compute `expires_at = now + expires_in - 30s` (RFC 3339 UTC) when `expires_in` present
 - [ ] 5.3 `kubectl create secret generic` if absent, else `kubectl patch secret` with base64 `data`
 - [ ] 5.4 Omit keys whose value is empty or absent
+- [ ] 5.5 On Secret create/patch, set label `ark.mckinsey.com/mcp-token-secret: "true"` for the controller real-time Secret watch
 
 ## 6. Output and errors
 
@@ -46,6 +47,7 @@
 - [ ] 7.2 End-to-end `runAuth` spec (`auth.spec.ts`) with mock OAuth endpoints + fake `kubectl`; assert patched Secret payload for `ark mcp auth login`
 - [ ] 7.3 Negative paths: state mismatch, callback timeout, missing `tokenEndpoint`, bad `redirect_uris`
 - [ ] 7.4 Namespace resolution unit tests: explicit `--namespace` flag, `kubectl` context fallback, `default` fallback when both absent
+- [ ] 7.5 `--no-open` test: assert the authorization URL is printed to stdout and `defaultDeps.openBrowser` is NOT invoked
 
 ## 8. Auth logout subcommand
 

--- a/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/proposal.md
+++ b/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Stage 1 (`mcp-auth-token-injection`) injects `Authorization: Bearer <access_token>` only in the `MCPServerReconciler` path — used to discover tools and flip `status.authorization.state` to `Authorized`. The runtime tool-dispatch paths construct their own MCP clients elsewhere and never read `spec.authorization.tokenSecretRef`. Result: `Available=True`, `AUTH=Authorized`, 14 tools listed, every agent tool call gets `401 Unauthorized`.
+
+Two dispatch paths are affected:
+
+- `ark/executors/completions/agent_tools.go::createMCPExecutor` builds `MCPClientConfig.Headers` from `spec.headers` only.
+- `lib/ark-sdk/.../extensions/query.py::_resolve_mcp_server` builds `MCPServerConfig.headers` for named (external) execution engines from `spec.headers` only.
+
+The architecture intent (per `mcp-server-resolution`) is that the controller resolves all MCP config and ships fully-formed `headers` to executors. Executor authors must never touch Secrets themselves. Today both resolvers leak this responsibility back to the executor, and neither end picks it up.
+
+There is also a UX gap on the same Stage 2 "Secret as source of truth" story: peer MCP clients (Cursor, Claude Desktop) reload tokens immediately when their stored Secret changes, but Ark today only re-reads the token Secret on the periodic resync interval. An operator who patches a token Secret has no signal that anything is happening for tens of seconds. The `MCPServerReconciler` does not watch Secrets at all, so an out-of-band token rotation is invisible until the next resync tick — which makes the dashboard "authorize" affordance feel laggy and the kubectl edit experience feel broken.
+
+## What Changes
+
+- Add a shared helper `internal/resolution/mcp_auth.go::ResolveBearerToken(ctx, k8sClient, mcpServer)` returning the access token (empty string when `spec.authorization` is unset or the Secret/key is absent).
+- `ark/internal/controller/mcpserver_controller.go::resolveAuthorizationMaterial` SHALL use the new helper for the read; eventing stays in the controller.
+- `ark/executors/completions/agent_tools.go::createMCPExecutor` SHALL call the helper after resolving `spec.headers` and SHALL set `headers["Authorization"] = "Bearer <token>"` when a token is returned. `spec.headers` precedence rules are unchanged: a user-set `Authorization` in `spec.headers` takes priority and the helper-derived header is skipped.
+- `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py::_resolve_mcp_server` SHALL fetch the Secret named in `spec.authorization.tokenSecretRef` and SHALL set `MCPServerConfig.headers["Authorization"] = "Bearer <token>"` when present. Same precedence rule for a user-set `Authorization` in `spec.headers`.
+- `docs/content/developer-guide/building-execution-engines.mdx` SHALL state that `MCPServerConfig.headers` already carries the resolved `Authorization` header when the MCPServer has `spec.authorization.tokenSecretRef`. Executor authors construct MCP clients from `headers` opaquely.
+- `MCPServerReconciler` SHALL gain a label-driven Secret watch. Token Secrets carrying the convention label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. A field indexer on `spec.authorization.tokenSecretRef.name` resolves the reverse mapping. Helm charts that ship token Secrets stamp the label automatically; operators who hand-create Secrets stamp it manually for the real-time UX. Unlabelled Secrets keep working via the existing periodic resync — slower, but functionally equivalent. The cache SHALL NOT be filtered by the label, so reconciler reads of any token Secret continue to succeed regardless.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `mcp-auth-token-injection`: extends Bearer injection from the reconcile path to every MCP client construction path inside Ark (built-in completions executor + ark-sdk resolver for named executors). Reconcile-side behaviour unchanged.
+- `mcp-server-resolution`: `MCPServerConfig.headers` carries the resolved `Authorization` header for OAuth-protected MCPServers. Executor authors no longer need to know about `spec.authorization`.
+
+## Impact
+
+- **Scope:** `ark/internal/resolution/`, `ark/executors/completions/agent_tools.go`, `ark/internal/controller/mcpserver_controller.go` (refactor only), `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py`, `docs/content/developer-guide/building-execution-engines.mdx`.
+- **CRD / RBAC:** none. Stage 1 already grants `get/list/watch` on Secrets to the controller SA. The completions executor runs under the same SA today.
+- **Behavioural break:** an OAuth-protected MCPServer whose tool calls used to silently 401 will now succeed. No regression risk for non-OAuth MCPServers (`spec.authorization == nil` short-circuits before any Secret read).
+
+## Non-Goals
+
+- Token refresh — Stage 2 (`mcp-auth-token-refresh`).
+- Reacting to dispatch-path 401s by collapsing `status.authorization.state` back to `Required` — Stage 1's reconcile-side rollback already covers expired-token detection on the next reconcile; tool-call 401 surfaces as a query error to the user.
+- Per-executor SAs / fine-grained RBAC for non-controller executors — out of scope.

--- a/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
+++ b/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Bearer injection applies to all in-cluster MCP client construction paths
+
+When `spec.authorization.tokenSecretRef` is set on an MCPServer, every Ark code path that constructs an MCP client for that MCPServer SHALL inject `Authorization: Bearer <access_token>` derived from the referenced Secret. This applies at minimum to:
+
+- The `MCPServerReconciler` (already covered by the original Stage 1 requirement).
+- The built-in completions executor's tool dispatch path (`ark/executors/completions/agent_tools.go::createMCPExecutor`).
+- The ark-sdk Python resolver that builds `MCPServerConfig.headers` for named execution engines (`lib/ark-sdk/.../extensions/query.py::_resolve_mcp_server`).
+
+When `spec.authorization` is unset, no path SHALL attempt to read any Secret for token injection.
+
+#### Scenario: Built-in completions executor dispatches a tool against an Authorized MCPServer
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret carrying `access_token`
+- **WHEN** an agent without `executionEngine` invokes a tool backed by that MCPServer
+- **THEN** the built `MCPClientConfig.Headers` SHALL contain `Authorization: Bearer <access_token>` and the tool call SHALL NOT produce a 401 caused by missing credentials
+
+#### Scenario: Named execution engine receives MCPServerConfig for an Authorized MCPServer
+
+- **GIVEN** the same Authorized MCPServer
+- **WHEN** the controller dispatches a query to a named execution engine via A2A
+- **THEN** the resulting `ExecutionEngineRequest.mcpServers[*].headers` SHALL contain `Authorization: Bearer <access_token>` for that server
+
+#### Scenario: User has supplied Authorization in spec.headers
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef` set AND a `spec.headers` entry whose name is `Authorization`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** the explicit `spec.headers` value SHALL win and the helper-derived Bearer SHALL NOT overwrite it
+
+#### Scenario: spec.headers carries a malformed Authorization value
+
+- **GIVEN** an MCPServer whose `spec.headers` contains an `Authorization` entry with a non-Bearer or otherwise malformed value
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** the value SHALL be passed through unchanged — the CLI / controller does not validate or rewrite explicit `spec.headers` values; this is the user's escape hatch and they accept the consequences
+
+#### Scenario: spec.authorization is unset
+
+- **GIVEN** an MCPServer with `spec.authorization == nil`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no Secret read SHALL occur for token injection and no `Authorization` header SHALL be added beyond what `spec.headers` already supplies
+
+#### Scenario: Secret exists but the access-token key is empty
+
+- **GIVEN** the referenced Secret exists but the configured access-token key is missing or empty
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no `Authorization` header SHALL be injected and the call SHALL fall through to whatever `spec.headers` supplies
+
+### Requirement: Token resolution shares default key names across paths
+
+The reconciler and the executor dispatch paths SHALL share the same default access-token key name (`access_token`) and the same `accessTokenKey` override semantics, so an MCPServer that produces an `Authorized` state in reconcile is guaranteed to also yield a Bearer header at dispatch time. Implementations MAY share a helper or a constant; the binding requirement is that the two paths can never diverge on key resolution. Any shared helper SHALL be event-free — eventing for missing keys / Secrets stays in the reconciler.
+
+#### Scenario: Helper honours custom accessTokenKey override
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_TOKEN`
+- **WHEN** the helper is invoked against a Secret whose `MY_TOKEN` key carries a value
+- **THEN** the helper SHALL return that value
+
+#### Scenario: Helper short-circuits when authorization is unset
+
+- **GIVEN** `spec.authorization == nil`
+- **WHEN** the helper is invoked
+- **THEN** it SHALL return an empty string and SHALL NOT issue any API server reads
+
+### Requirement: Labelled token Secrets reconcile in real time
+
+Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval.
+
+#### Scenario: Operator patches a labelled token Secret
+
+- **GIVEN** an MCPServer in state `Authorized` whose `tokenSecretRef` points at a Secret carrying the label `ark.mckinsey.com/mcp-token-secret=true`
+- **WHEN** the operator patches the Secret to empty `access_token`
+- **THEN** the controller SHALL reconcile within seconds and SHALL transition `status.authorization.state` to `Required`
+
+#### Scenario: Multiple MCPServers reference the same labelled Secret
+
+- **GIVEN** two MCPServers in the same namespace whose `spec.authorization.tokenSecretRef.name` points at the same labelled Secret
+- **WHEN** the Secret is patched
+- **THEN** the controller SHALL enqueue a reconcile for each MCPServer
+
+### Requirement: Unlabelled token Secrets remain functional
+
+When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer on its periodic resync interval. The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
+
+#### Scenario: Operator patches an unlabelled token Secret
+
+- **GIVEN** an MCPServer whose `tokenSecretRef` points at a Secret with no `ark.mckinsey.com/mcp-token-secret` label
+- **WHEN** the operator patches the Secret
+- **THEN** the controller SHALL NOT immediately enqueue a reconcile based on the Secret event
+- **AND** on the next periodic resync the reconciler SHALL read the updated Secret and transition state accordingly

--- a/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
+++ b/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-auth-token-injection/spec.md
@@ -64,7 +64,7 @@ The reconciler and the executor dispatch paths SHALL share the same default acce
 
 ### Requirement: Labelled token Secrets reconcile in real time
 
-Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval.
+Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval. The label has no functional authorization behaviour — its absence SHALL NOT prevent authentication, only delay reconciliation until the next `pollInterval` tick. Login (`ark mcp auth login`) stamps the label on Secret create/patch as a real-time-reconcile convenience; charts and manual operators SHOULD also stamp it for the same reason.
 
 #### Scenario: Operator patches a labelled token Secret
 
@@ -80,11 +80,11 @@ Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger im
 
 ### Requirement: Unlabelled token Secrets remain functional
 
-When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer on its periodic resync interval. The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
+When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer at the cadence set by `MCPServer.spec.pollInterval` (default `30s`). The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
 
 #### Scenario: Operator patches an unlabelled token Secret
 
 - **GIVEN** an MCPServer whose `tokenSecretRef` points at a Secret with no `ark.mckinsey.com/mcp-token-secret` label
 - **WHEN** the operator patches the Secret
 - **THEN** the controller SHALL NOT immediately enqueue a reconcile based on the Secret event
-- **AND** on the next periodic resync the reconciler SHALL read the updated Secret and transition state accordingly
+- **AND** on the next `pollInterval`-driven reconcile (default `30s`) the reconciler SHALL read the updated Secret and transition state accordingly

--- a/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-server-resolution/spec.md
+++ b/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/specs/mcp-server-resolution/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Resolved MCPServerConfig.headers carries Authorization for OAuth-protected servers
+
+When an MCPServer has `spec.authorization.tokenSecretRef` set and the referenced Secret carries a non-empty access token, the resolver SHALL set `MCPServerConfig.headers["Authorization"] = "Bearer <access_token>"`. The Bearer header SHALL be derived inside the resolver from the cluster Secret — executors SHALL NOT receive `tokenSecretRef` or any other Secret-related field over the A2A wire.
+
+#### Scenario: Authorized MCPServer is resolved into MCPServerConfig
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret containing `access_token`
+- **WHEN** the controller resolves the agent's MCP servers
+- **THEN** the corresponding `MCPServerConfig.headers` SHALL contain `Authorization: Bearer <access_token>`
+
+#### Scenario: spec.headers Authorization wins over tokenSecretRef
+
+- **GIVEN** an MCPServer with both `spec.authorization.tokenSecretRef` set and a `spec.headers` entry named `Authorization`
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** the explicit `spec.headers` value SHALL be used and the helper-derived Bearer SHALL NOT replace it
+
+#### Scenario: MCPServer without authorization
+
+- **GIVEN** an MCPServer with `spec.authorization` unset
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** no `Authorization` header SHALL be added beyond `spec.headers`
+
+### Requirement: Executor authors do not handle MCPServer authorization
+
+`MCPServerConfig.headers` SHALL be the single contract executors consume for MCP authentication. Executor authors SHALL NOT need to read MCPServer CRDs, Secrets, or `spec.authorization` to call OAuth-protected MCP servers. Documentation describing how to build a new execution engine SHALL state this explicitly.
+
+#### Scenario: New execution engine consumes Authorization opaquely
+
+- **GIVEN** a custom execution engine receiving `ExecutionEngineRequest.mcpServers[i]`
+- **WHEN** it constructs an MCP client
+- **THEN** passing `MCPServerConfig.headers` to the client SHALL be sufficient for OAuth-protected servers — no extra resolution step SHALL be required

--- a/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/tasks.md
+++ b/openspec/changes/archive/2026-05-08-mcp-auth-dispatch-injection/tasks.md
@@ -1,0 +1,45 @@
+## 1. Shared helper
+
+- [ ] 1.1 Add `ark/internal/resolution/mcp_auth.go` with `ResolveBearerToken(ctx, k8sClient, mcpServer) (string, error)` returning `("", nil)` when `spec.authorization == nil`, the Secret is missing, or the access-token key is empty
+- [ ] 1.2 Unit tests: nil authorization, missing Secret, empty key, custom `accessTokenKey` override, populated token
+
+## 2. Reconciler alignment
+
+- [ ] 2.1 `ark/internal/controller/mcpserver_controller.go::resolveAuthorizationMaterial` reads access tokens via the same default key constant as the helper (`resolution.DefaultAccessTokenKey`) so the two paths cannot drift; no behaviour change
+- [ ] 2.2 All existing reconciler tests pass unchanged
+
+## 3. Built-in completions executor
+
+- [ ] 3.1 `ark/executors/completions/agent_tools.go::createMCPExecutor` calls `ResolveBearerToken` after the `spec.headers` loop
+- [ ] 3.2 Skip the helper-derived header when the user has already set `Authorization` in `spec.headers` (precedence rule)
+- [ ] 3.3 Unit test: MCPServer with `spec.authorization.tokenSecretRef` and a populated Secret → built `MCPClientConfig.Headers` contains `Authorization: Bearer <token>`
+
+## 4. ark-sdk Python resolver
+
+- [ ] 4.1 `lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/extensions/query.py::_resolve_mcp_server` reads the Secret named in `spec.authorization.tokenSecretRef` (with the same default + override key names as the controller)
+- [ ] 4.2 Set `headers["Authorization"] = f"Bearer {token}"` when present, skip when `spec.headers` already supplied an `Authorization` header
+- [ ] 4.3 Test in `lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_query_extension.py` covering: no authorization, populated Secret, header precedence
+
+## 5. Docs
+
+- [ ] 5.1 `docs/content/developer-guide/building-execution-engines.mdx`: note that `MCPServerConfig.headers` already carries the resolved `Authorization` header when `spec.authorization.tokenSecretRef` is set; executor authors construct clients from `headers` opaquely
+
+## 6. End-to-end verification
+
+- [ ] 6.1 Local: agent referencing an OAuth-protected MCPServer with a populated `tokenSecretRef` Secret completes a tool call without 401
+- [ ] 6.2 Local: same agent with `spec.authorization` cleared still works against an unprotected MCPServer
+
+## 7. Secret watch for real-time reconciliation
+
+- [ ] 7.1 Add `MCPTokenSecretLabel = "ark.mckinsey.com/mcp-token-secret"` constant in `ark/internal/labels/labels.go`, mirroring the existing constant style
+- [ ] 7.2 In `MCPServerReconciler.SetupWithManager`, register a field indexer on `&arkv1alpha1.MCPServer{}` for `spec.authorization.tokenSecretRef.name` (use a package-level constant `mcpTokenSecretRefField` for the field path string). Indexer returns `nil` when `spec.Authorization == nil`, otherwise `[]string{ref.Name}`
+- [ ] 7.2.1 Field indexer is namespace-scoped (not cluster-wide) — controller-runtime's default cache scope; no cross-namespace Secret reverse lookups
+- [ ] 7.3 Extend the controller builder with `Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.findMCPServersForSecret), builder.WithPredicates(predicate.NewPredicateFuncs(hasMCPTokenSecretLabel)))`. The predicate filters at event-handler level only — the cache is left unfiltered so reconciler reads of any token Secret continue to succeed
+- [ ] 7.4 Implement `findMCPServersForSecret` on `*MCPServerReconciler`: list MCPServers via the field index in the Secret's namespace and return one `reconcile.Request` per match. On list error, log and return `nil` so event delivery is not blocked
+- [ ] 7.5 Implement `hasMCPTokenSecretLabel(obj client.Object) bool` returning true when `obj.GetLabels()[labels.MCPTokenSecretLabel] == "true"`
+- [ ] 7.6 Envtest in `ark/internal/controller/mcpserver_secret_watch_test.go`:
+  - Labelled Secret patch enqueues a reconcile for the referencing MCPServer within seconds (use `Eventually` against a counting reconciler hook)
+  - Unlabelled Secret patch does NOT enqueue an event-driven reconcile within the same window (`Consistently` asserts the counter does not increment)
+  - Two MCPServers referencing the same labelled Secret both get enqueued on a single Secret patch
+- [ ] 7.7 Note in the marketplace chart authoring guide that token-Secret-bearing charts SHOULD stamp `ark.mckinsey.com/mcp-token-secret: "true"` on the Secret to opt in to real-time reconciliation. Unlabelled Secrets remain functional via the periodic resync.
+- [ ] 7.8 RBAC unchanged — Stage 1 already grants `get/list/watch` on Secrets to the controller SA

--- a/openspec/specs/ark-cli-mcp-auth/spec.md
+++ b/openspec/specs/ark-cli-mcp-auth/spec.md
@@ -3,9 +3,10 @@
 ## Purpose
 TBD - created by archiving change ark-cli-mcp-auth. Update Purpose after archive.
 ## Requirements
+
 ### Requirement: ark-cli exposes `mcp auth login` and `mcp auth logout` subcommands
 
-The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <ms>`; `--port` and `--timeout` SHALL reject non-integer or negative values.
+The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <duration>`. `--port` SHALL reject non-integer or negative values. `--timeout` SHALL be a Go-duration string (e.g. `60s`, `5m`) and SHALL reject non-parseable or non-positive values. The default `--timeout` is `5m`.
 
 #### Scenario: User runs ark mcp auth login against a Required MCPServer
 
@@ -33,6 +34,14 @@ The command SHALL refuse to run unless `status.authorization.state` is `Required
 - **WHEN** the user runs `ark mcp auth login <name> --force`
 - **THEN** the CLI SHALL run the full flow regardless of state
 
+#### Scenario: --force fails mid-flow
+
+- **GIVEN** an MCPServer in state `Authorized` whose Secret carries valid tokens
+- **AND** the user runs `ark mcp auth login <name> --force`
+- **WHEN** any step of the OAuth flow fails (DCR rejected, callback timeout, token exchange 4xx, etc.)
+- **THEN** the CLI SHALL exit non-zero
+- **AND** the existing Secret SHALL be left unchanged — `--force` only bypasses the pre-flight `Required` guard, it never weakens the "Secret untouched on flow failure" invariant
+
 ### Requirement: Namespace resolution prefers explicit flag, then context, then default
 
 The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl` context namespace, else `default`.
@@ -40,6 +49,12 @@ The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl`
 #### Scenario: User passes --namespace explicitly
 
 - **WHEN** the user runs `ark mcp auth login <name> --namespace tenant-a`
+- **THEN** the CLI SHALL use `tenant-a` for every kubectl call
+
+#### Scenario: --namespace omitted, kubectl context has a namespace
+
+- **GIVEN** the active `kubectl` context has `namespace: tenant-a` configured
+- **WHEN** the user runs `ark mcp auth login <name>` with no `--namespace` flag
 - **THEN** the CLI SHALL use `tenant-a` for every kubectl call
 
 #### Scenario: kubectl context has no namespace
@@ -65,7 +80,7 @@ The CLI SHALL generate a PKCE code verifier of 43-128 unreserved characters and 
 
 ### Requirement: Loopback callback listener handles success and error cases
 
-The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`.
+The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`. The listener SHALL bind dual-stack so both `127.0.0.1:<port>` and `[::1]:<port>` accept callbacks. The authorization URL the CLI prints SHALL use `http://127.0.0.1:<port>/callback` (IPv4 form, broader AS compatibility); requests arriving via `[::1]` on the same port SHALL be handled identically.
 
 #### Scenario: Authorization server redirects with code and state
 
@@ -79,7 +94,7 @@ The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port
 
 #### Scenario: Callback never arrives within --timeout
 
-- **GIVEN** `--timeout 60000`
+- **GIVEN** `--timeout 60s`
 - **WHEN** no callback is received within 60 seconds
 - **THEN** the CLI SHALL exit non-zero with a timeout message naming the elapsed budget
 
@@ -89,6 +104,21 @@ The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port
 - **AND** port 8080 is already in use on the loopback interface
 - **THEN** the CLI SHALL exit non-zero with an error message naming the port and suggesting the user omit `--port` to let the OS pick a free port
 - **AND** SHALL NOT silently fall back to auto-selection
+
+#### Scenario: --no-open suppresses browser launch
+
+- **GIVEN** the user runs `ark mcp auth login <name> --no-open`
+- **THEN** the CLI SHALL print the full authorization URL to stdout
+- **AND** SHALL NOT spawn a browser process
+- **AND** SHALL continue waiting for the loopback callback in the normal way
+
+Note: this follows the CLI's `--no-X` convention — every boolean flag whose default is "yes, do X" supports a corresponding `--no-X` to opt out.
+
+#### Scenario: Callback arrives via the IPv6 loopback
+
+- **GIVEN** the listener is bound dual-stack
+- **WHEN** the browser is redirected and resolves loopback to `[::1]`
+- **THEN** the listener SHALL respond 200 and surface `(code, state)` to the flow identically to the IPv4 path
 
 ### Requirement: Dynamic Client Registration enforces the loopback redirect URI
 
@@ -142,7 +172,7 @@ The CLI SHALL POST to `status.authorization.tokenEndpoint` with `grant_type=auth
 
 ### Requirement: Tokens are written to the Secret using the configured key names
 
-The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch.
+The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch. When the CLI creates or patches the Secret, it SHALL also set the label `ark.mckinsey.com/mcp-token-secret: "true"` on the Secret. The label enables the controller's real-time Secret watch (see `mcp-auth-token-injection` capability); absence does not affect authentication correctness, only reconcile latency.
 
 #### Scenario: Token response carries access, refresh, and expires_in
 
@@ -165,6 +195,12 @@ The CLI SHALL write the token endpoint response into the Secret named in `spec.a
 - **GIVEN** the token endpoint returns no `expires_in` (or `expires_in <= 0`)
 - **THEN** the patched Secret SHALL NOT contain an `expires_at` key
 - **AND** the CLI SHALL emit a single warning line indicating the token has no advertised lifetime
+
+#### Scenario: Login stamps the mcp-token-secret label
+
+- **WHEN** `ark mcp auth login` writes tokens to the Secret (create or patch path)
+- **THEN** the resulting Secret SHALL carry the label `ark.mckinsey.com/mcp-token-secret: "true"`
+- **AND** removing or omitting the label SHALL NOT break authentication — only delays controller reconcile to the next `pollInterval` tick
 
 ### Requirement: Secrets and tokens never appear in logs
 
@@ -244,4 +280,3 @@ The CLI SHALL never log access tokens, refresh tokens, client secrets, or `Autho
 
 - **WHEN** `ark mcp auth logout <name>` succeeds against a populated Secret
 - **THEN** stdout/stderr SHALL name the cleared keys but SHALL NOT contain any token, refresh-token, or client-secret value
-

--- a/openspec/specs/ark-cli-mcp-auth/spec.md
+++ b/openspec/specs/ark-cli-mcp-auth/spec.md
@@ -1,0 +1,247 @@
+# ark-cli-mcp-auth Specification
+
+## Purpose
+TBD - created by archiving change ark-cli-mcp-auth. Update Purpose after archive.
+## Requirements
+### Requirement: ark-cli exposes `mcp auth login` and `mcp auth logout` subcommands
+
+The Ark CLI SHALL expose `ark mcp auth` as a parent command with two verbs: `login` and `logout`. `ark mcp auth login <server-name>` SHALL drive an end-to-end OAuth 2.1 flow against an `MCPServer`'s discovered authorization endpoints and write the resulting tokens to the Secret named in `spec.authorization.tokenSecretRef`. `ark mcp auth logout <server-name>` SHALL clear (or delete) that same Secret so the controller's next reconcile collapses the server back to `Required`. The `login` subcommand SHALL accept `--namespace`, `--force`, `--port <int>`, `--no-open`, and `--timeout <ms>`; `--port` and `--timeout` SHALL reject non-integer or negative values.
+
+#### Scenario: User runs ark mcp auth login against a Required MCPServer
+
+- **GIVEN** an `MCPServer` named `notion` whose `status.authorization.state` is `Required`
+- **WHEN** the user runs `ark mcp auth login notion`
+- **THEN** the CLI SHALL drive DCR + PKCE + loopback callback + token exchange and patch the Secret named in `spec.authorization.tokenSecretRef`
+
+#### Scenario: User passes an unparseable port
+
+- **WHEN** the user runs `ark mcp auth login notion --port abc`
+- **THEN** the CLI SHALL exit non-zero with a message naming `--port` and the offending value
+
+### Requirement: Pre-flight refuses non-Required state without --force
+
+The command SHALL refuse to run unless `status.authorization.state` is `Required`. The user MAY override with `--force`.
+
+#### Scenario: MCPServer is already Authorized
+
+- **GIVEN** an `MCPServer` whose `status.authorization.state` is `Authorized`
+- **WHEN** the user runs `ark mcp auth login <name>` without `--force`
+- **THEN** the CLI SHALL exit non-zero and explain that the server is already authorized
+
+#### Scenario: User passes --force on an Authorized MCPServer
+
+- **WHEN** the user runs `ark mcp auth login <name> --force`
+- **THEN** the CLI SHALL run the full flow regardless of state
+
+### Requirement: Namespace resolution prefers explicit flag, then context, then default
+
+The CLI SHALL resolve namespace as: `--namespace` if set, else current `kubectl` context namespace, else `default`.
+
+#### Scenario: User passes --namespace explicitly
+
+- **WHEN** the user runs `ark mcp auth login <name> --namespace tenant-a`
+- **THEN** the CLI SHALL use `tenant-a` for every kubectl call
+
+#### Scenario: kubectl context has no namespace
+
+- **GIVEN** the active `kubectl` context has no namespace configured
+- **WHEN** the user omits `--namespace`
+- **THEN** the CLI SHALL use `default`
+
+### Requirement: PKCE primitives meet RFC 7636 S256
+
+The CLI SHALL generate a PKCE code verifier of 43-128 unreserved characters and an S256-derived challenge, plus a cryptographically random opaque `state`.
+
+#### Scenario: Verifier and challenge are derived correctly
+
+- **WHEN** `generatePkcePair()` is invoked
+- **THEN** the verifier SHALL contain only `[A-Za-z0-9-._~]`, SHALL be 43-128 chars, and the challenge SHALL equal `BASE64URL(SHA-256(verifier))`
+
+#### Scenario: Default lengths balance entropy and compatibility
+
+- **WHEN** `generatePkcePair()` and `generateState()` are invoked with no overrides
+- **THEN** the verifier SHALL be 64 characters from the unreserved set
+- **AND** the `state` SHALL be at least 128 bits (16 bytes) of cryptographically secure random data, base64url-encoded
+
+### Requirement: Loopback callback listener handles success and error cases
+
+The CLI SHALL start an `http://127.0.0.1:<port>/callback` listener using `--port` if provided, else a free port. The listener SHALL respond 200 to a request with both `code` and `state`, SHALL respond 400 to a request whose query carries `error`, and SHALL respond 400 to a request missing `code` or `state`.
+
+#### Scenario: Authorization server redirects with code and state
+
+- **WHEN** the browser is redirected to `/callback?code=abc&state=<our-state>`
+- **THEN** the listener SHALL respond 200 and surface `(code, state)` to the flow
+
+#### Scenario: Authorization server redirects with error
+
+- **WHEN** the browser is redirected to `/callback?error=access_denied`
+- **THEN** the listener SHALL respond 400 and the CLI SHALL exit non-zero with the OAuth `error` value in the message
+
+#### Scenario: Callback never arrives within --timeout
+
+- **GIVEN** `--timeout 60000`
+- **WHEN** no callback is received within 60 seconds
+- **THEN** the CLI SHALL exit non-zero with a timeout message naming the elapsed budget
+
+#### Scenario: User-supplied --port is already bound
+
+- **GIVEN** the user runs `ark mcp auth login <name> --port 8080`
+- **AND** port 8080 is already in use on the loopback interface
+- **THEN** the CLI SHALL exit non-zero with an error message naming the port and suggesting the user omit `--port` to let the OS pick a free port
+- **AND** SHALL NOT silently fall back to auto-selection
+
+### Requirement: Dynamic Client Registration enforces the loopback redirect URI
+
+The CLI SHALL POST to `status.authorization.registrationEndpoint` with `client_name=ark mcp auth`, `redirect_uris=[<loopback>]`, `grant_types=["authorization_code","refresh_token"]`, `response_types=["code"]`, and `token_endpoint_auth_method=client_secret_basic`. If the registration response includes `redirect_uris` and the loopback URI is absent, the CLI SHALL reject the registration and exit non-zero before continuing.
+
+#### Scenario: Registration endpoint omits the loopback URI
+
+- **GIVEN** the registration endpoint returns a `redirect_uris` array that does not include the loopback URL
+- **THEN** the CLI SHALL exit non-zero with an error naming the offending response
+
+#### Scenario: Registration response omits redirect_uris entirely
+
+- **GIVEN** the registration response does not include `redirect_uris` at all
+- **THEN** the CLI SHALL exit non-zero with the same loopback-enforcement error — fail-closed since we cannot confirm the loopback URL was registered
+
+### Requirement: DCR response uses a supported token_endpoint_auth_method
+
+The CLI registers with `token_endpoint_auth_method: client_secret_basic`. If the registration response advertises a different `token_endpoint_auth_method` that is neither `client_secret_basic` nor `none`, the CLI SHALL exit non-zero with an error naming the unsupported method.
+
+#### Scenario: Registration endpoint returns token_endpoint_auth_method=client_secret_post
+
+- **GIVEN** the registration response sets `token_endpoint_auth_method: "client_secret_post"`
+- **THEN** the CLI SHALL exit non-zero with an error naming the unsupported method
+
+### Requirement: Authorization request includes PKCE S256 and resource indicator
+
+The CLI SHALL build the authorization URL with `response_type=code`, `client_id`, `redirect_uri=<loopback>`, generated `state`, S256 `code_challenge` and `code_challenge_method=S256`, and `resource=<MCP URL>` per RFC 8707. `scope` SHALL be included only when supplied.
+
+#### Scenario: Authorization URL is constructed for an MCP at https://mcp.example/mcp
+
+- **WHEN** the CLI builds the authorization URL for an MCP whose discovered resource is `https://mcp.example/mcp`
+- **THEN** the URL SHALL include `code_challenge_method=S256`, the matching `code_challenge`, and `resource=https%3A%2F%2Fmcp.example%2Fmcp`
+
+### Requirement: State parameter is verified before token exchange
+
+The CLI SHALL refuse to exchange a code unless the returned `state` exactly matches the value the CLI generated.
+
+#### Scenario: Callback returns a tampered state
+
+- **WHEN** `/callback` arrives with a `state` value the CLI did not generate
+- **THEN** the CLI SHALL exit non-zero before posting to the token endpoint
+
+### Requirement: Token exchange uses HTTP Basic auth and PKCE verifier
+
+The CLI SHALL POST to `status.authorization.tokenEndpoint` with `grant_type=authorization_code`, `code`, `redirect_uri=<loopback>`, `code_verifier`, and `resource=<MCP URL>`, authenticating via HTTP Basic with the registered `client_id` / `client_secret`. On non-2xx the CLI SHALL surface the OAuth error verbatim.
+
+#### Scenario: Token endpoint returns 400 invalid_grant
+
+- **WHEN** the token endpoint returns `{"error":"invalid_grant"}` with HTTP 400
+- **THEN** the CLI SHALL exit non-zero and the error message SHALL include `invalid_grant`
+
+### Requirement: Tokens are written to the Secret using the configured key names
+
+The CLI SHALL write the token endpoint response into the Secret named in `spec.authorization.tokenSecretRef.name` using the key names from the same `tokenSecretRef` (defaults `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`). When `expires_in` is present the CLI SHALL write `expires_at = now + expires_in - 30s` (RFC 3339 UTC). The CLI SHALL omit any key whose value is empty or absent. Missing Secret → create; existing Secret → patch.
+
+#### Scenario: Token response carries access, refresh, and expires_in
+
+- **GIVEN** the token endpoint returns `{access_token, refresh_token, expires_in: 3600}`
+- **THEN** the patched Secret SHALL contain `access_token`, `refresh_token`, `expires_at` set to `now + 3600s - 30s` (RFC 3339 UTC), `client_id`, and `client_secret`
+
+#### Scenario: Token response omits refresh_token
+
+- **GIVEN** the token endpoint returns no `refresh_token`
+- **THEN** the patched Secret SHALL NOT contain a `refresh_token` key
+
+#### Scenario: User has overridden accessTokenKey on tokenSecretRef
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_ACCESS_TOKEN`
+- **WHEN** tokens are written
+- **THEN** the patched Secret SHALL store the access token under `MY_ACCESS_TOKEN`
+
+#### Scenario: Token response omits expires_in or sets it ≤ 0
+
+- **GIVEN** the token endpoint returns no `expires_in` (or `expires_in <= 0`)
+- **THEN** the patched Secret SHALL NOT contain an `expires_at` key
+- **AND** the CLI SHALL emit a single warning line indicating the token has no advertised lifetime
+
+### Requirement: Secrets and tokens never appear in logs
+
+The CLI SHALL never log access tokens, refresh tokens, client secrets, or `Authorization` headers. Diagnostic output SHALL be limited to: resource URL, chosen loopback port, registered `client_id`, computed `expires_at`, and high-level state transitions.
+
+#### Scenario: Successful run
+
+- **WHEN** `ark mcp auth login` succeeds
+- **THEN** stdout/stderr SHALL contain the resource URL and `expires_at` but SHALL NOT contain access or refresh token values
+
+### Requirement: Failures exit non-zero with a single error line
+
+Every failure path SHALL exit non-zero with one `output.error("mcp auth failed:", <message>)` line — never a raw stack trace.
+
+#### Scenario: Token exchange fails
+
+- **WHEN** the token endpoint returns 400
+- **THEN** the process SHALL exit non-zero and stderr SHALL contain exactly one `mcp auth failed:` line
+
+### Requirement: ark-cli exposes an `mcp auth logout` subcommand
+
+The CLI SHALL expose `ark mcp auth logout <server-name>` that empties (or deletes) the Secret named on `spec.authorization.tokenSecretRef`, returning the MCPServer to a state where `ark mcp auth login <server-name>` can run cleanly. The command SHALL accept `--namespace`, `--keep-client`, and `--delete-secret`. By default the CLI SHALL `kubectl patch` the Secret so `access_token`, `refresh_token`, `expires_at`, `client_id`, and `client_secret` (or their `*Key`-overridden names) all hold empty strings, leaving the Secret resource itself in place. `--keep-client` SHALL empty only `access_token`, `refresh_token`, and `expires_at`, preserving `client_id` and `client_secret` so a follow-up `login` re-uses the registered DCR client. `--delete-secret` SHALL `kubectl delete secret <name>` instead of patching. `--keep-client` and `--delete-secret` SHALL be mutually exclusive.
+
+#### Scenario: User logs out of an Authorized MCPServer
+
+- **GIVEN** an MCPServer whose state is `Authorized` and whose Secret carries all five token+client keys
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the patched Secret SHALL contain empty values for `access_token`, `refresh_token`, `expires_at`, `client_id`, `client_secret`
+
+#### Scenario: User passes --keep-client
+
+- **GIVEN** an Authorized MCPServer with all five keys populated
+- **WHEN** the user runs `ark mcp auth logout <name> --keep-client`
+- **THEN** the patched Secret SHALL contain empty `access_token`, `refresh_token`, `expires_at`
+- **AND** the patched Secret SHALL still contain the original `client_id` and `client_secret` values
+
+#### Scenario: User passes --delete-secret
+
+- **WHEN** the user runs `ark mcp auth logout <name> --delete-secret`
+- **THEN** the CLI SHALL `kubectl delete secret <referenced-name>` and exit zero
+
+#### Scenario: User passes both --keep-client and --delete-secret
+
+- **WHEN** the user runs `ark mcp auth logout <name> --keep-client --delete-secret`
+- **THEN** the CLI SHALL exit non-zero before contacting the cluster, naming the conflict between the two flags
+
+### Requirement: Logout honours overridden key names
+
+The CLI SHALL operate on the overridden key names from `spec.authorization.tokenSecretRef` rather than the defaults whenever any of `accessTokenKey`, `refreshTokenKey`, `expiresAtKey`, `clientIDKey`, or `clientSecretKey` is set. With `--keep-client`, the CLI SHALL empty only the overridden access-token, refresh-token, and expires-at keys.
+
+#### Scenario: tokenSecretRef has accessTokenKey override
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_ACCESS_TOKEN`
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the patched Secret SHALL have `MY_ACCESS_TOKEN` set to empty (and SHALL NOT add an `access_token` key)
+
+### Requirement: Logout is idempotent against a missing Secret
+
+When the referenced Secret does not exist, the CLI SHALL exit zero with a no-op message. When the MCPServer itself does not exist, the CLI SHALL exit non-zero.
+
+#### Scenario: Secret named in tokenSecretRef does not exist
+
+- **GIVEN** the MCPServer's Secret has been deleted out of band
+- **WHEN** the user runs `ark mcp auth logout <name>`
+- **THEN** the CLI SHALL exit zero with a one-line message indicating no-op
+
+#### Scenario: MCPServer does not exist
+
+- **WHEN** the user runs `ark mcp auth logout does-not-exist`
+- **THEN** the CLI SHALL exit non-zero with an error
+
+### Requirement: Logout never logs token material
+
+The CLI SHALL never log access tokens, refresh tokens, client secrets, or `Authorization` headers during a logout run. Logout reads the Secret only to construct the patch payload; diagnostic output SHALL be limited to the Secret name, the keys cleared (or that the Secret was deleted), and a hint to re-run `ark mcp auth login <server-name>`.
+
+#### Scenario: Successful logout
+
+- **WHEN** `ark mcp auth logout <name>` succeeds against a populated Secret
+- **THEN** stdout/stderr SHALL name the cleared keys but SHALL NOT contain any token, refresh-token, or client-secret value
+

--- a/openspec/specs/mcp-auth-token-injection/spec.md
+++ b/openspec/specs/mcp-auth-token-injection/spec.md
@@ -218,7 +218,7 @@ The reconciler and the executor dispatch paths SHALL share the same default acce
 
 ### Requirement: Labelled token Secrets reconcile in real time
 
-Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval.
+Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval. The label has no functional authorization behaviour — its absence SHALL NOT prevent authentication, only delay reconciliation until the next `pollInterval` tick. Login (`ark mcp auth login`) stamps the label on Secret create/patch as a real-time-reconcile convenience; charts and manual operators SHOULD also stamp it for the same reason.
 
 #### Scenario: Operator patches a labelled token Secret
 
@@ -234,12 +234,12 @@ Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger im
 
 ### Requirement: Unlabelled token Secrets remain functional
 
-When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer on its periodic resync interval. The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
+When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer at the cadence set by `MCPServer.spec.pollInterval` (default `30s`). The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
 
 #### Scenario: Operator patches an unlabelled token Secret
 
 - **GIVEN** an MCPServer whose `tokenSecretRef` points at a Secret with no `ark.mckinsey.com/mcp-token-secret` label
 - **WHEN** the operator patches the Secret
 - **THEN** the controller SHALL NOT immediately enqueue a reconcile based on the Secret event
-- **AND** on the next periodic resync the reconciler SHALL read the updated Secret and transition state accordingly
+- **AND** on the next `pollInterval`-driven reconcile (default `30s`) the reconciler SHALL read the updated Secret and transition state accordingly
 

--- a/openspec/specs/mcp-auth-token-injection/spec.md
+++ b/openspec/specs/mcp-auth-token-injection/spec.md
@@ -154,3 +154,92 @@ All behaviours defined by `mcp-auth-detection` SHALL continue to hold unchanged.
 - **THEN** the controller SHALL stop injecting the Bearer header on subsequent reconciles
 - **AND** SHALL re-run detection — if the server still returns 401, state returns to `Required`; if the server now accepts unauthenticated calls, `status.authorization` SHALL be cleared
 
+### Requirement: Bearer injection applies to all in-cluster MCP client construction paths
+
+When `spec.authorization.tokenSecretRef` is set on an MCPServer, every Ark code path that constructs an MCP client for that MCPServer SHALL inject `Authorization: Bearer <access_token>` derived from the referenced Secret. This applies at minimum to:
+
+- The `MCPServerReconciler` (already covered by the original Stage 1 requirement).
+- The built-in completions executor's tool dispatch path (`ark/executors/completions/agent_tools.go::createMCPExecutor`).
+- The ark-sdk Python resolver that builds `MCPServerConfig.headers` for named execution engines (`lib/ark-sdk/.../extensions/query.py::_resolve_mcp_server`).
+
+When `spec.authorization` is unset, no path SHALL attempt to read any Secret for token injection.
+
+#### Scenario: Built-in completions executor dispatches a tool against an Authorized MCPServer
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret carrying `access_token`
+- **WHEN** an agent without `executionEngine` invokes a tool backed by that MCPServer
+- **THEN** the built `MCPClientConfig.Headers` SHALL contain `Authorization: Bearer <access_token>` and the tool call SHALL NOT produce a 401 caused by missing credentials
+
+#### Scenario: Named execution engine receives MCPServerConfig for an Authorized MCPServer
+
+- **GIVEN** the same Authorized MCPServer
+- **WHEN** the controller dispatches a query to a named execution engine via A2A
+- **THEN** the resulting `ExecutionEngineRequest.mcpServers[*].headers` SHALL contain `Authorization: Bearer <access_token>` for that server
+
+#### Scenario: User has supplied Authorization in spec.headers
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef` set AND a `spec.headers` entry whose name is `Authorization`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** the explicit `spec.headers` value SHALL win and the helper-derived Bearer SHALL NOT overwrite it
+
+#### Scenario: spec.headers carries a malformed Authorization value
+
+- **GIVEN** an MCPServer whose `spec.headers` contains an `Authorization` entry with a non-Bearer or otherwise malformed value
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** the value SHALL be passed through unchanged — the CLI / controller does not validate or rewrite explicit `spec.headers` values; this is the user's escape hatch and they accept the consequences
+
+#### Scenario: spec.authorization is unset
+
+- **GIVEN** an MCPServer with `spec.authorization == nil`
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no Secret read SHALL occur for token injection and no `Authorization` header SHALL be added beyond what `spec.headers` already supplies
+
+#### Scenario: Secret exists but the access-token key is empty
+
+- **GIVEN** the referenced Secret exists but the configured access-token key is missing or empty
+- **WHEN** any in-cluster path constructs the MCP client
+- **THEN** no `Authorization` header SHALL be injected and the call SHALL fall through to whatever `spec.headers` supplies
+
+### Requirement: Token resolution shares default key names across paths
+
+The reconciler and the executor dispatch paths SHALL share the same default access-token key name (`access_token`) and the same `accessTokenKey` override semantics, so an MCPServer that produces an `Authorized` state in reconcile is guaranteed to also yield a Bearer header at dispatch time. Implementations MAY share a helper or a constant; the binding requirement is that the two paths can never diverge on key resolution. Any shared helper SHALL be event-free — eventing for missing keys / Secrets stays in the reconciler.
+
+#### Scenario: Helper honours custom accessTokenKey override
+
+- **GIVEN** `spec.authorization.tokenSecretRef.accessTokenKey = MY_TOKEN`
+- **WHEN** the helper is invoked against a Secret whose `MY_TOKEN` key carries a value
+- **THEN** the helper SHALL return that value
+
+#### Scenario: Helper short-circuits when authorization is unset
+
+- **GIVEN** `spec.authorization == nil`
+- **WHEN** the helper is invoked
+- **THEN** it SHALL return an empty string and SHALL NOT issue any API server reads
+
+### Requirement: Labelled token Secrets reconcile in real time
+
+Secrets carrying label `ark.mckinsey.com/mcp-token-secret=true` SHALL trigger immediate reconciliation of every MCPServer whose `spec.authorization.tokenSecretRef.name` matches the changed Secret. The `MCPServerReconciler` SHALL register a field indexer on `spec.authorization.tokenSecretRef.name` and SHALL watch labelled Secrets via `builder.WithPredicates` so the reconcile loop fires on Secret events without depending on the resync interval.
+
+#### Scenario: Operator patches a labelled token Secret
+
+- **GIVEN** an MCPServer in state `Authorized` whose `tokenSecretRef` points at a Secret carrying the label `ark.mckinsey.com/mcp-token-secret=true`
+- **WHEN** the operator patches the Secret to empty `access_token`
+- **THEN** the controller SHALL reconcile within seconds and SHALL transition `status.authorization.state` to `Required`
+
+#### Scenario: Multiple MCPServers reference the same labelled Secret
+
+- **GIVEN** two MCPServers in the same namespace whose `spec.authorization.tokenSecretRef.name` points at the same labelled Secret
+- **WHEN** the Secret is patched
+- **THEN** the controller SHALL enqueue a reconcile for each MCPServer
+
+### Requirement: Unlabelled token Secrets remain functional
+
+When a Secret referenced by `spec.authorization.tokenSecretRef` lacks the `ark.mckinsey.com/mcp-token-secret` label, the controller SHALL still reconcile the MCPServer on its periodic resync interval. The label is a real-time convenience, not a correctness requirement. The cache SHALL NOT be filtered by this label — reconciler reads of any token Secret SHALL succeed regardless.
+
+#### Scenario: Operator patches an unlabelled token Secret
+
+- **GIVEN** an MCPServer whose `tokenSecretRef` points at a Secret with no `ark.mckinsey.com/mcp-token-secret` label
+- **WHEN** the operator patches the Secret
+- **THEN** the controller SHALL NOT immediately enqueue a reconcile based on the Secret event
+- **AND** on the next periodic resync the reconciler SHALL read the updated Secret and transition state accordingly
+

--- a/openspec/specs/mcp-server-resolution/spec.md
+++ b/openspec/specs/mcp-server-resolution/spec.md
@@ -1,6 +1,9 @@
 # MCP Server Resolution for Named Executors
 
-## ADDED Requirements
+## Purpose
+Resolution of MCPServer references for named execution engines so the engine receives fully-resolved connection info (URLs, headers, transport) without requiring direct cluster access.
+
+## Requirements
 
 ### Requirement: MCPServerConfig type on ExecutionEngineRequest
 The `ExecutionEngineRequest` SHALL include an `mcpServers` field containing a list of `MCPServerConfig` objects. The `tools` field and `ToolDefinition` type SHALL be removed.
@@ -67,3 +70,35 @@ If an MCPServer CRD cannot be found or its address/headers cannot be resolved, t
 #### Scenario: MCPServer secret resolution fails
 - **WHEN** an MCPServer header references a secret that cannot be read
 - **THEN** that server SHALL be skipped with a warning log
+
+### Requirement: Resolved MCPServerConfig.headers carries Authorization for OAuth-protected servers
+
+When an MCPServer has `spec.authorization.tokenSecretRef` set and the referenced Secret carries a non-empty access token, the resolver SHALL set `MCPServerConfig.headers["Authorization"] = "Bearer <access_token>"`. The Bearer header SHALL be derived inside the resolver from the cluster Secret — executors SHALL NOT receive `tokenSecretRef` or any other Secret-related field over the A2A wire.
+
+#### Scenario: Authorized MCPServer is resolved into MCPServerConfig
+
+- **GIVEN** an MCPServer with `spec.authorization.tokenSecretRef.name = notion-oauth` and a Secret containing `access_token`
+- **WHEN** the controller resolves the agent's MCP servers
+- **THEN** the corresponding `MCPServerConfig.headers` SHALL contain `Authorization: Bearer <access_token>`
+
+#### Scenario: spec.headers Authorization wins over tokenSecretRef
+
+- **GIVEN** an MCPServer with both `spec.authorization.tokenSecretRef` set and a `spec.headers` entry named `Authorization`
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** the explicit `spec.headers` value SHALL be used and the helper-derived Bearer SHALL NOT replace it
+
+#### Scenario: MCPServer without authorization
+
+- **GIVEN** an MCPServer with `spec.authorization` unset
+- **WHEN** the resolver builds `MCPServerConfig.headers`
+- **THEN** no `Authorization` header SHALL be added beyond `spec.headers`
+
+### Requirement: Executor authors do not handle MCPServer authorization
+
+`MCPServerConfig.headers` SHALL be the single contract executors consume for MCP authentication. Executor authors SHALL NOT need to read MCPServer CRDs, Secrets, or `spec.authorization` to call OAuth-protected MCP servers. Documentation describing how to build a new execution engine SHALL state this explicitly.
+
+#### Scenario: New execution engine consumes Authorization opaquely
+
+- **GIVEN** a custom execution engine receiving `ExecutionEngineRequest.mcpServers[i]`
+- **WHEN** it constructs an MCP client
+- **THEN** passing `MCPServerConfig.headers` to the client SHALL be sufficient for OAuth-protected servers — no extra resolution step SHALL be required

--- a/tools/ark-cli/src/commands/completion/index.ts
+++ b/tools/ark-cli/src/commands/completion/index.ts
@@ -32,7 +32,7 @@ _ark_completion() {
   
   case \${COMP_CWORD} in
     1)
-      opts="agents chat cluster completion config dashboard docs export generate import install marketplace memory models queries query routes status targets teams tools uninstall help"
+      opts="agents chat cluster completion config dashboard docs export generate import install marketplace mcp memory models queries query routes status targets teams tools uninstall help"
       COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
       return 0
       ;;
@@ -88,6 +88,11 @@ _ark_completion() {
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
+        mcp)
+          opts="auth"
+          COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
+          return 0
+          ;;
         memory)
           opts="list ls delete reset"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
@@ -127,6 +132,15 @@ _ark_completion() {
           ;;
         queries)
           opts="get delete resubmit"
+          COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
+          return 0
+          ;;
+      esac
+      ;;
+    3)
+      case "\${COMP_WORDS[1]} \${COMP_WORDS[2]}" in
+        "mcp auth")
+          opts="login logout"
           COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
           return 0
           ;;
@@ -173,6 +187,7 @@ _ark() {
         'import[Import ARK resources from a file]' \\
         'install[Install ARK services]' \\
         'marketplace[Manage marketplace services]' \\
+        'mcp[Interact with MCPServer resources]' \\
         'memory[Manage memory sessions and queries]' \\
         'models[List available models]' \\
         'queries[Manage query resources]' \\
@@ -240,6 +255,16 @@ _ark() {
           _values 'marketplace commands' \\
             'list[List available marketplace services]' \\
             'ls[List available marketplace services]'
+          ;;
+        mcp)
+          if (( CURRENT == 4 )) && [[ $words[3] == auth ]]; then
+            _values 'mcp auth commands' \\
+              'login[Authenticate against an MCPServer]' \\
+              'logout[Clear OAuth tokens for an MCPServer]'
+          else
+            _values 'mcp commands' \\
+              'auth[Manage OAuth credentials]'
+          fi
           ;;
         memory)
           _values 'memory commands' \\

--- a/tools/ark-cli/src/commands/mcp/auth.spec.ts
+++ b/tools/ark-cli/src/commands/mcp/auth.spec.ts
@@ -1,0 +1,559 @@
+import {Buffer} from 'buffer';
+import http from 'http';
+import {AddressInfo} from 'net';
+import {URL, URLSearchParams} from 'url';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  buildAuthorizeUrl,
+  exchangeCode,
+  registerClient,
+  runAuth,
+  runLogout,
+  writeSecret,
+  type AuthDeps,
+  type MCPServerResource,
+} from './auth.js';
+
+function startMockOAuthServer(opts: {
+  expectResource: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}) {
+  const server = http.createServer((req, res) => {
+    if (req.url?.startsWith('/register') && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const parsed = JSON.parse(body);
+        res.writeHead(201, {'content-type': 'application/json'});
+        res.end(
+          JSON.stringify({
+            client_id: 'test-client',
+            client_secret: 'test-secret',
+            redirect_uris: parsed.redirect_uris,
+          })
+        );
+      });
+      return;
+    }
+    if (req.url?.startsWith('/token') && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const params = new URLSearchParams(body);
+        if (params.get('resource') !== opts.expectResource) {
+          res.writeHead(400, {'content-type': 'application/json'});
+          res.end(JSON.stringify({error: 'bad_resource'}));
+          return;
+        }
+        const auth = req.headers['authorization'] || '';
+        if (!auth.toString().startsWith('Basic ')) {
+          res.writeHead(401, {'content-type': 'application/json'});
+          res.end(JSON.stringify({error: 'invalid_client'}));
+          return;
+        }
+        res.writeHead(200, {'content-type': 'application/json'});
+        res.end(
+          JSON.stringify({
+            access_token: opts.accessToken,
+            refresh_token: opts.refreshToken,
+            expires_in: opts.expiresIn,
+            token_type: 'bearer',
+          })
+        );
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  return new Promise<{baseUrl: string; close: () => Promise<void>}>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+describe('buildAuthorizeUrl', () => {
+  it('includes all required OAuth + RFC 8707 params', () => {
+    const url = buildAuthorizeUrl({
+      authorizationEndpoint: 'https://as.example/authorize',
+      clientId: 'abc',
+      redirectUri: 'http://127.0.0.1:9999/callback',
+      state: 'xyz',
+      codeChallenge: 'challenge',
+      resource: 'https://mcp.example/mcp',
+    });
+    const u = new URL(url);
+    expect(u.searchParams.get('response_type')).toBe('code');
+    expect(u.searchParams.get('client_id')).toBe('abc');
+    expect(u.searchParams.get('redirect_uri')).toBe(
+      'http://127.0.0.1:9999/callback'
+    );
+    expect(u.searchParams.get('state')).toBe('xyz');
+    expect(u.searchParams.get('code_challenge')).toBe('challenge');
+    expect(u.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(u.searchParams.get('resource')).toBe('https://mcp.example/mcp');
+  });
+});
+
+describe('registerClient', () => {
+  it('rejects when redirect_uris mismatch', async () => {
+    const server = await startMockOAuthServer({
+      expectResource: 'x',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresIn: 10,
+    });
+    try {
+      const custom: typeof fetch = async (input, init) => {
+        // Rewrite the response to drop redirect_uris.
+        const real = await fetch(input as string, init);
+        const json = await real.json();
+        delete (json as Record<string, unknown>).redirect_uris;
+        (json as Record<string, unknown>).redirect_uris = ['http://evil/cb'];
+        // eslint-disable-next-line no-undef
+        return new Response(JSON.stringify(json), {
+          status: real.status,
+          headers: {'content-type': 'application/json'},
+        });
+      };
+      await expect(
+        registerClient(
+          `${server.baseUrl}/register`,
+          'http://127.0.0.1:1/callback',
+          custom
+        )
+      ).rejects.toThrow(/redirect_uris/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns client_id + client_secret on success', async () => {
+    const server = await startMockOAuthServer({
+      expectResource: 'x',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresIn: 10,
+    });
+    try {
+      const reg = await registerClient(
+        `${server.baseUrl}/register`,
+        'http://127.0.0.1:1/callback',
+        fetch
+      );
+      expect(reg.client_id).toBe('test-client');
+      expect(reg.client_secret).toBe('test-secret');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('exchangeCode', () => {
+  it('posts form-encoded with Basic auth and parses tokens', async () => {
+    const server = await startMockOAuthServer({
+      expectResource: 'https://mcp.example/mcp',
+      accessToken: 'access-123',
+      refreshToken: 'refresh-456',
+      expiresIn: 3600,
+    });
+    try {
+      const tokens = await exchangeCode({
+        tokenEndpoint: `${server.baseUrl}/token`,
+        clientId: 'test-client',
+        clientSecret: 'test-secret',
+        code: 'the-code',
+        redirectUri: 'http://127.0.0.1:1/callback',
+        codeVerifier: 'the-verifier',
+        resource: 'https://mcp.example/mcp',
+        fetchImpl: fetch,
+      });
+      expect(tokens.access_token).toBe('access-123');
+      expect(tokens.refresh_token).toBe('refresh-456');
+      expect(tokens.expires_in).toBe(3600);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('surfaces 4xx response body in error', async () => {
+    const server = await startMockOAuthServer({
+      expectResource: 'match',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresIn: 10,
+    });
+    try {
+      await expect(
+        exchangeCode({
+          tokenEndpoint: `${server.baseUrl}/token`,
+          clientId: 'test-client',
+          clientSecret: 'test-secret',
+          code: 'c',
+          redirectUri: 'http://127.0.0.1:1/callback',
+          codeVerifier: 'v',
+          resource: 'wrong',
+          fetchImpl: fetch,
+        })
+      ).rejects.toThrow(/token exchange failed.*bad_resource/);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('writeSecret', () => {
+  it('patches when the secret exists', async () => {
+    const kubectl = vi.fn(async (_bin: string, args: string[]) => {
+      if (args[0] === 'get') return {stdout: '{}'} as any;
+      return {stdout: ''} as any;
+    });
+    await writeSecret(
+      {
+        namespace: 'default',
+        name: 'notion-tokens',
+        keys: {
+          accessTokenKey: 'access_token',
+          refreshTokenKey: 'refresh_token',
+          expiresAtKey: 'expires_at',
+          clientIDKey: 'client_id',
+          clientSecretKey: 'client_secret',
+        },
+        accessToken: 'a',
+        refreshToken: 'r',
+        expiresAt: '2025-01-01T00:00:00.000Z',
+        clientId: 'cid',
+        clientSecret: 'csec',
+      },
+      kubectl as any
+    );
+    const calls = kubectl.mock.calls.map((c) => c[1]);
+    expect(calls[0][0]).toBe('get');
+    expect(calls[1][0]).toBe('patch');
+    // The patch payload is the last arg; confirm base64 encoding happened.
+    const patchJson = JSON.parse(calls[1][calls[1].length - 1] as string);
+    expect(
+      Buffer.from(patchJson.data.access_token, 'base64').toString('utf8')
+    ).toBe('a');
+    expect(
+      Buffer.from(patchJson.data.refresh_token, 'base64').toString('utf8')
+    ).toBe('r');
+  });
+
+  it('creates a new Opaque secret when missing', async () => {
+    const kubectl = vi.fn(async (_bin: string, args: string[]) => {
+      if (args[0] === 'get') throw new Error('NotFound');
+      return {stdout: ''} as any;
+    });
+    await writeSecret(
+      {
+        namespace: 'ns',
+        name: 'tokens',
+        keys: {
+          accessTokenKey: 'access_token',
+          refreshTokenKey: 'refresh_token',
+          expiresAtKey: 'expires_at',
+          clientIDKey: 'client_id',
+          clientSecretKey: 'client_secret',
+        },
+        accessToken: 'a',
+        expiresAt: 't',
+        clientId: 'cid',
+      },
+      kubectl as any
+    );
+    const applyCall = kubectl.mock.calls.find((c) => (c[1] as string[])[0] === 'apply');
+    expect(applyCall).toBeTruthy();
+    const opts = applyCall![2] as {input: string};
+    const manifest = JSON.parse(opts.input);
+    expect(manifest.kind).toBe('Secret');
+    expect(manifest.type).toBe('Opaque');
+    expect(manifest.metadata.namespace).toBe('ns');
+  });
+});
+
+describe('runAuth end-to-end', () => {
+  let mock: {baseUrl: string; close: () => Promise<void>};
+
+  beforeEach(async () => {
+    mock = await startMockOAuthServer({
+      expectResource: 'https://mcp.example/mcp',
+      accessToken: 'e2e-access',
+      refreshToken: 'e2e-refresh',
+      expiresIn: 120,
+    });
+  });
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it('runs DCR + PKCE + callback + token exchange + secret patch', async () => {
+    const mcpServer: MCPServerResource = {
+      metadata: {name: 'notion', namespace: 'default'},
+      spec: {authorization: {tokenSecretRef: {name: 'notion-tokens'}}},
+      status: {
+        authorization: {
+          state: 'Required',
+          resource: 'https://mcp.example/mcp',
+          registrationEndpoint: `${mock.baseUrl}/register`,
+          authorizationEndpoint: `${mock.baseUrl}/authorize`,
+          tokenEndpoint: `${mock.baseUrl}/token`,
+        },
+      },
+    };
+
+    // Capture kubectl calls and simulate cluster responses.
+    const kubectlCalls: string[][] = [];
+    const kubectl = vi.fn(async (_bin: string, args: string[]) => {
+      kubectlCalls.push(args);
+      if (args[0] === 'config') return {stdout: 'default'} as any;
+      if (args[0] === 'get' && args[1] === 'mcpserver') {
+        return {stdout: JSON.stringify(mcpServer)} as any;
+      }
+      if (args[0] === 'get' && args[1] === 'secret') {
+        // Pretend it exists so we exercise the patch path.
+        return {stdout: '{}'} as any;
+      }
+      return {stdout: ''} as any;
+    });
+
+    // The opener walks the authorize URL and drives the callback itself, same
+    // shape a browser would.
+    const openBrowser = vi.fn(async (url: string) => {
+      const u = new URL(url);
+      const redirect = u.searchParams.get('redirect_uri')!;
+      const state = u.searchParams.get('state')!;
+      const cb = new URL(redirect);
+      cb.searchParams.set('code', 'mock-auth-code');
+      cb.searchParams.set('state', state);
+      const res = await fetch(cb.toString());
+      await res.text();
+    });
+
+    const deps: AuthDeps = {
+      openBrowser,
+      kubectl: kubectl as any,
+      fetch,
+    };
+
+    await runAuth('notion', {namespace: 'default', timeout: 10_000}, deps);
+
+    expect(openBrowser).toHaveBeenCalledOnce();
+    const patchCall = kubectlCalls.find((c) => c[0] === 'patch');
+    expect(patchCall).toBeTruthy();
+    const patch = JSON.parse(patchCall![patchCall!.length - 1]);
+    expect(
+      Buffer.from(patch.data.access_token, 'base64').toString('utf8')
+    ).toBe('e2e-access');
+    expect(
+      Buffer.from(patch.data.refresh_token, 'base64').toString('utf8')
+    ).toBe('e2e-refresh');
+    expect(
+      Buffer.from(patch.data.client_id, 'base64').toString('utf8')
+    ).toBe('test-client');
+    expect(
+      Buffer.from(patch.data.client_secret, 'base64').toString('utf8')
+    ).toBe('test-secret');
+    // expires_at must be ISO 8601.
+    const expIso = Buffer.from(patch.data.expires_at, 'base64').toString(
+      'utf8'
+    );
+    expect(Number.isNaN(Date.parse(expIso))).toBe(false);
+  });
+
+  it('refuses when state is not Required and --force not passed', async () => {
+    const mcpServer: MCPServerResource = {
+      metadata: {name: 'notion'},
+      spec: {authorization: {tokenSecretRef: {name: 'notion-tokens'}}},
+      status: {authorization: {state: 'Authorized'}},
+    };
+    const kubectl = vi.fn(async (_bin: string, args: string[]) => {
+      if (args[0] === 'config') return {stdout: 'default'} as any;
+      if (args[0] === 'get' && args[1] === 'mcpserver') {
+        return {stdout: JSON.stringify(mcpServer)} as any;
+      }
+      return {stdout: ''} as any;
+    });
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: kubectl as any,
+      fetch,
+    };
+    await expect(runAuth('notion', {}, deps)).rejects.toThrow(/--force/);
+  });
+});
+
+describe('runLogout', () => {
+  const baseServer: MCPServerResource = {
+    metadata: {name: 'notion', namespace: 'default'},
+    spec: {authorization: {tokenSecretRef: {name: 'notion-tokens'}}},
+    status: {authorization: {state: 'Authorized'}},
+  };
+
+  function makeKubectl(opts: {
+    server?: MCPServerResource;
+    secretExists?: boolean;
+    onCall?: (args: string[]) => void;
+  }) {
+    const server = opts.server ?? baseServer;
+    const secretExists = opts.secretExists ?? true;
+    const calls: string[][] = [];
+    const fn = vi.fn(async (_bin: string, args: string[]) => {
+      calls.push(args);
+      opts.onCall?.(args);
+      if (args[0] === 'config') return {stdout: 'default'} as any;
+      if (args[0] === 'get' && args[1] === 'mcpserver') {
+        return {stdout: JSON.stringify(server)} as any;
+      }
+      if (args[0] === 'get' && args[1] === 'secret') {
+        if (!secretExists) throw new Error('NotFound');
+        return {stdout: '{}'} as any;
+      }
+      return {stdout: ''} as any;
+    });
+    return {fn, calls};
+  }
+
+  it('default logout patches all five keys to empty', async () => {
+    const {fn, calls} = makeKubectl({});
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: fn as any,
+      fetch,
+    };
+    await runLogout('notion', {namespace: 'default'}, deps);
+    const patchCall = calls.find((c) => c[0] === 'patch');
+    expect(patchCall).toBeTruthy();
+    const patch = JSON.parse(patchCall![patchCall!.length - 1]);
+    expect(Object.keys(patch.data).sort()).toEqual([
+      'access_token',
+      'client_id',
+      'client_secret',
+      'expires_at',
+      'refresh_token',
+    ]);
+    for (const v of Object.values(patch.data)) expect(v).toBe('');
+  });
+
+  it('--keep-client patches only the three token keys', async () => {
+    const {fn, calls} = makeKubectl({});
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: fn as any,
+      fetch,
+    };
+    await runLogout(
+      'notion',
+      {namespace: 'default', keepClient: true},
+      deps
+    );
+    const patchCall = calls.find((c) => c[0] === 'patch');
+    expect(patchCall).toBeTruthy();
+    const patch = JSON.parse(patchCall![patchCall!.length - 1]);
+    expect(Object.keys(patch.data).sort()).toEqual([
+      'access_token',
+      'expires_at',
+      'refresh_token',
+    ]);
+    for (const v of Object.values(patch.data)) expect(v).toBe('');
+  });
+
+  it('--delete-secret issues kubectl delete with --ignore-not-found=true', async () => {
+    const {fn, calls} = makeKubectl({});
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: fn as any,
+      fetch,
+    };
+    await runLogout(
+      'notion',
+      {namespace: 'default', deleteSecret: true},
+      deps
+    );
+    const deleteCall = calls.find((c) => c[0] === 'delete');
+    expect(deleteCall).toBeTruthy();
+    expect(deleteCall).toEqual([
+      'delete',
+      'secret',
+      'notion-tokens',
+      '-n',
+      'default',
+      '--ignore-not-found=true',
+    ]);
+    expect(calls.find((c) => c[0] === 'patch')).toBeUndefined();
+  });
+
+  it('rejects --keep-client + --delete-secret without issuing any kubectl call', async () => {
+    const fn = vi.fn(async () => ({stdout: ''}) as any);
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: fn as any,
+      fetch,
+    };
+    await expect(
+      runLogout(
+        'notion',
+        {namespace: 'default', keepClient: true, deleteSecret: true},
+        deps
+      )
+    ).rejects.toThrow(/mutually exclusive/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('missing Secret is a no-op and exits zero', async () => {
+    const {fn, calls} = makeKubectl({secretExists: false});
+    const deps: AuthDeps = {
+      openBrowser: vi.fn(),
+      kubectl: fn as any,
+      fetch,
+    };
+    await runLogout('notion', {namespace: 'default'}, deps);
+    expect(calls.find((c) => c[0] === 'patch')).toBeUndefined();
+    expect(calls.find((c) => c[0] === 'delete')).toBeUndefined();
+  });
+
+  it('never echoes any token value to stdout/stderr', async () => {
+    // Pre-existing tokens in the secret would only be visible if logout
+    // logged them; runLogout never reads the secret data, so probe the
+    // command surface to be sure no stray value appears.
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const {fn} = makeKubectl({});
+      const deps: AuthDeps = {
+        openBrowser: vi.fn(),
+        kubectl: fn as any,
+        fetch,
+      };
+      await runLogout('notion', {namespace: 'default'}, deps);
+      const captured = [
+        ...stdoutWrite.mock.calls,
+        ...stderrWrite.mock.calls,
+        ...consoleLog.mock.calls,
+        ...consoleError.mock.calls,
+      ]
+        .flat()
+        .map((c) => (typeof c === 'string' ? c : String(c)))
+        .join('\n');
+      // Sentinels for token-shaped strings — none should ever leak.
+      expect(captured).not.toMatch(/eyJ[A-Za-z0-9_-]+\./); // JWT-ish
+      expect(captured).not.toMatch(/Bearer\s+[A-Za-z0-9._-]+/);
+      expect(captured).not.toMatch(/access_token["']?\s*[:=]\s*["'][^"']+["']/);
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+      consoleLog.mockRestore();
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/tools/ark-cli/src/commands/mcp/auth.spec.ts
+++ b/tools/ark-cli/src/commands/mcp/auth.spec.ts
@@ -9,7 +9,9 @@ import {
   registerClient,
   runAuth,
   runLogout,
+  startCallbackListener,
   writeSecret,
+  MCP_TOKEN_SECRET_LABEL,
   type AuthDeps,
   type MCPServerResource,
 } from './auth.js';
@@ -246,6 +248,7 @@ describe('writeSecret', () => {
     expect(
       Buffer.from(patchJson.data.refresh_token, 'base64').toString('utf8')
     ).toBe('r');
+    expect(patchJson.metadata.labels[MCP_TOKEN_SECRET_LABEL]).toBe('true');
   });
 
   it('creates a new Opaque secret when missing', async () => {
@@ -277,6 +280,65 @@ describe('writeSecret', () => {
     expect(manifest.kind).toBe('Secret');
     expect(manifest.type).toBe('Opaque');
     expect(manifest.metadata.namespace).toBe('ns');
+    expect(manifest.metadata.labels[MCP_TOKEN_SECRET_LABEL]).toBe('true');
+  });
+});
+
+describe('startCallbackListener IPv6 dual-stack', () => {
+  it('accepts callbacks arriving on [::1]', async () => {
+    const listener = startCallbackListener(undefined, 5000);
+    try {
+      const port = await listener.port;
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: '::1',
+            port,
+            path: '/callback?code=ipv6-code&state=ipv6-state',
+            method: 'GET',
+          },
+          (res) => {
+            res.resume();
+            res.on('end', () => resolve());
+          }
+        );
+        req.on('error', reject);
+        req.end();
+      });
+      const result = await listener.awaitCode;
+      expect(result.code).toBe('ipv6-code');
+      expect(result.state).toBe('ipv6-state');
+    } finally {
+      listener.server.close();
+    }
+  });
+
+  it('accepts callbacks arriving on 127.0.0.1 identically', async () => {
+    const listener = startCallbackListener(undefined, 5000);
+    try {
+      const port = await listener.port;
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: '127.0.0.1',
+            port,
+            path: '/callback?code=ipv4-code&state=ipv4-state',
+            method: 'GET',
+          },
+          (res) => {
+            res.resume();
+            res.on('end', () => resolve());
+          }
+        );
+        req.on('error', reject);
+        req.end();
+      });
+      const result = await listener.awaitCode;
+      expect(result.code).toBe('ipv4-code');
+      expect(result.state).toBe('ipv4-state');
+    } finally {
+      listener.server.close();
+    }
   });
 });
 
@@ -367,6 +429,7 @@ describe('runAuth end-to-end', () => {
       'utf8'
     );
     expect(Number.isNaN(Date.parse(expIso))).toBe(false);
+    expect(patch.metadata.labels[MCP_TOKEN_SECRET_LABEL]).toBe('true');
   });
 
   it('refuses when state is not Required and --force not passed', async () => {

--- a/tools/ark-cli/src/commands/mcp/auth.ts
+++ b/tools/ark-cli/src/commands/mcp/auth.ts
@@ -239,9 +239,10 @@ export function startCallbackListener(
     resolveCode({code, state});
   });
 
-  // Empty string binds to all, but we want loopback only — 127.0.0.1 keeps the
-  // OAuth redirect off the LAN.
-  server.listen(port ?? 0, '127.0.0.1', () => {
+  // Bind dual-stack so callbacks arriving on [::1] are accepted identically
+  // to 127.0.0.1. Node listens on both v4 and v6 loopback when passed '::'
+  // unless ipv6Only is set.
+  server.listen(port ?? 0, '::', () => {
     const addr = server.address() as AddressInfo | null;
     if (!addr) {
       rejectPort(new Error('failed to bind callback listener'));
@@ -349,6 +350,10 @@ interface SecretWriteInput {
   clientSecret?: string;
 }
 
+// Label the MCPServer controller's Secret watch keys off — its absence only
+// delays reconcile to the next pollInterval tick rather than breaking auth.
+export const MCP_TOKEN_SECRET_LABEL = 'ark.mckinsey.com/mcp-token-secret';
+
 // Merges tokens into the named Secret — creates it opaque if missing, patches it
 // otherwise. Patch (not replace) is deliberate so unrelated keys survive.
 export async function writeSecret(
@@ -367,6 +372,8 @@ export async function writeSecret(
     data[input.keys.clientSecretKey] = b64(input.clientSecret);
   }
 
+  const labels = {[MCP_TOKEN_SECRET_LABEL]: 'true'};
+
   let exists = false;
   try {
     await kubectl(
@@ -380,7 +387,7 @@ export async function writeSecret(
   }
 
   if (exists) {
-    const patch = JSON.stringify({data});
+    const patch = JSON.stringify({metadata: {labels}, data});
     await kubectl(
       'kubectl',
       ['patch', 'secret', input.name, '-n', input.namespace, '--type=merge', '-p', patch],
@@ -391,7 +398,7 @@ export async function writeSecret(
       apiVersion: 'v1',
       kind: 'Secret',
       type: 'Opaque',
-      metadata: {name: input.name, namespace: input.namespace},
+      metadata: {name: input.name, namespace: input.namespace, labels},
       data,
     };
     await kubectl('kubectl', ['apply', '-f', '-'], {

--- a/tools/ark-cli/src/commands/mcp/auth.ts
+++ b/tools/ark-cli/src/commands/mcp/auth.ts
@@ -1,0 +1,655 @@
+import {Buffer} from 'buffer';
+import http from 'http';
+import {AddressInfo} from 'net';
+import {URL, URLSearchParams} from 'url';
+import {execa} from 'execa';
+import openDefault from 'open';
+import output from '../../lib/output.js';
+import {generatePkcePair, generateState} from './pkce.js';
+
+// Kept out of the command surface so integration tests can stand in a mock.
+export interface BrowserOpener {
+  (url: string): Promise<unknown>;
+}
+
+export interface AuthDeps {
+  openBrowser: BrowserOpener;
+  kubectl: typeof execa;
+  fetch: typeof fetch;
+}
+
+export const defaultDeps: AuthDeps = {
+  openBrowser: (url) => openDefault(url),
+  kubectl: execa,
+  fetch: (...args) => fetch(...(args as Parameters<typeof fetch>)),
+};
+
+export interface AuthorizationStatus {
+  state?: string;
+  resource?: string;
+  resourceName?: string;
+  registrationEndpoint?: string;
+  authorizationEndpoint?: string;
+  tokenEndpoint?: string;
+  scopesSupported?: string[];
+}
+
+export interface TokenSecretRef {
+  name: string;
+  accessTokenKey?: string;
+  refreshTokenKey?: string;
+  expiresAtKey?: string;
+  clientIDKey?: string;
+  clientSecretKey?: string;
+}
+
+export interface MCPServerResource {
+  metadata: {name: string; namespace?: string};
+  spec?: {
+    authorization?: {
+      tokenSecretRef: TokenSecretRef;
+    };
+  };
+  status?: {
+    authorization?: AuthorizationStatus;
+  };
+}
+
+export interface AuthOptions {
+  namespace?: string;
+  force?: boolean;
+  port?: number;
+  open?: boolean;
+  timeout?: number; // ms
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+const SECRET_KEY_DEFAULTS = {
+  accessTokenKey: 'access_token',
+  refreshTokenKey: 'refresh_token',
+  expiresAtKey: 'expires_at',
+  clientIDKey: 'client_id',
+  clientSecretKey: 'client_secret',
+};
+
+function resolvedKeys(ref: TokenSecretRef) {
+  return {
+    accessTokenKey: ref.accessTokenKey || SECRET_KEY_DEFAULTS.accessTokenKey,
+    refreshTokenKey: ref.refreshTokenKey || SECRET_KEY_DEFAULTS.refreshTokenKey,
+    expiresAtKey: ref.expiresAtKey || SECRET_KEY_DEFAULTS.expiresAtKey,
+    clientIDKey: ref.clientIDKey || SECRET_KEY_DEFAULTS.clientIDKey,
+    clientSecretKey:
+      ref.clientSecretKey || SECRET_KEY_DEFAULTS.clientSecretKey,
+  };
+}
+
+export async function getMCPServer(
+  name: string,
+  namespace: string | undefined,
+  kubectl: typeof execa
+): Promise<MCPServerResource> {
+  const args = ['get', 'mcpserver', name, '-o', 'json'];
+  if (namespace) args.push('-n', namespace);
+  const {stdout} = await kubectl('kubectl', args, {stdio: 'pipe'});
+  return JSON.parse(stdout) as MCPServerResource;
+}
+
+export async function resolveNamespace(
+  flag: string | undefined,
+  kubectl: typeof execa
+): Promise<string> {
+  if (flag) return flag;
+  try {
+    const {stdout} = await kubectl(
+      'kubectl',
+      [
+        'config',
+        'view',
+        '--minify',
+        '-o',
+        'jsonpath={..namespace}',
+      ],
+      {stdio: 'pipe'}
+    );
+    const ns = stdout.trim();
+    return ns || 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+interface RegisteredClient {
+  client_id: string;
+  client_secret?: string;
+}
+
+export async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  fetchImpl: typeof fetch
+): Promise<RegisteredClient> {
+  const body = {
+    client_name: 'ark mcp auth',
+    redirect_uris: [redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'client_secret_basic',
+  };
+  const res = await fetchImpl(registrationEndpoint, {
+    method: 'POST',
+    headers: {'content-type': 'application/json', accept: 'application/json'},
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `dynamic client registration failed: ${res.status} ${text}`
+    );
+  }
+  const data = (await res.json()) as RegisteredClient & {
+    redirect_uris?: string[];
+  };
+  if (data.redirect_uris && !data.redirect_uris.includes(redirectUri)) {
+    throw new Error(
+      `registration endpoint returned redirect_uris that do not include ${redirectUri}`
+    );
+  }
+  return data;
+}
+
+export function buildAuthorizeUrl(params: {
+  authorizationEndpoint: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  resource: string;
+  scope?: string;
+}): string {
+  const u = new URL(params.authorizationEndpoint);
+  u.searchParams.set('response_type', 'code');
+  u.searchParams.set('client_id', params.clientId);
+  u.searchParams.set('redirect_uri', params.redirectUri);
+  u.searchParams.set('state', params.state);
+  u.searchParams.set('code_challenge', params.codeChallenge);
+  u.searchParams.set('code_challenge_method', 'S256');
+  u.searchParams.set('resource', params.resource);
+  if (params.scope) u.searchParams.set('scope', params.scope);
+  return u.toString();
+}
+
+interface CallbackResult {
+  code: string;
+  state: string;
+}
+
+export function startCallbackListener(
+  port: number | undefined,
+  timeoutMs: number
+): {
+  server: http.Server;
+  port: Promise<number>;
+  awaitCode: Promise<CallbackResult>;
+} {
+  let resolvePort!: (p: number) => void;
+  let rejectPort!: (e: Error) => void;
+  const portPromise = new Promise<number>((res, rej) => {
+    resolvePort = res;
+    rejectPort = rej;
+  });
+
+  let resolveCode!: (r: CallbackResult) => void;
+  let rejectCode!: (e: Error) => void;
+  const codePromise = new Promise<CallbackResult>((res, rej) => {
+    resolveCode = res;
+    rejectCode = rej;
+  });
+
+  const server = http.createServer((req, res) => {
+    if (!req.url || !req.url.startsWith('/callback')) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const reqUrl = new URL(req.url, 'http://127.0.0.1');
+    const code = reqUrl.searchParams.get('code');
+    const state = reqUrl.searchParams.get('state');
+    const error = reqUrl.searchParams.get('error');
+
+    if (error) {
+      res.writeHead(400, {'content-type': 'text/html'});
+      res.end(
+        `<html><body><h1>Authorization failed</h1><p>${escapeHtml(error)}</p></body></html>`
+      );
+      rejectCode(new Error(`authorization error: ${error}`));
+      return;
+    }
+    if (!code || !state) {
+      res.writeHead(400, {'content-type': 'text/html'});
+      res.end('<html><body>missing code or state</body></html>');
+      rejectCode(new Error('callback missing code or state'));
+      return;
+    }
+
+    res.writeHead(200, {'content-type': 'text/html'});
+    res.end(
+      '<html><body><h1>Authorization complete</h1><p>You may close this window.</p></body></html>'
+    );
+    resolveCode({code, state});
+  });
+
+  // Empty string binds to all, but we want loopback only — 127.0.0.1 keeps the
+  // OAuth redirect off the LAN.
+  server.listen(port ?? 0, '127.0.0.1', () => {
+    const addr = server.address() as AddressInfo | null;
+    if (!addr) {
+      rejectPort(new Error('failed to bind callback listener'));
+      return;
+    }
+    resolvePort(addr.port);
+  });
+
+  server.on('error', (e) => {
+    rejectPort(e);
+    rejectCode(e);
+  });
+
+  const timer = setTimeout(() => {
+    rejectCode(
+      new Error(`timed out waiting for OAuth callback after ${timeoutMs}ms`)
+    );
+    server.close();
+  }, timeoutMs);
+  // Never let the timer keep Node alive past a resolved promise.
+  timer.unref?.();
+  codePromise.finally(() => clearTimeout(timer)).catch(() => {});
+
+  return {server, port: portPromise, awaitCode: codePromise};
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    c === '&'
+      ? '&amp;'
+      : c === '<'
+        ? '&lt;'
+        : c === '>'
+          ? '&gt;'
+          : c === '"'
+            ? '&quot;'
+            : '&#39;'
+  );
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+export async function exchangeCode(params: {
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret?: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+  resource: string;
+  fetchImpl: typeof fetch;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: params.code,
+    redirect_uri: params.redirectUri,
+    code_verifier: params.codeVerifier,
+    resource: params.resource,
+  });
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+    accept: 'application/json',
+  };
+  if (params.clientSecret) {
+    const b64 = Buffer.from(
+      `${params.clientId}:${params.clientSecret}`
+    ).toString('base64');
+    headers['authorization'] = `Basic ${b64}`;
+  } else {
+    body.set('client_id', params.clientId);
+  }
+
+  const res = await params.fetchImpl(params.tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `token exchange failed: ${res.status} ${res.statusText} — ${text}`
+    );
+  }
+  return (await res.json()) as TokenResponse;
+}
+
+function b64(s: string): string {
+  return Buffer.from(s, 'utf8').toString('base64');
+}
+
+interface SecretWriteInput {
+  namespace: string;
+  name: string;
+  keys: ReturnType<typeof resolvedKeys>;
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: string;
+  clientId: string;
+  clientSecret?: string;
+}
+
+// Merges tokens into the named Secret — creates it opaque if missing, patches it
+// otherwise. Patch (not replace) is deliberate so unrelated keys survive.
+export async function writeSecret(
+  input: SecretWriteInput,
+  kubectl: typeof execa
+): Promise<void> {
+  const data: Record<string, string> = {
+    [input.keys.accessTokenKey]: b64(input.accessToken),
+    [input.keys.expiresAtKey]: b64(input.expiresAt),
+    [input.keys.clientIDKey]: b64(input.clientId),
+  };
+  if (input.refreshToken) {
+    data[input.keys.refreshTokenKey] = b64(input.refreshToken);
+  }
+  if (input.clientSecret) {
+    data[input.keys.clientSecretKey] = b64(input.clientSecret);
+  }
+
+  let exists = false;
+  try {
+    await kubectl(
+      'kubectl',
+      ['get', 'secret', input.name, '-n', input.namespace],
+      {stdio: 'pipe'}
+    );
+    exists = true;
+  } catch {
+    // Secret does not exist — we'll create it below.
+  }
+
+  if (exists) {
+    const patch = JSON.stringify({data});
+    await kubectl(
+      'kubectl',
+      ['patch', 'secret', input.name, '-n', input.namespace, '--type=merge', '-p', patch],
+      {stdio: 'pipe'}
+    );
+  } else {
+    const manifest = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      type: 'Opaque',
+      metadata: {name: input.name, namespace: input.namespace},
+      data,
+    };
+    await kubectl('kubectl', ['apply', '-f', '-'], {
+      input: JSON.stringify(manifest),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+}
+
+export async function runAuth(
+  serverName: string,
+  options: AuthOptions,
+  deps: AuthDeps = defaultDeps
+): Promise<void> {
+  const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+  const namespace = await resolveNamespace(options.namespace, deps.kubectl);
+  const server = await getMCPServer(serverName, namespace, deps.kubectl);
+
+  const auth = server.status?.authorization;
+  if (!auth) {
+    throw new Error(
+      `MCPServer ${serverName} has no status.authorization — nothing to authorize against. ` +
+        `Has the controller reconciled it yet?`
+    );
+  }
+  if (auth.state !== 'Required' && !options.force) {
+    throw new Error(
+      `MCPServer ${serverName} is in state ${auth.state ?? '(empty)'}; ` +
+        `pass --force to rotate tokens anyway`
+    );
+  }
+  if (!auth.authorizationEndpoint || !auth.tokenEndpoint) {
+    throw new Error(
+      `MCPServer ${serverName} is missing authorizationEndpoint / tokenEndpoint in status — discovery incomplete`
+    );
+  }
+  if (!auth.resource) {
+    throw new Error(
+      `MCPServer ${serverName} is missing status.authorization.resource — required for RFC 8707`
+    );
+  }
+  const tokenSecretRef = server.spec?.authorization?.tokenSecretRef;
+  if (!tokenSecretRef) {
+    throw new Error(
+      `MCPServer ${serverName} has no spec.authorization.tokenSecretRef — cannot persist tokens`
+    );
+  }
+
+  // Bind the loopback FIRST so we know the port to register with DCR.
+  const listener = startCallbackListener(options.port, timeoutMs);
+  let boundPort: number;
+  try {
+    boundPort = await listener.port;
+  } catch (e) {
+    listener.server.close();
+    throw e;
+  }
+  const redirectUri = `http://127.0.0.1:${boundPort}/callback`;
+
+  try {
+    let clientId: string;
+    let clientSecret: string | undefined;
+    if (auth.registrationEndpoint) {
+      const reg = await registerClient(
+        auth.registrationEndpoint,
+        redirectUri,
+        deps.fetch
+      );
+      clientId = reg.client_id;
+      clientSecret = reg.client_secret;
+      output.info(`registered OAuth client_id=${clientId}`);
+    } else {
+      throw new Error(
+        'no registrationEndpoint in status and pre-registered client support is not implemented yet'
+      );
+    }
+
+    const pkce = generatePkcePair();
+    const state = generateState();
+    const authorizeUrl = buildAuthorizeUrl({
+      authorizationEndpoint: auth.authorizationEndpoint,
+      clientId,
+      redirectUri,
+      state,
+      codeChallenge: pkce.challenge,
+      resource: auth.resource,
+    });
+
+    console.log('\nOpen this URL in your browser to authorize:\n');
+    console.log(authorizeUrl);
+    console.log('');
+
+    if (options.open !== false) {
+      try {
+        await deps.openBrowser(authorizeUrl);
+      } catch {
+        output.warning('failed to open browser automatically; paste the URL above');
+      }
+    }
+
+    const callback = await listener.awaitCode;
+    if (callback.state !== state) {
+      throw new Error(
+        'state parameter mismatch — aborting, possible CSRF'
+      );
+    }
+
+    const tokens = await exchangeCode({
+      tokenEndpoint: auth.tokenEndpoint,
+      clientId,
+      clientSecret,
+      code: callback.code,
+      redirectUri,
+      codeVerifier: pkce.verifier,
+      resource: auth.resource,
+      fetchImpl: deps.fetch,
+    });
+
+    const expiresAt = new Date(
+      Date.now() + (tokens.expires_in ?? 3600) * 1000
+    ).toISOString();
+
+    await writeSecret(
+      {
+        namespace,
+        name: tokenSecretRef.name,
+        keys: resolvedKeys(tokenSecretRef),
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresAt,
+        clientId,
+        clientSecret,
+      },
+      deps.kubectl
+    );
+
+    output.success(
+      `tokens written to secret ${tokenSecretRef.name} in namespace ${namespace}`
+    );
+    console.log(`  resource:   ${auth.resource}`);
+    console.log(`  expires_at: ${expiresAt}`);
+    console.log(
+      `  state:      Required -> Authorized (expected within pollInterval)`
+    );
+  } finally {
+    listener.server.close();
+  }
+}
+
+export interface LogoutOptions {
+  namespace?: string;
+  keepClient?: boolean;
+  deleteSecret?: boolean;
+}
+
+async function secretExists(
+  name: string,
+  namespace: string,
+  kubectl: typeof execa
+): Promise<boolean> {
+  try {
+    await kubectl(
+      'kubectl',
+      ['get', 'secret', name, '-n', namespace],
+      {stdio: 'pipe'}
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function runLogout(
+  serverName: string,
+  options: LogoutOptions,
+  deps: AuthDeps = defaultDeps
+): Promise<void> {
+  if (options.keepClient && options.deleteSecret) {
+    throw new Error(
+      '--keep-client and --delete-secret are mutually exclusive'
+    );
+  }
+
+  const namespace = await resolveNamespace(options.namespace, deps.kubectl);
+  const server = await getMCPServer(serverName, namespace, deps.kubectl);
+
+  const tokenSecretRef = server.spec?.authorization?.tokenSecretRef;
+  if (!tokenSecretRef) {
+    throw new Error(
+      `MCPServer ${serverName} has no spec.authorization.tokenSecretRef — nothing to clear`
+    );
+  }
+  const keys = resolvedKeys(tokenSecretRef);
+  const secretName = tokenSecretRef.name;
+
+  if (options.deleteSecret) {
+    await deps.kubectl(
+      'kubectl',
+      [
+        'delete',
+        'secret',
+        secretName,
+        '-n',
+        namespace,
+        '--ignore-not-found=true',
+      ],
+      {stdio: 'pipe'}
+    );
+    output.success(
+      `deleted secret ${secretName} in namespace ${namespace}`
+    );
+    console.log(
+      `  run 'ark mcp auth login ${serverName}' to re-authenticate`
+    );
+    return;
+  }
+
+  const exists = await secretExists(secretName, namespace, deps.kubectl);
+  if (!exists) {
+    output.info(
+      `secret ${secretName} not found in namespace ${namespace} — nothing to do`
+    );
+    return;
+  }
+
+  const clearedKeys: string[] = options.keepClient
+    ? [keys.accessTokenKey, keys.refreshTokenKey, keys.expiresAtKey]
+    : [
+        keys.accessTokenKey,
+        keys.refreshTokenKey,
+        keys.expiresAtKey,
+        keys.clientIDKey,
+        keys.clientSecretKey,
+      ];
+
+  const data: Record<string, string> = {};
+  for (const k of clearedKeys) data[k] = '';
+  const patch = JSON.stringify({data});
+
+  await deps.kubectl(
+    'kubectl',
+    [
+      'patch',
+      'secret',
+      secretName,
+      '-n',
+      namespace,
+      '--type=merge',
+      '-p',
+      patch,
+    ],
+    {stdio: 'pipe'}
+  );
+
+  output.success(
+    `cleared ${clearedKeys.join(', ')} in secret ${secretName} (namespace ${namespace})`
+  );
+  console.log(
+    `  run 'ark mcp auth login ${serverName}' to re-authenticate`
+  );
+}

--- a/tools/ark-cli/src/commands/mcp/duration.spec.ts
+++ b/tools/ark-cli/src/commands/mcp/duration.spec.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect} from 'vitest';
+import {parseGoDuration} from './duration.js';
+
+describe('parseGoDuration', () => {
+  it('parses seconds', () => {
+    expect(parseGoDuration('60s')).toBe(60_000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseGoDuration('5m')).toBe(300_000);
+  });
+
+  it('parses compound 1h30m', () => {
+    expect(parseGoDuration('1h30m')).toBe(5_400_000);
+  });
+
+  it('parses milliseconds', () => {
+    expect(parseGoDuration('500ms')).toBe(500);
+  });
+
+  it('parses microseconds (us)', () => {
+    expect(parseGoDuration('2000us')).toBe(2);
+  });
+
+  it('parses microseconds (µs)', () => {
+    expect(parseGoDuration('2000µs')).toBe(2);
+  });
+
+  it('parses hours', () => {
+    expect(parseGoDuration('2h')).toBe(7_200_000);
+  });
+
+  it('parses fractional values', () => {
+    expect(parseGoDuration('1.5s')).toBe(1500);
+  });
+
+  it('rejects negative durations', () => {
+    expect(() => parseGoDuration('-5s')).toThrow(/positive Go-duration/);
+  });
+
+  it('rejects non-duration strings', () => {
+    expect(() => parseGoDuration('abc')).toThrow(/Go-duration/);
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => parseGoDuration('')).toThrow(/Go-duration/);
+  });
+
+  it('rejects partial consumption', () => {
+    expect(() => parseGoDuration('5sxyz')).toThrow(/Go-duration/);
+  });
+
+  it('rejects bare numbers without a unit', () => {
+    expect(() => parseGoDuration('5')).toThrow(/Go-duration/);
+  });
+});

--- a/tools/ark-cli/src/commands/mcp/duration.ts
+++ b/tools/ark-cli/src/commands/mcp/duration.ts
@@ -1,0 +1,31 @@
+const UNIT_MS: Record<string, number> = {
+  ns: 1 / 1_000_000,
+  us: 1 / 1000,
+  µs: 1 / 1000,
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+};
+
+export function parseGoDuration(value: string): number {
+  if (!value) {
+    throw new Error(
+      '--timeout must be a Go-duration string (e.g. 60s, 5m)'
+    );
+  }
+  const re = /(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)/g;
+  let total = 0;
+  let consumed = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(value)) !== null) {
+    consumed += match[0].length;
+    total += parseFloat(match[1]) * UNIT_MS[match[2]];
+  }
+  if (consumed !== value.length || total <= 0) {
+    throw new Error(
+      `--timeout must be a positive Go-duration string (e.g. 60s, 5m), got "${value}"`
+    );
+  }
+  return Math.round(total);
+}

--- a/tools/ark-cli/src/commands/mcp/index.ts
+++ b/tools/ark-cli/src/commands/mcp/index.ts
@@ -1,0 +1,95 @@
+import {Command} from 'commander';
+import type {ArkConfig} from '../../lib/config.js';
+import output from '../../lib/output.js';
+import {runAuth, runLogout} from './auth.js';
+
+function parsePositiveInt(value: string, field: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`${field} must be a non-negative integer, got ${value}`);
+  }
+  return n;
+}
+
+export function createMcpCommand(_config: ArkConfig): Command {
+  const mcp = new Command('mcp');
+  mcp.description('Interact with MCPServer resources');
+
+  const auth = new Command('auth');
+  auth.description('Manage OAuth credentials for MCPServer resources');
+
+  auth
+    .command('login')
+    .description(
+      'Drive the OAuth 2.1 (DCR + PKCE) flow for an MCPServer and write the ' +
+        'resulting tokens to its referenced Secret'
+    )
+    .argument('<server-name>', 'Name of the MCPServer resource')
+    .option('-n, --namespace <namespace>', 'Kubernetes namespace')
+    .option(
+      '--force',
+      'Run the flow even when status.authorization.state is not Required'
+    )
+    .option(
+      '--port <port>',
+      'Fixed loopback port for the OAuth redirect (default: pick a free port)',
+      (v) => parsePositiveInt(v, '--port')
+    )
+    .option('--no-open', "Don't auto-open the browser; just print the URL")
+    .option(
+      '--timeout <ms>',
+      'Max wait for the callback, in milliseconds',
+      (v) => parsePositiveInt(v, '--timeout')
+    )
+    .action(async (serverName: string, opts) => {
+      try {
+        await runAuth(serverName, {
+          namespace: opts.namespace,
+          force: opts.force,
+          port: opts.port,
+          open: opts.open,
+          timeout: opts.timeout,
+        });
+      } catch (e) {
+        output.error(
+          'mcp auth login failed:',
+          e instanceof Error ? e.message : String(e)
+        );
+        process.exit(1);
+      }
+    });
+
+  auth
+    .command('logout')
+    .description(
+      'Clear OAuth tokens from the Secret referenced by an MCPServer'
+    )
+    .argument('<server-name>', 'Name of the MCPServer resource')
+    .option('-n, --namespace <namespace>', 'Kubernetes namespace')
+    .option(
+      '--keep-client',
+      'Clear access/refresh/expires tokens only; preserve client_id and client_secret'
+    )
+    .option(
+      '--delete-secret',
+      'Delete the Secret entirely instead of patching empty values'
+    )
+    .action(async (serverName: string, opts) => {
+      try {
+        await runLogout(serverName, {
+          namespace: opts.namespace,
+          keepClient: opts.keepClient,
+          deleteSecret: opts.deleteSecret,
+        });
+      } catch (e) {
+        output.error(
+          'mcp auth logout failed:',
+          e instanceof Error ? e.message : String(e)
+        );
+        process.exit(1);
+      }
+    });
+
+  mcp.addCommand(auth);
+  return mcp;
+}

--- a/tools/ark-cli/src/commands/mcp/index.ts
+++ b/tools/ark-cli/src/commands/mcp/index.ts
@@ -2,6 +2,7 @@ import {Command} from 'commander';
 import type {ArkConfig} from '../../lib/config.js';
 import output from '../../lib/output.js';
 import {runAuth, runLogout} from './auth.js';
+import {parseGoDuration} from './duration.js';
 
 function parsePositiveInt(value: string, field: string): number {
   const n = Number(value);
@@ -37,9 +38,9 @@ export function createMcpCommand(_config: ArkConfig): Command {
     )
     .option('--no-open', "Don't auto-open the browser; just print the URL")
     .option(
-      '--timeout <ms>',
-      'Max wait for the callback, in milliseconds',
-      (v) => parsePositiveInt(v, '--timeout')
+      '--timeout <duration>',
+      'Max wait for the callback as a Go-duration string (e.g. 60s, 5m)',
+      parseGoDuration
     )
     .action(async (serverName: string, opts) => {
       try {

--- a/tools/ark-cli/src/commands/mcp/pkce.spec.ts
+++ b/tools/ark-cli/src/commands/mcp/pkce.spec.ts
@@ -1,0 +1,48 @@
+import {Buffer} from 'buffer';
+import {createHash} from 'crypto';
+import {describe, it, expect} from 'vitest';
+import {generatePkcePair, generateState} from './pkce.js';
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('pkce', () => {
+  it('produces S256 challenge that matches sha256(verifier) base64url-encoded', () => {
+    const pair = generatePkcePair();
+
+    expect(pair.method).toBe('S256');
+    expect(pair.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(pair.challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(pair.verifier.includes('=')).toBe(false);
+    expect(pair.challenge.includes('=')).toBe(false);
+
+    const expected = base64UrlEncode(
+      createHash('sha256').update(pair.verifier).digest()
+    );
+    expect(pair.challenge).toBe(expected);
+  });
+
+  it('verifier length falls in RFC 7636 43..128 range', () => {
+    const {verifier} = generatePkcePair();
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('generates distinct pairs', () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+
+  it('state is hex and long enough to resist guessing', () => {
+    const s = generateState();
+    expect(s).toMatch(/^[0-9a-f]+$/);
+    expect(s.length).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/tools/ark-cli/src/commands/mcp/pkce.ts
+++ b/tools/ark-cli/src/commands/mcp/pkce.ts
@@ -1,0 +1,29 @@
+import {Buffer} from 'buffer';
+import {createHash, randomBytes} from 'crypto';
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+  method: 'S256';
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function generatePkcePair(): PkcePair {
+  // 32 bytes -> 43 char base64url verifier, comfortably inside RFC 7636's 43-128 range.
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(
+    createHash('sha256').update(verifier).digest()
+  );
+  return {verifier, challenge, method: 'S256'};
+}
+
+export function generateState(): string {
+  return randomBytes(6).toString('hex');
+}

--- a/tools/ark-cli/src/index.tsx
+++ b/tools/ark-cli/src/index.tsx
@@ -21,6 +21,7 @@ import {createGenerateCommand} from './commands/generate/index.js';
 import {createImportCommand} from './commands/import/index.js';
 import {createInstallCommand} from './commands/install/index.js';
 import {createMarketplaceCommand} from './commands/marketplace/index.js';
+import {createMcpCommand} from './commands/mcp/index.js';
 import {createMemoryCommand} from './commands/memory/index.js';
 import {createModelsCommand} from './commands/models/index.js';
 import {createQueryCommand} from './commands/query/index.js';
@@ -64,6 +65,7 @@ async function main() {
   program.addCommand(createImportCommand(config));
   program.addCommand(createInstallCommand(config));
   program.addCommand(createMarketplaceCommand(config));
+  program.addCommand(createMcpCommand(config));
   program.addCommand(createMemoryCommand(config));
   program.addCommand(createModelsCommand(config));
   program.addCommand(createQueryCommand(config));


### PR DESCRIPTION
## Summary

**DO NOT MERGE — reference branch for #2174 review.**

Surfaces the Stage 2 CLI implementation from #2081 (closed) as a reference for the secret-management approach discussed in #2174 review.

## What this shows

- `ark mcp auth login/logout <server>` end-to-end OAuth 2.1 flow on the CLI side
- Uniform Bearer injection across built-in completions executor + ark-sdk Python resolver
- Label-driven Secret watch (`ark.mckinsey.com/mcp-token-secret=true`) for real-time reconcile on token edits
- `tokenSecretRef.name` declared in manifest — operator owns spec, no API-side spec mutation
- IPv6 dual-stack loopback listener, `parseGoDuration`, Secret labeling helpers

## Why it's here

Reference for the architectural cuts proposed in #2174 review:

1. Operator authors `spec.authorization.tokenSecretRef.name` — no auto-provision branch needed (#2174 critical #1)
2. Secret labeling provides forward-compatible watch hook (matches `mcp-token-secret` stamp in #2174)
3. Flow state can be stored in the labeled Secret instead of in-memory cache (#2174 critical #3)

## Closes

Nothing. Reference only. Do not merge.