### PR TITLE
fix(completions): tolerate SSE keepalive/comment frames in streaming decoder

### DIFF
--- a/ark/executors/completions/provider_openai.go
+++ b/ark/executors/completions/provider_openai.go
@@ -266,6 +266,7 @@ func (op *OpenAIProvider) ChatCompletionStream(ctx context.Context, messages []M
 }
 
 func (op *OpenAIProvider) initClients() {
+	registerKeepaliveTolerantSSEDecoder()
 	op.httpClient = &http.Client{Transport: common.NewLoggingTransport(common.NewSharedTransport())}
 	op.probeClient = common.NewHTTPClientWithoutTracing()
 }

--- a/ark/executors/completions/sse_decoder.go
+++ b/ark/executors/completions/sse_decoder.go
@@ -1,0 +1,109 @@
+/* Copyright 2025. McKinsey & Company */
+
+package completions
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/openai/openai-go/packages/ssestream"
+)
+
+var registerSSEDecoderOnce sync.Once
+
+// registerKeepaliveTolerantSSEDecoder installs a text/event-stream decoder that
+// skips frames whose data buffer is empty or whitespace-only.
+//
+// Anthropic's OpenAI-compatible endpoint emits SSE keepalive comment frames
+// (": ping - ...") roughly every 15s during a stream. The openai-go default
+// decoder dispatches an event with an empty data buffer for such frames, which
+// Stream.Next() then feeds to json.Unmarshal, producing "unexpected end of JSON
+// input" and killing any response long enough to receive a keepalive. The
+// WHATWG SSE spec says an event with an empty data buffer must not be
+// dispatched, so we skip those frames here while leaving real data frames
+// (including genuinely malformed JSON) untouched.
+func registerKeepaliveTolerantSSEDecoder() {
+	registerSSEDecoderOnce.Do(func() {
+		ssestream.RegisterDecoder("text/event-stream", func(rc io.ReadCloser) ssestream.Decoder {
+			scn := bufio.NewScanner(rc)
+			scn.Buffer(nil, bufio.MaxScanTokenSize<<4)
+			return &keepaliveTolerantDecoder{rc: rc, scn: scn}
+		})
+	})
+}
+
+type keepaliveTolerantDecoder struct {
+	evt ssestream.Event
+	rc  io.ReadCloser
+	scn *bufio.Scanner
+	err error
+}
+
+func (d *keepaliveTolerantDecoder) Next() bool {
+	if d.err != nil {
+		return false
+	}
+
+	event := ""
+	data := bytes.NewBuffer(nil)
+
+	for d.scn.Scan() {
+		txt := d.scn.Bytes()
+
+		// A blank line terminates an event. Skip empty/whitespace-only data
+		// buffers (comment-only keepalive frames, stray blank lines) so they
+		// never reach json.Unmarshal.
+		if len(txt) == 0 {
+			if len(bytes.TrimSpace(data.Bytes())) == 0 {
+				event = ""
+				data.Reset()
+				continue
+			}
+			d.evt = ssestream.Event{Type: event, Data: data.Bytes()}
+			return true
+		}
+
+		name, value, _ := bytes.Cut(txt, []byte(":"))
+
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+
+		switch string(name) {
+		case "":
+			// ": comment" line, ignored per the SSE spec.
+			continue
+		case "event":
+			event = string(value)
+		case "data":
+			if _, d.err = data.Write(value); d.err != nil {
+				return false
+			}
+			if _, d.err = data.WriteRune('\n'); d.err != nil {
+				return false
+			}
+		}
+	}
+
+	if d.scn.Err() != nil {
+		d.err = d.scn.Err()
+	}
+
+	return false
+}
+
+func (d *keepaliveTolerantDecoder) Event() ssestream.Event {
+	return d.evt
+}
+
+func (d *keepaliveTolerantDecoder) Close() error {
+	return d.rc.Close()
+}
+
+func (d *keepaliveTolerantDecoder) Err() error {
+	return d.err
+}
+
+var _ ssestream.Decoder = (*keepaliveTolerantDecoder)(nil)

--- a/ark/executors/completions/sse_decoder_test.go
+++ b/ark/executors/completions/sse_decoder_test.go
@@ -1,0 +1,88 @@
+/* Copyright 2025. McKinsey & Company */
+
+package completions
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/ssestream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSSEStream builds a ChatCompletionChunk stream over the given raw SSE body
+// using the keepalive-tolerant decoder, mirroring how openai-go decodes a
+// streaming response.
+func newSSEStream(body string) *ssestream.Stream[openai.ChatCompletionChunk] {
+	registerKeepaliveTolerantSSEDecoder()
+	res := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:   io.NopCloser(strings.NewReader(body)),
+	}
+	return ssestream.NewStream[openai.ChatCompletionChunk](ssestream.NewDecoder(res), nil)
+}
+
+func TestKeepaliveTolerantDecoder(t *testing.T) {
+	chunk := func(content string) string {
+		return `data: {"id":"chunk","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + content + `"}}]}`
+	}
+
+	tests := []struct {
+		name        string
+		body        string
+		wantContent []string
+		wantErr     bool
+	}{
+		{
+			name: "ping keepalive frames interleaved with data",
+			// Anthropic emits ": ping" comment frames every ~15s; these must
+			// not produce a JSON parse error.
+			body: ": ping - 2026-06-17 09:09:52.087033\r\n\r\n" +
+				chunk("hello") + "\n\n" +
+				": ping - 2026-06-17 09:10:07.087033\r\n\r\n" +
+				chunk(" world") + "\n\n" +
+				"data: [DONE]\n\n",
+			wantContent: []string{"hello", " world"},
+		},
+		{
+			name:        "leading and trailing comment-only frames",
+			body:        ": ping\n\n" + chunk("hi") + "\n\n: ping\n\ndata: [DONE]\n\n",
+			wantContent: []string{"hi"},
+		},
+		{
+			name:        "no keepalives still decodes",
+			body:        chunk("a") + "\n\n" + chunk("b") + "\n\ndata: [DONE]\n\n",
+			wantContent: []string{"a", "b"},
+		},
+		{
+			name:    "malformed json in real data frame still errors",
+			body:    "data: {not valid json}\n\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := newSSEStream(tt.body)
+			var got []string
+			for stream.Next() {
+				cur := stream.Current()
+				if len(cur.Choices) > 0 {
+					got = append(got, cur.Choices[0].Delta.Content)
+				}
+			}
+
+			if tt.wantErr {
+				require.Error(t, stream.Err())
+				return
+			}
+
+			require.NoError(t, stream.Err())
+			assert.Equal(t, tt.wantContent, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Anthropic's OpenAI-compatible endpoint (`https://api.anthropic.com/v1/`) emits SSE keepalive comment frames (`: ping - ...`) roughly every 15s during a stream.
- Root cause: the `openai-go` default `text/event-stream` decoder dispatches an event with an *empty data buffer* for a comment-only frame; `Stream.Next()` then runs `json.Unmarshal([]byte{})` → `unexpected end of JSON input`, killing the stream. Only responses long enough (>~15s) to receive a keepalive hit it; short responses finish first and succeed. Per the WHATWG SSE spec an empty-data event must not be dispatched, so the default decoder is non-compliant.
- Fix: register a custom `text/event-stream` decoder (via `ssestream.RegisterDecoder`, wired in at OpenAI client init) that skips frames whose data buffer is empty or whitespace-only, so comment/keepalive frames never reach `json.Unmarshal`. Genuine malformed JSON in a real data frame still errors.
- Adds a table-driven test feeding `: ping` keepalive frames interleaved with real `data: {...}` chunks and asserting clean decode of exactly the real chunks.
- Fixes #1346. Root-cause detail: https://github.com/mckinsey/agents-at-scale-ark/issues/1346#issuecomment-4728271299