### PR TITLE
feat: cascade-delete broker messages when Query is deleted

### DIFF
--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -21,7 +21,6 @@ const (
 	MessagesEndpoint         = "/messages"
 	ConversationsEndpoint    = "/conversations"
 	CompletionEndpoint       = "/stream/%s/complete"
-	QueryMessagesEndpointFmt = "/queries/%s/messages"
 	MaxRetries               = 3
 	RetryDelay               = 100 * time.Millisecond
 	UserAgent                = "ark-memory-client/1.0"

--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -16,14 +16,15 @@ import (
 )
 
 const (
-	DefaultTimeoutSeconds = 30 // Default timeout in seconds
-	ContentTypeJSON       = "application/json"
-	MessagesEndpoint      = "/messages"
-	ConversationsEndpoint = "/conversations"
-	CompletionEndpoint    = "/stream/%s/complete"
-	MaxRetries            = 3
-	RetryDelay            = 100 * time.Millisecond
-	UserAgent             = "ark-memory-client/1.0"
+	DefaultTimeoutSeconds    = 30 // Default timeout in seconds
+	ContentTypeJSON          = "application/json"
+	MessagesEndpoint         = "/messages"
+	ConversationsEndpoint    = "/conversations"
+	CompletionEndpoint       = "/stream/%s/complete"
+	QueryMessagesEndpointFmt = "/queries/%s/messages"
+	MaxRetries               = 3
+	RetryDelay               = 100 * time.Millisecond
+	UserAgent                = "ark-memory-client/1.0"
 )
 
 // getMemoryTimeout reads ARK_MEMORY_HTTP_TIMEOUT_SECONDS env var or returns default
@@ -40,6 +41,7 @@ func getMemoryTimeout() time.Duration {
 type MemoryInterface interface {
 	AddMessages(ctx context.Context, queryID string, messages []Message) error
 	GetMessages(ctx context.Context) ([]Message, error)
+	DeleteQuery(ctx context.Context, queryID string) error
 	Close() error
 }
 

--- a/ark/executors/completions/memory_http.go
+++ b/ark/executors/completions/memory_http.go
@@ -321,7 +321,7 @@ func (m *HTTPMemory) DeleteQuery(ctx context.Context, queryID string) error {
 		return fmt.Errorf("failed to resolve memory address: %w", err)
 	}
 
-	requestURL := fmt.Sprintf("%s"+QueryMessagesEndpointFmt, m.baseURL, url.PathEscape(queryID))
+	requestURL := fmt.Sprintf("%s"+common.QueryMessagesEndpointFmt, m.baseURL, url.PathEscape(queryID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/ark/executors/completions/memory_http.go
+++ b/ark/executors/completions/memory_http.go
@@ -315,6 +315,36 @@ func (m *HTTPMemory) GetName() string {
 	return m.name
 }
 
+// DeleteQuery removes all messages for the given query from the memory backend.
+func (m *HTTPMemory) DeleteQuery(ctx context.Context, queryID string) error {
+	if err := m.resolveAndUpdateAddress(ctx); err != nil {
+		return fmt.Errorf("failed to resolve memory address: %w", err)
+	}
+
+	requestURL := fmt.Sprintf("%s"+QueryMessagesEndpointFmt, m.baseURL, url.PathEscape(queryID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", UserAgent)
+	for name, value := range m.headers {
+		req.Header.Set(name, value)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
 // Close closes the HTTP client connections
 func (m *HTTPMemory) Close() error {
 	if m.httpClient != nil {

--- a/ark/executors/completions/memory_http.go
+++ b/ark/executors/completions/memory_http.go
@@ -339,7 +339,7 @@ func (m *HTTPMemory) DeleteQuery(ctx context.Context, queryID string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("HTTP status %d", resp.StatusCode)
+		return fmt.Errorf("broker at %s returned HTTP %d deleting messages for query %s", requestURL, resp.StatusCode, queryID)
 	}
 
 	return nil

--- a/ark/executors/completions/memory_http_test.go
+++ b/ark/executors/completions/memory_http_test.go
@@ -770,6 +770,86 @@ func TestNewMemoryForQueryTtl(t *testing.T) {
 	})
 }
 
+func TestHTTPMemoryDeleteQuery(t *testing.T) {
+	t.Run("sends DELETE to /queries/:queryId/messages", func(t *testing.T) {
+		var capturedMethod, capturedPath string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		resolvedAddress := server.URL
+		mem := &arkv1alpha1.Memory{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-memory", Namespace: "default"},
+			Spec: arkv1alpha1.MemorySpec{
+				Address: arkv1alpha1.ValueSource{Value: server.URL},
+			},
+			Status: arkv1alpha1.MemoryStatus{
+				LastResolvedAddress: &resolvedAddress,
+				Phase:               "ready",
+			},
+		}
+
+		httpMemory := &HTTPMemory{
+			client:           setupMemoryTestClient([]client.Object{mem}),
+			httpClient:       server.Client(),
+			baseURL:          server.URL,
+			conversationId:   "conv-1",
+			name:             "test-memory",
+			namespace:        "default",
+			headers:          map[string]string{},
+			eventingRecorder: &noOpMemoryRecorder{},
+		}
+
+		err := httpMemory.DeleteQuery(context.Background(), "my-query")
+		require.NoError(t, err)
+		require.Equal(t, http.MethodDelete, capturedMethod)
+		require.Equal(t, "/queries/my-query/messages", capturedPath)
+	})
+
+	t.Run("returns error on non-2xx status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		resolvedAddress := server.URL
+		mem := &arkv1alpha1.Memory{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-memory", Namespace: "default"},
+			Spec: arkv1alpha1.MemorySpec{
+				Address: arkv1alpha1.ValueSource{Value: server.URL},
+			},
+			Status: arkv1alpha1.MemoryStatus{
+				LastResolvedAddress: &resolvedAddress,
+				Phase:               "ready",
+			},
+		}
+
+		httpMemory := &HTTPMemory{
+			client:           setupMemoryTestClient([]client.Object{mem}),
+			httpClient:       server.Client(),
+			baseURL:          server.URL,
+			conversationId:   "conv-1",
+			name:             "test-memory",
+			namespace:        "default",
+			headers:          map[string]string{},
+			eventingRecorder: &noOpMemoryRecorder{},
+		}
+
+		err := httpMemory.DeleteQuery(context.Background(), "my-query")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "500")
+	})
+}
+
+func TestNoopMemoryDeleteQuery(t *testing.T) {
+	noop := NewNoopMemory()
+	require.NoError(t, noop.DeleteQuery(context.Background(), "any-query"))
+}
+
 func TestAddMessagesTtlSeconds(t *testing.T) {
 	ttl := int64(3600)
 

--- a/ark/executors/completions/memory_noop.go
+++ b/ark/executors/completions/memory_noop.go
@@ -22,6 +22,10 @@ func (n *NoopMemory) GetMessages(ctx context.Context) ([]Message, error) {
 	return []Message{}, nil
 }
 
+func (n *NoopMemory) DeleteQuery(_ context.Context, _ string) error {
+	return nil
+}
+
 func (n *NoopMemory) Close() error {
 	logf.Log.V(2).Info("NoopMemory: Close called - no cleanup needed")
 	return nil

--- a/ark/internal/common/transport.go
+++ b/ark/internal/common/transport.go
@@ -14,6 +14,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const QueryMessagesEndpointFmt = "/queries/%s/messages"
+
 // LoggingTransport wraps an http.RoundTripper to provide optional HTTP request/response logging.
 type LoggingTransport struct {
 	Transport http.RoundTripper

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -843,7 +843,7 @@ func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("broker returned HTTP %d for delete query messages", resp.StatusCode)
+		return fmt.Errorf("broker at %s returned HTTP %d deleting messages for query %s", baseURL, resp.StatusCode, query.Name)
 	}
 
 	log.Info("deleted broker messages for query", "query", query.Name)

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -823,7 +823,7 @@ func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1
 		baseURL = strings.TrimSuffix(resolved, "/")
 	}
 
-	requestURL := fmt.Sprintf("%s/queries/%s/messages", baseURL, url.PathEscape(query.Name))
+	requestURL := fmt.Sprintf("%s"+common.QueryMessagesEndpointFmt, baseURL, url.PathEscape(query.Name))
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete request: %w", err)

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +30,7 @@ import (
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
 	arka2a "mckinsey.com/ark/internal/a2a"
+	"mckinsey.com/ark/internal/common"
 	eventingconfig "mckinsey.com/ark/internal/eventing/config"
 	"mckinsey.com/ark/internal/resolution"
 	"mckinsey.com/ark/internal/telemetry"
@@ -39,6 +43,9 @@ const (
 	targetTypeTeam  = "team"
 	targetTypeModel = "model"
 	targetTypeTool  = "tool"
+
+	messageCleanupGracePeriod   = 5 * time.Minute
+	messageCleanupRetryInterval = 15 * time.Second
 )
 
 type QueryReconciler struct {
@@ -56,6 +63,7 @@ type QueryReconciler struct {
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=agents,verbs=get;list
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=teams,verbs=get;list
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=models,verbs=get;list
+// +kubebuilder:rbac:groups=ark.mckinsey.com,resources=memories,verbs=get
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=arkconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;list;watch;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=impersonate
@@ -112,7 +120,16 @@ func (r *QueryReconciler) handleFinalizer(ctx context.Context, obj *arkv1alpha1.
 	}
 
 	if controllerutil.ContainsFinalizer(obj, finalizer) {
-		r.finalize(ctx, obj)
+		if err := r.finalize(ctx, obj); err != nil {
+			log := logf.FromContext(ctx)
+			if time.Since(obj.DeletionTimestamp.Time) > messageCleanupGracePeriod {
+				log.Error(err, "giving up on broker message cleanup after grace period", "query", obj.Name)
+				controllerutil.RemoveFinalizer(obj, finalizer)
+				return &ctrl.Result{}, r.Update(ctx, obj)
+			}
+			log.Error(err, "broker message cleanup failed, will retry", "query", obj.Name)
+			return &ctrl.Result{RequeueAfter: messageCleanupRetryInterval}, nil
+		}
 		controllerutil.RemoveFinalizer(obj, finalizer)
 		return &ctrl.Result{}, r.Update(ctx, obj)
 	}
@@ -754,7 +771,7 @@ func (r *QueryReconciler) determineQueryStatus(response *arkv1alpha1.Response) s
 	return statusDone
 }
 
-func (r *QueryReconciler) finalize(ctx context.Context, query *arkv1alpha1.Query) {
+func (r *QueryReconciler) finalize(ctx context.Context, query *arkv1alpha1.Query) error {
 	log := logf.FromContext(ctx)
 	log.Info("finalizing query", "name", query.Name, "namespace", query.Namespace)
 
@@ -766,6 +783,71 @@ func (r *QueryReconciler) finalize(ctx context.Context, query *arkv1alpha1.Query
 		r.operations.Delete(nsName)
 		log.Info("cancelled running operation for query", "name", query.Name, "namespace", query.Namespace)
 	}
+
+	return r.deleteBrokerMessages(ctx, query)
+}
+
+func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1alpha1.Query) error {
+	log := logf.FromContext(ctx)
+
+	var memoryName, memoryNamespace string
+	if query.Spec.Memory != nil {
+		memoryName = query.Spec.Memory.Name
+		memoryNamespace = query.Spec.Memory.Namespace
+		if memoryNamespace == "" {
+			memoryNamespace = query.Namespace
+		}
+	} else {
+		memoryName = "default" //nolint:goconst
+		memoryNamespace = query.Namespace
+	}
+
+	var memory arkv1alpha1.Memory
+	if err := r.Get(ctx, client.ObjectKey{Name: memoryName, Namespace: memoryNamespace}, &memory); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.Info("memory not found, skipping broker message cleanup", "memory", memoryName, "query", query.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to get memory %s/%s: %w", memoryNamespace, memoryName, err)
+	}
+
+	var baseURL string
+	if memory.Status.LastResolvedAddress != nil && *memory.Status.LastResolvedAddress != "" {
+		baseURL = strings.TrimSuffix(*memory.Status.LastResolvedAddress, "/")
+	} else {
+		resolver := common.NewValueSourceResolver(r.Client)
+		resolved, err := resolver.ResolveValueSource(ctx, memory.Spec.Address, memoryNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to resolve memory address: %w", err)
+		}
+		baseURL = strings.TrimSuffix(resolved, "/")
+	}
+
+	requestURL := fmt.Sprintf("%s/queries/%s/messages", baseURL, url.PathEscape(query.Name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+	req.Header.Set("User-Agent", "ark-controller/1.0")
+
+	httpClient := common.NewHTTPClientWithLogging()
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		log.Info("broker does not support delete query messages, skipping", "query", query.Name, "status", resp.StatusCode)
+		return nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("broker returned HTTP %d for delete query messages", resp.StatusCode)
+	}
+
+	log.Info("deleted broker messages for query", "query", query.Name)
+	return nil
 }
 
 func (r *QueryReconciler) getClientForQuery(query arkv1alpha1.Query) (client.Client, error) {

--- a/ark/internal/controller/query_delete_broker_test.go
+++ b/ark/internal/controller/query_delete_broker_test.go
@@ -1,0 +1,241 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func memoryWithAddress(name, brokerURL string) *arkv1alpha1.Memory {
+	return &arkv1alpha1.Memory{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: arkv1alpha1.MemorySpec{
+			Address: arkv1alpha1.ValueSource{Value: brokerURL},
+		},
+		Status: arkv1alpha1.MemoryStatus{
+			LastResolvedAddress: &brokerURL,
+		},
+	}
+}
+
+func makeBrokerServer(t *testing.T, status int) (*httptest.Server, *string, *string) {
+	t.Helper()
+	var capturedMethod, capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &capturedMethod, &capturedPath
+}
+
+func TestDeleteBrokerMessages_ExplicitMemory(t *testing.T) {
+	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
+
+	memory := memoryWithAddress("my-memory", srv.URL)
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithObjects(memory).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "my-memory", Namespace: "default"},
+		},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, *capturedMethod)
+	assert.Equal(t, "/queries/my-query/messages", *capturedPath)
+}
+
+func TestDeleteBrokerMessages_DefaultMemoryFallback(t *testing.T) {
+	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
+
+	memory := memoryWithAddress("default", srv.URL)
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithObjects(memory).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec:       arkv1alpha1.QuerySpec{},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, *capturedMethod)
+	assert.Equal(t, "/queries/my-query/messages", *capturedPath)
+}
+
+func TestDeleteBrokerMessages_NoMemory(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec:       arkv1alpha1.QuerySpec{},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.NoError(t, err)
+	assert.False(t, called, "should not call broker when no memory exists")
+}
+
+func TestDeleteBrokerMessages_MemoryNotFound(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "nonexistent", Namespace: "default"},
+		},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.NoError(t, err)
+	assert.False(t, called, "should not call broker when referenced memory is not found")
+}
+
+func TestDeleteBrokerMessages_Broker500ReturnsError(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
+
+	memory := memoryWithAddress("my-memory", srv.URL)
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithObjects(memory).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "my-memory", Namespace: "default"},
+		},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestDeleteBrokerMessages_Broker404IsSkipped(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
+
+	memory := memoryWithAddress("my-memory", srv.URL)
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithObjects(memory).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "my-memory", Namespace: "default"},
+		},
+	}
+
+	err := r.deleteBrokerMessages(context.Background(), query)
+	require.NoError(t, err)
+}
+
+func TestHandleFinalizer_BrokerFailure_RequeuesUntilGrace(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
+
+	memory := memoryWithAddress("my-memory", srv.URL)
+	fc := fake.NewClientBuilder().
+		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithObjects(memory).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+
+	now := metav1.Now()
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-query",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+		},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "my-memory", Namespace: "default"},
+		},
+	}
+
+	result, err := r.handleFinalizer(context.Background(), query)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, messageCleanupRetryInterval, result.RequeueAfter)
+}
+
+func TestHandleFinalizer_GracePeriodExpired_RemovesFinalizer(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
+
+	memory := memoryWithAddress("my-memory", srv.URL)
+	pastGrace := metav1.Time{Time: time.Now().Add(-messageCleanupGracePeriod - time.Second)}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-query",
+			Namespace:         "default",
+			DeletionTimestamp: &pastGrace,
+			Finalizers:        []string{finalizer},
+		},
+		Spec: arkv1alpha1.QuerySpec{
+			Memory: &arkv1alpha1.MemoryRef{Name: "my-memory", Namespace: "default"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = arkv1alpha1.AddToScheme(scheme)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(memory, query).
+		Build()
+
+	r := &QueryReconciler{Client: fc}
+
+	result, err := r.handleFinalizer(context.Background(), query)
+	require.NoError(t, err)
+	assert.Equal(t, &ctrl.Result{}, result)
+	assert.Empty(t, query.Finalizers)
+}

--- a/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
@@ -2,6 +2,18 @@ import {BrokerItem} from './stream/broker-item.js';
 import type {Stream} from './stream/stream.js';
 import {PaginatedList, PaginationParams} from './pagination.js';
 
+interface WithDeleteByQuery {
+  deleteByQuery(queryId: string): Promise<void>;
+}
+
+function hasDeleteByQuery(
+  stream: Stream<MessageData>
+): stream is Stream<MessageData> & WithDeleteByQuery {
+  return (
+    typeof (stream as unknown as WithDeleteByQuery).deleteByQuery === 'function'
+  );
+}
+
 export type Message = unknown;
 
 export interface MessageData {
@@ -83,6 +95,12 @@ export class MemoryBroker {
         item.data.conversationId === conversationId &&
         item.data.queryId === queryId
     );
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    if (hasDeleteByQuery(this.stream))
+      return this.stream.deleteByQuery(queryId);
+    return this.stream.delete((item) => item.data.queryId === queryId);
   }
 
   subscribe(callback: (item: BrokerItem<MessageData>) => void): () => void {

--- a/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
@@ -1,18 +1,6 @@
 import {BrokerItem} from './stream/broker-item.js';
-import type {Stream} from './stream/stream.js';
+import type {MessageStream} from './stream/message-stream.js';
 import {PaginatedList, PaginationParams} from './pagination.js';
-
-interface WithDeleteByQuery {
-  deleteByQuery(queryId: string): Promise<void>;
-}
-
-function hasDeleteByQuery(
-  stream: Stream<MessageData>
-): stream is Stream<MessageData> & WithDeleteByQuery {
-  return (
-    typeof (stream as unknown as WithDeleteByQuery).deleteByQuery === 'function'
-  );
-}
 
 export type Message = unknown;
 
@@ -23,9 +11,9 @@ export interface MessageData {
 }
 
 export class MemoryBroker {
-  private readonly stream: Stream<MessageData>;
+  private readonly stream: MessageStream;
 
-  constructor(stream: Stream<MessageData>) {
+  constructor(stream: MessageStream) {
     this.stream = stream;
   }
 
@@ -98,9 +86,7 @@ export class MemoryBroker {
   }
 
   async deleteByQuery(queryId: string): Promise<void> {
-    if (hasDeleteByQuery(this.stream))
-      return this.stream.deleteByQuery(queryId);
-    return this.stream.delete((item) => item.data.queryId === queryId);
+    return this.stream.deleteByQuery(queryId);
   }
 
   subscribe(callback: (item: BrokerItem<MessageData>) => void): () => void {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -139,6 +139,28 @@ describe('PostgresMessageStream', () => {
     });
   });
 
+  describe('deleteByQuery', () => {
+    it('removes only rows with the given query_id', async () => {
+      const qA = 'qa-' + Math.random().toString(36).slice(2);
+      const qB = 'qb-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({queryId: qA}));
+      await stream.append(makeMessageData({queryId: qA}));
+      await stream.append(makeMessageData({queryId: qB}));
+
+      await stream.deleteByQuery(qA);
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0].data.queryId).toBe(qB);
+    });
+
+    it('is a no-op when no rows match', async () => {
+      await stream.append(makeMessageData());
+      await stream.deleteByQuery('nonexistent-query-id');
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+
   describe('getCurrentSequence', () => {
     it('returns 0 when stream is empty', async () => {
       expect(await stream.getCurrentSequence()).toBe(0);

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -1,0 +1,17 @@
+import type {Logger} from '@ark-broker/logging/logger.js';
+import type {MessageData} from '../memory-broker.js';
+import {InMemoryStream} from './in-memory-stream.js';
+import type {MessageStream} from './message-stream.js';
+
+export class InMemoryMessageStream
+  extends InMemoryStream<MessageData>
+  implements MessageStream
+{
+  constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
+    super(logger, name, path, maxItems);
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    await this.delete((item) => item.data.queryId === queryId);
+  }
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/message-stream-factory.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/message-stream-factory.ts
@@ -1,16 +1,15 @@
 import type {AppConfig} from '@ark-broker/config/index.js';
 import type {Db} from '@ark-broker/db/db.js';
 import type {Logger} from '@ark-broker/logging/logger.js';
-import type {MessageData} from '../memory-broker.js';
-import type {Stream} from './stream.js';
-import {InMemoryStream} from './in-memory-stream.js';
+import type {MessageStream} from './message-stream.js';
+import {InMemoryMessageStream} from './in-memory-message-stream.js';
 import {PostgresMessageStream} from './postgres-message-stream.js';
 
 export function createMessageStream(
   config: AppConfig,
   logger: Logger,
   db?: Db
-): Stream<MessageData> {
+): MessageStream {
   if (config.backends.message === 'postgres') {
     return new PostgresMessageStream(
       logger.child({broker: 'postgres'}),
@@ -18,7 +17,7 @@ export function createMessageStream(
       config.backends.messageVisibilityTtlSeconds
     );
   }
-  return new InMemoryStream<MessageData>(
+  return new InMemoryMessageStream(
     logger.child({broker: 'memory'}),
     'Memory',
     config.persistence.memoryFilePath,

--- a/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
@@ -1,0 +1,6 @@
+import type {MessageData} from '../memory-broker.js';
+import type {Stream} from './stream.js';
+
+export interface MessageStream extends Stream<MessageData> {
+  deleteByQuery(queryId: string): Promise<void>;
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -115,6 +115,11 @@ export class PostgresMessageStream implements Stream<MessageData> {
       .db`DELETE FROM messages WHERE sequence_number = ANY(${toDelete})`;
   }
 
+  async deleteByQuery(queryId: string): Promise<void> {
+    this.logger.info({queryId}, 'deleting messages by query');
+    await this.db`DELETE FROM messages WHERE query_id = ${queryId}`;
+  }
+
   async save(): Promise<void> {}
 
   async getCurrentSequence(): Promise<number> {

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -9,7 +9,8 @@ import {
   type PaginatedList,
   type PaginationParams,
 } from '../pagination.js';
-import type {Stream, Predicate} from './stream.js';
+import type {Predicate} from './stream.js';
+import type {MessageStream} from './message-stream.js';
 
 type MessageRow = {
   sequence_number: string;
@@ -31,7 +32,7 @@ function rowToBrokerItem(row: MessageRow): BrokerItem<MessageData> {
   };
 }
 
-export class PostgresMessageStream implements Stream<MessageData> {
+export class PostgresMessageStream implements MessageStream {
   private readonly emitter = new EventEmitter();
 
   constructor(

--- a/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
@@ -338,6 +338,59 @@ export function createMemoryRouter(
 
   /**
    * @swagger
+   * /queries/{queryId}/messages:
+   *   delete:
+   *     summary: Delete all messages for a specific query
+   *     description: Removes all messages for a specific query across all conversations
+   *     tags:
+   *       - Memory
+   *     parameters:
+   *       - in: path
+   *         name: queryId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Query ID to delete messages for
+   *     responses:
+   *       200:
+   *         description: Query messages deleted successfully
+   *       400:
+   *         description: Invalid query ID
+   *       500:
+   *         description: Failed to delete query messages
+   */
+  router.delete<{queryId: string}>(
+    '/queries/:queryId/messages',
+    async (req, res) => {
+      const {queryId} = req.params;
+
+      if (!queryId) {
+        res.status(400).json({
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'Query ID is required',
+            requestId: req.id === undefined ? undefined : String(req.id),
+          },
+        });
+        return;
+      }
+
+      try {
+        req.log.info({queryId}, 'deleting messages for query');
+        await memory.deleteByQuery(queryId);
+        res.json({
+          status: 'success',
+          message: `Query ${queryId} messages deleted`,
+        });
+      } catch (error) {
+        req.log.error({err: error}, 'failed to delete query messages');
+        sendInternalError(res, req.id);
+      }
+    }
+  );
+
+  /**
+   * @swagger
    * /conversations:
    *   delete:
    *     summary: Delete all conversations

--- a/services/ark-broker/ark-broker/src/server.ts
+++ b/services/ark-broker/ark-broker/src/server.ts
@@ -8,8 +8,8 @@ import {
 } from './http/middleware/error-handler.js';
 import {createHttpLogger} from './http/middleware/http-logger.js';
 import {requestId} from './http/middleware/request-id.js';
-import {MemoryBroker, type MessageData} from './brokers/memory-broker.js';
-import type {Stream} from './brokers/stream/stream.js';
+import {MemoryBroker} from './brokers/memory-broker.js';
+import type {MessageStream} from './brokers/stream/message-stream.js';
 import {type Db, pingDb} from './db/db.js';
 import {CompletionChunkBroker} from './brokers/chunks-broker.js';
 import {TraceBroker} from './brokers/trace-broker.js';
@@ -40,7 +40,7 @@ export function buildApp(deps: {
   config: AppConfig;
   logger: Logger;
   version: string;
-  messageStream: Stream<MessageData>;
+  messageStream: MessageStream;
   db?: Db;
 }): AppBundle {
   const {config, logger, version, messageStream, db} = deps;

--- a/services/ark-broker/ark-broker/test/memory-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/memory-broker.test.ts
@@ -137,6 +137,28 @@ describe('MemoryBroker', () => {
     });
   });
 
+  describe('deleteByQuery', () => {
+    test('should delete all messages for a query regardless of conversation', async () => {
+      await broker.addMessage('conv1', 'query1', 'message1');
+      await broker.addMessage('conv2', 'query1', 'message2');
+      await broker.addMessage('conv1', 'query2', 'message3');
+
+      await broker.deleteByQuery('query1');
+
+      const allMessages = await broker.all();
+      expect(allMessages).toHaveLength(1);
+      expect(allMessages[0].data.queryId).toBe('query2');
+    });
+
+    test('should be a no-op when the query has no messages', async () => {
+      await broker.addMessage('conv1', 'query1', 'message1');
+
+      await broker.deleteByQuery('nonexistent');
+
+      expect(await broker.all()).toHaveLength(1);
+    });
+  });
+
   describe('delete', () => {
     test('should delete all messages when called without predicate', async () => {
       await broker.addMessage('conv1', 'query1', 'message1');

--- a/services/ark-broker/ark-broker/test/memory-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/memory-broker.test.ts
@@ -1,7 +1,6 @@
 import {createLogger} from '../src/logging/logger.js';
 import {MemoryBroker} from '../src/brokers/memory-broker.js';
-import {InMemoryStream} from '../src/brokers/stream/in-memory-stream.js';
-import type {MessageData} from '../src/brokers/memory-broker.js';
+import {InMemoryMessageStream} from '../src/brokers/stream/in-memory-message-stream.js';
 
 const silentLogger = createLogger({level: 'silent', pretty: false});
 
@@ -10,7 +9,7 @@ describe('MemoryBroker', () => {
 
   beforeEach(() => {
     broker = new MemoryBroker(
-      new InMemoryStream<MessageData>(silentLogger, 'Memory')
+      new InMemoryMessageStream(silentLogger, 'Memory')
     );
   });
 

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -89,6 +89,31 @@ describeIntegration('postgres backend — HTTP integration', () => {
     await request(app).get('/readyz').expect(200);
   });
 
+  it('DELETE /queries/:queryId/messages removes only that query rows', async () => {
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'del-conv-1', query_id: 'del-q', messages: ['a']})
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'del-conv-2', query_id: 'del-q', messages: ['b']})
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'del-conv-1',
+        query_id: 'keep-q',
+        messages: ['c'],
+      })
+      .expect(200);
+
+    await request(app).delete('/queries/del-q/messages').expect(200);
+
+    const res = await request(app).get('/messages').expect(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].query_id).toBe('keep-q');
+  });
+
   it('expired messages are not returned by GET /messages', async () => {
     await request(app)
       .post('/messages')

--- a/services/ark-broker/ark-broker/test/server.test.ts
+++ b/services/ark-broker/ark-broker/test/server.test.ts
@@ -356,6 +356,32 @@ describe('ARK Broker API', () => {
     });
   });
 
+  describe('DELETE /queries/:queryId/messages', () => {
+    test('should delete all messages for a query across conversations', async () => {
+      await request(app)
+        .post('/messages')
+        .send({conversation_id: 'conv-a', query_id: 'q-del', messages: ['m1']});
+      await request(app)
+        .post('/messages')
+        .send({conversation_id: 'conv-b', query_id: 'q-del', messages: ['m2']});
+      await request(app)
+        .post('/messages')
+        .send({
+          conversation_id: 'conv-a',
+          query_id: 'q-keep',
+          messages: ['m3'],
+        });
+
+      const delRes = await request(app).delete('/queries/q-del/messages');
+      expect(delRes.status).toBe(200);
+      expect(delRes.body.status).toBe('success');
+
+      const remaining = await request(app).get('/messages');
+      expect(remaining.body.items).toHaveLength(1);
+      expect(remaining.body.items[0].query_id).toBe('q-keep');
+    });
+  });
+
   describe('Error Handling', () => {
     test('should return 404 for unknown routes', async () => {
       const response = await request(app).get('/unknown');

--- a/tests/query-broker-delete-cleanup-default/chainsaw-test.yaml
+++ b/tests/query-broker-delete-cleanup-default/chainsaw-test.yaml
@@ -91,9 +91,10 @@ spec:
   - name: delete-query
     try:
     - delete:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        name: delete-cleanup-default-query
+        ref:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          name: delete-cleanup-default-query
     - wait:
         apiVersion: ark.mckinsey.com/v1alpha1
         kind: Query

--- a/tests/query-broker-delete-cleanup-default/chainsaw-test.yaml
+++ b/tests/query-broker-delete-cleanup-default/chainsaw-test.yaml
@@ -1,0 +1,133 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: query-broker-delete-cleanup-default
+  labels:
+    postgresql: "true"
+spec:
+  description: Deleting a Query with no spec.memory falls back to the "default" Memory and removes its messages from the broker backend
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query
+    try:
+    - apply:
+        file: manifests/a00-rbac.yaml
+    - apply:
+        file: manifests/a00-memory.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Memory
+        name: default
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.lastResolvedAddress}'
+    - apply:
+        file: manifests/a01-agent.yaml
+    - apply:
+        file: manifests/a02-query.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-default-query
+        timeout: 4m
+        for:
+          jsonPath:
+            path: '{.status.response.content}'
+    - assert:
+        timeout: 1s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: delete-cleanup-default-query
+          status:
+            phase: done
+            (response != null): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-default-query
+
+  - name: verify-messages-present
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT COUNT(*) FROM messages WHERE query_id='delete-cleanup-default-query';" \
+            | tr -d ' \n')
+          echo "Message count before delete: ${COUNT}"
+          [ "${COUNT}" -gt "0" ] || { echo "expected messages in broker, got 0"; exit 1; }
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+    catch:
+    - events: {}
+
+  - name: delete-query
+    try:
+    - delete:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-default-query
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-default-query
+        timeout: 2m
+        for:
+          deletion: {}
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-default-query
+
+  - name: verify-messages-absent
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT COUNT(*) FROM messages WHERE query_id='delete-cleanup-default-query';" \
+            | tr -d ' \n')
+          echo "Message count after delete: ${COUNT}"
+          [ "${COUNT}" = "0" ] || { echo "expected 0 messages in broker, got ${COUNT}"; exit 1; }
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+    catch:
+    - events: {}
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/query-broker-delete-cleanup-default/manifests/a00-memory.yaml
+++ b/tests/query-broker-delete-cleanup-default/manifests/a00-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Memory
+metadata:
+  name: default
+spec:
+  address:
+    valueFrom:
+      serviceRef:
+        name: ark-broker
+        namespace: default
+        port: http

--- a/tests/query-broker-delete-cleanup-default/manifests/a00-rbac.yaml
+++ b/tests/query-broker-delete-cleanup-default/manifests/a00-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: query-broker-delete-cleanup-default-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: query-broker-delete-cleanup-default-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ($namespace)
+roleRef:
+  kind: Role
+  name: query-broker-delete-cleanup-default-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/query-broker-delete-cleanup-default/manifests/a01-agent.yaml
+++ b/tests/query-broker-delete-cleanup-default/manifests/a01-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: delete-cleanup-default-agent
+spec:
+  prompt: You are a helpful assistant.
+  modelRef:
+    name: test-model-mock

--- a/tests/query-broker-delete-cleanup-default/manifests/a02-query.yaml
+++ b/tests/query-broker-delete-cleanup-default/manifests/a02-query.yaml
@@ -1,0 +1,9 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: delete-cleanup-default-query
+spec:
+  input: What is 2+2?
+  target:
+    type: agent
+    name: delete-cleanup-default-agent

--- a/tests/query-broker-delete-cleanup-default/mock-llm-values.yaml
+++ b/tests/query-broker-delete-cleanup-default/mock-llm-values.yaml
@@ -1,0 +1,24 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [{"id": "gpt-4.1-mini", "object": "model", "owned_by": "openai"}]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+        }

--- a/tests/query-broker-delete-cleanup/chainsaw-test.yaml
+++ b/tests/query-broker-delete-cleanup/chainsaw-test.yaml
@@ -91,9 +91,10 @@ spec:
   - name: delete-query
     try:
     - delete:
-        apiVersion: ark.mckinsey.com/v1alpha1
-        kind: Query
-        name: delete-cleanup-query
+        ref:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          name: delete-cleanup-query
     - wait:
         apiVersion: ark.mckinsey.com/v1alpha1
         kind: Query

--- a/tests/query-broker-delete-cleanup/chainsaw-test.yaml
+++ b/tests/query-broker-delete-cleanup/chainsaw-test.yaml
@@ -1,0 +1,133 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: query-broker-delete-cleanup
+  labels:
+    postgresql: "true"
+spec:
+  description: Deleting a Query with explicit spec.memory removes its messages from the broker backend
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query
+    try:
+    - apply:
+        file: manifests/a00-rbac.yaml
+    - apply:
+        file: manifests/a00-memory.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Memory
+        name: delete-cleanup-memory
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.lastResolvedAddress}'
+    - apply:
+        file: manifests/a01-agent.yaml
+    - apply:
+        file: manifests/a02-query.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-query
+        timeout: 4m
+        for:
+          jsonPath:
+            path: '{.status.response.content}'
+    - assert:
+        timeout: 1s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: delete-cleanup-query
+          status:
+            phase: done
+            (response != null): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-query
+
+  - name: verify-messages-present
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT COUNT(*) FROM messages WHERE query_id='delete-cleanup-query';" \
+            | tr -d ' \n')
+          echo "Message count before delete: ${COUNT}"
+          [ "${COUNT}" -gt "0" ] || { echo "expected messages in broker, got 0"; exit 1; }
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+    catch:
+    - events: {}
+
+  - name: delete-query
+    try:
+    - delete:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-query
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-query
+        timeout: 2m
+        for:
+          deletion: {}
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: delete-cleanup-query
+
+  - name: verify-messages-absent
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT COUNT(*) FROM messages WHERE query_id='delete-cleanup-query';" \
+            | tr -d ' \n')
+          echo "Message count after delete: ${COUNT}"
+          [ "${COUNT}" = "0" ] || { echo "expected 0 messages in broker, got ${COUNT}"; exit 1; }
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+    catch:
+    - events: {}
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/query-broker-delete-cleanup/manifests/a00-memory.yaml
+++ b/tests/query-broker-delete-cleanup/manifests/a00-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Memory
+metadata:
+  name: delete-cleanup-memory
+spec:
+  address:
+    valueFrom:
+      serviceRef:
+        name: ark-broker
+        namespace: default
+        port: http

--- a/tests/query-broker-delete-cleanup/manifests/a00-rbac.yaml
+++ b/tests/query-broker-delete-cleanup/manifests/a00-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: query-broker-delete-cleanup-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: query-broker-delete-cleanup-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ($namespace)
+roleRef:
+  kind: Role
+  name: query-broker-delete-cleanup-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/query-broker-delete-cleanup/manifests/a01-agent.yaml
+++ b/tests/query-broker-delete-cleanup/manifests/a01-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: delete-cleanup-agent
+spec:
+  prompt: You are a helpful assistant.
+  modelRef:
+    name: test-model-mock

--- a/tests/query-broker-delete-cleanup/manifests/a02-query.yaml
+++ b/tests/query-broker-delete-cleanup/manifests/a02-query.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: delete-cleanup-query
+spec:
+  input: What is 2+2?
+  target:
+    type: agent
+    name: delete-cleanup-agent
+  memory:
+    name: delete-cleanup-memory

--- a/tests/query-broker-delete-cleanup/mock-llm-values.yaml
+++ b/tests/query-broker-delete-cleanup/mock-llm-values.yaml
@@ -1,0 +1,24 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [{"id": "gpt-4.1-mini", "object": "model", "owned_by": "openai"}]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+        }


### PR DESCRIPTION
## Summary

Closes #2533, follow-up of #2153.

When a Query CR is deleted — whether via the dashboard, kubectl, API, or TTL-triggered CR deletion — its messages in the broker backend (Postgres or in-memory) are never cleaned up. This PR closes that lifecycle gap by wiring a cascade-delete into the Query finalizer.

**Scope:** this PR covers explicit Query CR deletion only. Messages written to Postgres already carry an \`expires_at\` column (set by propagating \`spec.ttl\` in #2508) and expire naturally via that mechanism. This PR does not change or replace that behaviour — the two mechanisms are complementary and independent.

## Problem

After Phase 1 (messages persisted to Postgres), deleted Queries leave orphan rows indefinitely. The asymmetry is structural: the broker stores messages keyed by \`query_id\`, but nothing ever removes them when the Query object goes away. At scale, this accumulates unbounded rows.

## Design decisions

**Where the delete happens — controller finalizer, not executor**

The controller finalizer is the only place that covers *all* deletion paths (dashboard, kubectl, API, TTL-triggered CR deletion). An executor-side cleanup would miss deletes that happen when no executor is running. The finalizer already cancels in-flight A2A operations; broker cleanup is a natural extension of that teardown.

**Scope — messages only, hard delete**

Events, chunks, and traces are out of scope: they have different retention semantics and are not part of the Memory contract. Messages are deleted immediately (no soft-delete), consistent with how \`DELETE /conversations\` already works in the broker.

**\`deleteByQuery\` as a first-class contract method, not a bespoke broker call**

The broker is one implementation of the Memory abstraction. Adding \`DELETE /queries/{queryId}/messages\` as a proper REST endpoint (rather than a controller-only side-channel) means the operation is part of the public contract and is available to any executor that needs it in future. For the same reason, \`DeleteQuery\` was added to \`MemoryInterface\` in the completions executor and gets a real implementation in \`HTTPMemory\` and a no-op in \`NoopMemory\`.

**No shared Go client between controller and executor**

The controller issues a plain stateless HTTP DELETE. Importing \`executors/completions\` from \`internal/controller\` would introduce a downstream dependency cycle and couple the operator to a specific executor implementation. The call is simple enough not to warrant extraction.

**Memory resolution — mirrors the executor invariant**

Messages exist when a Query uses \`spec.memory\` *or* when a Memory named \`"default"\` exists in the namespace. The finalizer replicates this resolution exactly: check \`spec.memory\`, fall back to \`"default"\`, skip silently if neither exists. If \`Memory.status.lastResolvedAddress\` is populated the address is used directly; otherwise it falls back through \`common.ValueSourceResolver\`.

**Failure policy — blocking with cap**

If the broker is unreachable, the finalizer does not remove itself and requeues after 15 s. After 5 minutes the finalizer gives up and removes itself, so no Query can be permanently stuck in \`Deleting\`. This matches the existing pattern for A2A task cancellation in the same finalizer.

**\`MessageStream\` interface in the broker (TypeScript)**

The initial implementation used a runtime type guard (\`hasDeleteByQuery\`) to check whether the underlying stream supported native SQL deletion. The guard was removed in favour of a proper \`MessageStream\` interface that extends \`Stream<MessageData>\` with \`deleteByQuery\`. This makes the contract compile-time rather than runtime, and keeps the generic \`Stream<T>\` clean for the other brokers (TraceBroker, EventBroker, ChunksBroker) which use different \`T\` types and have no concept of \`queryId\`.

\`InMemoryMessageStream\` extends \`InMemoryStream<MessageData>\` and implements \`deleteByQuery\` via the existing predicate-based \`delete\`. \`PostgresMessageStream\` gets a native \`DELETE FROM messages WHERE query_id = $1\`, which avoids the full-table scan that the predicate fallback would require.

## Files changed

- \`services/ark-broker/\` — new \`DELETE /queries/:queryId/messages\` route; \`MessageStream\` interface; \`InMemoryMessageStream\`; \`PostgresMessageStream\` implements \`MessageStream\`
- \`ark/executors/completions/\` — \`DeleteQuery\` added to \`MemoryInterface\`, \`HTTPMemory\`, \`NoopMemory\`
- \`ark/internal/controller/query_controller.go\` — \`deleteBrokerMessages\` helper; \`finalize()\` returns error; blocking-with-cap policy in \`handleFinalizer\`
- \`tests/query-broker-delete-cleanup/\` and \`tests/query-broker-delete-cleanup-default/\` — two Postgres-labelled chainsaw e2e tests covering explicit \`spec.memory\` and the \`"default"\` Memory fallback