### PR TITLE
docs(ref): add Secure Software Architecture page

### DIFF
--- a/docs/content/reference/_meta.js
+++ b/docs/content/reference/_meta.js
@@ -18,6 +18,7 @@ export default {
   troubleshooting: 'Troubleshooting',
   'utility-images': 'Utility Images',
   'secure-sdlc': 'Secure Software Development Lifecycle',
+  'secure-software-architecture': 'Secure Software Architecture',
   'vulnerability-management': 'Vulnerability Management',
 
   '---project': { type: 'separator', title: 'Project' },

--- a/docs/content/reference/secure-software-architecture.mdx
+++ b/docs/content/reference/secure-software-architecture.mdx
@@ -33,13 +33,6 @@ The Ark API service has a namespace-scoped Role granting access to Ark resources
 
 The dashboard and broker are stateless services with no Kubernetes API permissions beyond their own service account identity. They do not read or write Ark custom resources directly.
 
-### MCP service
-
-The MCP service has read-only access to Agents and Namespaces, plus create/manage access to Queries — the minimum required to expose Ark resources as MCP tools.
-
-### Deployer role
-
-An optional `ark-deployer` ClusterRole is provided for CI/CD systems. It grants create and update permissions for Ark resources, CRDs, RBAC, and cert-manager objects, but intentionally excludes delete permissions for most resource types to follow the principle of least privilege in deployment automation.
 
 ## Input validation and error handling
 

--- a/docs/content/reference/secure-software-architecture.mdx
+++ b/docs/content/reference/secure-software-architecture.mdx
@@ -11,26 +11,9 @@ Ark runs inside customer-controlled Kubernetes clusters. Many of the controls de
 
 ## Access control
 
-### Authentication modes
+Ark supports OIDC-based SSO, API key authentication, and a hybrid mode combining both. When user impersonation is enabled, Kubernetes RBAC is enforced against the authenticated user's identity rather than the Ark service account. Ark ships viewer / editor / admin ClusterRoles for each resource type that can be combined or extended.
 
-The Ark API supports four authentication modes, configured via `AUTH_MODE`:
-
-- **`sso`** — OIDC/JWT authentication. Users authenticate with an external identity provider.
-- **`basic`** — API key authentication only (HTTP Basic). Designed for headless and service-to-service access.
-- **`hybrid`** (recommended) — Both OIDC and API key authentication. Dashboard users authenticate via OIDC; services use API keys.
-- **`open`** — No authentication. Intended for development only.
-
-See the [Authentication](/developer-guide/authentication) guide for configuration details, OIDC provider setup, and API key management.
-
-### User impersonation
-
-When enabled, the Ark API forwards the authenticated user's identity to Kubernetes via `Impersonate-User` and `Impersonate-Group` headers. This means Kubernetes RBAC applies to the actual user rather than the Ark API service account.
-
-Impersonation applies to SSO and hybrid (JWT path) modes. API key and open modes do not carry a user identity.
-
-### User-facing RBAC roles
-
-Ark ships a set of ClusterRoles for each resource type, following a viewer / editor / admin tier pattern. These are role definitions — cluster administrators create namespace-scoped RoleBindings to grant access to specific users or groups. The roles can be combined, extended, or replaced entirely to match your organization's needs. See the [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for details on creating custom roles and bindings.
+See the [Authentication](/developer-guide/authentication) guide for full details on authentication modes, impersonation, RBAC roles, and API key management.
 
 ## Segregation of duties
 

--- a/docs/content/reference/secure-software-architecture.mdx
+++ b/docs/content/reference/secure-software-architecture.mdx
@@ -40,18 +40,7 @@ The dashboard and broker are stateless services with no Kubernetes API permissio
 
 Ark registers validating and mutating webhooks for its core resource types. All webhooks are configured with `failurePolicy: Fail` — invalid resources are rejected, never silently accepted.
 
-**Validating webhooks** enforce:
-
-- **Referential integrity** — Agents, Teams, and Queries must reference resources that exist in the same namespace.
-- **Structural correctness** — Tool input schemas must be valid JSON Schema; Team strategies must have valid configurations (e.g., selector strategy requires `maxTurns`); ArkConfig must use valid duration syntax.
-- **Security constraints** — Model base URLs must use HTTPS (with an exception for `*.svc.cluster.local`), and are blocked from targeting loopback addresses, cloud metadata endpoints (169.254.0.0/16), and private IP ranges (configurable via `ALLOWED_PRIVATE_IP_RANGES`). Domain whitelisting is available via `WHITELISTED_MODEL_DOMAINS`.
-- **Self-reference prevention** — Teams cannot reference themselves.
-
-**Mutating webhooks** apply defaults and handle migrations:
-
-- Assign a default model when none is specified on an Agent.
-- Migrate deprecated resource configurations (e.g., deprecated team strategies) and annotate resources with migration warnings so users can update their manifests.
-- Inject default TTL from ArkConfig on Queries that don't specify one.
+Validating webhooks check referential integrity, structural correctness, and security constraints (e.g., HTTPS enforcement and private IP blocking for model URLs). Mutating webhooks apply defaults and migrate deprecated configurations, annotating resources with warnings so users can update their manifests.
 
 ### API-level validation
 
@@ -65,14 +54,7 @@ Webhook validation errors are returned to the user with context: field paths, ar
 
 ### TLS
 
-The controller uses [cert-manager](https://cert-manager.io/) to generate TLS certificates for two internal endpoints:
-
-- **Webhook serving** — Mutating and validating webhooks are served over TLS with certificates issued by a self-signed Issuer scoped to the Ark namespace.
-- **Metrics** — The controller metrics endpoint (port 8443) is TLS-protected using a separate certificate from the same Issuer.
-
-Both certificates use a private key rotation policy of `Always` (rotated on every renewal). Custom CA certificates can be mounted from a Kubernetes Secret for environments using internal certificate authorities.
-
-For inter-service communication beyond webhooks and metrics, Ark relies on cluster-level controls. See the in-transit encryption table in [Data Flow and Encryption](/operations-guide/data-flow-and-encryption#in-transit-encryption) for the TLS status of each hop and recommendations for enabling mTLS via a service mesh.
+Webhook and metrics endpoints are served over TLS. The default Helm chart uses [cert-manager](https://cert-manager.io/) with a self-signed Issuer, but production deployments can substitute any certificate provisioning mechanism. For inter-service communication beyond these endpoints, Ark relies on cluster-level controls — see [Data Flow and Encryption](/operations-guide/data-flow-and-encryption#in-transit-encryption) for the TLS status of each hop.
 
 ### Secret storage
 

--- a/docs/content/reference/secure-software-architecture.mdx
+++ b/docs/content/reference/secure-software-architecture.mdx
@@ -1,0 +1,115 @@
+---
+title: Secure Software Architecture
+description: Runtime security architecture of Ark — access control, segregation of duties, input validation, error handling, and cryptographic practices
+---
+
+# Secure Software Architecture
+
+This page describes the runtime security architecture of Ark. It complements the [Secure Software Development Lifecycle](/reference/secure-sdlc), which covers the engineering process, and the [Data Flow and Encryption](/operations-guide/data-flow-and-encryption) guide, which details per-surface encryption status and log sanitization.
+
+Ark runs inside customer-controlled Kubernetes clusters. Many of the controls described here depend on correct cluster and cloud configuration — see the [Disclaimer](/disclaimer).
+
+## Access control
+
+### Authentication modes
+
+The Ark API supports four authentication modes, configured via `AUTH_MODE`:
+
+- **`sso`** — OIDC/JWT authentication. Users authenticate with an external identity provider.
+- **`basic`** — API key authentication only (HTTP Basic). Designed for headless and service-to-service access.
+- **`hybrid`** (recommended) — Both OIDC and API key authentication. Dashboard users authenticate via OIDC; services use API keys.
+- **`open`** — No authentication. Intended for development only.
+
+See the [Authentication](/developer-guide/authentication) guide for configuration details, OIDC provider setup, and API key management.
+
+### User impersonation
+
+When enabled, the Ark API forwards the authenticated user's identity to Kubernetes via `Impersonate-User` and `Impersonate-Group` headers. This means Kubernetes RBAC applies to the actual user rather than the Ark API service account.
+
+Impersonation applies to SSO and hybrid (JWT path) modes. API key and open modes do not carry a user identity.
+
+### User-facing RBAC roles
+
+Ark ships a set of ClusterRoles for each resource type, following a viewer / editor / admin tier pattern. These are role definitions — cluster administrators create namespace-scoped RoleBindings to grant access to specific users or groups. The roles can be combined, extended, or replaced entirely to match your organization's needs. See the [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for details on creating custom roles and bindings.
+
+## Segregation of duties
+
+Each Ark service runs under its own Kubernetes service account with permissions scoped to what that service needs. All service accounts set `automountServiceAccountToken: false` — tokens are mounted explicitly only where required.
+
+### Controller
+
+The controller manages the full lifecycle of Ark custom resources across all namespaces. Its ClusterRole grants create, read, update, and delete access to all `ark.mckinsey.com` resources, plus read access to Secrets and ConfigMaps it needs to resolve references. When RBAC impersonation is enabled, the controller can impersonate service accounts to execute queries under tenant-specific identities.
+
+A separate leader-election Role, scoped to the controller's own namespace, manages ConfigMap and Lease resources for HA leader election.
+
+### API
+
+The Ark API service has a namespace-scoped Role granting access to Ark resources, Secrets, and supporting Kubernetes objects within its deployment namespace. A separate ClusterRole covers cluster-scoped resources (ArkConfig) and, when impersonation is enabled, the ability to impersonate users and groups.
+
+### Dashboard and broker
+
+The dashboard and broker are stateless services with no Kubernetes API permissions beyond their own service account identity. They do not read or write Ark custom resources directly.
+
+### MCP service
+
+The MCP service has read-only access to Agents and Namespaces, plus create/manage access to Queries — the minimum required to expose Ark resources as MCP tools.
+
+### Deployer role
+
+An optional `ark-deployer` ClusterRole is provided for CI/CD systems. It grants create and update permissions for Ark resources, CRDs, RBAC, and cert-manager objects, but intentionally excludes delete permissions for most resource types to follow the principle of least privilege in deployment automation.
+
+## Input validation and error handling
+
+### Admission webhooks
+
+Ark registers validating and mutating webhooks for its core resource types. All webhooks are configured with `failurePolicy: Fail` — invalid resources are rejected, never silently accepted.
+
+**Validating webhooks** enforce:
+
+- **Referential integrity** — Agents, Teams, and Queries must reference resources that exist in the same namespace.
+- **Structural correctness** — Tool input schemas must be valid JSON Schema; Team strategies must have valid configurations (e.g., selector strategy requires `maxTurns`); ArkConfig must use valid duration syntax.
+- **Security constraints** — Model base URLs must use HTTPS (with an exception for `*.svc.cluster.local`), and are blocked from targeting loopback addresses, cloud metadata endpoints (169.254.0.0/16), and private IP ranges (configurable via `ALLOWED_PRIVATE_IP_RANGES`). Domain whitelisting is available via `WHITELISTED_MODEL_DOMAINS`.
+- **Self-reference prevention** — Teams cannot reference themselves.
+
+**Mutating webhooks** apply defaults and handle migrations:
+
+- Assign a default model when none is specified on an Agent.
+- Migrate deprecated resource configurations (e.g., deprecated team strategies) and annotate resources with migration warnings so users can update their manifests.
+- Inject default TTL from ArkConfig on Queries that don't specify one.
+
+### API-level validation
+
+The Ark API (FastAPI) validates inbound requests using Pydantic models with field constraints. Path segments are validated against traversal attacks (`..`, `/`, `\`), and URLs are constructed with proper encoding.
+
+### Error handling
+
+Webhook validation errors are returned to the user with context: field paths, array indices, and specific violation descriptions. Errors are never swallowed — the `failurePolicy: Fail` configuration ensures the API server rejects requests when webhooks are unreachable. Mutation webhooks return non-blocking warnings for deprecated configurations, allowing the request to proceed while surfacing the migration path.
+
+## Cryptographic practices
+
+### TLS
+
+The controller uses [cert-manager](https://cert-manager.io/) to generate TLS certificates for two internal endpoints:
+
+- **Webhook serving** — Mutating and validating webhooks are served over TLS with certificates issued by a self-signed Issuer scoped to the Ark namespace.
+- **Metrics** — The controller metrics endpoint (port 8443) is TLS-protected using a separate certificate from the same Issuer.
+
+Both certificates use a private key rotation policy of `Always` (rotated on every renewal). Custom CA certificates can be mounted from a Kubernetes Secret for environments using internal certificate authorities.
+
+For inter-service communication beyond webhooks and metrics, Ark relies on cluster-level controls. See the in-transit encryption table in [Data Flow and Encryption](/operations-guide/data-flow-and-encryption#in-transit-encryption) for the TLS status of each hop and recommendations for enabling mTLS via a service mesh.
+
+### Secret storage
+
+Model credentials and other sensitive values are stored as Kubernetes Secrets. Secrets are base64-encoded but not encrypted by default in etcd — encryption at rest requires configuring the Kubernetes API server's `EncryptionConfiguration`. See the [Kubernetes encryption-at-rest documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for setup instructions.
+
+### API key hashing
+
+API key secret components are hashed using bcrypt with an automatically generated salt before storage. The plaintext secret is shown only once at creation time and is never stored or returned again. Verification uses bcrypt's constant-time comparison.
+
+### OIDC token validation
+
+JWT tokens are validated by fetching the issuer's JWKS endpoint via OIDC discovery (RFC 8414). The Ark API verifies the token signature, expiration, audience, and issuer. RSA and EC key types are supported. No signing keys are stored locally — they are fetched from the identity provider.
+
+### OAuth for MCP authorization
+
+When MCP servers require OAuth, Ark implements the authorization code flow with PKCE (RFC 7636, S256 method). The code verifier is generated with 64 cryptographically random characters, and the challenge is derived via SHA-256. Callback URLs enforce HTTPS for non-loopback hosts per RFC 8252.


### PR DESCRIPTION
## Summary

- Add a new Reference → Operations page documenting the runtime security architecture of Ark
- Covers access control (auth modes, impersonation, user-facing RBAC roles)
- Documents segregation of duties: per-service account scoping for controller, API, dashboard, broker, MCP, and the optional deployer role
- Describes input validation via admission webhooks (validating + mutating) and API-level validation
- Covers cryptographic practices: cert-manager TLS, Kubernetes Secret storage, bcrypt API key hashing, OIDC token validation, and OAuth PKCE for MCP
- Cross-references existing Authentication, Data Flow and Encryption, and Secure SDLC docs
- Intended as both a controller reference and a citable statement of practice for audits