### PR TITLE
chore: pin base image tags instead of :latest

### DIFF
--- a/charts/ark-tenant/values.yaml
+++ b/charts/ark-tenant/values.yaml
@@ -58,7 +58,7 @@ aigwTokenRefresh:
   saCredentialsSecret: aigw-sa-credentials
   schedule: "0 2 * * *"
   saEndpoint: "https://service-account.prod.ai-gateway.quantumblack.com/api/service-account-credentials"
-  image: bitnami/kubectl:latest
+  image: bitnami/kubectl:1.33.4
 
 # Builtin tools configuration
 builtinTools:

--- a/samples/a2a/simple-agent/Dockerfile
+++ b/samples/a2a/simple-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN adduser --system --uid 1001 --home /home/ark ark && \
     mkdir -p /home/ark && \
     chown -R ark:nogroup /home/ark
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
 COPY pyproject.toml ./
 COPY src/ ./src/

--- a/services/argo-workflows/samples/minio-artifact-template.yaml
+++ b/services/argo-workflows/samples/minio-artifact-template.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         workflows.argoproj.io/description: "Generate a sample file and save as artifact"
     script:
-      image: alpine:latest
+      image: alpine:3.22
       command: [sh]
       source: |
         set -e
@@ -57,7 +57,7 @@ spec:
       - name: input-file
         path: /tmp/input.txt
     script:
-      image: alpine:latest
+      image: alpine:3.22
       command: [sh]
       source: |
         set -e

--- a/services/ark-api/Dockerfile
+++ b/services/ark-api/Dockerfile
@@ -15,7 +15,7 @@ RUN adduser --system --uid 1001 --home /home/ark ark && \
   && chown -R ark:nogroup /home/ark
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
 # Copy dependency files and install dependencies (cached unless deps change)
 COPY ark-api/pyproject.toml ark-api/uv.lock ./

--- a/services/ark-api/Dockerfile.dev
+++ b/services/ark-api/Dockerfile.dev
@@ -6,7 +6,7 @@ RUN adduser --system --uid 1001 --home /home/ark ark && \
   rm -rf /var/lib/apt/lists/* && \
   curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
 WORKDIR /app/ark-api
 COPY ark-api/pyproject.toml ark-api/uv.lock ./

--- a/services/ark-mcp/Dockerfile
+++ b/services/ark-mcp/Dockerfile
@@ -12,7 +12,7 @@ RUN adduser --system --uid 1001 --home /home/arkmcp arkmcp && \
     chown -R arkmcp:nogroup /home/arkmcp
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
 # Copy dependency files
 COPY ark-mcp/pyproject.toml ark-mcp/uv.lock ./

--- a/templates/mcp-server/Dockerfile
+++ b/templates/mcp-server/Dockerfile
@@ -63,7 +63,7 @@ ENTRYPOINT [ "/bin/bash", "-c", "mcp-proxy --debug --port 8080 --host 0.0.0.0 --
 {{- end }}
 
 {{- else if eq .Values.technology "go" }}
-FROM golang:latest AS go-builder
+FROM golang:1.26.3-alpine AS go-builder
 {{- if .Values.packageSource }}
 {{- if eq .Values.packageSource "go-install" }}
 RUN go install {{ .Values.packageName }}@latest

--- a/tools/fark/Dockerfile
+++ b/tools/fark/Dockerfile
@@ -11,7 +11,7 @@ COPY cmd/ ./cmd/
 # Build with vendored dependencies
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o fark ./cmd/fark
 
-FROM alpine:latest
+FROM alpine:3.22
 
 RUN adduser --system --uid 1001 fark && \
     apk --no-cache add ca-certificates


### PR DESCRIPTION
Replace floating :latest tags with specific versions across Dockerfiles to improve supply-chain hygiene and build reproducibility.

- alpine:latest -> alpine:3.22 (tools/fark, argo-workflows minio sample)
- bitnami/kubectl:latest -> bitnami/kubectl:1.33.4 (ark-tenant chart)
- golang:latest -> golang:1.26.3-alpine (mcp-server template, matches rest of repo)
- ghcr.io/astral-sh/uv:latest -> ghcr.io/astral-sh/uv:0.11.21 (ark-api, ark-api dev, ark-mcp, simple-agent sample)

These generally picked the most recent tags as of right now, so presumably the same thing that would be happening if :latest was kept. 

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 