### PR TITLE
fix(sdk): refetch JWKS on unknown kid to survive IdP key rotation

### DIFF
--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import json
+import time
 from typing import Optional, Dict, Any
 import jwt
 from jwt.exceptions import InvalidTokenError, ExpiredSignatureError, InvalidAudienceError, InvalidIssuerError
@@ -15,6 +16,11 @@ from .exceptions import TokenValidationError, InvalidTokenError as AuthInvalidTo
 from .config import AuthConfig
 
 logger = logging.getLogger(__name__)
+
+# OIDC providers rotate signing keys (Dex rotates ~every 6h), so a JWKS set
+# cached for the process lifetime goes stale and rejects tokens signed by a
+# newly-rotated key. Bound the cache and refetch on an unknown kid.
+JWKS_CACHE_TTL_SECONDS = int(os.getenv("OIDC_JWKS_CACHE_TTL_SECONDS", "300"))
 
 
 class TokenValidator:
@@ -101,10 +107,13 @@ class TokenValidator:
             logger.error(f"Failed to fetch JWKS: {e}")
             raise TokenValidationError(f"Failed to fetch JWKS: {e}")
     
-    def _get_jwks(self) -> Dict[str, Any]:
-        """Get JWKS with caching."""
-        if self._jwks_cache is None:
+    def _get_jwks(self, force_refresh: bool = False) -> Dict[str, Any]:
+        """Get JWKS, cached with a TTL. ``force_refresh`` bypasses the cache."""
+        now = time.monotonic()
+        expired = self._cache_expiry is not None and now >= self._cache_expiry
+        if force_refresh or self._jwks_cache is None or expired:
             self._jwks_cache = self._fetch_jwks()
+            self._cache_expiry = now + JWKS_CACHE_TTL_SECONDS
         return self._jwks_cache
     
     def _jwk_to_pem(self, jwk_dict: Dict[str, Any]) -> str:
@@ -142,14 +151,13 @@ class TokenValidator:
             if not kid:
                 raise TokenValidationError("Token header does not contain 'kid'")
 
-            # Get JWKS
-            jwks = self._get_jwks()
-
-            # Find the key with matching kid
-            for key in jwks.get('keys', []):
-                if key.get('kid') == kid:
-                    # Convert JWK to PEM
-                    return self._jwk_to_pem(key)
+            # Try the cached JWKS first; on an unknown kid, refetch once in case
+            # the IdP rotated its signing keys since the cache was populated.
+            for force_refresh in (False, True):
+                jwks = self._get_jwks(force_refresh=force_refresh)
+                for key in jwks.get('keys', []):
+                    if key.get('kid') == kid:
+                        return self._jwk_to_pem(key)
 
             raise TokenValidationError(f"Unable to find key with kid: {kid}")
 

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
@@ -70,6 +70,60 @@ class TestTokenValidator(unittest.TestCase):
         mock_get.assert_called_once()
 
     @patch('ark_sdk.auth.validator.requests.get')
+    def test_get_jwks_force_refresh_bypasses_cache(self, mock_get):
+        """force_refresh refetches even when the cache is warm."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"keys": [{"kid": "k1"}]}
+        mock_get.return_value = mock_response
+
+        self.validator._get_jwks()
+        self.validator._get_jwks(force_refresh=True)
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch('ark_sdk.auth.validator.requests.get')
+    def test_get_jwks_refetches_after_ttl(self, mock_get):
+        """The cache expires after its TTL and refetches."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"keys": [{"kid": "k1"}]}
+        mock_get.return_value = mock_response
+
+        with patch('ark_sdk.auth.validator.time.monotonic', side_effect=[0.0, 10_000.0]):
+            self.validator._get_jwks()
+            self.validator._get_jwks()
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch.object(TokenValidator, '_jwk_to_pem', return_value="PEM")
+    @patch.object(TokenValidator, '_fetch_jwks')
+    @patch('ark_sdk.auth.validator.jwt.get_unverified_header')
+    def test_get_signing_key_refetches_on_unknown_kid(self, mock_header, mock_fetch, _mock_pem):
+        """A kid missing from the cached JWKS triggers a single refetch (key rotation)."""
+        mock_header.return_value = {"kid": "rotated-kid"}
+        # Stale cache lacks the kid; the refetch returns the rotated key.
+        mock_fetch.side_effect = [
+            {"keys": [{"kid": "old-kid"}]},
+            {"keys": [{"kid": "rotated-kid"}]},
+        ]
+
+        result = self.validator._get_signing_key("token")
+
+        self.assertEqual(result, "PEM")
+        self.assertEqual(mock_fetch.call_count, 2)
+
+    @patch.object(TokenValidator, '_fetch_jwks')
+    @patch('ark_sdk.auth.validator.jwt.get_unverified_header')
+    def test_get_signing_key_unknown_kid_after_refetch_raises(self, mock_header, mock_fetch):
+        """A kid absent even after refetch raises rather than looping."""
+        mock_header.return_value = {"kid": "ghost-kid"}
+        mock_fetch.return_value = {"keys": [{"kid": "other-kid"}]}
+
+        with self.assertRaises(TokenValidationError) as context:
+            self.validator._get_signing_key("token")
+
+        self.assertIn("Unable to find key with kid: ghost-kid", str(context.exception))
+
+    @patch('ark_sdk.auth.validator.requests.get')
     def test_fetch_jwks_exception(self, mock_get):
         """Test JWKS fetching with exception."""
         import requests


### PR DESCRIPTION
## Summary
- The ark-sdk token validator cached the JWKS set on first use and never refreshed it (`_cache_expiry` was declared but unused), so a long-lived process eventually rejected valid tokens signed by a newly-rotated key with `Unable to find key with kid` until the pod restarted. OIDC providers rotate signing keys (Dex rotates ~every 6h).
- Bound the cache with a TTL (`OIDC_JWKS_CACHE_TTL_SECONDS`, default 300) and refetch the JWKS once on an unknown `kid` before failing, matching how resilient JWKS clients (e.g. PyJWKClient) handle key rotation.
- Adds unit tests covering force-refresh, TTL expiry, refetch-on-unknown-kid, and the still-missing-after-refetch failure path.
- Re-originated from an upstream branch so `sonar_scan` can run (fork-origin PRs don't get Sonar secrets); supersedes #2457. Same fix.