### PR TITLE
fix(ark-dashboard): clear stale OIDC-flow cookies on logout to prevent error=Configuration

### DIFF
--- a/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.test.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.test.ts
@@ -1,18 +1,26 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openidConfigManager } from '@/lib/auth/openid-config-manager';
+
+import { GET } from './route';
 
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }));
 vi.mock('@/lib/auth/auth-config', () => ({
   SESSION_COOKIE_NAME: '__Secure-session-token',
   useSecureCookies: true,
+  OIDC_FLOW_COOKIE_NAMES: [
+    '__Secure-callback-url',
+    '__Host-csrf-token',
+    '__Secure-pkce.code_verifier',
+    '__Secure-state',
+    '__Secure-nonce',
+  ],
 }));
 vi.mock('@/lib/auth/openid-config-manager', () => ({
   openidConfigManager: { getConfig: vi.fn() },
 }));
-
-import { getToken } from 'next-auth/jwt';
-import { openidConfigManager } from '@/lib/auth/openid-config-manager';
-import { GET } from './route';
 
 const SESSION = '__Secure-session-token';
 
@@ -43,6 +51,23 @@ describe('GET /api/auth/federated-signout', () => {
     expect(res.cookies.get(`${SESSION}.7`)?.value).toBe('');
   });
 
+  it('clears the transient OIDC-flow cookies (state, PKCE, nonce, callback-url, CSRF)', async () => {
+    vi.mocked(getToken).mockResolvedValue(null as never);
+
+    const res = await GET(request());
+
+    for (const name of [
+      '__Secure-callback-url',
+      '__Host-csrf-token',
+      '__Secure-pkce.code_verifier',
+      '__Secure-state',
+      '__Secure-nonce',
+    ]) {
+      expect(res.cookies.get(name)?.value).toBe('');
+      expect(res.cookies.get(name)?.maxAge).toBe(0);
+    }
+  });
+
   it('falls back to local /signout (clearing cookies) when the provider has no end_session_endpoint', async () => {
     vi.mocked(getToken).mockResolvedValue({ id_token: 'id-tok' } as never);
     vi.mocked(openidConfigManager.getConfig).mockResolvedValue({} as never);
@@ -65,7 +90,9 @@ describe('GET /api/auth/federated-signout', () => {
     const res = await GET(request());
 
     const loc = new URL(res.headers.get('location') as string);
-    expect(`${loc.origin}${loc.pathname}`).toBe('https://idp.example.com/logout');
+    expect(`${loc.origin}${loc.pathname}`).toBe(
+      'https://idp.example.com/logout',
+    );
     expect(loc.searchParams.get('id_token_hint')).toBe('id-tok');
     expect(loc.searchParams.get('post_logout_redirect_uri')).toBe(
       'https://dashboard.example.com/signout',

--- a/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/auth/federated-signout/route.ts
@@ -2,7 +2,11 @@ import { getToken } from 'next-auth/jwt';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { SESSION_COOKIE_NAME, useSecureCookies } from '@/lib/auth/auth-config';
+import {
+  OIDC_FLOW_COOKIE_NAMES,
+  SESSION_COOKIE_NAME,
+  useSecureCookies,
+} from '@/lib/auth/auth-config';
 import { openidConfigManager } from '@/lib/auth/openid-config-manager';
 
 // NextAuth splits a session JWT larger than ~4KB into `${name}.0`, `${name}.1`,
@@ -16,6 +20,9 @@ function clearSessionCookies(res: NextResponse) {
   for (let i = 0; i < MAX_COOKIE_CHUNKS; i++) {
     names.push(`${SESSION_COOKIE_NAME}.${i}`);
   }
+  // Also clear transient OIDC-flow cookies; a stale `state`/PKCE cookie
+  // surviving logout fails the next sign-in's callback (error=Configuration).
+  names.push(...OIDC_FLOW_COOKIE_NAMES);
   for (const name of names) {
     res.cookies.set(name, '', {
       path: '/',
@@ -39,7 +46,9 @@ export async function GET(request: NextRequest) {
   const redirectURL = `${baseURL}/signout`;
   if (!token?.id_token) {
     // no session, just go home
-    return clearSessionCookies(NextResponse.redirect(new URL('/signout', baseURL)));
+    return clearSessionCookies(
+      NextResponse.redirect(new URL('/signout', baseURL)),
+    );
   }
 
   // Get or fetch the openid config from the OIDC provider's well-known configuration

--- a/services/ark-dashboard/ark-dashboard/lib/auth/auth-config.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/auth/auth-config.ts
@@ -128,6 +128,19 @@ const cookies: NextAuthConfig['cookies'] = {
   },
 };
 
+// Transient OIDC-flow cookies (state, PKCE verifier, nonce, callback-url, CSRF
+// token). Sign-out must clear these alongside the session: Auth.js writes a
+// fresh `state`/PKCE cookie at sign-in and reads it back at the callback, but a
+// stale value left over from a prior flow fails state validation
+// (CallbackRouteError -> error=Configuration), breaking the next sign-in.
+export const OIDC_FLOW_COOKIE_NAMES = [
+  `${cookiePrefix}${COOKIE_CALLBACK_URL}`,
+  `${useSecureCookies ? '__Host-' : ''}${COOKIE_CSRF_TOKEN}`,
+  `${cookiePrefix}${COOKIE_PKCE_CODE_VERIFIER}`,
+  `${cookiePrefix}${COOKIE_STATE}`,
+  `${cookiePrefix}${COOKIE_NONCE}`,
+];
+
 const callbacks: NextAuthConfig['callbacks'] = {
   jwt: jwtCallback,
   session: sessionCallback,


### PR DESCRIPTION
## Summary
- Reworked onto current `main` after #2512 ("Dashboard runtime basepath for multi-tenant") deleted `proxy.ts` and rearchitected the dashboard auth (middleware removed; proxy is now the `app/api/v1/[...proxy]` route handler).
- Original PR had two halves; the rearchitecture made one moot and left the other unfixed:
  - **Unauthenticated `/api/*` → 401 (no OIDC redirect): MOOT.** There is no longer a Next.js middleware to intercept and redirect `/api/*` to the OIDC sign-in. The proxy route handler never redirects; for an unauthenticated request `getToken` returns null and the backend's status flows straight back. The PKCE race no longer exists.
  - **Logout clearing stale OIDC-flow cookies: STILL BROKEN, now fixed here.** `app/api/auth/federated-signout` cleared only the session-token cookie (and chunks). A stale `state`/`pkce.code_verifier`/`nonce` cookie surviving logout fails the next sign-in's callback state validation (`CallbackRouteError` → `error=Configuration`).

## Fix
- `lib/auth/auth-config.ts`: export `OIDC_FLOW_COOKIE_NAMES` (callback-url, csrf-token, pkce verifier, state, nonce) with the same secure/`__Host-` prefixing as the live cookie config.
- `app/api/auth/federated-signout/route.ts`: clear those cookies alongside the session token + chunks on every sign-out path.
- Added a unit test asserting the OIDC-flow cookies are expired (`maxAge: 0`) on signout.

## Gates
- `npm run build` (next build): passes.
- `npx vitest run`: 1690 passed, 4 skipped.
- `npx prettier --check` on changed files: clean. (`npm run lint` is `next lint`, removed in Next 16 — fails on pristine main too.)
