### PR TITLE
fix(ark-dashboard): preserve namespace on settings navigation

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockReplace = vi.fn();
+const mockPush = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useParams: vi.fn(),
   useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
 }));
 
 vi.mock('@/providers/NamespaceProvider', () => ({
@@ -32,8 +33,11 @@ describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
-      replace: mockReplace,
+      push: mockPush,
     });
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      new URLSearchParams('namespace=demo'),
+    );
   });
 
   const renderPage = () =>
@@ -43,18 +47,18 @@ describe('SettingsPage', () => {
       </JotaiProvider>,
     );
 
-  it('should redirect to default page when no page segment is provided', () => {
+  it('should redirect to default page preserving namespace when no page segment is provided', () => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({ page: undefined });
     renderPage();
-    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers');
+    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
-  it('should redirect to default page when an invalid page is provided', () => {
+  it('should redirect to default page preserving namespace when an invalid page is provided', () => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({
       page: ['nonexistent'],
     });
     renderPage();
-    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers');
+    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
   it('should not redirect when a valid page is provided', () => {
@@ -62,7 +66,7 @@ describe('SettingsPage', () => {
       page: ['secrets'],
     });
     renderPage();
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('should pass the valid page key to sidebar and content', () => {
@@ -97,7 +101,7 @@ describe('SettingsPage', () => {
   ])('should accept "%s" as a valid page', page => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({ page: [page] });
     renderPage();
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
     expect(screen.getByTestId('settings-content')).toHaveTextContent(page);
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/(settings)/settings-page.test.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useParams: vi.fn(),
@@ -34,6 +35,7 @@ describe('SettingsPage', () => {
     vi.clearAllMocks();
     (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
       push: mockPush,
+      replace: mockReplace,
     });
     (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
       new URLSearchParams('namespace=demo'),
@@ -50,7 +52,7 @@ describe('SettingsPage', () => {
   it('should redirect to default page preserving namespace when no page segment is provided', () => {
     (useParams as ReturnType<typeof vi.fn>).mockReturnValue({ page: undefined });
     renderPage();
-    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
+    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
   it('should redirect to default page preserving namespace when an invalid page is provided', () => {
@@ -58,7 +60,7 @@ describe('SettingsPage', () => {
       page: ['nonexistent'],
     });
     renderPage();
-    expect(mockPush).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
+    expect(mockReplace).toHaveBeenCalledWith('/settings/a2a-servers?namespace=demo');
   });
 
   it('should not redirect when a valid page is provided', () => {
@@ -66,6 +68,7 @@ describe('SettingsPage', () => {
       page: ['secrets'],
     });
     renderPage();
+    expect(mockReplace).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
   });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-keyboard-shortcut.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-keyboard-shortcut.test.tsx
@@ -8,6 +8,7 @@ import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
   usePathname: vi.fn(),
+  useSearchParams: vi.fn(() => new URLSearchParams('')),
 }));
 
 import { SettingsKeyboardShortcut } from '@/components/settings/settings-keyboard-shortcut';

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
@@ -65,7 +65,7 @@ describe('SettingsSidebar', () => {
 
     await user.click(screen.getByText('Memory'));
 
-    expect(mockPush).toHaveBeenCalledWith('/settings/memory?namespace=demo');
+    expect(mockReplace).toHaveBeenCalledWith('/settings/memory?namespace=demo');
   });
 
   it('should navigate to entry URL preserving namespace when close button is clicked after soft navigation', async () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider, createStore } from 'jotai';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
@@ -10,6 +10,7 @@ import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
 }));
 
 describe('SettingsSidebar', () => {
@@ -26,6 +27,9 @@ describe('SettingsSidebar', () => {
       replace: mockReplace,
       back: mockBack,
     });
+    (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(
+      new URLSearchParams('namespace=demo'),
+    );
   });
 
   const renderWithStore = (activePage: SettingPage = 'a2a-servers') =>
@@ -55,16 +59,16 @@ describe('SettingsSidebar', () => {
     expect(screen.getByText('Secrets')).toBeInTheDocument();
   });
 
-  it('should navigate to settings page when a menu item is clicked', async () => {
+  it('should navigate to settings page preserving namespace when a menu item is clicked', async () => {
     const user = userEvent.setup();
     renderWithStore();
 
     await user.click(screen.getByText('Memory'));
 
-    expect(mockReplace).toHaveBeenCalledWith('/settings/memory');
+    expect(mockPush).toHaveBeenCalledWith('/settings/memory?namespace=demo');
   });
 
-  it('should navigate to entry URL when close button is clicked after soft navigation', async () => {
+  it('should navigate to entry URL preserving namespace when close button is clicked after soft navigation', async () => {
     store.set(settingsEntryUrlAtom, '/agents');
 
     const user = userEvent.setup();
@@ -72,16 +76,16 @@ describe('SettingsSidebar', () => {
 
     await user.click(screen.getByLabelText('Close settings'));
 
-    expect(mockPush).toHaveBeenCalledWith('/agents');
+    expect(mockPush).toHaveBeenCalledWith('/agents?namespace=demo');
   });
 
-  it('should navigate to home when close button is clicked on direct navigation', async () => {
+  it('should navigate to home preserving namespace when close button is clicked on direct navigation', async () => {
     const user = userEvent.setup();
     renderWithStore();
 
     await user.click(screen.getByLabelText('Close settings'));
 
-    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mockPush).toHaveBeenCalledWith('/?namespace=demo');
     expect(mockBack).not.toHaveBeenCalled();
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-namespaced-navigation.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-namespaced-navigation.test.tsx
@@ -3,9 +3,10 @@ import { useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  useRouter: vi.fn(() => ({ push: mockPush })),
+  useRouter: vi.fn(() => ({ push: mockPush, replace: mockReplace })),
   useSearchParams: vi.fn(() => new URLSearchParams('namespace=test-ns')),
 }));
 
@@ -19,63 +20,113 @@ describe('useNamespacedNavigation', () => {
     );
   });
 
-  it('appends existing query params when pushing a path', () => {
-    const { result } = renderHook(() => useNamespacedNavigation());
+  describe('push', () => {
+    it('appends existing query params when pushing a path', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-    result.current.push('/agents');
+      result.current.push('/agents');
 
-    expect(mockPush).toHaveBeenCalledWith('/agents?namespace=test-ns');
-  });
+      expect(mockPush).toHaveBeenCalledWith('/agents?namespace=test-ns');
+    });
 
-  it('merges path query params with existing search params', () => {
-    const { result } = renderHook(() => useNamespacedNavigation());
+    it('merges path query params with existing search params', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-    result.current.push('/query/new?target_tool=mytool');
+      result.current.push('/query/new?target_tool=mytool');
 
-    expect(mockPush).toHaveBeenCalledWith(
-      '/query/new?namespace=test-ns&target_tool=mytool',
-    );
-  });
+      expect(mockPush).toHaveBeenCalledWith(
+        '/query/new?namespace=test-ns&target_tool=mytool',
+      );
+    });
 
-  it('preserves multiple existing query params', () => {
-    vi.mocked(useSearchParams).mockReturnValue(
-      new URLSearchParams('namespace=test-ns&filter=active') as any,
-    );
+    it('preserves multiple existing query params', () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('namespace=test-ns&filter=active') as any,
+      );
 
-    const { result } = renderHook(() => useNamespacedNavigation());
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-    result.current.push('/agents');
+      result.current.push('/agents');
 
-    expect(mockPush).toHaveBeenCalledWith(
-      '/agents?namespace=test-ns&filter=active',
-    );
-  });
+      expect(mockPush).toHaveBeenCalledWith(
+        '/agents?namespace=test-ns&filter=active',
+      );
+    });
 
-  it('passes router options through', () => {
-    const { result } = renderHook(() => useNamespacedNavigation());
+    it('passes router options through', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-    result.current.push('/agents', { scroll: false });
+      result.current.push('/agents', { scroll: false });
 
-    expect(mockPush).toHaveBeenCalledWith('/agents?namespace=test-ns', {
-      scroll: false,
+      expect(mockPush).toHaveBeenCalledWith('/agents?namespace=test-ns', {
+        scroll: false,
+      });
+    });
+
+    it('handles null searchParams gracefully', () => {
+      vi.mocked(useSearchParams).mockReturnValue(null as any);
+
+      const { result } = renderHook(() => useNamespacedNavigation());
+
+      result.current.push('/agents');
+
+      expect(mockPush).toHaveBeenCalledWith('/agents');
+    });
+
+    it('does not duplicate params already in the path', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
+
+      result.current.push('/agents?namespace=other-ns');
+
+      expect(mockPush).toHaveBeenCalledWith('/agents?namespace=other-ns');
     });
   });
 
-  it('handles null searchParams gracefully', () => {
-    vi.mocked(useSearchParams).mockReturnValue(null as any);
+  describe('replace', () => {
+    it('appends existing query params when replacing a path', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-    const { result } = renderHook(() => useNamespacedNavigation());
+      result.current.replace('/settings/memory');
 
-    result.current.push('/agents');
+      expect(mockReplace).toHaveBeenCalledWith('/settings/memory?namespace=test-ns');
+    });
 
-    expect(mockPush).toHaveBeenCalledWith('/agents');
-  });
+    it('merges path query params with existing search params', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
 
-  it('does not duplicate params already in the path', () => {
-    const { result } = renderHook(() => useNamespacedNavigation());
+      result.current.replace('/settings/memory?tab=general');
 
-    result.current.push('/agents?namespace=other-ns');
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/settings/memory?namespace=test-ns&tab=general',
+      );
+    });
 
-    expect(mockPush).toHaveBeenCalledWith('/agents?namespace=other-ns');
+    it('passes router options through', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
+
+      result.current.replace('/settings/memory', { scroll: false });
+
+      expect(mockReplace).toHaveBeenCalledWith('/settings/memory?namespace=test-ns', {
+        scroll: false,
+      });
+    });
+
+    it('handles null searchParams gracefully', () => {
+      vi.mocked(useSearchParams).mockReturnValue(null as any);
+
+      const { result } = renderHook(() => useNamespacedNavigation());
+
+      result.current.replace('/settings/memory');
+
+      expect(mockReplace).toHaveBeenCalledWith('/settings/memory');
+    });
+
+    it('does not duplicate params already in the path', () => {
+      const { result } = renderHook(() => useNamespacedNavigation());
+
+      result.current.replace('/settings/memory?namespace=other-ns');
+
+      expect(mockReplace).toHaveBeenCalledWith('/settings/memory?namespace=other-ns');
+    });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { SettingsContent } from '@/components/settings/settings-content';
 import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 import { type SettingPage, settingsSections } from '@/components/settings/settings-types';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 
 const DEFAULT_SETTINGS_PAGE: SettingPage = 'a2a-servers';
 
@@ -15,7 +16,7 @@ const VALID_SETTINGS_PAGES: SettingPage[] = settingsSections.flatMap(s =>
 
 export default function SettingsPage() {
   const params = useParams();
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
 
   const pageSegments = params.page as string[] | undefined;
   const pageKey = pageSegments?.[0] as SettingPage | undefined;
@@ -25,9 +26,9 @@ export default function SettingsPage() {
 
   useEffect(() => {
     if (!isValidPage) {
-      router.replace(`/settings/${DEFAULT_SETTINGS_PAGE}`);
+      push(`/settings/${DEFAULT_SETTINGS_PAGE}`);
     }
-  }, [isValidPage, router]);
+  }, [isValidPage, push]);
 
   return (
     <div className="bg-sidebar flex h-full w-full overflow-hidden">

--- a/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(settings)/settings/[[...page]]/page.tsx
@@ -16,7 +16,7 @@ const VALID_SETTINGS_PAGES: SettingPage[] = settingsSections.flatMap(s =>
 
 export default function SettingsPage() {
   const params = useParams();
-  const { push } = useNamespacedNavigation();
+  const { replace } = useNamespacedNavigation();
 
   const pageSegments = params.page as string[] | undefined;
   const pageKey = pageSegments?.[0] as SettingPage | undefined;
@@ -26,9 +26,9 @@ export default function SettingsPage() {
 
   useEffect(() => {
     if (!isValidPage) {
-      push(`/settings/${DEFAULT_SETTINGS_PAGE}`);
+      replace(`/settings/${DEFAULT_SETTINGS_PAGE}`);
     }
-  }, [isValidPage, push]);
+  }, [isValidPage, replace]);
 
   return (
     <div className="bg-sidebar flex h-full w-full overflow-hidden">

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-keyboard-shortcut.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-keyboard-shortcut.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 
 const SETTINGS_KEYBOARD_SHORTCUT = 'e';
 
 export function SettingsKeyboardShortcut() {
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
   const pathname = usePathname();
   const settingsEntryUrl = useAtomValue(settingsEntryUrlAtom);
 
@@ -21,16 +22,16 @@ export function SettingsKeyboardShortcut() {
       ) {
         event.preventDefault();
         if (pathname.startsWith('/settings')) {
-          router.push(settingsEntryUrl ?? '/');
+          push(settingsEntryUrl ?? '/');
         } else {
-          router.push('/settings');
+          push('/settings');
         }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [router, pathname, settingsEntryUrl]);
+  }, [push, pathname, settingsEntryUrl]);
 
   return null;
 }

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
@@ -2,10 +2,10 @@
 
 import { useAtomValue } from 'jotai';
 import { X } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 
 import { isMarketplaceEnabledAtom } from '@/atoms/experimental-features';
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
+import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 import { cn } from '@/lib/utils';
 
 import { MANAGE_MARKETPLACE_KEY, type SettingPage, settingsSections } from './settings-types';
@@ -15,16 +15,18 @@ type SettingsSidebarProps = {
 };
 
 export function SettingsSidebar({ activePage }: SettingsSidebarProps) {
-  const router = useRouter();
+  const { push } = useNamespacedNavigation();
   const isMarketplaceEnabled = useAtomValue(isMarketplaceEnabledAtom);
   const settingsEntryUrl = useAtomValue(settingsEntryUrlAtom);
 
   const handleSettingClick = (settingKey: SettingPage) => {
-    router.replace(`/settings/${settingKey}`);
+    push(`/settings/${settingKey}`);
   };
 
+  // settingsEntryUrl is captured from the in-app location the user came from,
+  // so it may already carry a namespace query; push merges params and won't double it.
   const handleClose = () => {
-    router.push(settingsEntryUrl ?? '/');
+    push(settingsEntryUrl ?? '/');
   };
 
   return (

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
@@ -15,12 +15,12 @@ type SettingsSidebarProps = {
 };
 
 export function SettingsSidebar({ activePage }: SettingsSidebarProps) {
-  const { push } = useNamespacedNavigation();
+  const { push, replace } = useNamespacedNavigation();
   const isMarketplaceEnabled = useAtomValue(isMarketplaceEnabledAtom);
   const settingsEntryUrl = useAtomValue(settingsEntryUrlAtom);
 
   const handleSettingClick = (settingKey: SettingPage) => {
-    push(`/settings/${settingKey}`);
+    replace(`/settings/${settingKey}`);
   };
 
   // settingsEntryUrl is captured from the in-app location the user came from,

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-namespaced-navigation.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-namespaced-navigation.ts
@@ -5,25 +5,28 @@ import { useCallback } from 'react';
 
 type NavigationOptions = Parameters<ReturnType<typeof useRouter>['push']>[1];
 
+function buildFullPath(path: string, searchParams: URLSearchParams | null): string {
+  const [pathname, pathQuery] = path.split('?');
+  const merged = new URLSearchParams(searchParams?.toString() ?? '');
+
+  if (pathQuery) {
+    const pathParams = new URLSearchParams(pathQuery);
+    for (const [key, value] of pathParams) {
+      merged.set(key, value);
+    }
+  }
+
+  const queryString = merged.toString();
+  return queryString ? `${pathname}?${queryString}` : pathname;
+}
+
 export function useNamespacedNavigation() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const push = useCallback(
     (path: string, options?: NavigationOptions) => {
-      const [pathname, pathQuery] = path.split('?');
-      const merged = new URLSearchParams(searchParams?.toString() ?? '');
-
-      if (pathQuery) {
-        const pathParams = new URLSearchParams(pathQuery);
-        for (const [key, value] of pathParams) {
-          merged.set(key, value);
-        }
-      }
-
-      const queryString = merged.toString();
-      const fullPath = queryString ? `${pathname}?${queryString}` : pathname;
-
+      const fullPath = buildFullPath(path, searchParams);
       if (options) {
         router.push(fullPath, options);
       } else {
@@ -33,5 +36,17 @@ export function useNamespacedNavigation() {
     [router, searchParams],
   );
 
-  return { push };
+  const replace = useCallback(
+    (path: string, options?: NavigationOptions) => {
+      const fullPath = buildFullPath(path, searchParams);
+      if (options) {
+        router.replace(fullPath, options);
+      } else {
+        router.replace(fullPath);
+      }
+    },
+    [router, searchParams],
+  );
+
+  return { push, replace };
 }


### PR DESCRIPTION
## Summary
- Route settings navigation (sidebar, default-page redirect, Cmd/Ctrl+E shortcut) through `useNamespacedNavigation` instead of raw `next/navigation` router, so the active `?namespace=` query param is preserved.
- Previously the namespace was dropped on entering/navigating settings, silently falling back to the `default` namespace where the user has no RBAC, producing 403s.
- Updates the related unit tests to assert namespace preservation.

Re-originated from an upstream branch on current main (so Sonar runs) and rebased onto current main. Supersedes #2482.