### PR TITLE
feat(ark-api): authorization preflight in /v1/context via SelfSubjectRulesReview

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
@@ -13,6 +13,7 @@ from ark_sdk.impersonation import ImpersonationConfig
 
 from ...auth.dependencies import get_impersonation_config
 from ...core.namespace import get_current_context
+from ...core.permissions import get_ark_permissions
 from ...models.context import ContextResponse
 from .client_utils import get_impersonating_api_client
 from .exceptions import handle_k8s_errors
@@ -78,7 +79,7 @@ async def create_namespace(body: NamespaceCreateRequest, impersonation: Optional
 
 
 @router.get("/context", response_model=ContextResponse)
-async def get_context_endpoint(namespace: str = None) -> ContextResponse:
+async def get_context_endpoint(namespace: str = None, impersonation: Optional[ImpersonationConfig] = Depends(get_impersonation_config)) -> ContextResponse:
     """
     Get the current Kubernetes context information.
 
@@ -127,8 +128,11 @@ async def get_context_endpoint(namespace: str = None) -> ContextResponse:
         # Fall back to environment variable if we can't check the namespace
         read_only_mode = os.getenv("READ_ONLY_MODE", "false").lower() == "true"
 
+    permissions = await get_ark_permissions(impersonation, target_namespace)
+
     return ContextResponse(
         namespace=target_namespace,
         cluster=current_context["cluster"],
-        read_only_mode=read_only_mode
+        read_only_mode=read_only_mode,
+        permissions=permissions
     )

--- a/services/ark-api/ark-api/src/ark_api/core/permissions.py
+++ b/services/ark-api/ark-api/src/ark_api/core/permissions.py
@@ -1,0 +1,78 @@
+import logging
+from contextlib import asynccontextmanager
+from typing import Optional
+
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from ark_sdk.impersonation import ImpersonationConfig
+
+from ..models.context import PermissionsResponse
+
+logger = logging.getLogger(__name__)
+
+ARK_API_GROUP = "ark.mckinsey.com"
+WILDCARD = "*"
+
+
+@asynccontextmanager
+async def _impersonating_api_client(impersonation: ImpersonationConfig):
+    async with ApiClient() as api:
+        api.set_default_header("Impersonate-User", impersonation.username)
+        if impersonation.groups:
+            api.set_default_header(
+                "Impersonate-Group", ",".join(impersonation.groups)
+            )
+        yield api
+
+
+def build_ark_rules(resource_rules) -> dict[str, list[str]]:
+    rules: dict[str, set[str]] = {}
+    for rule in resource_rules or []:
+        api_groups = rule.api_groups or []
+        if ARK_API_GROUP not in api_groups and WILDCARD not in api_groups:
+            continue
+        for resource in rule.resources or []:
+            verbs = rules.setdefault(resource, set())
+            verbs.update(rule.verbs or [])
+    return {resource: sorted(verbs) for resource, verbs in rules.items()}
+
+
+async def get_ark_permissions(
+    impersonation: Optional[ImpersonationConfig],
+    namespace: str,
+) -> PermissionsResponse:
+    if impersonation is None:
+        return PermissionsResponse(
+            status="unavailable",
+            reason="No user identity to evaluate permissions",
+        )
+
+    try:
+        async with _impersonating_api_client(impersonation) as api:
+            authz = client.AuthorizationV1Api(api)
+            review = await authz.create_self_subject_rules_review(
+                client.V1SelfSubjectRulesReview(
+                    spec=client.V1SelfSubjectRulesReviewSpec(namespace=namespace)
+                )
+            )
+    except Exception as e:
+        logger.warning("SelfSubjectRulesReview failed: %s", e)
+        return PermissionsResponse(status="unavailable", reason=str(e))
+
+    status = review.status
+    if status is None:
+        return PermissionsResponse(
+            status="unavailable", reason="No review status returned"
+        )
+
+    if status.incomplete or status.evaluation_error:
+        return PermissionsResponse(
+            status="unavailable",
+            reason=status.evaluation_error or "Authorization evaluation incomplete",
+        )
+
+    return PermissionsResponse(
+        status="ok",
+        rules=build_ark_rules(status.resource_rules),
+    )

--- a/services/ark-api/ark-api/src/ark_api/models/context.py
+++ b/services/ark-api/ark-api/src/ark_api/models/context.py
@@ -1,7 +1,16 @@
+from typing import Literal
+
 from pydantic import BaseModel
+
+
+class PermissionsResponse(BaseModel):
+    status: Literal["ok", "unavailable"]
+    reason: str | None = None
+    rules: dict[str, list[str]] = {}
 
 
 class ContextResponse(BaseModel):
     namespace: str
     cluster: str | None
     read_only_mode: bool
+    permissions: PermissionsResponse | None = None

--- a/services/ark-api/ark-api/tests/services/test_permissions.py
+++ b/services/ark-api/ark-api/tests/services/test_permissions.py
@@ -1,0 +1,106 @@
+"""Tests for ark permission preflight (SelfSubjectRulesReview)."""
+
+import os
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+os.environ.setdefault("AUTH_MODE", "open")
+
+from ark_sdk.impersonation import ImpersonationConfig
+
+from ark_api.core.permissions import build_ark_rules, get_ark_permissions
+
+
+def _rule(api_groups, resources, verbs):
+    rule = Mock()
+    rule.api_groups = api_groups
+    rule.resources = resources
+    rule.verbs = verbs
+    return rule
+
+
+class TestBuildArkRules(unittest.TestCase):
+    def test_namespaced_binding(self):
+        rules = build_ark_rules(
+            [_rule(["ark.mckinsey.com"], ["agents", "models"], ["get", "list"])]
+        )
+        self.assertEqual(rules, {"agents": ["get", "list"], "models": ["get", "list"]})
+
+    def test_ignores_other_groups(self):
+        rules = build_ark_rules([_rule([""], ["pods"], ["get"])])
+        self.assertEqual(rules, {})
+
+    def test_wildcard_group_and_resource(self):
+        rules = build_ark_rules([_rule(["*"], ["*"], ["*"])])
+        self.assertEqual(rules, {"*": ["*"]})
+
+    def test_merges_and_dedupes_verbs(self):
+        rules = build_ark_rules(
+            [
+                _rule(["ark.mckinsey.com"], ["queries"], ["get", "list"]),
+                _rule(["ark.mckinsey.com"], ["queries"], ["list", "create"]),
+            ]
+        )
+        self.assertEqual(rules, {"queries": ["create", "get", "list"]})
+
+    def test_empty(self):
+        self.assertEqual(build_ark_rules([]), {})
+        self.assertEqual(build_ark_rules(None), {})
+
+
+class TestGetArkPermissions(unittest.IsolatedAsyncioTestCase):
+    async def test_no_impersonation_unavailable(self):
+        result = await get_ark_permissions(None, "default")
+        self.assertEqual(result.status, "unavailable")
+        self.assertEqual(result.rules, {})
+
+    @patch("ark_api.core.permissions._impersonating_api_client")
+    async def test_ok_with_rules(self, mock_client):
+        review = Mock()
+        review.status.incomplete = False
+        review.status.evaluation_error = None
+        review.status.resource_rules = [
+            _rule(["ark.mckinsey.com"], ["agents"], ["get", "list"])
+        ]
+        api = AsyncMock()
+        api.create_self_subject_rules_review = AsyncMock(return_value=review)
+        mock_client.return_value.__aenter__.return_value = Mock()
+        with patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.rules, {"agents": ["get", "list"]})
+
+    @patch("ark_api.core.permissions._impersonating_api_client")
+    async def test_incomplete_unavailable(self, mock_client):
+        review = Mock()
+        review.status.incomplete = True
+        review.status.evaluation_error = "webhook authorizer unavailable"
+        review.status.resource_rules = []
+        api = AsyncMock()
+        api.create_self_subject_rules_review = AsyncMock(return_value=review)
+        mock_client.return_value.__aenter__.return_value = Mock()
+        with patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "unavailable")
+        self.assertIn("webhook", result.reason)
+
+    @patch("ark_api.core.permissions._impersonating_api_client")
+    async def test_review_raises_unavailable(self, mock_client):
+        mock_client.return_value.__aenter__.side_effect = RuntimeError("boom")
+        result = await get_ark_permissions(
+            ImpersonationConfig(username="u", groups=["g"]), "default"
+        )
+        self.assertEqual(result.status, "unavailable")
+        self.assertIn("boom", result.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -2949,6 +2949,7 @@ export interface components {
             cluster: string | null;
             /** Namespace */
             namespace: string;
+            permissions?: components["schemas"]["PermissionsResponse"] | null;
             /** Read Only Mode */
             read_only_mode: boolean;
         };
@@ -3687,6 +3688,23 @@ export interface components {
             baseUrl: string | components["schemas"]["ModelValueSource"];
             /** Headers */
             headers?: components["schemas"]["AgentHeader"][] | null;
+        };
+        /** PermissionsResponse */
+        PermissionsResponse: {
+            /** Reason */
+            reason?: string | null;
+            /**
+             * Rules
+             * @default {}
+             */
+            rules: {
+                [key: string]: string[];
+            };
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "unavailable";
         };
         /**
          * QueryConfigMapKeyRef


### PR DESCRIPTION
## Summary
- /v1/context now runs SelfSubjectRulesReview as the impersonated user and returns the caller's Ark (ark.mckinsey.com) permissions as {resource: [verbs]}
- Lets clients/dashboard show access-denied warnings and render read-only vs editable UI from real RBAC, before issuing calls
- Advisory only: returns status "unavailable" with a reason on webhook/identity/eval failure, never hard-fails
- Foundation for a follow-up dashboard access-gate PR