### PR TITLE
feat(ark-api): authorization preflight in /v1/context via SelfSubjectRulesReview

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/namespaces.py
@@ -13,6 +13,7 @@ from ark_sdk.impersonation import ImpersonationConfig
 
 from ...auth.dependencies import get_impersonation_config
 from ...core.namespace import get_current_context
+from ...core.permissions import get_ark_permissions
 from ...models.context import ContextResponse
 from .client_utils import get_impersonating_api_client
 from .exceptions import handle_k8s_errors
@@ -78,7 +79,10 @@ async def create_namespace(body: NamespaceCreateRequest, impersonation: Optional
 
 
 @router.get("/context", response_model=ContextResponse)
-async def get_context_endpoint(namespace: str = None) -> ContextResponse:
+async def get_context_endpoint(
+    namespace: str = None,
+    impersonation: Optional[ImpersonationConfig] = Depends(get_impersonation_config),
+) -> ContextResponse:
     """
     Get the current Kubernetes context information.
 
@@ -127,8 +131,11 @@ async def get_context_endpoint(namespace: str = None) -> ContextResponse:
         # Fall back to environment variable if we can't check the namespace
         read_only_mode = os.getenv("READ_ONLY_MODE", "false").lower() == "true"
 
+    permissions = await get_ark_permissions(impersonation, target_namespace)
+
     return ContextResponse(
         namespace=target_namespace,
         cluster=current_context["cluster"],
-        read_only_mode=read_only_mode
+        read_only_mode=read_only_mode,
+        permissions=permissions,
     )

--- a/services/ark-api/ark-api/src/ark_api/core/permissions.py
+++ b/services/ark-api/ark-api/src/ark_api/core/permissions.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Optional
+
+from kubernetes_asyncio import client
+
+from ark_sdk.impersonation import ImpersonationConfig
+
+from ..models.context import PermissionsResponse
+
+logger = logging.getLogger(__name__)
+
+ARK_API_GROUP = "ark.mckinsey.com"
+WILDCARD = "*"
+
+# Returned to the client when permissions cannot be determined. The underlying
+# cause (exception text, evaluation errors) is logged server-side rather than
+# echoed back, so internal details are not exposed to callers.
+UNAVAILABLE_REASON = "Unable to evaluate permissions"
+
+
+def build_ark_rules(resource_rules) -> dict[str, list[str]]:
+    rules: dict[str, set[str]] = {}
+    for rule in resource_rules or []:
+        api_groups = rule.api_groups or []
+        if ARK_API_GROUP not in api_groups and WILDCARD not in api_groups:
+            continue
+        for resource in rule.resources or []:
+            verbs = rules.setdefault(resource, set())
+            verbs.update(rule.verbs or [])
+    return {resource: sorted(verbs) for resource, verbs in rules.items()}
+
+
+async def get_ark_permissions(
+    impersonation: Optional[ImpersonationConfig],
+    namespace: str,
+) -> PermissionsResponse:
+    if impersonation is None:
+        return PermissionsResponse(
+            status="unavailable",
+            reason="No user identity to evaluate permissions",
+        )
+
+    # Imported lazily: client_utils lives under api.v1, whose package __init__
+    # imports this module's caller (namespaces), so a top-level import here is a
+    # circular import.
+    from ..api.v1.client_utils import get_impersonating_api_client
+
+    try:
+        async with get_impersonating_api_client(impersonation) as api:
+            authz = client.AuthorizationV1Api(api)
+            review = await authz.create_self_subject_rules_review(
+                client.V1SelfSubjectRulesReview(
+                    spec=client.V1SelfSubjectRulesReviewSpec(namespace=namespace)
+                )
+            )
+    except Exception as e:
+        logger.warning("SelfSubjectRulesReview failed: %s", e)
+        return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
+
+    status = review.status
+    if status is None:
+        logger.warning("SelfSubjectRulesReview returned no status")
+        return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
+
+    if status.incomplete or status.evaluation_error:
+        logger.warning(
+            "SelfSubjectRulesReview incomplete: %s", status.evaluation_error
+        )
+        return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
+
+    return PermissionsResponse(
+        status="ok",
+        rules=build_ark_rules(status.resource_rules),
+    )

--- a/services/ark-api/ark-api/src/ark_api/models/context.py
+++ b/services/ark-api/ark-api/src/ark_api/models/context.py
@@ -1,7 +1,16 @@
+from typing import Literal
+
 from pydantic import BaseModel
+
+
+class PermissionsResponse(BaseModel):
+    status: Literal["ok", "unavailable"]
+    reason: str | None = None
+    rules: dict[str, list[str]] = {}
 
 
 class ContextResponse(BaseModel):
     namespace: str
     cluster: str | None
     read_only_mode: bool
+    permissions: PermissionsResponse | None = None

--- a/services/ark-api/ark-api/tests/services/test_permissions.py
+++ b/services/ark-api/ark-api/tests/services/test_permissions.py
@@ -1,0 +1,129 @@
+"""Tests for ark permission preflight (SelfSubjectRulesReview)."""
+
+import os
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+os.environ.setdefault("AUTH_MODE", "open")
+
+from ark_sdk.impersonation import ImpersonationConfig
+
+from ark_api.core.permissions import (
+    UNAVAILABLE_REASON,
+    build_ark_rules,
+    get_ark_permissions,
+)
+
+
+def _rule(api_groups, resources, verbs):
+    rule = Mock()
+    rule.api_groups = api_groups
+    rule.resources = resources
+    rule.verbs = verbs
+    return rule
+
+
+class TestBuildArkRules(unittest.TestCase):
+    def test_namespaced_binding(self):
+        rules = build_ark_rules(
+            [_rule(["ark.mckinsey.com"], ["agents", "models"], ["get", "list"])]
+        )
+        self.assertEqual(rules, {"agents": ["get", "list"], "models": ["get", "list"]})
+
+    def test_ignores_other_groups(self):
+        rules = build_ark_rules([_rule([""], ["pods"], ["get"])])
+        self.assertEqual(rules, {})
+
+    def test_wildcard_group_and_resource(self):
+        rules = build_ark_rules([_rule(["*"], ["*"], ["*"])])
+        self.assertEqual(rules, {"*": ["*"]})
+
+    def test_merges_and_dedupes_verbs(self):
+        rules = build_ark_rules(
+            [
+                _rule(["ark.mckinsey.com"], ["queries"], ["get", "list"]),
+                _rule(["ark.mckinsey.com"], ["queries"], ["list", "create"]),
+            ]
+        )
+        self.assertEqual(rules, {"queries": ["create", "get", "list"]})
+
+    def test_empty(self):
+        self.assertEqual(build_ark_rules([]), {})
+        self.assertEqual(build_ark_rules(None), {})
+
+
+def _mock_helper(review=None, raises=None):
+    """Patch get_impersonating_api_client to yield an AuthorizationV1Api mock."""
+    api = AsyncMock()
+    if raises is not None:
+        api.create_self_subject_rules_review = AsyncMock(side_effect=raises)
+    else:
+        api.create_self_subject_rules_review = AsyncMock(return_value=review)
+    cm = AsyncMock()
+    cm.__aenter__.return_value = Mock()
+    cm.__aexit__.return_value = False
+    return api, cm
+
+
+class TestGetArkPermissions(unittest.IsolatedAsyncioTestCase):
+    async def test_no_impersonation_unavailable(self):
+        result = await get_ark_permissions(None, "default")
+        self.assertEqual(result.status, "unavailable")
+        self.assertEqual(result.rules, {})
+
+    async def test_ok_with_rules(self):
+        review = Mock()
+        review.status.incomplete = False
+        review.status.evaluation_error = None
+        review.status.resource_rules = [
+            _rule(["ark.mckinsey.com"], ["agents"], ["get", "list"])
+        ]
+        api, cm = _mock_helper(review=review)
+        with patch(
+            "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
+        ), patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.rules, {"agents": ["get", "list"]})
+
+    async def test_incomplete_returns_generic_reason(self):
+        review = Mock()
+        review.status.incomplete = True
+        review.status.evaluation_error = "webhook authorizer unavailable"
+        review.status.resource_rules = []
+        api, cm = _mock_helper(review=review)
+        with patch(
+            "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
+        ), patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "unavailable")
+        # Internal evaluation_error must not leak to the client.
+        self.assertEqual(result.reason, UNAVAILABLE_REASON)
+        self.assertNotIn("webhook", result.reason or "")
+
+    async def test_review_raises_returns_generic_reason(self):
+        api, cm = _mock_helper(raises=RuntimeError("boom"))
+        with patch(
+            "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
+        ), patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "unavailable")
+        # Exception text must not leak to the client.
+        self.assertEqual(result.reason, UNAVAILABLE_REASON)
+        self.assertNotIn("boom", result.reason or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -2949,6 +2949,7 @@ export interface components {
             cluster: string | null;
             /** Namespace */
             namespace: string;
+            permissions?: components["schemas"]["PermissionsResponse"] | null;
             /** Read Only Mode */
             read_only_mode: boolean;
         };
@@ -3687,6 +3688,23 @@ export interface components {
             baseUrl: string | components["schemas"]["ModelValueSource"];
             /** Headers */
             headers?: components["schemas"]["AgentHeader"][] | null;
+        };
+        /** PermissionsResponse */
+        PermissionsResponse: {
+            /** Reason */
+            reason?: string | null;
+            /**
+             * Rules
+             * @default {}
+             */
+            rules: {
+                [key: string]: string[];
+            };
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "unavailable";
         };
         /**
          * QueryConfigMapKeyRef


### PR DESCRIPTION
## Summary
- `/v1/context` now runs a `SelfSubjectRulesReview` as the impersonated user and returns their Ark (`ark.mckinsey.com`) permissions as `{resource: [verbs]}` plus a `status` of `ok | unavailable`.
- Lets clients (e.g. the dashboard) show an access-denied warning and render read-only vs editable UI from real RBAC, before issuing calls.
- Advisory only: returns `status="unavailable"` with a generic reason on webhook/identity/eval failure — never hard-fails.
- Reuses `get_impersonating_api_client` (shared ArkAPI user-agent + impersonation headers) rather than duplicating header logic; imported lazily to avoid an api↔core import cycle.
- Error/eval-failure detail is logged server-side only; the client-facing `reason` is generic so internal details aren't leaked.
- Regenerates the dashboard `types.ts` for the new `permissions` field.

Re-opened from upstream (supersedes #2521, which originated from a fork). Incorporates @CDimonaco's review on #2521 (reuse the shared client helper; don't echo raw error text to clients).