### PR TITLE
fix: report discovered A2A agents as available

### DIFF
--- a/ark/internal/controller/agent_controller.go
+++ b/ark/internal/controller/agent_controller.go
@@ -19,6 +19,7 @@ import (
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
+	arka2a "mckinsey.com/ark/internal/a2a"
 	"mckinsey.com/ark/internal/eventing"
 )
 
@@ -186,6 +187,14 @@ func (r *AgentReconciler) checkToolDependencies(ctx context.Context, agent *arkv
 // checkExecutionEngineDependency validates execution engine dependency
 func (r *AgentReconciler) checkExecutionEngineDependency(ctx context.Context, agent *arkv1alpha1.Agent) (bool, string, string) {
 	engineName := agent.Spec.ExecutionEngine.Name
+
+	// The "a2a" engine is built into the controller, not a deployed
+	// ExecutionEngine resource, so there is no CR to look up. Availability for
+	// A2A agents is governed by the owning A2AServer (checkA2AServerDependency).
+	if engineName == arka2a.ExecutionEngineA2A {
+		return true, "", ""
+	}
+
 	engineNamespace := agent.Namespace
 
 	if agent.Spec.ExecutionEngine.Namespace != "" {

--- a/ark/internal/controller/agent_controller_test.go
+++ b/ark/internal/controller/agent_controller_test.go
@@ -333,6 +333,88 @@ var _ = Describe("Agent Controller", func() {
 			Expect(condition.Message).To(ContainSubstring("ExecutionEngine 'non-existent-engine' not found"))
 		})
 
+		It("should mark an A2A agent available without an ExecutionEngine resource", func() {
+			const a2aServerName = "test-a2a-server-ready"
+			const a2aEngineAgentName = "test-a2a-engine-agent"
+			a2aEngineAgentNamespacedName := types.NamespacedName{
+				Name:      a2aEngineAgentName,
+				Namespace: "default",
+			}
+
+			By("creating a Ready A2AServer that owns the agent")
+			a2aServer := &arkv1prealpha1.A2AServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      a2aServerName,
+					Namespace: "default",
+				},
+				Spec: arkv1prealpha1.A2AServerSpec{
+					Address: arkv1prealpha1.ValueSource{
+						Value: "http://test-a2a-server:80",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, a2aServer)).To(Succeed())
+			a2aServer.Status.Conditions = []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				Message:            "A2AServer is ready",
+				LastTransitionTime: metav1.Now(),
+			}}
+			Expect(k8sClient.Status().Update(ctx, a2aServer)).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, a2aServer)).To(Succeed())
+			}()
+
+			By("creating an A2A agent (executionEngine 'a2a') with no ExecutionEngine resource present")
+			a2aEngineAgent := &arkv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      a2aEngineAgentName,
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "ark.mckinsey.com/v1prealpha1",
+						Kind:       "A2AServer",
+						Name:       a2aServerName,
+						UID:        a2aServer.UID,
+					}},
+				},
+				Spec: arkv1alpha1.AgentSpec{
+					Prompt: "test prompt",
+					ExecutionEngine: &arkv1alpha1.ExecutionEngineRef{
+						Name: "a2a",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, a2aEngineAgent)).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, a2aEngineAgent)).To(Succeed())
+			}()
+
+			controllerReconciler := &AgentReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Eventing: eventnoop.NewProvider(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: a2aEngineAgentNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: a2aEngineAgentNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the agent is Available even though no 'a2a' ExecutionEngine resource exists")
+			var reconciledAgent arkv1alpha1.Agent
+			Expect(k8sClient.Get(ctx, a2aEngineAgentNamespacedName, &reconciledAgent)).To(Succeed())
+			Expect(reconciledAgent.Status.Conditions).To(HaveLen(1))
+			condition := reconciledAgent.Status.Conditions[0]
+			Expect(condition.Type).To(Equal("Available"))
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		})
+
 		It("should mark agent unavailable when execution engine is not ready", func() {
 			const notReadyEngineAgentName = "test-not-ready-engine-agent"
 			const notReadyEngineName = "not-ready-engine"


### PR DESCRIPTION
## Summary
Fixes #2532.

Agents created by A2AServer discovery use the **built-in** `a2a` execution engine — handled directly by the controller, with no `ExecutionEngine` custom resource behind it. The agent availability check (`checkExecutionEngineDependency`) looked one up regardless and always failed with `ExecutionEngine 'a2a' not found`, so every discovered A2A agent was pinned `Available=False` / "Unavailable" in the dashboard even though queries route fine.

This mirrors how query dispatch already special-cases the engine (`query_controller.go` checks `arka2a.ExecutionEngineA2A` before any CR lookup). The availability path now does the same: short-circuit the built-in `a2a` engine and let the owning A2AServer drive availability via `checkA2AServerDependency` (which already runs first in `checkDependencies`).

### Changes
- `agent_controller.go`: in `checkExecutionEngineDependency`, return available when `engineName == arka2a.ExecutionEngineA2A` (built-in; no CR to resolve).
- `agent_controller_test.go`: new test — an A2A agent owned by a `Ready` A2AServer reaches `Available=True` with no `ExecutionEngine` resource present. The existing "execution engine not found" / "not ready" tests still pass (non-built-in engines unchanged).

### Verification
- `make test` passes (controller suite green, including the new spec).
- Focused run: `ok mckinsey.com/ark/internal/controller`.
- gofmt clean. (`make lint` hits the known local golangci-lint/Go-version mismatch; full golangci-lint runs in CI.)