### PR TITLE
fix(ark-api): align MCP auth callback default to CLI port-forward port

### DIFF
--- a/services/ark-api/chart/values.yaml
+++ b/services/ark-api/chart/values.yaml
@@ -81,8 +81,12 @@ app:
     # loopback literal (127.0.0.1, [::1] bracketed per RFC 3986 §3.2.2, or
     # localhost). The path /v1/mcp/auth/callback is appended automatically
     # if the configured URL has no path.
+    # The default port matches the local port that `ark mcp auth login`
+    # forwards ark-api to (k8sPortForwardLocalPort in tools/ark-cli), so the
+    # IdP redirect lands on the CLI's live port-forward. Override with a public
+    # https ingress URL for real deployments.
     - name: ARK_API_PUBLIC_CALLBACK_URL
-      value: "http://localhost:8088/v1/mcp/auth/callback"
+      value: "http://localhost:34780/v1/mcp/auth/callback"
     # Base URL of the dashboard, used to build the post-callback redirect for
     # dashboard-initiated auth flows. The redirect target is <value>/mcp, so the
     # value MUST include any path prefix the dashboard is served under (e.g.


### PR DESCRIPTION
## Summary
- The ark-api chart defaulted `ARK_API_PUBLIC_CALLBACK_URL` to `http://localhost:8088/v1/mcp/auth/callback`, but `ark mcp auth login` forwards ark-api to `localhost:34780` (`k8sPortForwardLocalPort` in `tools/ark-cli/src/arkServices.ts`).
- ark-api embeds that value as the OAuth `redirect_uri`, so after IdP login the browser was redirected to `:8088` where nothing was listening — the CLI polled until timeout and the callback appeared broken.
- Point the default at `34780` so the IdP redirect lands on the CLI's live port-forward. Real deployments still override with a public https ingress URL.
- Verified with `helm lint` and `helm template` (renders the corrected env var).