### PR TITLE
fix(security): CVE-2026-42504 (Go 1.26.4) and CVE-2026-45149 (brace-expansion 5.0.6)

### DIFF
--- a/ark/go.mod
+++ b/ark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
@@ -51,7 +52,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	k8s.io/kms v0.34.0 // indirect
 )
@@ -149,7 +149,7 @@ require (
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3632,9 +3632,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,6 +45,7 @@
     "@napi-rs/simple-git-linux-x64-musl": "^0.1.19"
   },
   "overrides": {
+    "brace-expansion": ">=5.0.6",
     "undici": "^7.24.0",
     "rollup": "4.59.0",
     "minimatch": "^10.2.3",

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -73,6 +73,7 @@
     },
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
-    "express-rate-limit": "^8.3.0"
+    "express-rate-limit": "^8.3.0",
+    "brace-expansion": ">=5.0.6"
   }
 }

--- a/services/ark-dashboard/ark-dashboard/package-lock.json
+++ b/services/ark-dashboard/ark-dashboard/package-lock.json
@@ -6000,9 +6000,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/services/ark-dashboard/ark-dashboard/package.json
+++ b/services/ark-dashboard/ark-dashboard/package.json
@@ -111,6 +111,7 @@
     "express-rate-limit": "^8.3.0",
     "uuid": "^14.0.0",
     "postcss": "^8.5.10",
-    "ws": "^8.20.1"
+    "ws": "^8.20.1",
+    "brace-expansion": ">=5.0.6"
   }
 }

--- a/services/ark-landing-page/package-lock.json
+++ b/services/ark-landing-page/package-lock.json
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/services/ark-landing-page/package.json
+++ b/services/ark-landing-page/package.json
@@ -33,6 +33,7 @@
     "typescript": "5.7.3"
   },
   "overrides": {
+    "brace-expansion": ">=5.0.6",
     "jsonpath-plus": "^10.3.0",
     "tough-cookie": "^4.1.3",
     "form-data": "^4.0.4",

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -85,6 +85,7 @@
     "node": ">=18.0.0"
   },
   "overrides": {
+    "brace-expansion": ">=5.0.6",
     "minimatch": "^10.2.3",
     "rollup": "4.59.0",
     "hono": "^4.12.18",

--- a/tools/fark/go.mod
+++ b/tools/fark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark/tools/fark
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.26.3 to 1.26.4 in `ark/go.mod` and `tools/fark/go.mod` to fix CVE-2026-42504
- Pin `brace-expansion` to `>=5.0.6` via `overrides` in `ark-broker` and `ark-dashboard` to fix CVE-2026-45149
- Regenerate all lock files (`go.sum`, `package-lock.json`)

Addresses the JFrog Xray violations tracked in issue #2329.

### CVE-2026-42504 (XRAY-995089) — High

Decoding a maliciously-crafted MIME header containing many invalid encoded-words triggers quadratic CPU usage in `net/mail` `WordDecoder.DecodeHeader`. Fixed in Go 1.26.4.

### CVE-2026-45149 (XRAY-985837) — High

`brace-expansion` 5.0.0–5.0.5 applies the `max` option after generating all intermediate elements, causing ~505 MB memory and excessive CPU for large numeric ranges like `{1..10000000}`. Fixed in 5.0.6. The package is a transitive dependency of `minimatch` in both `ark-broker` and `ark-dashboard`.