### PR TITLE
ci: pin k3s and uv version to avoid stable-channel resolution failures

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -77,7 +77,6 @@ runs:
       with:
         metrics-enabled: false
         traefik-enabled: false
-        k3s-channel: stable
 
     - name: Run setup-e2e script
       shell: bash

--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -25,7 +25,9 @@ inputs:
   k3s-version:
     description: K3S version (https://github.com/rancher/k3s/releases)
     required: false
-    default: ""
+    # Pinned to avoid intermittent failures resolving the "stable" channel via
+    # update.k3s.io, which the upstream install script does not handle gracefully.
+    default: "v1.35.5+k3s1"
   k3s-channel:
     description: K3S channel (https://update.k3s.io/v1-release/channels)
     required: false

--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -76,7 +76,6 @@ runs:
       with:
         metrics-enabled: false
         traefik-enabled: false
-        k3s-channel: stable
 
     - name: Install Ark CLI
       shell: bash

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -294,9 +294,11 @@ jobs:
             dockerfile: Dockerfile.completions
           - path: services/ark-api
             image: ark-api
+            install-uv: true
             prebuild: "make ark-api-deps && mkdir -p services/ark-api/ark-api/out && cp out/ark-sdk/py-sdk/dist/ark_sdk-*.whl services/ark-api/ark-api/out/"
           - path: services/ark-dashboard
             image: ark-dashboard
+            install-uv: true
             prebuild: "make ark-dashboard-deps"
           - path: services/ark-broker/ark-broker
             image: ark-broker
@@ -305,6 +307,7 @@ jobs:
             dockerfile: Dockerfile.migrate
           - path: services/ark-mcp
             image: ark-mcp
+            install-uv: true
             prebuild: "make ark-mcp-deps && mkdir -p services/ark-mcp/ark-mcp/out && cp out/ark-sdk/py-sdk/dist/ark_sdk-*.whl services/ark-mcp/ark-mcp/out/"
           - path: tools/ark-cli
             image: ark-cli
@@ -323,7 +326,12 @@ jobs:
           path: out/
 
       - name: Install uv
+        if: matrix.install-uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Pinned to match the Dockerfile uv version and to skip setup-uv's
+          # "find latest" GitHub API lookup, which has stalled CI for minutes.
+          version: "0.11.21"
 
       - name: Login to Docker Registry
         if: ${{ needs.setup-container-cache-registry.outputs.is-fork-pr == 'false' }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1420,7 +1420,6 @@ jobs:
         with:
           metrics-enabled: false
           traefik-enabled: false
-          k3s-channel: stable
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
 
       - name: Export uv lockfiles to requirements.txt for Xray
         shell: bash
@@ -244,6 +246,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
 
       - name: Install ruff
         uses: astral-sh/ruff-action@v3
@@ -394,6 +398,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
 
       - name: Build libraries
         run: make libs-build-all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -351,7 +351,6 @@ jobs:
         with:
           metrics-enabled: false
           traefik-enabled: false
-          k3s-channel: stable
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
 
       - name: Build libraries
         run: make libs-build-all

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -112,6 +112,8 @@ jobs:
       - name: Install uv
         if: steps.check-coverage.outputs.found == 'false'
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
 
       - name: Install Helm
         if: steps.check-coverage.outputs.found == 'false'


### PR DESCRIPTION
The k3s install script resolves INSTALL_K3S_CHANNEL by calling update.k3s.io and parsing the redirect URL, but does not check curl's exit code. When that endpoint blips (TLS resets are intermittent but recurring), VERSION_K3S silently becomes the literal string "stable", and the next download targets a non-existent release tag. Pinning INSTALL_K3S_VERSION skips the resolution branch entirely. It also means we don't get surprise changes in k3s behavior. The version chosen here is the most recent stable version at the time of this PR.

The setup-uv action does something similar if no specific version is named, and a similar problem can happen there, so we also pin a specific version for uv. We also now specify which of containers in build-containers should actually install uv, since only a few need it.

This should resolve the intermittent failures we see in setup-k3s or in building containers. It also aligns with the security recommendations that we pin versions for consistency.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 