### PR TITLE
fix(security): bump hono to 4.12.25 to address CVE-2026-54290

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -4209,9 +4209,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -88,7 +88,7 @@
     "brace-expansion": ">=5.0.6",
     "minimatch": "^10.2.3",
     "rollup": "4.59.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.25",
     "@hono/node-server": "^1.19.13",
     "flatted": "^3.4.2",
     "tar": "^7.5.11",


### PR DESCRIPTION
CVE-2026-54290 (GHSA-88fw-hqm2-52qc, High) affects hono CORS middleware. When credentials: true is set without an explicit origin, the middleware reflects any request Origin and sends Access-Control-Allow-Credentials: true, violating the Fetch spec and allowing any site a logged-in user visits to make credentialed cross-origin requests and read responses from cookie-authenticated endpoints.

hono is a transitive dependency pulled in by @modelcontextprotocol/sdk. The existing override in tools/ark-cli/package.json is updated from ^4.12.18 to ^4.12.25, which resolves to the patched version.

Ark context: ark-cli is a local CLI tool. Hono serves its MCP HTTP adapter for local developer workflows. The CORS risk is low in practice since the server binds to localhost, but the fix is straightforward and eliminates the scanner finding tracked in issue #2515.

Closes #2515

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 