### PR TITLE
ci: cache WARP apt packages in sonar_scan workflow

### DIFF
--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -147,12 +147,46 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Compute WARP apt cache key
+        id: warp-cache-key
+        run: echo "week=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore WARP apt packages
+        id: warp-apt-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/warp-apt-cache
+          key: warp-apt-${{ runner.os }}-${{ runner.arch }}-v1-${{ steps.warp-cache-key.outputs.week }}
+          restore-keys: |
+            warp-apt-${{ runner.os }}-${{ runner.arch }}-v1-
+
+      - name: Prime apt archive from cache
+        run: |
+          mkdir -p "$HOME/warp-apt-cache"
+          shopt -s nullglob
+          debs=("$HOME"/warp-apt-cache/*.deb)
+          if (( ${#debs[@]} )); then
+            sudo cp -n "${debs[@]}" /var/cache/apt/archives/
+            echo "Primed ${#debs[@]} cached .debs into /var/cache/apt/archives/"
+          else
+            echo "WARP apt cache empty; first run will download fresh packages."
+          fi
+
       - name: Set up Cloudflare WARP
         uses: Boostport/setup-cloudflare-warp@v1
         with:
           organization: ${{ secrets.CF_ORGANIZATION }}
           auth_client_id: ${{ secrets.CLOUDFLARE_AUTH_CLIENT_ID }}
           auth_client_secret: ${{ secrets.CLOUDFLARE_AUTH_CLIENT_SECRET }}
+
+      - name: Sync apt archive back to cache
+        if: always()
+        run: |
+          mkdir -p "$HOME/warp-apt-cache"
+          sudo find /var/cache/apt/archives -maxdepth 1 -name '*.deb' \
+            -exec cp -n {} "$HOME/warp-apt-cache/" \;
+          sudo chown -R "$USER" "$HOME/warp-apt-cache"
+          echo "WARP apt cache now contains $(ls "$HOME/warp-apt-cache" | wc -l) .debs"
 
       - name: Run SonarQube Scan (Branch)
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
The Set up Cloudflare WARP step can take up to ~22 minutes in extreme cases pulling libwebkit2gtk-4.1-0 and the rest of cloudflare-warp's dependency chain from Azure's Ubuntu mirror (observed at ~91 kB/s in one recent run). The actual WARP daemon and SonarQube scan combined run in under two minutes, so the apt fetch dominates the job's worst-case time.

Cache /var/cache/apt/archives via a user-owned mirror keyed on ISO week with a version-keyed restore-keys fallback, prime the apt archive before the WARP action runs, and sync any new .debs back afterwards with if: always() so partial fetches still seed the cache.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 