### PR TITLE
fix(completions): cache Model CRD to avoid per-query k8s API calls

### DIFF
--- a/ark/executors/completions/model.go
+++ b/ark/executors/completions/model.go
@@ -3,6 +3,8 @@ package completions
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/openai/openai-go/option"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,6 +16,15 @@ import (
 	"mckinsey.com/ark/internal/eventing"
 	"mckinsey.com/ark/internal/telemetry"
 )
+
+const modelCRDCacheTTL = 5 * time.Minute
+
+type modelCRDCacheEntry struct {
+	crd       *arkv1alpha1.Model
+	expiresAt time.Time
+}
+
+var modelCRDCache sync.Map
 
 const defaultModelName = "default"
 
@@ -100,13 +111,20 @@ func LoadModel(ctx context.Context, k8sClient client.Client, modelSpec interface
 }
 
 func loadModelCRD(ctx context.Context, k8sClient client.Client, name, namespace string) (*arkv1alpha1.Model, error) {
-	var modelCRD arkv1alpha1.Model
-	key := types.NamespacedName{Name: name, Namespace: namespace}
+	cacheKey := namespace + "/" + name
+	if v, ok := modelCRDCache.Load(cacheKey); ok {
+		entry := v.(*modelCRDCacheEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.crd, nil
+		}
+	}
 
-	if err := k8sClient.Get(ctx, key, &modelCRD); err != nil {
+	var modelCRD arkv1alpha1.Model
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &modelCRD); err != nil {
 		return nil, fmt.Errorf("failed to get Model %s/%s: %w", namespace, name, err)
 	}
 
+	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{crd: &modelCRD, expiresAt: time.Now().Add(modelCRDCacheTTL)})
 	return &modelCRD, nil
 }
 

--- a/ark/executors/completions/model_test.go
+++ b/ark/executors/completions/model_test.go
@@ -3,6 +3,7 @@ package completions
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -87,6 +88,28 @@ func setupModelTestClient(objects []client.Object) client.Client {
 	_ = corev1.AddToScheme(scheme)
 	_ = arkv1alpha1.AddToScheme(scheme)
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func TestLoadModelCRD_ConcurrentAccess(t *testing.T) {
+	name, ns := "concurrent-model", "default"
+	cacheKey := ns + "/" + name
+	modelCRDCache.Delete(cacheKey)
+	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
+
+	model := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	fakeClient := setupModelTestClient([]client.Object{model})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := loadModelCRD(context.Background(), fakeClient, name, ns)
+			require.NoError(t, err)
+			require.Equal(t, name, got.Name)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestResolveModelHeaders_DirectValue(t *testing.T) {

--- a/ark/executors/completions/model_test.go
+++ b/ark/executors/completions/model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -153,6 +154,59 @@ func TestResolveModelHeaders_FromQueryParameter(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "user-123", got["X-User-ID"])
+}
+
+func TestLoadModelCRD_CacheHit(t *testing.T) {
+	cacheKey := "default/cached-model"
+	cached := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: "default"}}
+	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{
+		crd:       cached,
+		expiresAt: time.Now().Add(modelCRDCacheTTL),
+	})
+	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
+
+	fakeClient := setupModelTestClient(nil)
+
+	got, err := loadModelCRD(context.Background(), fakeClient, "cached-model", "default")
+	require.NoError(t, err)
+	require.Same(t, cached, got)
+}
+
+func TestLoadModelCRD_CacheMiss(t *testing.T) {
+	name, ns := "miss-model", "default"
+	cacheKey := ns + "/" + name
+	modelCRDCache.Delete(cacheKey)
+	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
+
+	model := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	fakeClient := setupModelTestClient([]client.Object{model})
+
+	got, err := loadModelCRD(context.Background(), fakeClient, name, ns)
+	require.NoError(t, err)
+	require.Equal(t, name, got.Name)
+
+	v, ok := modelCRDCache.Load(cacheKey)
+	require.True(t, ok)
+	require.Equal(t, name, v.(*modelCRDCacheEntry).crd.Name)
+}
+
+func TestLoadModelCRD_ExpiredEntry(t *testing.T) {
+	name, ns := "expired-model", "default"
+	cacheKey := ns + "/" + name
+
+	stale := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{
+		crd:       stale,
+		expiresAt: time.Now().Add(-time.Second),
+	})
+	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
+
+	fresh := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	fakeClient := setupModelTestClient([]client.Object{fresh})
+
+	got, err := loadModelCRD(context.Background(), fakeClient, name, ns)
+	require.NoError(t, err)
+	require.NotSame(t, stale, got)
 }
 
 func TestResolveModelHeaders_QueryParameterWithoutContext(t *testing.T) {


### PR DESCRIPTION
## Context

Part of the ongoing memory leak investigation in the completions executor (issue #2247). That issue documents progressive RSS growth proportional to query volume, empirically validated with pprof on a local Kind cluster. This PR addresses finding #10 from that analysis.

The completions executor uses a plain REST `client.New` (no informer cache), so every `k8sClient.Get` is a real network round-trip to the API server.

## Problem

`loadModelCRD` is called on every query execution — from `MakeAgent` via `LoadModel`. It performs a `k8sClient.Get` to fetch the `*arkv1alpha1.Model` CR, which deserializes the full object from JSON each time.

Empirical measurement from pprof (20 sequential queries, mock-llm backend):
```
0.50 MB cumulative  completions.LoadModel
0.50 MB cumulative  completions.loadModelCRD   ← entire cost is here
```

The Model CR is effectively static across queries: it holds provider configuration (endpoint, model name, Secret references) that changes rarely and only on explicit user update.

## Fix

Cache the `*arkv1alpha1.Model` returned by `loadModelCRD`, keyed by `namespace/name`, with a 5-minute TTL.

**What stays uncached (intentionally):**
- Secret resolution (`ResolveValueSource` for API keys) — still called fresh per query, so credential rotation takes effect within the TTL window
- `additionalHeaders` — derived from per-query and per-agent overrides, vary across callers of `LoadModel`
- Provider construction (OpenAI/Azure/Anthropic client) — depends on the resolved secrets

**Implementation:** `sync.Map` with a `*modelCRDCacheEntry` value holding the CRD pointer and an `expiresAt` timestamp. No locks beyond what `sync.Map` provides.

## Behaviour in HA deployments

The cache is in-memory and per-process — each replica maintains its own independent `sync.Map` with no coordination across pods.

In practice this means:
- Each replica warms up independently on its first query per model, then serves from cache for 5 minutes. No worse than the current behaviour on cold replicas, strictly better from the second query onward.
- During a Model CR update, replicas refresh at different times within the 5-minute window — one pod may serve the new version while another still serves the old one. This is acceptable for model configuration (endpoint, model name), which changes rarely and is not request-scoped.
- API server load at scale: N replicas × M distinct models × (1 refresh / 5 min). At 10 replicas and 20 models this is ~0.67 req/s — negligible. A shared external cache (e.g. Redis) would reduce this further but adds infrastructure with no practical benefit at this scale.

## Files changed

- `ark/executors/completions/model.go` — cache struct, `sync.Map` var, TTL constant, updated `loadModelCRD`
- `ark/executors/completions/model_test.go` — four new tests: cache hit, cache miss (verifies stored), expired entry (verifies re-fetch), concurrent access (passes with `-race`)

## Review guide

1. **`model.go:102-120`** — `loadModelCRD`: check the cache lookup/store logic and that the expired-entry path falls through to the k8s Get correctly.
2. **`model.go:18-26`** — cache types: `modelCRDCacheEntry` holds a pointer to the CRD; callers in `LoadModel` read from `modelCRD.Spec.*` but never mutate the struct, so sharing the pointer across queries is safe.
3. **`model_test.go` — `TestLoadModelCRD_CacheHit`**: populates the cache directly and uses a fake client with no objects — if the cache miss path were taken, `k8sClient.Get` would return not-found and the test would fail.
4. **`model_test.go` — `TestLoadModelCRD_ExpiredEntry`**: stores an entry with `expiresAt` in the past, then checks the returned pointer is not the stale one (`require.NotSame`).
5. **`model_test.go` — `TestLoadModelCRD_ConcurrentAccess`**: 10 goroutines hit the same key simultaneously; passes with `-race`.
6. **TTL choice (5 min)**: balances avoiding repeated API calls against reflecting Model CR updates promptly. Credential rotation is unaffected since Secrets are resolved fresh every call.

Closes finding #10 from #2247.