### PR TITLE
fix(mcp-auth): drop nonexistent dashboard authorize flow references

### DIFF
--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -477,7 +477,7 @@ func (r *MCPServerReconciler) handleAuthorizationRequired(ctx context.Context, m
 	if displayName == "" {
 		displayName = authStatus.Resource
 	}
-	message := fmt.Sprintf("OAuth authorization required for %s. Authorize via dashboard or CLI.", displayName)
+	message := fmt.Sprintf("OAuth authorization required for %s. Run `ark mcp auth login %s` to authorize.", displayName, mcpServer.Name)
 
 	r.reconcileCondition(mcpServer, MCPServerAvailable, metav1.ConditionFalse, MCPServerReasonAuthorizationRequired, message)
 	r.reconcileCondition(mcpServer, MCPServerDiscovering, metav1.ConditionFalse, MCPServerReasonAuthorizationRequired, "Cannot attempt tool discovery until authorization is complete")

--- a/docs/content/operations-guide/mcp-oauth-callback.mdx
+++ b/docs/content/operations-guide/mcp-oauth-callback.mdx
@@ -5,7 +5,7 @@ description: Configuring ark-api as the OAuth callback target for MCP server aut
 
 # MCP OAuth Callback
 
-When a user authorizes an MCP server through the dashboard or `ark mcp auth login`, the IdP redirects the browser back to ark-api with the authorization code. ark-api exchanges the code for tokens, writes the result to the MCPServer's referenced Secret, and stamps the parent MCPServer with an annotation that records who triggered the flow.
+When a user authorizes an MCP server with `ark mcp auth login`, the IdP redirects the browser back to ark-api with the authorization code. ark-api exchanges the code for tokens, writes the result to the MCPServer's referenced Secret, and stamps the parent MCPServer with an annotation that records who triggered the flow.
 
 The redirect target is a single externally reachable URL that ark-api must own. This page covers configuring `ARK_API_PUBLIC_CALLBACK_URL` for both public ingress and air-gapped clusters.
 

--- a/docs/content/reference/resources/mcpserver.mdx
+++ b/docs/content/reference/resources/mcpserver.mdx
@@ -92,7 +92,7 @@ shell    True        1
 | _(empty)_     | Server does not require OAuth. |
 | `Required`    | Server returned 401 and metadata discovery succeeded. Ready for an authorize flow. |
 | `Authorized`  | A token was successfully written to the referenced Secret by ark-api. |
-| `DiscoveryFailed` | Server returned 401 but no usable RFC 9728 metadata was found. Dashboard/CLI cannot drive an OAuth flow against this server. |
+| `DiscoveryFailed` | Server returned 401 but no usable RFC 9728 metadata was found. The CLI cannot drive an OAuth flow against this server. |
 
 ### Prerequisites
 
@@ -107,18 +107,18 @@ spec:
 
 ### Token writes go through ark-api
 
-The interactive authorize flow (dynamic client registration, PKCE, token exchange, Secret write) is orchestrated by ark-api. The dashboard "Authorize" button and the [`ark mcp auth login`](/developer-guide/cli-tools#ark-mcp-auth) CLI are thin clients that POST to ark-api's `/api/v1/mcp-servers/{name}/auth/start` and poll `auth/status` — neither touches the Kubernetes Secret directly. See [MCP OAuth Callback](/operations-guide/mcp-oauth-callback) for the operator-side callback URL configuration.
+The interactive authorize flow (dynamic client registration, PKCE, token exchange, Secret write) is orchestrated by ark-api. The [`ark mcp auth login`](/developer-guide/cli-tools#ark-mcp-auth) CLI is a thin client that POSTs to ark-api's `/api/v1/mcp-servers/{name}/auth/start` and polls `auth/status` — it never touches the Kubernetes Secret directly. The CLI is the only client today; a dashboard authorize flow is not yet available. See [MCP OAuth Callback](/operations-guide/mcp-oauth-callback) for the operator-side callback URL configuration.
 
 A successful flow leaves two annotations on the MCPServer:
 
 ```yaml
 metadata:
   annotations:
-    ark.mckinsey.com/mcp-auth-authorized-by: cli       # cli | dashboard
+    ark.mckinsey.com/mcp-auth-authorized-by: cli       # cli (dashboard not yet supported)
     ark.mckinsey.com/mcp-auth-authorized-at: 2026-05-19T14:32:11Z
 ```
 
-`authorized-by` is `cli` for this phase. A future per-user-tokens capability will surface the OIDC subject of the authenticated dashboard user here so multi-user clusters can distinguish whose credentials wrote the Secret. Until that ships, MCPServer tokens are effectively a per-server singleton — only one user can hold an authorized session at a time.
+`authorized-by` is `cli` for this phase. A future per-user-tokens capability will surface the OIDC subject of the authenticated user here so multi-user clusters can distinguish whose credentials wrote the Secret. Until that ships, MCPServer tokens are effectively a per-server singleton — only one user can hold an authorized session at a time.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- The MCPServer `AuthorizationRequired` status message read "Authorize via dashboard or CLI", which the dashboard surfaces as a card error — but no dashboard authorize flow exists, only `ark mcp auth login`. The message now points users at the CLI command (`Run \`ark mcp auth login <name>\` to authorize.`).
- Removed dashboard-flow claims from the MCP OAuth docs (`mcp-oauth-callback.mdx`, `mcpserver.mdx`): the "dashboard Authorize button", the `cli | dashboard` annotation hint, and the "authenticated dashboard user" wording.

Closes #2417