### PR TITLE
docs: move Core Concepts below Quickstart in top-level nav

### DIFF
--- a/docs/content/_meta.js
+++ b/docs/content/_meta.js
@@ -1,8 +1,8 @@
 export default {
   index: 'Introduction',
   quickstart: 'Quickstart',
-  'how-to-guides': 'How-to Guides',
   'core-concepts': 'Core Concepts',
+  'how-to-guides': 'How-to Guides',
   tutorials: 'Tutorials',
   reference: 'Reference',
   


### PR DESCRIPTION
## Summary
Reorder the top-level docs nav so **Core Concepts** sits directly below **Quickstart**.

New order: Introduction → Quickstart → Core Concepts → How-to Guides → Tutorials → Reference.

One-line change to `content/_meta.js`.