### PR TITLE
fix(controller): replace O(n) list scans with FieldIndexer-based lookups

### DIFF
--- a/ark/internal/controller/agent_controller.go
+++ b/ark/internal/controller/agent_controller.go
@@ -282,6 +282,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, agent *arkv1alpha1.A
 	return err
 }
 
+// agentModelRefIndexer returns the model reference name for field-based Agent lookups.
 func agentModelRefIndexer(obj client.Object) []string {
 	agent := obj.(*arkv1alpha1.Agent)
 	if agent.Spec.ModelRef == nil {
@@ -290,6 +291,7 @@ func agentModelRefIndexer(obj client.Object) []string {
 	return []string{agent.Spec.ModelRef.Name}
 }
 
+// agentExecutionEngineIndexer returns the execution engine name for field-based Agent lookups.
 func agentExecutionEngineIndexer(obj client.Object) []string {
 	agent := obj.(*arkv1alpha1.Agent)
 	if agent.Spec.ExecutionEngine == nil {
@@ -298,6 +300,7 @@ func agentExecutionEngineIndexer(obj client.Object) []string {
 	return []string{agent.Spec.ExecutionEngine.Name}
 }
 
+// agentToolNamesIndexer returns indexed tool names for field-based Agent lookups, skipping built-in tools.
 func agentToolNamesIndexer(obj client.Object) []string {
 	agent := obj.(*arkv1alpha1.Agent)
 	var names []string

--- a/ark/internal/controller/agent_controller.go
+++ b/ark/internal/controller/agent_controller.go
@@ -283,24 +283,68 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, agent *arkv1alpha1.A
 }
 
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.modelRef.name",
+		func(obj client.Object) []string {
+			agent := obj.(*arkv1alpha1.Agent)
+			if agent.Spec.ModelRef == nil {
+				return nil
+			}
+			return []string{agent.Spec.ModelRef.Name}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.executionEngine.name",
+		func(obj client.Object) []string {
+			agent := obj.(*arkv1alpha1.Agent)
+			if agent.Spec.ExecutionEngine == nil {
+				return nil
+			}
+			return []string{agent.Spec.ExecutionEngine.Name}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.tools.name",
+		func(obj client.Object) []string {
+			agent := obj.(*arkv1alpha1.Agent)
+			var names []string
+			for _, tool := range agent.Spec.Tools {
+				if tool.Type == "built-in" {
+					continue
+				}
+				if tool.Name != "" {
+					names = append(names, tool.Name)
+				}
+				if tool.Partial != nil && tool.Partial.Name != "" {
+					names = append(names, tool.Partial.Name)
+				}
+			}
+			return names
+		},
+	); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arkv1alpha1.Agent{}).
-		// Watch for Tool events and reconcile dependent agents
 		Watches(
 			&arkv1alpha1.Tool{},
 			handler.EnqueueRequestsFromMapFunc(r.findAgentsForTool),
 		).
-		// Watch for Model events and reconcile dependent agents
 		Watches(
 			&arkv1alpha1.Model{},
 			handler.EnqueueRequestsFromMapFunc(r.findAgentsForModel),
 		).
-		// Watch for A2AServer events and reconcile owned agents
 		Watches(
 			&arkv1prealpha1.A2AServer{},
 			handler.EnqueueRequestsFromMapFunc(r.findAgentsForA2AServer),
 		).
-		// Watch for ExecutionEngine events and reconcile dependent agents
 		Watches(
 			&arkv1prealpha1.ExecutionEngine{},
 			handler.EnqueueRequestsFromMapFunc(r.findAgentsForExecutionEngine),
@@ -309,105 +353,47 @@ func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// findAgentsForTool finds agents that depend on the given tool
 func (r *AgentReconciler) findAgentsForTool(ctx context.Context, obj client.Object) []reconcile.Request {
-	tool, ok := obj.(*arkv1alpha1.Tool)
-	if !ok {
-		return nil
-	}
-
-	return r.findAgentsForDependency(ctx, tool.Name, tool.Namespace, "tool", func(agent *arkv1alpha1.Agent) bool {
-		return r.agentDependsOnTool(agent, tool.Name)
-	})
-}
-
-// findAgentsForModel finds agents that depend on the given model
-func (r *AgentReconciler) findAgentsForModel(ctx context.Context, obj client.Object) []reconcile.Request {
-	model, ok := obj.(*arkv1alpha1.Model)
-	if !ok {
-		return nil
-	}
-
-	return r.findAgentsForDependency(ctx, model.Name, model.Namespace, "model", func(agent *arkv1alpha1.Agent) bool {
-		return r.agentDependsOnModel(agent, model.Name)
-	})
-}
-
-// findAgentsForDependency is a generic function to find agents that depend on a given resource
-func (r *AgentReconciler) findAgentsForDependency(ctx context.Context, resourceName, namespace, resourceType string, dependencyCheck func(*arkv1alpha1.Agent) bool) []reconcile.Request {
-	log := logf.Log.WithName("agent-controller").WithValues(resourceType, resourceName, "namespace", namespace)
-
-	// List all agents in the same namespace
 	var agentList arkv1alpha1.AgentList
-	if err := r.List(ctx, &agentList, client.InNamespace(namespace)); err != nil {
-		log.Error(err, "Failed to list agents for dependency check", "resourceType", resourceType)
+	if err := r.List(ctx, &agentList,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{".spec.tools.name": obj.GetName()},
+	); err != nil {
 		return nil
 	}
+	return agentsToRequests(agentList.Items)
+}
 
-	var requests []reconcile.Request
-	seenAgents := make(map[string]bool) // Deduplication map
-
-	for _, agent := range agentList.Items {
-		// Check if this agent depends on the resource
-		if dependencyCheck(&agent) {
-			agentKey := agent.Namespace + "/" + agent.Name
-
-			// Skip if we've already added this agent
-			if seenAgents[agentKey] {
-				continue
-			}
-			seenAgents[agentKey] = true
-
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      agent.Name,
-					Namespace: agent.Namespace,
-				},
-			})
-		}
+func (r *AgentReconciler) findAgentsForModel(ctx context.Context, obj client.Object) []reconcile.Request {
+	var agentList arkv1alpha1.AgentList
+	if err := r.List(ctx, &agentList,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{".spec.modelRef.name": obj.GetName()},
+	); err != nil {
+		return nil
 	}
-
-	return requests
+	return agentsToRequests(agentList.Items)
 }
 
-// agentDependsOnTool checks if an agent depends on a specific tool
-func (r *AgentReconciler) agentDependsOnTool(agent *arkv1alpha1.Agent, toolName string) bool {
-	for _, toolSpec := range agent.Spec.Tools {
-		// Skip built-in tools - they don't reference Tool CRDs
-		if toolSpec.Type == "built-in" {
-			continue
-		}
-		// Check both the exposed name and the actual tool name (for partial tools)
-		if toolSpec.Name == toolName {
-			return true
-		}
-		if toolSpec.Partial != nil && toolSpec.Partial.Name == toolName {
-			return true
-		}
-	}
-	return false
-}
-
-// agentDependsOnModel checks if an agent depends on a specific model
-func (r *AgentReconciler) agentDependsOnModel(agent *arkv1alpha1.Agent, modelName string) bool {
-	return agent.Spec.ModelRef != nil && agent.Spec.ModelRef.Name == modelName
-}
-
-// findAgentsForExecutionEngine finds agents that depend on the given execution engine
 func (r *AgentReconciler) findAgentsForExecutionEngine(ctx context.Context, obj client.Object) []reconcile.Request {
-	engine, ok := obj.(*arkv1prealpha1.ExecutionEngine)
-	if !ok {
+	var agentList arkv1alpha1.AgentList
+	if err := r.List(ctx, &agentList,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{".spec.executionEngine.name": obj.GetName()},
+	); err != nil {
 		return nil
 	}
-
-	return r.findAgentsForDependency(ctx, engine.Name, engine.Namespace, "executionEngine", func(agent *arkv1alpha1.Agent) bool {
-		return r.agentDependsOnExecutionEngine(agent, engine.Name)
-	})
+	return agentsToRequests(agentList.Items)
 }
 
-// agentDependsOnExecutionEngine checks if an agent depends on a specific execution engine
-func (r *AgentReconciler) agentDependsOnExecutionEngine(agent *arkv1alpha1.Agent, engineName string) bool {
-	return agent.Spec.ExecutionEngine != nil && agent.Spec.ExecutionEngine.Name == engineName
+func agentsToRequests(agents []arkv1alpha1.Agent) []reconcile.Request {
+	requests := make([]reconcile.Request, len(agents))
+	for i, agent := range agents {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+		}
+	}
+	return requests
 }
 
 // findAgentsForA2AServer finds agents owned by the given A2AServer

--- a/ark/internal/controller/agent_controller.go
+++ b/ark/internal/controller/agent_controller.go
@@ -282,51 +282,54 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, agent *arkv1alpha1.A
 	return err
 }
 
+func agentModelRefIndexer(obj client.Object) []string {
+	agent := obj.(*arkv1alpha1.Agent)
+	if agent.Spec.ModelRef == nil {
+		return nil
+	}
+	return []string{agent.Spec.ModelRef.Name}
+}
+
+func agentExecutionEngineIndexer(obj client.Object) []string {
+	agent := obj.(*arkv1alpha1.Agent)
+	if agent.Spec.ExecutionEngine == nil {
+		return nil
+	}
+	return []string{agent.Spec.ExecutionEngine.Name}
+}
+
+func agentToolNamesIndexer(obj client.Object) []string {
+	agent := obj.(*arkv1alpha1.Agent)
+	var names []string
+	for _, tool := range agent.Spec.Tools {
+		if tool.Type == "built-in" {
+			continue
+		}
+		if tool.Name != "" {
+			names = append(names, tool.Name)
+		}
+		if tool.Partial != nil && tool.Partial.Name != "" {
+			names = append(names, tool.Partial.Name)
+		}
+	}
+	return names
+}
+
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(), &arkv1alpha1.Agent{}, ".spec.modelRef.name",
-		func(obj client.Object) []string {
-			agent := obj.(*arkv1alpha1.Agent)
-			if agent.Spec.ModelRef == nil {
-				return nil
-			}
-			return []string{agent.Spec.ModelRef.Name}
-		},
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.modelRef.name", agentModelRefIndexer,
 	); err != nil {
 		return err
 	}
 
 	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(), &arkv1alpha1.Agent{}, ".spec.executionEngine.name",
-		func(obj client.Object) []string {
-			agent := obj.(*arkv1alpha1.Agent)
-			if agent.Spec.ExecutionEngine == nil {
-				return nil
-			}
-			return []string{agent.Spec.ExecutionEngine.Name}
-		},
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.executionEngine.name", agentExecutionEngineIndexer,
 	); err != nil {
 		return err
 	}
 
 	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(), &arkv1alpha1.Agent{}, ".spec.tools.name",
-		func(obj client.Object) []string {
-			agent := obj.(*arkv1alpha1.Agent)
-			var names []string
-			for _, tool := range agent.Spec.Tools {
-				if tool.Type == "built-in" {
-					continue
-				}
-				if tool.Name != "" {
-					names = append(names, tool.Name)
-				}
-				if tool.Partial != nil && tool.Partial.Name != "" {
-					names = append(names, tool.Partial.Name)
-				}
-			}
-			return names
-		},
+		context.Background(), &arkv1alpha1.Agent{}, ".spec.tools.name", agentToolNamesIndexer,
 	); err != nil {
 		return err
 	}

--- a/ark/internal/controller/agent_controller_test.go
+++ b/ark/internal/controller/agent_controller_test.go
@@ -218,14 +218,6 @@ var _ = Describe("Agent Controller", func() {
 				NamespacedName: partialToolAgentTypeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying agentDependsOnTool works with partial tools")
-			// Test that agent depends on the exposed name
-			Expect(controllerReconciler.agentDependsOnTool(partialToolAgent, "get-weather")).To(BeTrue())
-			// Test that agent depends on the actual CRD name
-			Expect(controllerReconciler.agentDependsOnTool(partialToolAgent, weatherAPIToolName)).To(BeTrue())
-			// Test that agent does not depend on unrelated tool
-			Expect(controllerReconciler.agentDependsOnTool(partialToolAgent, "unrelated-tool")).To(BeFalse())
 		})
 
 		It("should fail reconciliation when partial tool CRD is missing", func() {
@@ -484,22 +476,6 @@ var _ = Describe("Agent Controller", func() {
 			Expect(condition.Type).To(Equal("Available"))
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(condition.Reason).To(Equal("Available"))
-		})
-
-		It("should not check execution engine when agent has no engine reference", func() {
-			controllerReconciler := &AgentReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Eventing: eventnoop.NewProvider(),
-			}
-
-			agentWithoutEngine := &arkv1alpha1.Agent{
-				Spec: arkv1alpha1.AgentSpec{
-					ExecutionEngine: nil,
-				},
-			}
-
-			Expect(controllerReconciler.agentDependsOnExecutionEngine(agentWithoutEngine, "any-engine")).To(BeFalse())
 		})
 
 		It("should not error when updating status of a deleted agent", func() {

--- a/ark/internal/controller/indexers_test.go
+++ b/ark/internal/controller/indexers_test.go
@@ -106,10 +106,21 @@ func TestAgentToolNamesIndexer(t *testing.T) {
 			}},
 			expected: []string{"weather-api"},
 		},
+		{
+			name: "multiple tools, built-in interleaved, all non-built-in are indexed",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				Tools: []arkv1alpha1.AgentTool{
+					{Type: "custom", Name: "tool-a"},
+					{Type: "built-in", Name: "terminate"},
+					{Type: "custom", Name: "tool-b"},
+				},
+			}},
+			expected: []string{"tool-a", "tool-b"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, agentToolNamesIndexer(tt.agent))
+			assert.ElementsMatch(t, tt.expected, agentToolNamesIndexer(tt.agent))
 		})
 	}
 }

--- a/ark/internal/controller/indexers_test.go
+++ b/ark/internal/controller/indexers_test.go
@@ -1,0 +1,152 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestAgentModelRefIndexer(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    *arkv1alpha1.Agent
+		expected []string
+	}{
+		{
+			name:     "nil ModelRef returns nil",
+			agent:    &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{ModelRef: nil}},
+			expected: nil,
+		},
+		{
+			name: "returns model name",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				ModelRef: &arkv1alpha1.AgentModelRef{Name: "gpt-4"},
+			}},
+			expected: []string{"gpt-4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, agentModelRefIndexer(tt.agent))
+		})
+	}
+}
+
+func TestAgentExecutionEngineIndexer(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    *arkv1alpha1.Agent
+		expected []string
+	}{
+		{
+			name:     "nil ExecutionEngine returns nil",
+			agent:    &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{ExecutionEngine: nil}},
+			expected: nil,
+		},
+		{
+			name: "returns engine name",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				ExecutionEngine: &arkv1alpha1.ExecutionEngineRef{Name: "my-engine"},
+			}},
+			expected: []string{"my-engine"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, agentExecutionEngineIndexer(tt.agent))
+		})
+	}
+}
+
+func TestAgentToolNamesIndexer(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    *arkv1alpha1.Agent
+		expected []string
+	}{
+		{
+			name:     "no tools returns nil",
+			agent:    &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{}},
+			expected: nil,
+		},
+		{
+			name: "built-in tool is skipped",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				Tools: []arkv1alpha1.AgentTool{{Type: "built-in", Name: "calculator"}},
+			}},
+			expected: nil,
+		},
+		{
+			name: "custom tool name is indexed",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				Tools: []arkv1alpha1.AgentTool{{Type: "custom", Name: "my-tool"}},
+			}},
+			expected: []string{"my-tool"},
+		},
+		{
+			name: "partial tool indexes both exposed name and CRD name",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				Tools: []arkv1alpha1.AgentTool{{
+					Type:    "custom",
+					Name:    "get-weather",
+					Partial: &arkv1alpha1.ToolPartial{Name: "weather-api"},
+				}},
+			}},
+			expected: []string{"get-weather", "weather-api"},
+		},
+		{
+			name: "partial tool with no exposed name indexes only CRD name",
+			agent: &arkv1alpha1.Agent{Spec: arkv1alpha1.AgentSpec{
+				Tools: []arkv1alpha1.AgentTool{{
+					Type:    "custom",
+					Partial: &arkv1alpha1.ToolPartial{Name: "weather-api"},
+				}},
+			}},
+			expected: []string{"weather-api"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, agentToolNamesIndexer(tt.agent))
+		})
+	}
+}
+
+func TestTeamAgentMemberIndexer(t *testing.T) {
+	tests := []struct {
+		name     string
+		team     *arkv1alpha1.Team
+		expected []string
+	}{
+		{
+			name:     "no members returns nil",
+			team:     &arkv1alpha1.Team{Spec: arkv1alpha1.TeamSpec{}},
+			expected: nil,
+		},
+		{
+			name: "non-agent members are skipped",
+			team: &arkv1alpha1.Team{Spec: arkv1alpha1.TeamSpec{
+				Members: []arkv1alpha1.TeamMember{{Type: "tool", Name: "my-tool"}},
+			}},
+			expected: nil,
+		},
+		{
+			name: "agent members are indexed",
+			team: &arkv1alpha1.Team{Spec: arkv1alpha1.TeamSpec{
+				Members: []arkv1alpha1.TeamMember{
+					{Type: "agent", Name: "agent-a"},
+					{Type: "tool", Name: "tool-x"},
+					{Type: "agent", Name: "agent-b"},
+				},
+			}},
+			expected: []string{"agent-a", "agent-b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, teamAgentMemberIndexer(tt.team))
+		})
+	}
+}

--- a/ark/internal/controller/lookups_test.go
+++ b/ark/internal/controller/lookups_test.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestAgentsToRequests(t *testing.T) {
+	agents := []arkv1alpha1.Agent{
+		{ObjectMeta: metav1.ObjectMeta{Name: "agent-a", Namespace: "ns1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "agent-b", Namespace: "ns2"}},
+	}
+	reqs := agentsToRequests(agents)
+	assert.Len(t, reqs, 2)
+	assert.Equal(t, "agent-a", reqs[0].Name)
+	assert.Equal(t, "ns1", reqs[0].Namespace)
+	assert.Equal(t, "agent-b", reqs[1].Name)
+	assert.Equal(t, "ns2", reqs[1].Namespace)
+}
+
+func TestAgentsToRequests_Empty(t *testing.T) {
+	reqs := agentsToRequests(nil)
+	assert.Empty(t, reqs)
+}
+
+func TestFindAgentsForModel_ReturnsMatchingAgent(t *testing.T) {
+	s := newTestScheme()
+	agent := &arkv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+		Spec:       arkv1alpha1.AgentSpec{ModelRef: &arkv1alpha1.AgentModelRef{Name: "gpt-4"}},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(&arkv1alpha1.Agent{}, ".spec.modelRef.name", agentModelRefIndexer).
+		WithObjects(agent).
+		Build()
+
+	r := &AgentReconciler{Client: fakeClient}
+	trigger := &arkv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "gpt-4", Namespace: "default"}}
+
+	reqs := r.findAgentsForModel(context.Background(), trigger)
+
+	assert.Len(t, reqs, 1)
+	assert.Equal(t, "my-agent", reqs[0].Name)
+	assert.Equal(t, "default", reqs[0].Namespace)
+}
+
+func TestFindAgentsForTool_ReturnsMatchingAgent(t *testing.T) {
+	s := newTestScheme()
+	agent := &arkv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+		Spec: arkv1alpha1.AgentSpec{
+			Tools: []arkv1alpha1.AgentTool{{Type: "custom", Name: "weather-api"}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(&arkv1alpha1.Agent{}, ".spec.tools.name", agentToolNamesIndexer).
+		WithObjects(agent).
+		Build()
+
+	r := &AgentReconciler{Client: fakeClient}
+	trigger := &arkv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "weather-api", Namespace: "default"}}
+
+	reqs := r.findAgentsForTool(context.Background(), trigger)
+
+	assert.Len(t, reqs, 1)
+	assert.Equal(t, "my-agent", reqs[0].Name)
+}
+
+func TestFindAgentsForExecutionEngine_ReturnsMatchingAgent(t *testing.T) {
+	s := newTestScheme()
+	agent := &arkv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+		Spec:       arkv1alpha1.AgentSpec{ExecutionEngine: &arkv1alpha1.ExecutionEngineRef{Name: "my-engine"}},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(&arkv1alpha1.Agent{}, ".spec.executionEngine.name", agentExecutionEngineIndexer).
+		WithObjects(agent).
+		Build()
+
+	r := &AgentReconciler{Client: fakeClient}
+	trigger := &arkv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "my-engine", Namespace: "default"}}
+
+	reqs := r.findAgentsForExecutionEngine(context.Background(), trigger)
+
+	assert.Len(t, reqs, 1)
+	assert.Equal(t, "my-agent", reqs[0].Name)
+}
+
+func TestFindTeamsForAgent_ReturnsMatchingTeam(t *testing.T) {
+	s := newTestScheme()
+	team := &arkv1alpha1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-team", Namespace: "default"},
+		Spec: arkv1alpha1.TeamSpec{
+			Members: []arkv1alpha1.TeamMember{
+				{Type: "agent", Name: "my-agent"},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(&arkv1alpha1.Team{}, ".spec.members.agent.name", teamAgentMemberIndexer).
+		WithObjects(team).
+		Build()
+
+	r := &TeamReconciler{Client: fakeClient}
+	trigger := &arkv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"}}
+
+	reqs := r.findTeamsForAgent(context.Background(), trigger)
+
+	assert.Len(t, reqs, 1)
+	assert.Equal(t, "my-team", reqs[0].Name)
+	assert.Equal(t, "default", reqs[0].Namespace)
+}

--- a/ark/internal/controller/lookups_test.go
+++ b/ark/internal/controller/lookups_test.go
@@ -105,10 +105,18 @@ func TestFindTeamsForAgent_ReturnsMatchingTeam(t *testing.T) {
 			},
 		},
 	}
+	otherTeam := &arkv1alpha1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-team", Namespace: "default"},
+		Spec: arkv1alpha1.TeamSpec{
+			Members: []arkv1alpha1.TeamMember{
+				{Type: "agent", Name: "other-agent"},
+			},
+		},
+	}
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(s).
 		WithIndex(&arkv1alpha1.Team{}, ".spec.members.agent.name", teamAgentMemberIndexer).
-		WithObjects(team).
+		WithObjects(team, otherTeam).
 		Build()
 
 	r := &TeamReconciler{Client: fakeClient}

--- a/ark/internal/controller/team_controller.go
+++ b/ark/internal/controller/team_controller.go
@@ -136,19 +136,20 @@ func (r *TeamReconciler) updateStatus(ctx context.Context, team *arkv1alpha1.Tea
 	return err
 }
 
+func teamAgentMemberIndexer(obj client.Object) []string {
+	team := obj.(*arkv1alpha1.Team)
+	var names []string
+	for _, member := range team.Spec.Members {
+		if member.Type == "agent" && member.Name != "" {
+			names = append(names, member.Name)
+		}
+	}
+	return names
+}
+
 func (r *TeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(), &arkv1alpha1.Team{}, ".spec.members.agent.name",
-		func(obj client.Object) []string {
-			team := obj.(*arkv1alpha1.Team)
-			var names []string
-			for _, member := range team.Spec.Members {
-				if member.Type == "agent" && member.Name != "" {
-					names = append(names, member.Name)
-				}
-			}
-			return names
-		},
+		context.Background(), &arkv1alpha1.Team{}, ".spec.members.agent.name", teamAgentMemberIndexer,
 	); err != nil {
 		return err
 	}

--- a/ark/internal/controller/team_controller.go
+++ b/ark/internal/controller/team_controller.go
@@ -137,6 +137,22 @@ func (r *TeamReconciler) updateStatus(ctx context.Context, team *arkv1alpha1.Tea
 }
 
 func (r *TeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &arkv1alpha1.Team{}, ".spec.members.agent.name",
+		func(obj client.Object) []string {
+			team := obj.(*arkv1alpha1.Team)
+			var names []string
+			for _, member := range team.Spec.Members {
+				if member.Type == "agent" && member.Name != "" {
+					names = append(names, member.Name)
+				}
+			}
+			return names
+		},
+	); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arkv1alpha1.Team{}).
 		Watches(&arkv1alpha1.Agent{}, handler.EnqueueRequestsFromMapFunc(r.findTeamsForAgent)).
@@ -145,27 +161,19 @@ func (r *TeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *TeamReconciler) findTeamsForAgent(ctx context.Context, obj client.Object) []reconcile.Request {
-	agent := obj.(*arkv1alpha1.Agent)
-
 	var teams arkv1alpha1.TeamList
-	if err := r.List(ctx, &teams, client.InNamespace(agent.Namespace)); err != nil {
+	if err := r.List(ctx, &teams,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{".spec.members.agent.name": obj.GetName()},
+	); err != nil {
 		return []reconcile.Request{}
 	}
 
-	var requests []reconcile.Request
-	for _, team := range teams.Items {
-		for _, member := range team.Spec.Members {
-			if member.Type == "agent" && member.Name == agent.Name {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      team.Name,
-						Namespace: team.Namespace,
-					},
-				})
-				break
-			}
+	requests := make([]reconcile.Request, len(teams.Items))
+	for i, team := range teams.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: team.Name, Namespace: team.Namespace},
 		}
 	}
-
 	return requests
 }

--- a/ark/internal/controller/team_controller.go
+++ b/ark/internal/controller/team_controller.go
@@ -136,6 +136,7 @@ func (r *TeamReconciler) updateStatus(ctx context.Context, team *arkv1alpha1.Tea
 	return err
 }
 
+// teamAgentMemberIndexer returns agent member names for field-based Team lookups.
 func teamAgentMemberIndexer(obj client.Object) []string {
 	team := obj.(*arkv1alpha1.Team)
 	var names []string


### PR DESCRIPTION
## Summary

Part of #2246 (finding #5).

### Problem

When a `Model`, `Tool`, or `ExecutionEngine` resource changes, the agent controller needs to find which `Agent` CRDs reference it so it can re-queue them for reconciliation. The previous implementation did this with a full namespace list scan followed by an in-memory filter:

```go
// old: list ALL agents, then filter
func (r *AgentReconciler) findAgentsForDependency(...) []reconcile.Request {
    r.List(ctx, &agentList, client.InNamespace(...))
    for _, agent := range agentList.Items {
        if agentDependsOnModel(agent, modelName) { ... }
    }
}
```

Same pattern in `team_controller.go`: every `Agent` change listed all `Team` CRDs in the namespace and filtered in memory.

This is O(n) in the number of Agent/Team resources. Every dependency event — model probe result, tool creation, execution engine update — scans the entire namespace. With many agents this generates unnecessary API server load and grows with cluster size.

### Fix

Register `FieldIndexer`s at controller startup (in `SetupWithManager`) so controller-runtime maintains an in-memory index of the relevant spec fields:

- `Agent` indexed by `.spec.modelRef.name`
- `Agent` indexed by `.spec.executionEngine.name`
- `Agent` indexed by `.spec.tools.name` (both direct name and partial CRD name)
- `Team` indexed by `.spec.members.agent.name`

The watch handlers then use `client.MatchingFields` instead of a full list + in-memory filter:

```go
// new: O(1) index lookup
func (r *AgentReconciler) findAgentsForModel(ctx context.Context, obj client.Object) []reconcile.Request {
    var agentList arkv1alpha1.AgentList
    r.List(ctx, &agentList,
        client.InNamespace(obj.GetNamespace()),
        client.MatchingFields{".spec.modelRef.name": obj.GetName()},
    )
    return agentsToRequests(agentList.Items)
}
```

The indexer functions are extracted as named package-level functions (`agentModelRefIndexer`, `agentExecutionEngineIndexer`, `agentToolNamesIndexer`, `teamAgentMemberIndexer`) so they can be unit-tested independently.

### Testing

Unit tests cover all four indexer functions (nil inputs, built-in tool skipping, partial tool dual-name indexing, non-agent team member filtering).

End-to-end validation on a Kind cluster using existing chainsaw suites:
- `agent-tools-lifecycle`: agent transitions `ToolNotFound` → `Available` when tool is created — confirms `.spec.tools.name` watch path
- `agent-default-model`: confirms `.spec.modelRef.name` watch path
- `team-selector`: confirms `.spec.members.agent.name` watch path

Manual test: created an agent referencing a non-existent model (`ModelNotFound`), then created the model. The agent re-reconciled in under 9 seconds and transitioned to `Available`, confirming the FieldIndexer triggered the watch correctly.