### PR TITLE
docs(nav): rename section headers to Basic use / Advanced use

### DIFF
--- a/docs/content/how-to-guides/_meta.js
+++ b/docs/content/how-to-guides/_meta.js
@@ -1,7 +1,7 @@
 export default {
   index: 'Overview',
   
-  '---build': { type: 'separator', title: 'Build with ARK (application developers)' },
+  '---build': { type: 'separator', title: 'Basic use' },
   models: {
     title: 'Configure providers and models',
     href: '/user-guide/models'
@@ -35,7 +35,7 @@ export default {
     href: '/user-guide/samples/teams/team-strategies'
   },
   
-  '---extend': { type: 'separator', title: 'Extend ARK (contributors)' },
+  '---extend': { type: 'separator', title: 'Advanced use' },
   'local-development': {
     title: 'Build and run locally',
     href: '/developer-guide/local-development'

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -2,7 +2,7 @@
 
 How-to guides help you complete **specific tasks**. Pick the task that matches what you need to do right now.
 
-## Build with ARK (application developers)
+## Basic use
 
 - [Create and manage models](/user-guide/models).
 - [Create and manage agents](/user-guide/agents).
@@ -16,7 +16,7 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
   - [Explore team samples](/user-guide/samples/teams/team-strategies).
   - [Explore MCP server samples](/user-guide/samples/mcp-servers).
 
-## Extend ARK (contributors and platform developers)
+## Advanced use
 
 - Build and run services locally:
   - [Develop locally](/developer-guide/local-development).

--- a/docs/content/user-guide/_meta.js
+++ b/docs/content/user-guide/_meta.js
@@ -4,7 +4,7 @@ export default {
   'starting-new-project': 'Starting a New Agentic Project',
   'starting-new-project-example': 'Complete Worked Example',
 
-  '---build': { type: 'separator', title: 'Build with ARK' },
+  '---build': { type: 'separator', title: 'Basic use' },
   models: 'Creating and Managing Models',
   agents: 'Creating and Managing Agents',
   teams: 'Creating and Managing Teams',


### PR DESCRIPTION
## Summary
- Rename the how-to-guides nav sections from audience-based labels to usage-level labels:
  - **Build with ARK (application developers)** → **Basic use**
  - **Extend ARK (contributors and platform developers)** → **Advanced use**
- Updated in both the separator titles (`how-to-guides/_meta.js`) and the matching H2 headings (`how-to-guides/index.mdx`), plus the `Build with ARK` separator in `user-guide/_meta.js` for consistency across the two sidebars.

Note: the third how-to-guides section, **Operate ARK (operators, SRE, and security)**, was left unchanged — happy to rename it too (e.g. "Operations") if you'd like a fully consistent set.