### PR TITLE
fix: Return 1 as exit code for service version-not-found

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.65",
+  "version": "0.1.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.65",
+      "version": "0.1.64",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -173,6 +173,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1823,7 +1846,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1844,7 +1866,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1903,7 +1924,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2108,7 +2128,6 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -2266,7 +2285,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3396,7 +3414,6 @@
       "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3693,7 +3710,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4197,7 +4213,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4306,7 +4321,6 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
       "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
@@ -4741,7 +4755,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5194,7 +5207,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5812,7 +5824,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5985,7 +5996,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6793,7 +6803,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6856,7 +6865,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6933,7 +6941,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7012,7 +7019,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -7233,7 +7239,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7279,7 +7284,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -7419,7 +7423,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -173,29 +173,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1846,6 +1823,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1866,6 +1844,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1924,6 +1903,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2128,6 +2108,7 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -2285,6 +2266,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3414,6 +3396,7 @@
       "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3710,6 +3693,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4213,6 +4197,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4321,6 +4306,7 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
       "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
@@ -4755,6 +4741,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5207,6 +5194,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5824,6 +5812,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5996,6 +5985,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6803,6 +6793,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6865,6 +6856,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6941,6 +6933,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7019,6 +7012,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -7239,6 +7233,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7284,6 +7279,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -7423,6 +7419,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -794,9 +794,6 @@ describe('install command', () => {
         command.parseAsync(['node', 'test', 'ark-completions', 'ark-api', '--ark-version', '0.1.50'])
       ).rejects.toThrow('process.exit called');
 
-      // The other service still installs best-effort, but the overall command
-      // fails with a single error (non-zero exit) naming the skipped service —
-      // no separate "skipping" warning.
       expect(mockOutput.success).toHaveBeenCalledWith('ark-api installed successfully');
       expect(mockOutput.warning).not.toHaveBeenCalled();
       expect(mockOutput.error).toHaveBeenCalledWith(
@@ -854,6 +851,55 @@ describe('install command', () => {
       expect(mockOutput.success).toHaveBeenCalledWith('ark-api installed successfully');
       expect(mockOutput.warning).not.toHaveBeenCalled();
       expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it('in -y mode, installs the rest then exits non-zero for the skipped version', async () => {
+      mockGetInstallableServices.mockReturnValue({
+        'ark-controller': {
+          name: 'ark-controller',
+          helmReleaseName: 'ark-controller',
+          chartPath: 'oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-controller:0.0.0-bad',
+          namespace: 'ark-system',
+          category: 'core',
+        },
+        'ark-completions': {
+          name: 'ark-completions',
+          helmReleaseName: 'ark-completions',
+          chartPath: 'oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-completions:0.0.0-bad',
+          namespace: 'ark-system',
+          category: 'core',
+        },
+      });
+
+      mockExeca
+        .mockResolvedValueOnce({stdout: '', stderr: ''})
+        .mockResolvedValueOnce({stdout: '', stderr: ''})
+        .mockResolvedValueOnce({stdout: '', stderr: ''})
+        .mockRejectedValueOnce({
+          stderr:
+            'Error: failed to perform "FetchReference" on source: ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-completions:0.0.0-bad: not found',
+          message: 'Command failed',
+        });
+
+      const command = createInstallCommand(mockConfig);
+      await expect(
+        command.parseAsync(['node', 'test', '-y', '--ark-version', '0.0.0-bad'])
+      ).rejects.toThrow('process.exit called');
+
+      const helmUpgradeCalls = mockExeca.mock.calls.filter(
+        (call: any) => call[0] === 'helm' && call[1][0] === 'upgrade'
+      );
+      expect(
+        helmUpgradeCalls.some((call: any) =>
+          call[1].some((arg: any) => String(arg).includes('ark-controller'))
+        )
+      ).toBe(true);
+
+      expect(mockOutput.warning).not.toHaveBeenCalled();
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        'installation incomplete: 1 service(s) skipped because the requested version was not found: ark-completions@0.0.0-bad'
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
 
     it('fails on other helm errors (not version-not-found)', async () => {

--- a/tools/ark-cli/src/commands/install/index.spec.ts
+++ b/tools/ark-cli/src/commands/install/index.spec.ts
@@ -790,10 +790,19 @@ describe('install command', () => {
         .mockResolvedValueOnce({stdout: '', stderr: ''});
 
       const command = createInstallCommand(mockConfig);
-      await command.parseAsync(['node', 'test', 'ark-completions', 'ark-api', '--ark-version', '0.1.50']);
+      await expect(
+        command.parseAsync(['node', 'test', 'ark-completions', 'ark-api', '--ark-version', '0.1.50'])
+      ).rejects.toThrow('process.exit called');
 
-      expect(mockOutput.warning).toHaveBeenCalledWith('ark-completions version 0.1.50 not found, skipping...');
+      // The other service still installs best-effort, but the overall command
+      // fails with a single error (non-zero exit) naming the skipped service —
+      // no separate "skipping" warning.
       expect(mockOutput.success).toHaveBeenCalledWith('ark-api installed successfully');
+      expect(mockOutput.warning).not.toHaveBeenCalled();
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        'installation incomplete: 1 service(s) skipped because the requested version was not found: ark-completions@0.1.50'
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
 
     it('shows warning and continues when marketplace version not found', async () => {
@@ -814,9 +823,37 @@ describe('install command', () => {
         });
 
       const command = createInstallCommand(mockConfig);
-      await command.parseAsync(['node', 'test', 'marketplace/services/phoenix', '--marketplace-version', '99.99.99']);
+      await expect(
+        command.parseAsync(['node', 'test', 'marketplace/services/phoenix', '--marketplace-version', '99.99.99'])
+      ).rejects.toThrow('process.exit called');
 
-      expect(mockOutput.warning).toHaveBeenCalledWith('phoenix version 99.99.99 not found, skipping...');
+      expect(mockOutput.warning).not.toHaveBeenCalled();
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        'installation incomplete: 1 service(s) skipped because the requested version was not found: phoenix@99.99.99'
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('exits successfully when all requested versions exist', async () => {
+      mockGetInstallableServices.mockReturnValue({
+        'ark-api': {
+          name: 'ark-api',
+          helmReleaseName: 'ark-api',
+          chartPath: 'oci://ghcr.io/mckinsey/agents-at-scale-ark/charts/ark-api:0.1.57',
+          namespace: 'ark-system',
+        },
+      });
+
+      mockExeca.mockResolvedValue({stdout: '', stderr: ''});
+
+      const command = createInstallCommand(mockConfig);
+      await expect(
+        command.parseAsync(['node', 'test', 'ark-api', '--ark-version', '0.1.57'])
+      ).resolves.not.toThrow();
+
+      expect(mockOutput.success).toHaveBeenCalledWith('ark-api installed successfully');
+      expect(mockOutput.warning).not.toHaveBeenCalled();
+      expect(mockExit).not.toHaveBeenCalled();
     });
 
     it('fails on other helm errors (not version-not-found)', async () => {

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -85,8 +85,6 @@ function isValidVersion(version: string): boolean {
   return /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version);
 }
 
-// Returns the requested version that helm reported as not found, or null if the
-// error is something else. Lets callers report which service@version was missing.
 function notFoundVersion(
   error: unknown,
   options: {
@@ -115,10 +113,6 @@ function notFoundVersion(
   return null;
 }
 
-// On a version-not-found error, returns a "service@version" descriptor for the
-// caller to record (reported as a single aggregate error at the end). For any
-// other error it fails fast with a non-zero exit. Returns false when there is no
-// error to handle.
 function handleInstallError(
   error: unknown,
   service: ArkService,
@@ -129,7 +123,7 @@ function handleInstallError(
 ): string | false {
   const version = notFoundVersion(error, options);
   if (version !== null) {
-    return `${service.name}@${version}`; // should continue to next service
+    return version; // should continue to next service
   }
 
   // Other errors still fail
@@ -138,10 +132,11 @@ function handleInstallError(
   process.exit(1);
 }
 
-function exitIfServicesSkipped(skipped: string[]): void {
+function exitIfServicesSkipped(skipped: {name: string; version: string}[]): void {
   if (skipped.length === 0) return;
+  const detail = skipped.map((s) => `${s.name}@${s.version}`).join(', ');
   output.error(
-    `installation incomplete: ${skipped.length} service(s) skipped because the requested version was not found: ${skipped.join(', ')}`
+    `installation incomplete: ${skipped.length} service(s) skipped because the requested version was not found: ${detail}`
   );
   process.exit(1);
 }
@@ -310,8 +305,7 @@ export async function installArk(
   }
   const backend: Backend = requestedBackend;
 
-  // Track services skipped due to a not-found version so we can fail at the end
-  const skippedServices: string[] = [];
+  const skippedServices: {name: string; version: string}[] = [];
 
   let postgresValues: PostgresStorageConfig | undefined;
   if (backend === 'postgresql') {
@@ -370,9 +364,9 @@ export async function installArk(
           );
           output.success(`${service.name} installed successfully`);
         } catch (error) {
-          const skipped = handleInstallError(error, service, options);
-          if (skipped) {
-            skippedServices.push(skipped);
+          const skippedVersion = handleInstallError(error, service, options);
+          if (skippedVersion) {
+            skippedServices.push({name: service.name, version: skippedVersion});
             continue;
           }
         }
@@ -421,9 +415,9 @@ export async function installArk(
           }
         }
       } catch (error) {
-        const skipped = handleInstallError(error, service, options);
-        if (skipped) {
-          skippedServices.push(skipped);
+        const skippedVersion = handleInstallError(error, service, options);
+        if (skippedVersion) {
+          skippedServices.push({name: service.name, version: skippedVersion});
           continue;
         }
       }
@@ -629,9 +623,9 @@ export async function installArk(
 
         console.log(); // Add blank line after command output
       } catch (error) {
-        const skipped = handleInstallError(error, service, options);
-        if (skipped) {
-          skippedServices.push(skipped);
+        const skippedVersion = handleInstallError(error, service, options);
+        if (skippedVersion) {
+          skippedServices.push({name: service.name, version: skippedVersion});
           console.log(); // Add blank line after warning
           continue;
         }
@@ -682,9 +676,9 @@ export async function installArk(
         );
         console.log(); // Add blank line after command output
       } catch (error) {
-        const skipped = handleInstallError(error, service, options);
-        if (skipped) {
-          skippedServices.push(skipped);
+        const skippedVersion = handleInstallError(error, service, options);
+        if (skippedVersion) {
+          skippedServices.push({name: service.name, version: skippedVersion});
           console.log(); // Add blank line after warning
           continue;
         }
@@ -692,9 +686,6 @@ export async function installArk(
       }
     }
   }
-
-  // Fail if any requested service was skipped due to a not-found version
-  exitIfServicesSkipped(skippedServices);
 
   // Show next steps after successful installation
   if (serviceNames.length === 0) {
@@ -712,7 +703,8 @@ export async function installArk(
           s.category === 'core' &&
           s.k8sDeploymentName &&
           s.namespace &&
-          (!s.requiresBackend || s.requiresBackend === backend)
+          (!s.requiresBackend || s.requiresBackend === backend) &&
+          !skippedServices.some((sk) => sk.name === s.name)
       );
 
       const spinner = ora(
@@ -757,6 +749,8 @@ export async function installArk(
       process.exit(1);
     }
   }
+
+  exitIfServicesSkipped(skippedServices);
 }
 
 export function createInstallCommand(config: ArkConfig) {

--- a/tools/ark-cli/src/commands/install/index.ts
+++ b/tools/ark-cli/src/commands/install/index.ts
@@ -85,13 +85,15 @@ function isValidVersion(version: string): boolean {
   return /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version);
 }
 
-function isVersionNotFoundError(
+// Returns the requested version that helm reported as not found, or null if the
+// error is something else. Lets callers report which service@version was missing.
+function notFoundVersion(
   error: unknown,
   options: {
     arkVersion?: string;
     marketplaceVersion?: string;
   }
-): boolean {
+): string | null {
   let errorMsg = '';
 
   if (error && typeof error === 'object') {
@@ -103,16 +105,20 @@ function isVersionNotFoundError(
   }
 
   if (options.arkVersion && errorMsg.includes(`:${options.arkVersion}: not found`)) {
-    return true;
+    return options.arkVersion;
   }
 
   if (options.marketplaceVersion && errorMsg.includes(`:${options.marketplaceVersion}: not found`)) {
-    return true;
+    return options.marketplaceVersion;
   }
 
-  return false;
+  return null;
 }
 
+// On a version-not-found error, returns a "service@version" descriptor for the
+// caller to record (reported as a single aggregate error at the end). For any
+// other error it fails fast with a non-zero exit. Returns false when there is no
+// error to handle.
 function handleInstallError(
   error: unknown,
   service: ArkService,
@@ -120,16 +126,23 @@ function handleInstallError(
     arkVersion?: string;
     marketplaceVersion?: string;
   }
-): boolean {
-  if (isVersionNotFoundError(error, options)) {
-    const version = options.arkVersion || options.marketplaceVersion;
-    output.warning(`${service.name} version ${version} not found, skipping...`);
-    return true; // should continue to next service
+): string | false {
+  const version = notFoundVersion(error, options);
+  if (version !== null) {
+    return `${service.name}@${version}`; // should continue to next service
   }
 
   // Other errors still fail
   output.error(`failed to install ${service.name}`);
   console.error(error);
+  process.exit(1);
+}
+
+function exitIfServicesSkipped(skipped: string[]): void {
+  if (skipped.length === 0) return;
+  output.error(
+    `installation incomplete: ${skipped.length} service(s) skipped because the requested version was not found: ${skipped.join(', ')}`
+  );
   process.exit(1);
 }
 
@@ -297,6 +310,9 @@ export async function installArk(
   }
   const backend: Backend = requestedBackend;
 
+  // Track services skipped due to a not-found version so we can fail at the end
+  const skippedServices: string[] = [];
+
   let postgresValues: PostgresStorageConfig | undefined;
   if (backend === 'postgresql') {
     try {
@@ -354,7 +370,9 @@ export async function installArk(
           );
           output.success(`${service.name} installed successfully`);
         } catch (error) {
-          if (handleInstallError(error, service, options)) {
+          const skipped = handleInstallError(error, service, options);
+          if (skipped) {
+            skippedServices.push(skipped);
             continue;
           }
         }
@@ -403,11 +421,14 @@ export async function installArk(
           }
         }
       } catch (error) {
-        if (handleInstallError(error, service, options)) {
+        const skipped = handleInstallError(error, service, options);
+        if (skipped) {
+          skippedServices.push(skipped);
           continue;
         }
       }
     }
+    exitIfServicesSkipped(skippedServices);
     return;
   }
 
@@ -608,7 +629,9 @@ export async function installArk(
 
         console.log(); // Add blank line after command output
       } catch (error) {
-        if (handleInstallError(error, service, options)) {
+        const skipped = handleInstallError(error, service, options);
+        if (skipped) {
+          skippedServices.push(skipped);
           console.log(); // Add blank line after warning
           continue;
         }
@@ -659,7 +682,9 @@ export async function installArk(
         );
         console.log(); // Add blank line after command output
       } catch (error) {
-        if (handleInstallError(error, service, options)) {
+        const skipped = handleInstallError(error, service, options);
+        if (skipped) {
+          skippedServices.push(skipped);
           console.log(); // Add blank line after warning
           continue;
         }
@@ -667,6 +692,9 @@ export async function installArk(
       }
     }
   }
+
+  // Fail if any requested service was skipped due to a not-found version
+  exitIfServicesSkipped(skippedServices);
 
   // Show next steps after successful installation
   if (serviceNames.length === 0) {


### PR DESCRIPTION
## Checklist
- exitIfServicesSkipped now returns clear error message, and exits 1 as status code
- a version-skip in the interactive or -y flow , run the full success epilogue for what did install. And only report the missing-version failure at the very end. 

**Before:**
<img width="1291" height="141" alt="Screenshot 2026-06-26 at 11 36 15 AM" src="https://github.com/user-attachments/assets/3662e70e-53f2-445c-8741-83eac9380592" />

**After**
<img width="1197" height="136" alt="Screenshot 2026-06-26 at 11 37 18 AM" src="https://github.com/user-attachments/assets/d30e74ee-da8b-46bd-909e-57cb268f6e7c" />
<img width="1474" height="345" alt="Screenshot 2026-06-26 at 11 44 34 AM" src="https://github.com/user-attachments/assets/b0902e57-4a6d-46d3-966d-8ef12c71adf8" />



- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 