### PR TITLE
fix(ark-sdk): use OIDC discovery for JWKS URL (drop Keycloak hardcode) (#2321)

### DIFF
--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
@@ -30,22 +30,63 @@ class TokenValidator:
 
     
     def _create_config_from_env(self) -> AuthConfig:
-        """Create AuthConfig from environment variables."""
-        # Read environment variables directly
+        """Create AuthConfig from environment variables.
+
+        JWKS URL resolution order:
+          1. ``OIDC_JWKS_URL`` explicit override (escape hatch for air-gapped
+             IdPs or unconventional well-known layouts).
+          2. ``<issuer>/.well-known/openid-configuration`` discovery per
+             RFC 8414 / OIDC Core §4 — works for Dex (``/keys``), Auth0
+             (``/.well-known/jwks.json``), Okta (``/v1/keys``), Keycloak
+             (``/protocol/openid-connect/certs``), Google, et al.
+
+        The previous implementation hardcoded the Keycloak path, which
+        404'd against every other IdP. Discovery is the OIDC-standard
+        way to learn ``jwks_uri`` and removes the per-IdP assumption.
+        """
         issuer = os.getenv("OIDC_ISSUER_URL")
         audience = os.getenv("OIDC_APPLICATION_ID")
-        jwks_url = None
-        if issuer:
-            # Use the correct JWKS endpoint for Keycloak/Okta
-            jwks_url = f"{issuer}/protocol/openid-connect/certs"
-        
-        logger.info(f"Creating AuthConfig from environment - issuer: {issuer}, audience: {audience}")
-        
+        jwks_url = os.getenv("OIDC_JWKS_URL") or None
+        if not jwks_url and issuer:
+            jwks_url = self._discover_jwks_url(issuer)
+
+        logger.info(
+            "Creating AuthConfig from environment - issuer: %s, audience: %s, jwks_url: %s",
+            issuer, audience, jwks_url,
+        )
+
         return AuthConfig(
             issuer=issuer,
             audience=audience,
-            jwks_url=jwks_url
+            jwks_url=jwks_url,
         )
+
+    @staticmethod
+    def _discover_jwks_url(issuer: str) -> Optional[str]:
+        """Resolve ``jwks_uri`` from the issuer's OIDC discovery document.
+
+        Returns ``None`` (with a warning) when discovery is unreachable
+        or malformed — callers can still proceed with an explicit
+        ``OIDC_JWKS_URL`` override on a later configuration pass.
+        """
+        discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+        try:
+            response = requests.get(discovery_url, timeout=10)
+            response.raise_for_status()
+            jwks_uri = response.json().get("jwks_uri")
+            if not jwks_uri:
+                logger.warning(
+                    "OIDC discovery document at %s did not include jwks_uri",
+                    discovery_url,
+                )
+                return None
+            return jwks_uri
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning(
+                "OIDC discovery failed for %s: %s. Set OIDC_JWKS_URL to override.",
+                discovery_url, exc,
+            )
+            return None
     
     def _fetch_jwks(self) -> Dict[str, Any]:
         """Fetch JWKS from the configured URL."""

--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
@@ -62,31 +62,31 @@ class TokenValidator:
         )
 
     @staticmethod
-    def _discover_jwks_url(issuer: str) -> Optional[str]:
+    def _discover_jwks_url(issuer: str) -> str:
         """Resolve ``jwks_uri`` from the issuer's OIDC discovery document.
 
-        Returns ``None`` (with a warning) when discovery is unreachable
-        or malformed — callers can still proceed with an explicit
-        ``OIDC_JWKS_URL`` override on a later configuration pass.
+        Raises ``TokenValidationError`` when discovery is unreachable,
+        malformed, or omits ``jwks_uri``. Failing fast here surfaces the
+        real misconfiguration instead of silently leaving ``jwks_url``
+        unset and later failing with an opaque "JWKS URL not configured".
+        Set ``OIDC_JWKS_URL`` to bypass discovery entirely.
         """
         discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
         try:
             response = requests.get(discovery_url, timeout=10)
             response.raise_for_status()
             jwks_uri = response.json().get("jwks_uri")
-            if not jwks_uri:
-                logger.warning(
-                    "OIDC discovery document at %s did not include jwks_uri",
-                    discovery_url,
-                )
-                return None
-            return jwks_uri
         except (requests.RequestException, ValueError) as exc:
-            logger.warning(
-                "OIDC discovery failed for %s: %s. Set OIDC_JWKS_URL to override.",
-                discovery_url, exc,
+            raise TokenValidationError(
+                f"OIDC discovery failed for {discovery_url}: {exc}. "
+                f"Set OIDC_JWKS_URL to override."
+            ) from exc
+        if not jwks_uri:
+            raise TokenValidationError(
+                f"OIDC discovery document at {discovery_url} did not include jwks_uri. "
+                f"Set OIDC_JWKS_URL to override."
             )
-            return None
+        return jwks_uri
     
     def _fetch_jwks(self) -> Dict[str, Any]:
         """Fetch JWKS from the configured URL."""

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
@@ -334,26 +334,29 @@ class TestJwksDiscoveryFromEnv(unittest.TestCase):
         'OIDC_ISSUER_URL': 'https://broken.example.com',
     }, clear=True)
     @patch('ark_sdk.auth.validator.requests.get')
-    def test_discovery_failure_returns_none(self, mock_get):
-        """A broken discovery endpoint logs a warning and leaves jwks_url unset
-        — the previous behaviour silently fell through to a hardcoded path."""
+    def test_discovery_failure_raises(self, mock_get):
+        """A broken discovery endpoint fails fast with a clear error rather than
+        silently leaving jwks_url unset and 404'ing later."""
         import requests
         mock_get.side_effect = requests.RequestException('boom')
-        validator = TokenValidator()
-        self.assertIsNone(validator.config.jwks_url)
+        with self.assertRaises(TokenValidationError) as context:
+            TokenValidator()
+        self.assertIn('OIDC discovery failed', str(context.exception))
+        self.assertIn('OIDC_JWKS_URL', str(context.exception))
 
     @patch.dict('os.environ', {
         'OIDC_ISSUER_URL': 'https://noisy.example.com',
     }, clear=True)
     @patch('ark_sdk.auth.validator.requests.get')
-    def test_discovery_missing_jwks_uri_returns_none(self, mock_get):
-        """Discovery doc without a jwks_uri field is treated as a non-result."""
+    def test_discovery_missing_jwks_uri_raises(self, mock_get):
+        """A discovery doc without jwks_uri fails fast with a clear error."""
         mock_get.return_value = Mock(
             json=lambda: {"issuer": "https://noisy.example.com"},
             raise_for_status=lambda: None,
         )
-        validator = TokenValidator()
-        self.assertIsNone(validator.config.jwks_url)
+        with self.assertRaises(TokenValidationError) as context:
+            TokenValidator()
+        self.assertIn('did not include jwks_uri', str(context.exception))
 
 
 if __name__ == '__main__':

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
@@ -278,5 +278,83 @@ class TestTokenValidator(unittest.TestCase):
         self.assertEqual(self.config.jwks_url, "https://test.okta.com/.well-known/jwks.json")
 
 
+class TestJwksDiscoveryFromEnv(unittest.TestCase):
+    """JWKS URL resolution from env vars + OIDC discovery (issue: hardcoded
+    Keycloak path 404'd against Dex / Auth0 / Okta / etc.)."""
+
+    @patch.dict('os.environ', {
+        'OIDC_ISSUER_URL': 'https://dex.example.com',
+        'OIDC_APPLICATION_ID': 'ark-dashboard',
+    }, clear=True)
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_uses_oidc_discovery_for_jwks_url(self, mock_get):
+        """jwks_uri comes from the well-known discovery doc, not a hardcoded path."""
+        mock_get.return_value = Mock(
+            json=lambda: {"jwks_uri": "https://dex.example.com/keys"},
+            raise_for_status=lambda: None,
+        )
+        validator = TokenValidator()
+        self.assertEqual(validator.config.jwks_url, 'https://dex.example.com/keys')
+        mock_get.assert_called_once_with(
+            'https://dex.example.com/.well-known/openid-configuration', timeout=10,
+        )
+
+    @patch.dict('os.environ', {
+        'OIDC_ISSUER_URL': 'https://keycloak.example.com/realms/demo',
+    }, clear=True)
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_discovery_handles_keycloak_path(self, mock_get):
+        """Discovery still works for Keycloak — it advertises the same path the
+        previous hardcode used."""
+        mock_get.return_value = Mock(
+            json=lambda: {
+                "jwks_uri": "https://keycloak.example.com/realms/demo/protocol/openid-connect/certs",
+            },
+            raise_for_status=lambda: None,
+        )
+        validator = TokenValidator()
+        self.assertEqual(
+            validator.config.jwks_url,
+            'https://keycloak.example.com/realms/demo/protocol/openid-connect/certs',
+        )
+
+    @patch.dict('os.environ', {
+        'OIDC_ISSUER_URL': 'https://dex.example.com',
+        'OIDC_JWKS_URL': 'https://override.example.com/jwks',
+    }, clear=True)
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_oidc_jwks_url_env_override_wins(self, mock_get):
+        """OIDC_JWKS_URL skips discovery entirely (escape hatch for air-gapped
+        IdPs / unconventional layouts)."""
+        validator = TokenValidator()
+        self.assertEqual(validator.config.jwks_url, 'https://override.example.com/jwks')
+        mock_get.assert_not_called()
+
+    @patch.dict('os.environ', {
+        'OIDC_ISSUER_URL': 'https://broken.example.com',
+    }, clear=True)
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_discovery_failure_returns_none(self, mock_get):
+        """A broken discovery endpoint logs a warning and leaves jwks_url unset
+        — the previous behaviour silently fell through to a hardcoded path."""
+        import requests
+        mock_get.side_effect = requests.RequestException('boom')
+        validator = TokenValidator()
+        self.assertIsNone(validator.config.jwks_url)
+
+    @patch.dict('os.environ', {
+        'OIDC_ISSUER_URL': 'https://noisy.example.com',
+    }, clear=True)
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_discovery_missing_jwks_uri_returns_none(self, mock_get):
+        """Discovery doc without a jwks_uri field is treated as a non-result."""
+        mock_get.return_value = Mock(
+            json=lambda: {"issuer": "https://noisy.example.com"},
+            raise_for_status=lambda: None,
+        )
+        validator = TokenValidator()
+        self.assertIsNone(validator.config.jwks_url)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #2321. ark-api's TokenValidator hardcoded `<issuer>/protocol/openid-connect/certs` (Keycloak-only), so any other IdP — Dex, Auth0, Google, etc. — 404'd on JWKS fetch and every request returned `Token validation failed`.
- Use OIDC discovery (RFC 8414 / OIDC Core §4) to learn `jwks_uri` from `<issuer>/.well-known/openid-configuration`. Keycloak still works — its discovery doc advertises the same path the hardcode used.
- Add `OIDC_JWKS_URL` env override as an escape hatch for air-gapped IdPs or unconventional well-known layouts.
- 5 new test cases covering Dex, Keycloak (via discovery), env override, discovery failure, and missing `jwks_uri` in the discovery doc.

Reproduced live against Dex on the ark-demo cluster — fix verified via fork-built ark-api image.

Closes #2321. Same lineage as #2319 (#2318) — both bugs assumed identity-provider conventions hardcoded against one IdP.