### PR TITLE
fix(dashboard): preserve namespace on settings navigation

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockReplace = vi.fn();
+const mockPush = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useParams: vi.fn(),
   useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
 }));
 
 vi.mock('@/providers/NamespaceProvider', () => ({
@@ -32,8 +33,11 @@ describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
-      replace: mockReplace,
+      push: mockPush,
     });
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      new URLSearchParams('namespace=demo'),
+    );
   });
 
   const renderPage = () =>
@@ -43,18 +47,18 @@ describe('SettingsPage', () => {
       </JotaiProvider>,
     );
 
-  it('should redirect to default page when no page segment is provided', () => {
+  it('should redirect to default page preserving namespace when no page segment is provided', () => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({ page: undefined });
     renderPage();
-    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers');
+    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
-  it('should redirect to default page when an invalid page is provided', () => {
+  it('should redirect to default page preserving namespace when an invalid page is provided', () => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({
       page: ['nonexistent'],
     });
     renderPage();
-    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers');
+    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
   it('should not redirect when a valid page is provided', () => {
@@ -62,7 +66,7 @@ describe('SettingsPage', () => {
       page: ['secrets'],
     });
     renderPage();
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('should pass the valid page key to sidebar and content', () => {
@@ -97,7 +101,7 @@ describe('SettingsPage', () => {
   ])('should accept "%s" as a valid page', page => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({ page: [page] });
     renderPage();
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
     expect(screen.getByTestId('settings-content')).toHaveTextContent(page);
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-keyboard-shortcut.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-keyboard-shortcut.test.tsx
@@ -8,6 +8,7 @@ import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
   usePathname: vi.fn(),
+  useSearchParams: vi.fn(() => new URLSearchParams('')),
 }));
 
 import { SettingsKeyboardShortcut } from '@/components/settings/settings-keyboard-shortcut';

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider, createStore } from 'jotai';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
@@ -10,6 +10,7 @@ import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
 }));
 
 describe('SettingsSidebar', () => {
@@ -26,6 +27,9 @@ describe('SettingsSidebar', () => {
       replace: mockReplace,
       back: mockBack,
     });
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      new URLSearchParams('namespace=demo'),
+    );
   });
 
   const renderWithStore = (activePage: SettingPage = 'a2a-servers') =>
@@ -55,16 +59,16 @@ describe('SettingsSidebar', () => {
     expect(screen.getByText('Secrets')).toBeInTheDocument();
   });
 
-  it('should navigate to settings page when a menu item is clicked', async () => {
+  it('should navigate to settings page preserving namespace when a menu item is clicked', async () => {
     const user = userEvent.setup();
     renderWithStore();
 
     await user.click(screen.getByText('Memory'));
 
-    expect(mockReplace).toHaveBeenCalledWith('/settings/memory');
+    expect(mockPush).toHaveBeenCalledWith('/settings/memory?namespace=demo');
   });
 
-  it('should navigate to entry URL when close button is clicked after soft navigation', async () => {
+  it('should navigate to entry URL preserving namespace when close button is clicked after soft navigation', async () => {
     store.set(settingsEntryUrlAtom, '/agents');
 
     const user = userEvent.setup();
@@ -72,16 +76,16 @@ describe('SettingsSidebar', () => {
 
     await user.click(screen.getByLabelText('Close settings'));
 
-    expect(mockPush).toHaveBeenCalledWith('/agents');
+    expect(mockPush).toHaveBeenCalledWith('/agents?namespace=demo');
   });
 
-  it('should navigate to home when close button is clicked on direct navigation', async () => {
+  it('should navigate to home preserving namespace when close button is clicked on direct navigation', async () => {
     const user = userEvent.setup();
     renderWithStore();
 
     await user.click(screen.getByLabelText('Close settings'));
 
-    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mockPush).toHaveBeenCalledWith('/?namespace=demo');
     expect(mockBack).not.toHaveBeenCalled();
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/providers/global-providers.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/providers/global-providers.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('next/navigation', () => ({
   usePathname: vi.fn(() => '/agents'),
   useRouter: vi.fn(() => ({ push: vi.fn() })),
+  useSearchParams: vi.fn(() => new URLSearchParams('')),
 }));
 
 vi.mock('@/providers/NamespaceProvider', () => ({

--- a/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { SettingsContent } from '@/components/settings/settings-content';
 import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 import { type SettingPage, settingsSections } from '@/components/settings/settings-types';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 
 const DEFAULT_SETTINGS_PAGE: SettingPage = 'a2a-servers';
 
@@ -15,7 +16,7 @@ const VALID_SETTINGS_PAGES: SettingPage[] = settingsSections.flatMap(s =>
 
 export default function SettingsPage() {
   const params = useParams();
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
 
   const pageSegments = params.page as string[] | undefined;
   const pageKey = pageSegments?.[0] as SettingPage | undefined;
@@ -25,9 +26,9 @@ export default function SettingsPage() {
 
   useEffect(() => {
     if (!isValidPage) {
-      router.replace(`/settings/${DEFAULT_SETTINGS_PAGE}`);
+      push(`/settings/${DEFAULT_SETTINGS_PAGE}`);
     }
-  }, [isValidPage, router]);
+  }, [isValidPage, push]);
 
   return (
     <div className="bg-sidebar flex h-full w-full overflow-hidden">

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-keyboard-shortcut.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-keyboard-shortcut.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 
 const SETTINGS_KEYBOARD_SHORTCUT = 'e';
 
 export function SettingsKeyboardShortcut() {
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
   const pathname = usePathname();
   const settingsEntryUrl = useAtomValue(settingsEntryUrlAtom);
 
@@ -21,16 +22,16 @@ export function SettingsKeyboardShortcut() {
       ) {
         event.preventDefault();
         if (pathname.startsWith('/settings')) {
-          router.push(settingsEntryUrl ?? '/');
+          push(settingsEntryUrl ?? '/');
         } else {
-          router.push('/settings');
+          push('/settings');
         }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [router, pathname, settingsEntryUrl]);
+  }, [push, pathname, settingsEntryUrl]);
 
   return null;
 }

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
@@ -2,10 +2,10 @@
 
 import { useAtomValue } from 'jotai';
 import { X } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 
 import { isMarketplaceEnabledAtom } from '@/atoms/experimental-features';
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 import { cn } from '@/lib/utils';
 
 import { MANAGE_MARKETPLACE_KEY, type SettingPage, settingsSections } from './settings-types';
@@ -15,16 +15,18 @@ type SettingsSidebarProps = {
 };
 
 export function SettingsSidebar({ activePage }: SettingsSidebarProps) {
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
   const isMarketplaceEnabled = useAtomValue(isMarketplaceEnabledAtom);
   const settingsEntryUrl = useAtomValue(settingsEntryUrlAtom);
 
   const handleSettingClick = (settingKey: SettingPage) => {
-    router.replace(`/settings/${settingKey}`);
+    push(`/settings/${settingKey}`);
   };
 
+  // settingsEntryUrl is captured from the in-app location the user came from,
+  // so it may already carry a namespace query; push merges params and won't double it.
   const handleClose = () => {
-    router.push(settingsEntryUrl ?? '/');
+    push(settingsEntryUrl ?? '/');
   };
 
   return (


### PR DESCRIPTION
## Summary
- Settings navigation dropped the active `?namespace` query param, silently falling back to the `default` namespace where the user may have no RBAC — every resource call then 403s.
- Cause: the settings sidebar, the settings default-page redirect, and the Cmd/Ctrl+E shortcut navigated with the raw `next/navigation` router (`router.push`/`router.replace`), which does not carry query params.
- Fix: route these through `useNamespacedNavigation`, which preserves the namespace (the convention already used elsewhere in the app).

## Tests
Updated/added unit tests for the settings sidebar, settings page redirect, and keyboard shortcut (seed `useSearchParams` with a namespace and assert the namespace-preserving URL). 23 tests pass.