### PR TITLE
fix: Various small CICD issues

### DIFF
--- a/.github/actions/collect-coverage-e2e/action.yml
+++ b/.github/actions/collect-coverage-e2e/action.yml
@@ -17,6 +17,9 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
+        # This step only `go install`s gcov2lcov; it does not build the
+        # project, so module caching has no value here.
+        cache: false
     
     - name: Install gcov2lcov
       shell: bash

--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -149,6 +149,33 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    # Wait for k3s to finish creating the bootstrap RBAC the cloud-controller
+    # manager needs before we apply anything on top of it. If we don't, the
+    # cloud-controller can race against its own rolebinding, hit a 403 reading
+    # kube-system/extension-apiserver-authentication, treat that as fatal, and
+    # take the rest of k3s down with it mid-calico-rollout. Symptom: calico-node
+    # never goes ready and every follow-up kubectl call returns "connection to
+    # 127.0.0.1:6443 was refused".
+    - name: Wait for k3s bootstrap RBAC
+      run: |
+        echo "::group::Wait for k3s bootstrap RBAC"
+        for attempt in $(seq 1 24); do
+          if kubectl -n kube-system get rolebinding extension-apiserver-authentication-reader >/dev/null 2>&1 \
+             && kubectl -n kube-system get configmap extension-apiserver-authentication >/dev/null 2>&1; then
+            echo "k3s bootstrap RBAC ready (attempt $attempt/24)"
+            break
+          fi
+          echo "Waiting for k3s bootstrap RBAC (attempt $attempt/24)..."
+          sleep 2
+          if [ "$attempt" -eq 24 ]; then
+            echo "Timed out waiting for k3s bootstrap RBAC"
+            kubectl -n kube-system get rolebinding,configmap || true
+            exit 1
+          fi
+        done
+        echo "::endgroup::"
+      shell: bash
+
     # Install calico as a CNI to enforce our NetworkPolicies. Note that canal
     # could do this job as well.
     #

--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -159,9 +159,12 @@ runs:
     - name: Wait for k3s bootstrap RBAC
       run: |
         echo "::group::Wait for k3s bootstrap RBAC"
+        # Probe the actual auth chain (rolebinding + configmap + apiserver
+        # cache) instead of pattern-matching resource names; the rolebinding
+        # the cloud-controller uses has been renamed across k3s versions.
         for attempt in $(seq 1 24); do
-          if kubectl -n kube-system get rolebinding extension-apiserver-authentication-reader >/dev/null 2>&1 \
-             && kubectl -n kube-system get configmap extension-apiserver-authentication >/dev/null 2>&1; then
+          if kubectl -n kube-system auth can-i get configmap/extension-apiserver-authentication \
+               --as=k3s-cloud-controller-manager >/dev/null 2>&1; then
             echo "k3s bootstrap RBAC ready (attempt $attempt/24)"
             break
           fi
@@ -170,6 +173,8 @@ runs:
           if [ "$attempt" -eq 24 ]; then
             echo "Timed out waiting for k3s bootstrap RBAC"
             kubectl -n kube-system get rolebinding,configmap || true
+            kubectl -n kube-system auth can-i get configmap/extension-apiserver-authentication \
+              --as=k3s-cloud-controller-manager -v=6 || true
             exit 1
           fi
         done

--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -52,10 +52,10 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24.x'
+        node-version: "24"
 
     - name: Configure K3s registry authentication
-      if: ${{ inputs.is-fork-pr == 'false' }}
+      if: ${{ inputs.is-fork-pr == "false' }}
       shell: bash
       run: |
         sudo mkdir -p /etc/rancher/k3s

--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -55,7 +55,7 @@ runs:
         node-version: "24"
 
     - name: Configure K3s registry authentication
-      if: ${{ inputs.is-fork-pr == "false' }}
+      if: ${{ inputs.is-fork-pr == 'false' }}
       shell: bash
       run: |
         sudo mkdir -p /etc/rancher/k3s

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ version: 2
 updates:
   # GitHub Actions
   - package-ecosystem: github-actions
-    directory: '.github/workflows'
+    directory: '.github'
     commit-message:
       prefix: 'chore(actions): '
     schedule:

--- a/.github/workflows/ark_agent.yml
+++ b/.github/workflows/ark_agent.yml
@@ -132,7 +132,7 @@ jobs:
         if: steps.check.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       # Clone the upstream claude-code-action repo at the pinned version.
       # We run it directly instead of using `uses:` because external actions

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Build Docs
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -254,7 +254,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - run: make -j24 services-build-all
 
@@ -898,7 +898,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Build and install ark-cli
         run: |
@@ -1031,7 +1031,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Build ARK CLI
         run: |
@@ -1406,7 +1406,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Install published ark-cli from npm
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -650,14 +650,36 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq
 
       - name: Warm up network connectivity
+        env:
+          AZURE_BASE_URL: ${{ secrets.CICD_AZURE_OPENAI_BASE_URL }}
+          OPENAI_BASE_URL: ${{ secrets.CICD_OPENAI_BASE_URL || 'https://api.openai.com/v1' }}
         run: |
-          echo "Warming up egress network paths..."
+          echo "Warming up egress network paths to LLM providers..."
           for i in {1..5}; do
-            echo "Attempt $i: Testing connectivity to external APIs"
-            curl -s -m 10 "https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.006&current_weather=true" > /dev/null && echo "✓ Weather API reachable" || echo "✗ Weather API unreachable (will retry)"
+            echo "Attempt $i:"
+            azure_ok=1
+            if [ -n "$AZURE_BASE_URL" ]; then
+              azure_ok=0
+              if curl -s -m 10 -o /dev/null "$AZURE_BASE_URL"; then
+                echo "✓ Azure OpenAI reachable"
+                azure_ok=1
+              else
+                echo "✗ Azure OpenAI unreachable (will retry)"
+              fi
+            fi
+            openai_ok=0
+            if curl -s -m 10 -o /dev/null "$OPENAI_BASE_URL"; then
+              echo "✓ OpenAI reachable"
+              openai_ok=1
+            else
+              echo "✗ OpenAI unreachable (will retry)"
+            fi
+            if [ "$azure_ok" = 1 ] && [ "$openai_ok" = 1 ]; then
+              echo "Network warm-up complete - LLM providers reachable"
+              break
+            fi
             sleep 3
           done
-          echo "Network warm-up complete - egress connectivity established"
 
       - name: Run multi-provider LLM tests
         env:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1094,6 +1094,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.26.2"
+          # Coverage tooling only; no project build, so module caching has no value here.
+          cache: false
 
       - name: Install Python coverage tools
         run: |
@@ -1334,6 +1336,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26.2'
+          # goreleaser builds tools/fark; cache against its go.sum.
+          cache-dependency-path: tools/fark/go.sum
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
           
       - name: Build Docs
         run: |
@@ -301,7 +301,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
           registry-url: https://registry.npmjs.org/
 
       - name: Publish to npm
@@ -353,7 +353,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Install published ark-cli from npm
         run: |

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -348,7 +348,7 @@ jobs:
         if: steps.check.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install OpenSpec CLI
         if: steps.check.outputs.run == 'true'
@@ -692,7 +692,7 @@ jobs:
         if: steps.verify-issue.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install OpenSpec CLI
         if: steps.verify-issue.outputs.run == 'true'
@@ -934,7 +934,7 @@ jobs:
         if: steps.check.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install OpenSpec CLI
         if: steps.check.outputs.run == 'true'

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Setup environment
         run: |

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -107,7 +107,7 @@ jobs:
         if: steps.check-coverage.outputs.found == 'false'
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Install uv
         if: steps.check-coverage.outputs.found == 'false'
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Set up Cloudflare WARP
         uses: Boostport/setup-cloudflare-warp@v1

--- a/services/ark-broker/ark-broker/src/testing/chunk-helpers.ts
+++ b/services/ark-broker/ark-broker/src/testing/chunk-helpers.ts
@@ -1,4 +1,27 @@
-export const createTextChunk = (content: string, index: number = 0) => ({
+export interface ChatCompletionChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id: string;
+        type: 'function';
+        function: {name: string; arguments: string};
+      }>;
+    };
+    finish_reason?: string;
+  }>;
+}
+
+export const createTextChunk = (
+  content: string,
+  index: number = 0
+): ChatCompletionChunk => ({
   id: `chatcmpl-${Date.now()}`,
   object: 'chat.completion.chunk',
   created: Date.now(),
@@ -10,7 +33,7 @@ export const createToolCallChunk = (
   toolName: string,
   args: string,
   index: number = 0
-) => ({
+): ChatCompletionChunk => ({
   id: `chatcmpl-${Date.now()}`,
   object: 'chat.completion.chunk',
   created: Date.now(),
@@ -35,7 +58,9 @@ export const createToolCallChunk = (
   ],
 });
 
-export const createFinishChunk = (reason: string = 'stop') => ({
+export const createFinishChunk = (
+  reason: string = 'stop'
+): ChatCompletionChunk => ({
   id: `chatcmpl-${Date.now()}`,
   object: 'chat.completion.chunk',
   created: Date.now(),

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -171,7 +171,7 @@ JMESPath's `contains()` requires a string or array — it throws a hard type err
       status:
         (contains(response.content, 'expected text')): true
 
-# Good - wait for completion first, then assert
+# Good - wait until response.content is populated, then assert against it
 - apply:
     file: manifests/a04-query.yaml
 - wait:
@@ -180,9 +180,8 @@ JMESPath's `contains()` requires a string or array — it throws a hard type err
     name: test-query
     timeout: 2m
     for:
-      condition:
-        name: Completed
-        value: 'True'
+      jsonPath:
+        path: '{.status.response.content}'
 - assert:
     resource:
       ...
@@ -190,7 +189,9 @@ JMESPath's `contains()` requires a string or array — it throws a hard type err
         (contains(response.content, 'expected text')): true
 ```
 
-This applies to both success and error queries — the `Completed` condition is set to `True` regardless of outcome (`QuerySucceeded`, `QueryErrored`, `QueryCanceled`).
+Prefer `for.jsonPath` over `for.condition: Completed=True` whenever the next step reads `response.content`. `Completed=True` can become visible on a watch before `response.content` has propagated to a subsequent read (especially on the postgresql backend, where watch events hop through the WAL consumer), and `contains(nil, ...)` errors rather than failing-with-retry. Waiting on the jsonpath itself fires only once the field is non-empty, so the follow-up assert and any shell-script `kubectl get … jsonpath='{.status.response.content}'` (which has no retry of its own) both see a populated value.
+
+`Completed=True` is still the right wait for tests that only care that the query terminated — for example, error queries where the body of `response.content` is not what's under test.
 
 ### Model Assertions
 Models should assert existence and readiness:

--- a/tests/agent-overrides/chainsaw-test.yaml
+++ b/tests/agent-overrides/chainsaw-test.yaml
@@ -72,9 +72,8 @@ spec:
         name: overrides-test-query
         timeout: 60s
         for:
-          condition:
-            name: Completed
-            value: 'True'
+          jsonPath:
+            path: '{.status.response.content}'
     catch:
     - events: {}
     - describe:
@@ -91,7 +90,6 @@ spec:
           metadata:
             name: overrides-test-query
           status:
-            (response != null): true
             (response.target.name): 'overrides-test-agent'
     - script:
         env:
@@ -138,9 +136,8 @@ spec:
         name: overrides-test-query-tool
         timeout: 60s
         for:
-          condition:
-            name: Completed
-            value: 'True'
+          jsonPath:
+            path: '{.status.response.content}'
     - script:
         env:
         - name: NAMESPACE

--- a/tests/llm-tests/run-multi-provider.sh
+++ b/tests/llm-tests/run-multi-provider.sh
@@ -4,11 +4,11 @@ set -e
 echo "=== Running Multi-Provider LLM Tests ==="
 
 MODELS=()
-FAILED_MODELS=()
-PASSED_MODELS=()
-TOTAL_TESTS=0
-TOTAL_PASSED=0
-TOTAL_FAILED=0
+# Index-aligned with MODELS. Indexed arrays (not associative) so this runs
+# on macOS /bin/bash 3.2 too.
+PASSED_PER_MODEL=()
+FAILED_PER_MODEL=()
+TOTAL_PER_MODEL=()
 
 # Check which providers are configured (OpenAI first for better network stability)
 if [ -n "${E2E_TEST_OPENAI_API_KEY}" ]; then
@@ -37,66 +37,76 @@ echo "Running tests for ${#MODELS[@]} provider(s): ${MODELS[*]}"
 echo ""
 
 mkdir -p /tmp/chainsaw-report
+REPORT=/tmp/chainsaw-report/chainsaw-report.json
 
-for MODEL in "${MODELS[@]}"; do
+# Fallback count if the report is missing (e.g. chainsaw crashed pre-write).
+TESTS_PER_PROVIDER=$(find llm-tests -mindepth 1 -maxdepth 1 -type d ! -name setup | wc -l | tr -d ' ')
+
+for i in "${!MODELS[@]}"; do
+  MODEL=${MODELS[$i]}
   echo "========================================"
   echo "Testing with MODEL=$MODEL"
   echo "========================================"
-  
+
   export MODEL
-  
-  # Count actual test directories (excluding setup/)
-  TESTS_PER_PROVIDER=$(find llm-tests -mindepth 1 -maxdepth 1 -type d ! -name setup | wc -l | tr -d ' ')
-  
-  if chainsaw test llm-tests/ --config .chainsaw.yaml; then
-    TOTAL_TESTS=$((TOTAL_TESTS + TESTS_PER_PROVIDER))
-    TOTAL_PASSED=$((TOTAL_PASSED + TESTS_PER_PROVIDER))
-    
-    echo "✓ $MODEL tests PASSED"
-    PASSED_MODELS+=("$MODEL")
+  rm -f "$REPORT"
+
+  chainsaw test llm-tests/ --config .chainsaw.yaml || true
+
+  if [ -f "$REPORT" ]; then
+    passed=$(jq '[.tests[]? | select(.status == "passed")] | length' "$REPORT")
+    failed=$(jq '[.tests[]? | select(.status == "failed")] | length' "$REPORT")
+    total=$(jq  '.tests   | length' "$REPORT")
   else
-    TOTAL_TESTS=$((TOTAL_TESTS + TESTS_PER_PROVIDER))
-    TOTAL_FAILED=$((TOTAL_FAILED + TESTS_PER_PROVIDER))
-    
-    echo "✗ $MODEL tests FAILED"
-    FAILED_MODELS+=("$MODEL")
+    passed=0
+    failed=$TESTS_PER_PROVIDER
+    total=$TESTS_PER_PROVIDER
+    echo "WARNING: no chainsaw report at $REPORT; assuming all $total tests failed"
   fi
-  
+
+  PASSED_PER_MODEL[$i]=$passed
+  FAILED_PER_MODEL[$i]=$failed
+  TOTAL_PER_MODEL[$i]=$total
+
+  if [ "$failed" -eq 0 ] && [ "$total" -gt 0 ]; then
+    echo "✓ $MODEL: $passed/$total tests passed"
+  else
+    echo "✗ $MODEL: $passed/$total tests passed ($failed failed)"
+  fi
   echo ""
 done
 
 echo "========================================"
 echo "Test Summary"
 echo "========================================"
-echo "Individual Tests: $TOTAL_PASSED/$TOTAL_TESTS passed"
-echo ""
 
-# Count test directories dynamically
-TESTS_PER_PROVIDER=$(find llm-tests -mindepth 1 -maxdepth 1 -type d ! -name setup | wc -l | tr -d ' ')
-
-# Show provider-level details
-for model in "${PASSED_MODELS[@]}"; do
-  echo "  ✓ $model: $TESTS_PER_PROVIDER/$TESTS_PER_PROVIDER tests passed"
+total_passed=0
+total_tests=0
+passed_providers=0
+for i in "${!MODELS[@]}"; do
+  total_passed=$((total_passed + PASSED_PER_MODEL[$i]))
+  total_tests=$((total_tests + TOTAL_PER_MODEL[$i]))
+  if [ "${FAILED_PER_MODEL[$i]}" -eq 0 ] && [ "${TOTAL_PER_MODEL[$i]}" -gt 0 ]; then
+    passed_providers=$((passed_providers + 1))
+  fi
 done
 
-if [ ${#FAILED_MODELS[@]} -gt 0 ]; then
-  for model in "${FAILED_MODELS[@]}"; do
-    echo "  ✗ $model: 0/$TESTS_PER_PROVIDER tests passed"
-  done
-fi
-
+echo "Individual Tests: $total_passed/$total_tests passed"
 echo ""
-echo "Providers: ${#PASSED_MODELS[@]}/${#MODELS[@]} passed"
-for model in "${PASSED_MODELS[@]}"; do
-  echo "  ✓ $model"
+
+for i in "${!MODELS[@]}"; do
+  model=${MODELS[$i]}
+  if [ "${FAILED_PER_MODEL[$i]}" -eq 0 ] && [ "${TOTAL_PER_MODEL[$i]}" -gt 0 ]; then
+    echo "  ✓ $model: ${PASSED_PER_MODEL[$i]}/${TOTAL_PER_MODEL[$i]} tests passed"
+  else
+    echo "  ✗ $model: ${PASSED_PER_MODEL[$i]}/${TOTAL_PER_MODEL[$i]} tests passed (${FAILED_PER_MODEL[$i]} failed)"
+  fi
 done
 
-if [ ${#FAILED_MODELS[@]} -gt 0 ]; then
-  echo ""
-  echo "Failed providers:"
-  for model in "${FAILED_MODELS[@]}"; do
-    echo "  ✗ $model"
-  done
+echo ""
+echo "Providers: $passed_providers/${#MODELS[@]} passed"
+
+if [ "$passed_providers" -ne "${#MODELS[@]}" ]; then
   echo ""
   echo "ERROR: Some tests failed"
   exit 1

--- a/tests/query-overrides/chainsaw-test.yaml
+++ b/tests/query-overrides/chainsaw-test.yaml
@@ -72,9 +72,8 @@ spec:
         name: query-overrides-test-query
         timeout: 60s
         for:
-          condition:
-            name: Completed
-            value: 'True'
+          jsonPath:
+            path: '{.status.response.content}'
     catch:
     - events: {}
     - describe:
@@ -91,7 +90,6 @@ spec:
           metadata:
             name: query-overrides-test-query
           status:
-            (response != null): true
             (response.target.name): 'query-overrides-test-agent'
     - script:
         env:
@@ -138,13 +136,8 @@ spec:
         name: query-overrides-test-query-tool
         timeout: 60s
         for:
-          condition:
-            name: Completed
-            value: 'True'
-    # Completed=True can fire before response.content is populated on the
-    # same status update. Use an assert with JP `contains()` so chainsaw
-    # retries until all three header markers are present, instead of a
-    # shell script that fails on the first empty read.
+          jsonPath:
+            path: '{.status.response.content}'
     - assert:
         resource:
           apiVersion: ark.mckinsey.com/v1alpha1
@@ -152,7 +145,6 @@ spec:
           metadata:
             name: query-overrides-test-query-tool
           status:
-            (response != null): true
             (contains(response.content, 'x-query-override-mcp-static')): true
             (contains(response.content, 'query-mcp-override-secret-value')): true
             (contains(response.content, 'query-mcp-override-configmap')): true
@@ -173,9 +165,8 @@ spec:
         name: query-overrides-precedence-test
         timeout: 60s
         for:
-          condition:
-            name: Completed
-            value: 'True'
+          jsonPath:
+            path: '{.status.response.content}'
     - script:
         env:
         - name: NAMESPACE


### PR DESCRIPTION
A bunch of things each too small to justify their own PR. Fixes some flaky tests and setup, deals with some of the warnings in the main CICD process, removes some redundant pings in e2e-llm-warmup, fixes misleading output on failure.

- Fix flaky E2E test agent/query-overrides: query would sometimes be marked complete before having content, causing failure. This should fix that.
- Updated tests claude.md accordingly
- Update Node version
- Points dependabot's github-actions to the .github folder and not just .github/workflows, so that hopefully these will be kept more up to date
- In e2e-tests-llm, warm up connection to the actual LLM providers and exit warmup when successfully connected instead of continuing to ping
- Update tests/llm-tests/run-multi-provider.sh so that the e2e-tests-llm output shows the correct error count instead of either showing all passed or all failed
- Add wait for configmap availability to avoid intermittent problem with k3s/calico in setup-e2e
- Fix setup-go cache warning by either pointing to the correct place or skipping caching where it wouldn't be meaningful
- Add return type for test chunk helpers in dashboard that were returning warnings

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 