### PR TITLE
fix(ark-api): suffix cluster-scoped RBAC names with release namespace

### DIFF
--- a/services/ark-api/chart/templates/rbac.yaml
+++ b/services/ark-api/chart/templates/rbac.yaml
@@ -83,7 +83,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.serviceAccount.name }}-cluster-role
+  name: {{ .Values.serviceAccount.name }}-cluster-role-{{ .Release.Namespace }}
   annotations:
     {{- with .Values.global.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -104,7 +104,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.serviceAccount.name }}-cluster-binding
+  name: {{ .Values.serviceAccount.name }}-cluster-binding-{{ .Release.Namespace }}
   annotations:
     {{- with .Values.global.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -115,6 +115,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.serviceAccount.name }}-cluster-role
+  name: {{ .Values.serviceAccount.name }}-cluster-role-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
## Summary
- Fixes the multi-tenant deployment blocker where the second `ark-api` release in a different namespace fails with `invalid ownership metadata` on the cluster-scoped ClusterRole/ClusterRoleBinding.
- Suffixes the cluster-scoped resource names with `.Release.Namespace` so each tenant owns its own `ClusterRole`/`ClusterRoleBinding` (`ark-api-sa-cluster-role-<ns>` / `ark-api-sa-cluster-binding-<ns>`).
- Rules and subjects are unchanged, so existing single-tenant installs keep identical permissions; Helm prunes the old fixed-name objects on upgrade.

Closes #2351

Made with [Cursor](https://cursor.com)