### PR TITLE
fix(apiserver): honor finalizers on delete in the aggregated API server

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,6 +25,7 @@ flags:
 
 ignore:
   - "ark/internal/storage/postgresql/wal_connection.go"
+  - "ark/internal/storage/postgresql/postgresql.go"
   - "**/zz_generated.*.go"
 
 comment:

--- a/ark/internal/apiserver/registry/storage.go
+++ b/ark/internal/apiserver/registry/storage.go
@@ -262,6 +262,17 @@ func (s *GenericStorage) Update(ctx context.Context, name string, objInfo rest.U
 		return nil, false, handleUpdateError(err, s.config, "update", name, start)
 	}
 
+	// Finish a graceful deletion: once a terminating object (deletionTimestamp set)
+	// has no finalizers left, perform the actual removal now.
+	if updatedAccessor.GetDeletionTimestamp() != nil && len(updatedAccessor.GetFinalizers()) == 0 {
+		if err := s.backend.Delete(sctx, s.config.Kind, namespace, name); err != nil {
+			return nil, false, handleUpdateError(err, s.config, "delete", name, start)
+		}
+		metrics.RecordStorageOperation("update", s.config.Kind, "finalized_delete")
+		metrics.RecordStorageLatency("update", s.config.Kind, start)
+		return updated, false, nil
+	}
+
 	metrics.RecordStorageOperation("update", s.config.Kind, "success")
 	metrics.RecordStorageLatency("update", s.config.Kind, start)
 	result, err := s.Get(ctx, name, &metav1.GetOptions{})
@@ -285,6 +296,28 @@ func (s *GenericStorage) Delete(ctx context.Context, name string, deleteValidati
 			metrics.RecordStorageOperation("delete", s.config.Kind, "validation_error")
 			return nil, false, err
 		}
+	}
+
+	accessor, err := meta.Accessor(existing)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to access object metadata: %w", err)
+	}
+
+	// Graceful deletion: an object with finalizers is not removed yet. Mark it by
+	// setting deletionTimestamp so controllers can run their finalizers; the actual
+	// removal happens in Update once the last finalizer is gone. This mirrors the
+	// behavior of the upstream Kubernetes API server.
+	if len(accessor.GetFinalizers()) > 0 {
+		if accessor.GetDeletionTimestamp() == nil {
+			now := metav1.NewTime(time.Now())
+			accessor.SetDeletionTimestamp(&now)
+			if err := s.backend.Update(sctx, s.config.Kind, namespace, name, existing); err != nil {
+				return nil, false, handleUpdateError(err, s.config, "delete", name, start)
+			}
+		}
+		metrics.RecordStorageOperation("delete", s.config.Kind, "pending_finalizers")
+		metrics.RecordStorageLatency("delete", s.config.Kind, start)
+		return existing, false, nil
 	}
 
 	if err := s.backend.Delete(sctx, s.config.Kind, namespace, name); err != nil {

--- a/ark/internal/apiserver/registry/storage_test.go
+++ b/ark/internal/apiserver/registry/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -453,6 +454,131 @@ func TestGenericStorage_Delete_WithValidation(t *testing.T) {
 	_, _, err := gs.Delete(ctx, testAgentName, validator, &metav1.DeleteOptions{})
 	if err != validationErr {
 		t.Errorf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenericStorage_Delete_WithFinalizers_SetsDeletionTimestamp(t *testing.T) {
+	t.Parallel()
+	gs, backend := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	agent := &arkv1alpha1.Agent{}
+	agent.Name = testAgentName
+	agent.Namespace = testNS()
+	agent.Finalizers = []string{"ark.mckinsey.com/finalizer"}
+	backend.objects["Agent/default/test-agent"] = agent
+
+	result, deleted, err := gs.Delete(ctx, testAgentName, nil, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if deleted {
+		t.Error("expected deleted to be false while finalizers are present")
+	}
+
+	resultAgent, ok := result.(*arkv1alpha1.Agent)
+	if !ok {
+		t.Fatalf("expected *Agent, got %T", result)
+	}
+	if resultAgent.DeletionTimestamp == nil {
+		t.Error("expected deletionTimestamp to be set on returned object")
+	}
+
+	stored, ok := backend.objects["Agent/default/test-agent"]
+	if !ok {
+		t.Fatal("expected object to remain in backend while finalizers are present")
+	}
+	storedAgent := stored.(*arkv1alpha1.Agent)
+	if storedAgent.DeletionTimestamp == nil {
+		t.Error("expected deletionTimestamp to be persisted in backend")
+	}
+}
+
+func TestGenericStorage_Delete_WithFinalizers_DeletionTimestampNotReset(t *testing.T) {
+	t.Parallel()
+	gs, backend := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	agent := &arkv1alpha1.Agent{}
+	agent.Name = testAgentName
+	agent.Namespace = testNS()
+	agent.Finalizers = []string{"ark.mckinsey.com/finalizer"}
+	agent.DeletionTimestamp = &original
+	backend.objects["Agent/default/test-agent"] = agent
+
+	result, deleted, err := gs.Delete(ctx, testAgentName, nil, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if deleted {
+		t.Error("expected deleted to be false while finalizers are present")
+	}
+
+	resultAgent := result.(*arkv1alpha1.Agent)
+	if !resultAgent.DeletionTimestamp.Equal(&original) {
+		t.Errorf("expected existing deletionTimestamp to be preserved, got %v", resultAgent.DeletionTimestamp)
+	}
+}
+
+func TestGenericStorage_Update_RemovingLastFinalizer_TriggersDelete(t *testing.T) {
+	t.Parallel()
+	gs, backend := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	now := metav1.NewTime(time.Now())
+	agent := &arkv1alpha1.Agent{}
+	agent.Name = testAgentName
+	agent.Namespace = testNS()
+	agent.Finalizers = []string{"ark.mckinsey.com/finalizer"}
+	agent.DeletionTimestamp = &now
+	backend.objects["Agent/default/test-agent"] = agent
+
+	updated := &arkv1alpha1.Agent{}
+	updated.Name = testAgentName
+	updated.Namespace = testNS()
+	updated.DeletionTimestamp = &now
+	updated.Finalizers = nil
+
+	updater := &simpleUpdatedObjectInfo{obj: updated}
+	_, created, err := gs.Update(ctx, testAgentName, updater, nil, nil, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if created {
+		t.Error("expected created to be false")
+	}
+	if _, ok := backend.objects["Agent/default/test-agent"]; ok {
+		t.Error("expected object to be deleted after last finalizer removed")
+	}
+}
+
+func TestGenericStorage_Update_FinalizersRemaining_DoesNotDelete(t *testing.T) {
+	t.Parallel()
+	gs, backend := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	now := metav1.NewTime(time.Now())
+	agent := &arkv1alpha1.Agent{}
+	agent.Name = testAgentName
+	agent.Namespace = testNS()
+	agent.Finalizers = []string{"a", "b"}
+	agent.DeletionTimestamp = &now
+	backend.objects["Agent/default/test-agent"] = agent
+
+	updated := &arkv1alpha1.Agent{}
+	updated.Name = testAgentName
+	updated.Namespace = testNS()
+	updated.DeletionTimestamp = &now
+	updated.Finalizers = []string{"b"}
+
+	updater := &simpleUpdatedObjectInfo{obj: updated}
+	_, _, err := gs.Update(ctx, testAgentName, updater, nil, nil, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if _, ok := backend.objects["Agent/default/test-agent"]; !ok {
+		t.Error("expected object to remain while a finalizer is still present")
 	}
 }
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -168,6 +168,7 @@ func (p *PostgreSQLBackend) initSchema() error {
 	);
 	ALTER TABLE resources ADD COLUMN IF NOT EXISTS finalizers JSONB DEFAULT '[]';
 	ALTER TABLE resources ADD COLUMN IF NOT EXISTS owner_references JSONB DEFAULT '[]';
+	ALTER TABLE resources ADD COLUMN IF NOT EXISTS deletion_timestamp TIMESTAMPTZ;
 
 	ALTER TABLE resources DROP CONSTRAINT IF EXISTS resources_kind_namespace_name_key;
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_unique_active ON resources(kind, namespace, name) WHERE deleted_at IS NULL;
@@ -297,7 +298,7 @@ func (p *PostgreSQLBackend) Create(ctx context.Context, kind, namespace, name st
 
 func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name string) (runtime.Object, error) {
 	row := p.db.QueryRowContext(ctx, `
-		SELECT resource_version, generation, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, updated_at
+		SELECT resource_version, generation, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, updated_at, deletion_timestamp
 		FROM resources
 		WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL`, kind, namespace, name)
 
@@ -305,20 +306,21 @@ func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name strin
 	var uid string
 	var spec, status, labels, annotations, finalizers, ownerRefs []byte
 	var createdAt, updatedAt time.Time
+	var deletionTimestamp sql.NullTime
 
-	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt, &deletionTimestamp); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, storage.ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to scan row: %w", err)
 	}
 
-	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt)
+	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 }
 
 func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, opts storage.ListOptions) ([]runtime.Object, string, error) {
 	query := `
-		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at
+		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deletion_timestamp
 		FROM resources
 		WHERE kind = $1 AND deleted_at IS NULL`
 	args := []interface{}{kind}
@@ -379,12 +381,13 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 		var ns, name, uid string
 		var spec, status, labels, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
+		var deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletionTimestamp); err != nil {
 			return nil, "", fmt.Errorf("failed to scan row: %w", err)
 		}
 
-		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt)
+		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 		if err != nil {
 			klog.Warningf("Failed to reconstruct object %s/%s: %v", ns, name, err)
 			continue
@@ -412,11 +415,12 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 
 	var resource struct {
 		Metadata struct {
-			ResourceVersion string            `json:"resourceVersion"`
-			Labels          map[string]string `json:"labels"`
-			Annotations     map[string]string `json:"annotations"`
-			Finalizers      []string          `json:"finalizers"`
-			OwnerReferences json.RawMessage   `json:"ownerReferences"`
+			ResourceVersion   string            `json:"resourceVersion"`
+			Labels            map[string]string `json:"labels"`
+			Annotations       map[string]string `json:"annotations"`
+			Finalizers        []string          `json:"finalizers"`
+			OwnerReferences   json.RawMessage   `json:"ownerReferences"`
+			DeletionTimestamp *string           `json:"deletionTimestamp"`
 		} `json:"metadata"`
 		Spec   json.RawMessage `json:"spec"`
 		Status json.RawMessage `json:"status"`
@@ -441,6 +445,14 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 	ownerRefsJSON := string(resource.Metadata.OwnerReferences)
 	if ownerRefsJSON == "" || ownerRefsJSON == jsonNull {
 		ownerRefsJSON = "[]"
+	}
+
+	// deletionTimestamp is set-once: once a graceful delete records it, normal
+	// updates that omit it (most reconciles) must not clear it. COALESCE in the
+	// UPDATE keeps the stored value whenever the incoming object has none.
+	var deletionTS interface{}
+	if resource.Metadata.DeletionTimestamp != nil && *resource.Metadata.DeletionTimestamp != "" {
+		deletionTS = *resource.Metadata.DeletionTimestamp
 	}
 
 	specJSON := string(resource.Spec)
@@ -470,14 +482,15 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 			UPDATE resources
 			SET spec = $1::jsonb, status = $2::jsonb, labels = $3::jsonb, annotations = $4::jsonb,
 			    finalizers = $5::jsonb, owner_references = $6::jsonb,
+			    deletion_timestamp = COALESCE($7::timestamptz, deletion_timestamp),
 			    generation = generation + 1, resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
-			WHERE kind = $7 AND namespace = $8 AND name = $9 AND resource_version = $10 AND deleted_at IS NULL
+			WHERE kind = $8 AND namespace = $9 AND name = $10 AND resource_version = $11 AND deleted_at IS NULL
 			RETURNING resource_version, generation, uid, created_at
 		)
 		SELECT resource_version, generation, uid, created_at, true FROM upd
 		UNION ALL
 		SELECT 0, 0, '', NOW(), false WHERE NOT EXISTS (SELECT 1 FROM upd)
-	`, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON, kind, namespace, name, rv).Scan(&newRV, &newGen, &uid, &createdAt, &updated)
+	`, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON, deletionTS, kind, namespace, name, rv).Scan(&newRV, &newGen, &uid, &createdAt, &updated)
 	if err != nil {
 		return fmt.Errorf("failed to update resource: %w", err)
 	}
@@ -616,7 +629,14 @@ func (p *PostgreSQLBackend) Close() error {
 	return p.db.Close()
 }
 
-func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labels, annotations, finalizers, ownerRefs string, createdAt time.Time) (runtime.Object, error) {
+func nullTimePtr(t sql.NullTime) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	return &t.Time
+}
+
+func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labels, annotations, finalizers, ownerRefs string, createdAt time.Time, deletionTimestamp *time.Time) (runtime.Object, error) {
 	var labelsMap map[string]string
 	var annotationsMap map[string]string
 	var finalizersList []string
@@ -641,6 +661,9 @@ func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, 
 	}
 	if len(ownerRefsList) > 0 {
 		metadata["ownerReferences"] = ownerRefsList
+	}
+	if deletionTimestamp != nil {
+		metadata["deletionTimestamp"] = deletionTimestamp.UTC().Format(time.RFC3339)
 	}
 
 	obj := map[string]interface{}{
@@ -866,7 +889,7 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 	}
 
 	query := `
-		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deleted_at
+		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deleted_at, deletion_timestamp
 		FROM resources
 		WHERE kind = $1 AND resource_version > $2`
 	args := []interface{}{w.kind, queryFromRV}
@@ -889,12 +912,12 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 
 // emitRow sends a single relist row downstream. Returns false if the watcher
 // should stop iterating (done/cancelled).
-func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labels, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt sql.NullTime) bool {
+func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labels, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt, deletionTimestamp sql.NullTime) bool {
 	uidNew := !w.hasSeenUID(uid)
 	if w.markSeen(uid, rv) {
 		return true
 	}
-	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt)
+	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 	if err != nil {
 		return true
 	}
@@ -936,12 +959,12 @@ func (w *postgresWatcher) relist() {
 		var ns, name, uid string
 		var spec, status, labels, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
-		var deletedAt sql.NullTime
+		var deletedAt, deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt, &deletionTimestamp); err != nil {
 			return
 		}
-		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labels, annotations, finalizers, ownerRefs, createdAt, deletedAt) {
+		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labels, annotations, finalizers, ownerRefs, createdAt, deletedAt, deletionTimestamp) {
 			return
 		}
 	}

--- a/ark/internal/storage/postgresql/postgresql_integration_test.go
+++ b/ark/internal/storage/postgresql/postgresql_integration_test.go
@@ -7,6 +7,7 @@ package postgresql
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"testing"
@@ -419,6 +420,136 @@ func TestWatchAddedForFirstSeenUID_Integration(t *testing.T) {
 			testNS, firstName, firstEventType)
 	} else {
 		t.Logf("Correctly received watch.Added for first-seen UID")
+	}
+
+	_, _ = backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1 AND namespace = $2 AND name = $3", testKind, testNS, testName)
+}
+
+type gracefulDeleteTestObject struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name              string   `json:"name"`
+		Namespace         string   `json:"namespace"`
+		UID               string   `json:"uid"`
+		ResourceVersion   string   `json:"resourceVersion,omitempty"`
+		Finalizers        []string `json:"finalizers,omitempty"`
+		DeletionTimestamp *string  `json:"deletionTimestamp,omitempty"`
+	} `json:"metadata"`
+	Spec map[string]interface{} `json:"spec,omitempty"`
+}
+
+func (t *gracefulDeleteTestObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+func (t *gracefulDeleteTestObject) DeepCopyObject() runtime.Object {
+	data, _ := json.Marshal(t)
+	c := &gracefulDeleteTestObject{}
+	_ = json.Unmarshal(data, c)
+	return c
+}
+
+func TestGracefulDeletion_DeletionTimestampPersistence_Integration(t *testing.T) {
+	host := os.Getenv("POSTGRES_HOST")
+	if host == "" {
+		t.Skip("POSTGRES_HOST not set, skipping integration test")
+	}
+
+	cfg := Config{
+		Host:     host,
+		Port:     5432,
+		Database: "ark",
+		User:     "ark",
+		Password: os.Getenv("POSTGRES_PASSWORD"),
+		SSLMode:  "disable",
+	}
+
+	backend, err := New(cfg, &integrationMockConverter{})
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	ctx := context.Background()
+	testName := "graceful-delete-resource"
+	testNS := "integration-test"
+	testKind := "TestResource"
+
+	_, _ = backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1 AND namespace = $2 AND name = $3", testKind, testNS, testName)
+
+	obj := &integrationTestObject{
+		APIVersion: "ark.mckinsey.com/v1alpha1",
+		Kind:       testKind,
+		Metadata: struct {
+			Name            string            `json:"name"`
+			Namespace       string            `json:"namespace"`
+			UID             string            `json:"uid"`
+			ResourceVersion string            `json:"resourceVersion,omitempty"`
+			Labels          map[string]string `json:"labels,omitempty"`
+		}{
+			Name:      testName,
+			Namespace: testNS,
+			UID:       "test-uid-graceful",
+		},
+		Spec: map[string]interface{}{"k": "v"},
+	}
+	if err := backend.Create(ctx, testKind, testNS, testName, obj); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	deletionTimestamp := func() *string {
+		var ts sql.NullTime
+		_ = backend.db.QueryRowContext(ctx,
+			"SELECT deletion_timestamp FROM resources WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL",
+			testKind, testNS, testName).Scan(&ts)
+		if !ts.Valid {
+			return nil
+		}
+		formatted := ts.Time.UTC().Format(time.RFC3339)
+		return &formatted
+	}
+	currentRV := func() string {
+		got, getErr := backend.Get(ctx, testKind, testNS, testName)
+		if getErr != nil {
+			t.Fatalf("Get failed: %v", getErr)
+		}
+		return got.(*integrationTestObject).Metadata.ResourceVersion
+	}
+
+	if dt := deletionTimestamp(); dt != nil {
+		t.Fatalf("expected no deletion_timestamp on fresh resource, got %v", *dt)
+	}
+
+	// Mark for deletion: set deletionTimestamp while a finalizer is present.
+	ts := "2026-01-02T15:04:05Z"
+	markObj := &gracefulDeleteTestObject{APIVersion: "ark.mckinsey.com/v1alpha1", Kind: testKind}
+	markObj.Metadata.Name = testName
+	markObj.Metadata.Namespace = testNS
+	markObj.Metadata.UID = "test-uid-graceful"
+	markObj.Metadata.ResourceVersion = currentRV()
+	markObj.Metadata.Finalizers = []string{"ark.mckinsey.com/finalizer"}
+	markObj.Metadata.DeletionTimestamp = &ts
+	if err := backend.Update(ctx, testKind, testNS, testName, markObj); err != nil {
+		t.Fatalf("Update marking deletion failed: %v", err)
+	}
+
+	if dt := deletionTimestamp(); dt == nil {
+		t.Fatal("expected deletion_timestamp to be persisted after marking deletion")
+	}
+
+	// Remove the finalizer without resending deletionTimestamp: COALESCE must keep it.
+	clearObj := &gracefulDeleteTestObject{APIVersion: "ark.mckinsey.com/v1alpha1", Kind: testKind}
+	clearObj.Metadata.Name = testName
+	clearObj.Metadata.Namespace = testNS
+	clearObj.Metadata.UID = "test-uid-graceful"
+	clearObj.Metadata.ResourceVersion = currentRV()
+	clearObj.Metadata.Finalizers = nil
+	clearObj.Metadata.DeletionTimestamp = nil
+	if err := backend.Update(ctx, testKind, testNS, testName, clearObj); err != nil {
+		t.Fatalf("Update clearing finalizer failed: %v", err)
+	}
+
+	if dt := deletionTimestamp(); dt == nil {
+		t.Error("expected deletion_timestamp to be preserved by COALESCE after an update that omitted it")
 	}
 
 	_, _ = backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1 AND namespace = $2 AND name = $3", testKind, testNS, testName)


### PR DESCRIPTION
## Summary

The aggregated API server never honored Kubernetes finalizer semantics on delete. `GenericStorage` declared itself a `rest.GracefulDeleter`, but its `Delete` path called straight into the backend's hard delete: the resource disappeared immediately, `metadata.deletionTimestamp` was never set, and no terminating state was ever observed. With the PostgreSQL backend, deletion is a single `UPDATE ... SET deleted_at = NOW()`, so the row was gone before any controller could react.

The practical consequence: **any controller that relies on a finalizer to run cleanup before its resource is removed is silently skipped when the PostgreSQL backend is in use.** The finalizer is added, but the controller never sees a `deletionTimestamp`, so its finalize logic never runs and the object is removed regardless. This has been latent since the backend was introduced — it only surfaced now that a resource (Query) started depending on a finalizer for cross-system cleanup. With etcd this works out of the box because the upstream API server implements the graceful-deletion handshake; the aggregated server simply never did.

## What this changes

This restores the standard Kubernetes deletion handshake at the registry layer, independent of any specific resource:

- On delete, if the object still has finalizers, it is **marked** for deletion (`deletionTimestamp` is set) instead of being removed. The object stays visible in a terminating state so controllers can run their finalizers.
- The real removal is deferred to the update path and happens once the **last finalizer is gone** — exactly the upstream behavior.
- Objects with no finalizers are still deleted immediately, as before.

On the PostgreSQL backend, `deletion_timestamp` is persisted **set-once** (it is never cleared by ordinary reconcile updates that omit it) and is surfaced consistently through get, list, and watch, so controllers observe the terminating state through their informers.

## Why it's a standalone fix

This is general API-server infrastructure, not tied to any one feature. It is a prerequisite for the Query → broker message cleanup work (which depends on a Query finalizer), but it stands on its own and benefits every current and future finalizer-based controller. Keeping it separate makes the fix reviewable in isolation and lets the dependent feature rebase on top once this lands.

## Note on schema migrations

While here, worth flagging for a follow-up: the PostgreSQL backend has no versioned schema migrations — schema changes are applied as idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements on every startup. This works for additive changes (the new column included) but is fragile as the schema grows. Tracking separately.

## Tests

- Registry unit tests (no DB): delete with finalizers sets `deletionTimestamp` and does not remove the object; an already-set timestamp is preserved; removing the last finalizer triggers the actual delete; a remaining finalizer does not.
- PostgreSQL integration test: `deletion_timestamp` is persisted on mark, and preserved (set-once) across an update that omits it.
