### PR TITLE
fix(completions): harden A2A streaming — shared http.Client and idle timeout

### DIFF
--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -158,6 +158,8 @@ type a2aStreamContext struct {
 	queryName    string
 }
 
+var a2aStreamIdleTimeout = 2 * time.Minute
+
 func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events <-chan protocol.StreamingMessageEvent, eventStream EventStreamInterface, modelID, completionID, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) (*ExecutionResult, error) {
 	var content strings.Builder
 	var response arka2a.A2AResponse
@@ -174,10 +176,15 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 		queryName:    queryName,
 	}
 
+	idleTimer := time.NewTimer(a2aStreamIdleTimeout)
+	defer idleTimer.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-idleTimer.C:
+			return nil, fmt.Errorf("a2a streaming idle timeout: no events received for %s", a2aStreamIdleTimeout)
 		case event, ok := <-events:
 			if !ok {
 				if !received {
@@ -185,6 +192,7 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 				}
 				return buildA2AStreamResult(&content, &response), nil
 			}
+			idleTimer.Reset(a2aStreamIdleTimeout)
 			received = true
 			if event.Result == nil {
 				continue

--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -194,7 +194,7 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-idleTimer.C:
-			return nil, fmt.Errorf("a2a streaming idle timeout: no events received for %s", idleTimeout)
+			return nil, fmt.Errorf("a2a streaming idle timeout: no events received for %s (agent=%s, namespace=%s)", idleTimeout, agentName, namespace)
 		case event, ok := <-events:
 			if !ok {
 				if !received {

--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -158,7 +158,16 @@ type a2aStreamContext struct {
 	queryName    string
 }
 
-var a2aStreamIdleTimeout = 2 * time.Minute
+var defaultA2AStreamIdleTimeout = 8 * time.Minute
+
+func effectiveIdleTimeout(a2aServer *arkv1prealpha1.A2AServer) time.Duration {
+	if a2aServer != nil && a2aServer.Spec.Timeout != "" {
+		if d, err := time.ParseDuration(a2aServer.Spec.Timeout); err == nil && d < defaultA2AStreamIdleTimeout {
+			return d
+		}
+	}
+	return defaultA2AStreamIdleTimeout
+}
 
 func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events <-chan protocol.StreamingMessageEvent, eventStream EventStreamInterface, modelID, completionID, agentName, namespace, queryName string, a2aServer *arkv1prealpha1.A2AServer) (*ExecutionResult, error) {
 	var content strings.Builder
@@ -176,7 +185,8 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 		queryName:    queryName,
 	}
 
-	idleTimer := time.NewTimer(a2aStreamIdleTimeout)
+	idleTimeout := effectiveIdleTimeout(a2aServer)
+	idleTimer := time.NewTimer(idleTimeout)
 	defer idleTimer.Stop()
 
 	for {
@@ -184,7 +194,7 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-idleTimer.C:
-			return nil, fmt.Errorf("a2a streaming idle timeout: no events received for %s", a2aStreamIdleTimeout)
+			return nil, fmt.Errorf("a2a streaming idle timeout: no events received for %s", idleTimeout)
 		case event, ok := <-events:
 			if !ok {
 				if !received {
@@ -192,7 +202,7 @@ func consumeA2AStreamEvents(ctx context.Context, k8sClient client.Client, events
 				}
 				return buildA2AStreamResult(&content, &response), nil
 			}
-			idleTimer.Reset(a2aStreamIdleTimeout)
+			idleTimer.Reset(idleTimeout)
 			received = true
 			if event.Result == nil {
 				continue

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -161,6 +161,33 @@ func TestConsumeA2AStreamEvents_IdleTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "idle timeout")
 }
 
+func TestConsumeA2AStreamEvents_IdleTimeoutReset(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec:       arkv1prealpha1.A2AServerSpec{Timeout: "150ms"},
+	}
+	events := make(chan protocol.StreamingMessageEvent)
+	stream := &mockEventStream{}
+
+	go func() {
+		for range 3 {
+			time.Sleep(50 * time.Millisecond)
+			events <- protocol.StreamingMessageEvent{
+				Result: &protocol.Message{
+					Role:  protocol.MessageRoleAgent,
+					Parts: []protocol.Part{protocol.NewTextPart("chunk")},
+				},
+			}
+		}
+		close(events)
+	}()
+
+	result, err := consumeA2AStreamEvents(context.Background(), nil, events, stream, "agent/test", "comp-1", "test", "default", "", a2aServer)
+	require.NoError(t, err)
+	assert.Equal(t, "chunkchunkchunk", result.A2AResponse.Content)
+	assert.Len(t, stream.chunks, 3)
+}
+
 func TestEffectiveIdleTimeout_Default(t *testing.T) {
 	assert.Equal(t, defaultA2AStreamIdleTimeout, effectiveIdleTimeout(nil))
 }

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
+	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
 	arka2a "mckinsey.com/ark/internal/a2a"
 )
 
@@ -148,15 +150,33 @@ func TestConsumeA2AStreamEventsTask(t *testing.T) {
 }
 
 func TestConsumeA2AStreamEvents_IdleTimeout(t *testing.T) {
-	old := a2aStreamIdleTimeout
-	a2aStreamIdleTimeout = 50 * time.Millisecond
-	t.Cleanup(func() { a2aStreamIdleTimeout = old })
-
+	a2aServer := &arkv1prealpha1.A2AServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec:       arkv1prealpha1.A2AServerSpec{Timeout: "50ms"},
+	}
 	events := make(chan protocol.StreamingMessageEvent)
 
-	_, err := consumeA2AStreamEvents(context.Background(), nil, events, nil, "agent/test", "comp-1", "test", "default", "", nil)
+	_, err := consumeA2AStreamEvents(context.Background(), nil, events, nil, "agent/test", "comp-1", "test", "default", "", a2aServer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "idle timeout")
+}
+
+func TestEffectiveIdleTimeout_Default(t *testing.T) {
+	assert.Equal(t, defaultA2AStreamIdleTimeout, effectiveIdleTimeout(nil))
+}
+
+func TestEffectiveIdleTimeout_ServerTimeoutShorter(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "3m"},
+	}
+	assert.Equal(t, 3*time.Minute, effectiveIdleTimeout(a2aServer))
+}
+
+func TestEffectiveIdleTimeout_ServerTimeoutLonger(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "30m"},
+	}
+	assert.Equal(t, defaultA2AStreamIdleTimeout, effectiveIdleTimeout(a2aServer))
 }
 
 func TestStreamContentChunkSkipsEmpty(t *testing.T) {

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -3,6 +3,7 @@ package completions
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,6 +145,18 @@ func TestConsumeA2AStreamEventsTask(t *testing.T) {
 	assert.Equal(t, "task result", result.A2AResponse.Content)
 	assert.Equal(t, "task-1", result.A2AResponse.TaskID)
 	assert.Len(t, stream.chunks, 1)
+}
+
+func TestConsumeA2AStreamEvents_IdleTimeout(t *testing.T) {
+	old := a2aStreamIdleTimeout
+	a2aStreamIdleTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { a2aStreamIdleTimeout = old })
+
+	events := make(chan protocol.StreamingMessageEvent)
+
+	_, err := consumeA2AStreamEvents(context.Background(), nil, events, nil, "agent/test", "comp-1", "test", "default", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "idle timeout")
 }
 
 func TestStreamContentChunkSkipsEmpty(t *testing.T) {

--- a/ark/internal/a2a/a2a.go
+++ b/ark/internal/a2a/a2a.go
@@ -40,6 +40,10 @@ var (
 	sharedA2ADiscoverTransport = otelhttp.NewTransport(sharedA2ABaseTransport,
 		otelhttp.WithSpanNameFormatter(func(_ string, _ *http.Request) string { return "a2a.discover" }),
 	)
+	sharedA2ASendClient = &http.Client{
+		Timeout:   5 * time.Minute,
+		Transport: sharedA2ASendTransport,
+	}
 )
 
 func getA2ADiscoveryTimeout() time.Duration {
@@ -120,18 +124,8 @@ func ExecuteA2AAgent(ctx context.Context, k8sClient client.Client, address strin
 }
 
 func CreateA2AClient(ctx context.Context, k8sClient client.Client, rpcURL string, headers []arkv1prealpha1.Header, namespace, agentName string, a2aRecorder eventing.A2aRecorder) (*a2aclient.A2AClient, error) {
-	timeout := 5 * time.Minute
-	if deadline, ok := ctx.Deadline(); ok {
-		timeout = time.Until(deadline)
-	}
-
-	httpClient := &http.Client{
-		Timeout:   timeout,
-		Transport: sharedA2ASendTransport,
-	}
-
 	var clientOptions []a2aclient.Option
-	clientOptions = append(clientOptions, a2aclient.WithHTTPClient(httpClient))
+	clientOptions = append(clientOptions, a2aclient.WithHTTPClient(sharedA2ASendClient))
 
 	if len(headers) > 0 {
 		resolvedHeaders, err := resolveA2AHeaders(ctx, k8sClient, headers, namespace)


### PR DESCRIPTION
## Context

Part of the memory leak and reliability investigation in the completions executor (issue #2247). This PR addresses findings #8 and #9 from that analysis, both in `a2a_execution.go` and the shared `internal/a2a/a2a.go`.

## Problem

**Finding #8 — new `http.Client` per A2A streaming call**

`executeStreaming` calls `arka2a.CreateA2AClient` on every invocation. Inside `CreateA2AClient`, a new `http.Client` struct was allocated per call with a per-call timeout derived from the context deadline:

```go
timeout := 5 * time.Minute
if deadline, ok := ctx.Deadline(); ok {
    timeout = time.Until(deadline)
}
httpClient := &http.Client{Timeout: timeout, Transport: sharedA2ASendTransport}
```

The transport was already shared (`sharedA2ASendTransport`, fixed in PR #2275). The per-call `http.Client` struct was redundant — context cancellation propagates through `StreamMessage(ctx, params)` and handles per-request deadlines without a client-level timeout.

**Finding #9 — no idle timeout in `consumeA2AStreamEvents`**

The streaming consumer loop had no idle timer:

```go
for {
    select {
    case <-ctx.Done():   return nil, ctx.Err()
    case event, ok := <-events:  ...
    }
}
```

If the A2A peer stops sending events without closing the channel (network partition, hung handler), the goroutine blocks indefinitely. The parent context only protects it when `A2AServer.Spec.Timeout` is configured — which is optional.

A fixed short idle timeout (e.g. 2 minutes) would be too aggressive for complex multi-step agents that make several sequential LLM calls: each call takes 10–30 seconds and produces no streaming events while thinking. A 5-step agent could legitimately go silent for several minutes between turns.

## Fix

**#8:** Replaced per-call `http.Client` construction with a package-level `sharedA2ASendClient` (5-minute default timeout, shared transport). Removed the per-call timeout derivation — context cancellation handles shorter per-request deadlines.

**#9:** Added an idle timer in `consumeA2AStreamEvents` that resets on each received event. The effective timeout is derived via `effectiveIdleTimeout(a2aServer)`:

- Default: **8 minutes** — generous enough for complex multi-step agents
- If `A2AServer.Spec.Timeout` is set and shorter than 8 minutes: uses the server timeout instead (no point waiting longer than the total operation limit)
- If `A2AServer.Spec.Timeout` is longer than 8 minutes: caps at 8 minutes

```go
func effectiveIdleTimeout(a2aServer *arkv1prealpha1.A2AServer) time.Duration {
    if a2aServer != nil && a2aServer.Spec.Timeout != "" {
        if d, err := time.ParseDuration(a2aServer.Spec.Timeout); err == nil && d < defaultA2AStreamIdleTimeout {
            return d
        }
    }
    return defaultA2AStreamIdleTimeout
}
```

## Files changed

- `ark/internal/a2a/a2a.go` — added `sharedA2ASendClient`; removed per-call `http.Client` construction from `CreateA2AClient`
- `ark/executors/completions/a2a_execution.go` — added `defaultA2AStreamIdleTimeout`, `effectiveIdleTimeout` helper, and idle timer in `consumeA2AStreamEvents`
- `ark/executors/completions/a2a_execution_test.go` — added `TestConsumeA2AStreamEvents_IdleTimeout` (uses A2AServer with 50ms timeout, no global mutation), plus `TestEffectiveIdleTimeout_*` for the three cases (nil server, shorter, longer than default)

## Review guide

1. **`a2a.go:36-43`** — `sharedA2ASendClient` alongside the other shared transport vars; 5-minute default timeout, context cancellation handles shorter deadlines.
2. **`a2a.go:CreateA2AClient`** — per-call timeout derivation removed; rest of the function (header resolution, `a2aclient.NewA2AClient`) unchanged.
3. **`a2a_execution.go:161-172`** — `effectiveIdleTimeout`: nil-safe, parses `Spec.Timeout`, caps at `defaultA2AStreamIdleTimeout`. Called once per `consumeA2AStreamEvents` invocation and stored in `idleTimeout` local var used for both `NewTimer` and `Reset`.
4. **`a2a_execution.go:consumeA2AStreamEvents`** — timer created before the loop, reset on every received event, stopped via `defer`. The `<-idleTimer.C` branch is a third select case alongside context cancellation and channel events.
5. **`a2a_execution_test.go:TestConsumeA2AStreamEvents_IdleTimeout`** — passes an A2AServer with `Timeout: "50ms"` so the idle fires quickly without mutating global state. Channel is open but never written to — simulates a stalled peer.
6. **`a2a_execution_test.go:TestEffectiveIdleTimeout_*`** — three cases: nil server → default, 3m server → 3m (shorter wins), 30m server → default (cap applies).

Closes findings #8 and #9 from #2247.