### PR TITLE
fix: Dashboard crashes on debug due to OTLP format

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/chat/embedded-chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/embedded-chat-panel.tsx
@@ -21,7 +21,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { getSessionDisplayNameFromEntries } from '@/lib/broker/session-utils';
+import {
+  getAttributeStringValue,
+  getSessionDisplayNameFromEntries,
+} from '@/lib/broker/session-utils';
 import { type BrokerStatus, proxyService } from '@/lib/services/proxy';
 import type { GraphEdge } from '@/lib/types/chat-message';
 
@@ -320,9 +323,10 @@ function DebugStreamView({
             attr !== null &&
             'key' in attr &&
             attr.key === 'ark.session.id',
-        ) as { value?: string } | undefined;
-        if (sessionAttr?.value) {
-          return sessionAttr.value;
+        ) as { value?: unknown } | undefined;
+        const sessionValue = getAttributeStringValue(sessionAttr?.value);
+        if (sessionValue) {
+          return sessionValue;
         }
       }
     }
@@ -335,9 +339,10 @@ function DebugStreamView({
           attr !== null &&
           'key' in attr &&
           attr.key === 'ark.session.id',
-      ) as { value?: string } | undefined;
-      if (sessionAttr?.value) {
-        return sessionAttr.value;
+      ) as { value?: unknown } | undefined;
+      const sessionValue = getAttributeStringValue(sessionAttr?.value);
+      if (sessionValue) {
+        return sessionValue;
       }
     }
 

--- a/services/ark-dashboard/ark-dashboard/lib/broker/session-utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/broker/session-utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractQueryIdAndSessionId,
+  getAttributeStringValue,
+  type StreamEntry,
+} from './session-utils';
+
+describe('getAttributeStringValue', () => {
+  it('returns plain string values unchanged', () => {
+    expect(getAttributeStringValue('session-123')).toBe('session-123');
+  });
+
+  it('extracts stringValue from OTLP AnyValue', () => {
+    expect(getAttributeStringValue({ stringValue: 'session-123' })).toBe(
+      'session-123',
+    );
+  });
+
+  it('extracts intValue (number) from OTLP AnyValue', () => {
+    expect(getAttributeStringValue({ intValue: 42 })).toBe('42');
+  });
+
+  it('extracts intValue (string, OTLP JSON int64 encoding) from OTLP AnyValue', () => {
+    expect(getAttributeStringValue({ intValue: '9007199254740993' })).toBe(
+      '9007199254740993',
+    );
+  });
+
+  it('extracts boolValue from OTLP AnyValue', () => {
+    expect(getAttributeStringValue({ boolValue: true })).toBe('true');
+    expect(getAttributeStringValue({ boolValue: false })).toBe('false');
+  });
+
+  it('extracts doubleValue from OTLP AnyValue', () => {
+    expect(getAttributeStringValue({ doubleValue: 3.14 })).toBe('3.14');
+  });
+
+  it('returns undefined for null, undefined, and unsupported shapes', () => {
+    expect(getAttributeStringValue(null)).toBeUndefined();
+    expect(getAttributeStringValue(undefined)).toBeUndefined();
+    expect(getAttributeStringValue({})).toBeUndefined();
+    expect(getAttributeStringValue({ arrayValue: { values: [] } })).toBeUndefined();
+    expect(getAttributeStringValue(42)).toBeUndefined();
+  });
+});
+
+describe('extractQueryIdAndSessionId', () => {
+  const traceEntry = (
+    sessionValue: unknown,
+    queryValue: unknown = 'q-1',
+  ): StreamEntry => ({
+    id: 'e1',
+    timestamp: '2026-06-10T00:00:00Z',
+    data: {
+      spans: [
+        {
+          attributes: [
+            { key: 'query.name', value: queryValue },
+            { key: 'ark.session.id', value: sessionValue },
+          ],
+        },
+      ],
+    },
+  });
+
+  it('returns a string sessionId when attribute value is OTLP-wrapped', () => {
+    const result = extractQueryIdAndSessionId(
+      traceEntry({ stringValue: 'sess-abc' }, { stringValue: 'q-name' }),
+    );
+    expect(result.sessionId).toBe('sess-abc');
+    expect(result.queryId).toBe('q-name');
+  });
+
+  it('returns a string sessionId when attribute value is a bare string', () => {
+    const result = extractQueryIdAndSessionId(traceEntry('sess-bare', 'q-bare'));
+    expect(result.sessionId).toBe('sess-bare');
+    expect(result.queryId).toBe('q-bare');
+  });
+
+  it('skips empty OTLP values and falls back through other paths', () => {
+    const entry: StreamEntry = {
+      id: 'e1',
+      timestamp: '2026-06-10T00:00:00Z',
+      data: {
+        spans: [{ attributes: [{ key: 'ark.session.id', value: {} }] }],
+        data: { sessionId: 'fallback-sess' },
+      },
+    };
+    expect(extractQueryIdAndSessionId(entry).sessionId).toBe('fallback-sess');
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/lib/broker/session-utils.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/broker/session-utils.ts
@@ -4,6 +4,20 @@ export interface StreamEntry {
   data: unknown;
 }
 
+export function getAttributeStringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    const v = value as Record<string, unknown>;
+    if (typeof v.stringValue === 'string') return v.stringValue;
+    if (typeof v.intValue === 'string' || typeof v.intValue === 'number') {
+      return String(v.intValue);
+    }
+    if (typeof v.boolValue === 'boolean') return String(v.boolValue);
+    if (typeof v.doubleValue === 'number') return String(v.doubleValue);
+  }
+  return undefined;
+}
+
 export function extractQueryIdAndSessionId(entry: StreamEntry): {
   queryId: string | undefined;
   sessionId: string | undefined;
@@ -28,12 +42,14 @@ export function extractQueryIdAndSessionId(entry: StreamEntry): {
       const attributes = span?.attributes as Array<Record<string, unknown>>;
       if (attributes) {
         const queryAttr = attributes.find(attr => attr?.key === 'query.name');
-        if (queryAttr?.value) {
-          queryId = queryAttr.value as string;
+        const queryValue = getAttributeStringValue(queryAttr?.value);
+        if (queryValue) {
+          queryId = queryValue;
         }
         const sessionAttr = attributes.find(attr => attr?.key === 'ark.session.id');
-        if (sessionAttr?.value) {
-          sessionId = sessionAttr.value as string;
+        const sessionValue = getAttributeStringValue(sessionAttr?.value);
+        if (sessionValue) {
+          sessionId = sessionValue;
           break;
         }
       }


### PR DESCRIPTION
Trace span attributes arrive in OTLP shape (e.g. {stringValue: "abc"}), not bare strings. The debug stream code cast attr.value directly to string, so the AnyValue object flowed through as the sessionId — used as a Map key (serializing to "[object Object]") and rendered as a React child, crashing the debug tab with "Objects are not valid as a React child".

Adds getAttributeStringValue() that handles both bare strings and OTLP AnyValue shapes, and routes both extraction sites through it.

Fixes #2413 


## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 