### PR TITLE
fix(e2e): install ark-controller before ark-broker to prevent CRD race

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -157,24 +157,6 @@ if [ "${STORAGE_BACKEND}" = "postgresql" ]; then
 fi
 
 BROKER_PID=""
-if [ "${INSTALL_BROKER}" = "true" ]; then
-  echo "=== Installing ARK Broker (background) ==="
-  BROKER_HELM_ARGS=(
-    --namespace default
-    --create-namespace
-    --set app.image.repository="${REGISTRY}/ark-broker"
-    --set app.image.tag="${ARK_IMAGE_TAG}"
-    --set app.image.pullPolicy=IfNotPresent
-    --set restartController.enabled=false
-    --wait --timeout=300s
-  )
-  if [ "${STORAGE_BACKEND}" = "postgresql" ]; then
-    BROKER_HELM_ARGS+=(--set memory.createMemoryCRD=false)
-  fi
-  helm upgrade --install ark-broker "${REPO_ROOT}/services/ark-broker/chart" \
-    "${BROKER_HELM_ARGS[@]}" &
-  BROKER_PID=$!
-fi
 
 echo "=== Installing ARK Controller ==="
 cd "${REPO_ROOT}/ark"
@@ -239,6 +221,25 @@ helm upgrade --install ark-completions ./executors/completions/chart \
 ARK_COMPLETIONS_PID=$!
 
 helm upgrade --install ark-controller ./dist/chart "${HELM_ARGS[@]}"
+
+if [ "${INSTALL_BROKER}" = "true" ]; then
+  echo "=== Installing ARK Broker (background) ==="
+  BROKER_HELM_ARGS=(
+    --namespace default
+    --create-namespace
+    --set app.image.repository="${REGISTRY}/ark-broker"
+    --set app.image.tag="${ARK_IMAGE_TAG}"
+    --set app.image.pullPolicy=IfNotPresent
+    --set restartController.enabled=false
+    --wait --timeout=300s
+  )
+  if [ "${STORAGE_BACKEND}" = "postgresql" ]; then
+    BROKER_HELM_ARGS+=(--set memory.createMemoryCRD=false)
+  fi
+  helm upgrade --install ark-broker "${REPO_ROOT}/services/ark-broker/chart" \
+    "${BROKER_HELM_ARGS[@]}" &
+  BROKER_PID=$!
+fi
 
 # Verify cert-manager issued the webhook certificate end-to-end. rollout status +
 # CABundle checks above confirm pods are running and the webhook config is patched,


### PR DESCRIPTION
The ark-broker Helm chart includes a Memory CR
(memory.createMemoryCRD=true by default). Previously, the broker was launched in the background before ark-controller installed the ark.mckinsey.com CRDs, causing intermittent failures:

  no matches for kind "Memory" in version "ark.mckinsey.com/v1alpha1"
  ensure CRDs are installed first

Move the broker background launch to after the synchronous ark-controller install so CRDs are guaranteed to exist. The broker still runs in parallel with the cert/completions waits, so total setup time is not significantly affected.

The postgresql path was unaffected because it passes --set memory.createMemoryCRD=false.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 