### PR TITLE
docs: move Build pipelines under Develop ARK

### DIFF
--- a/docs/content/how-to-guides/_meta.js
+++ b/docs/content/how-to-guides/_meta.js
@@ -66,6 +66,10 @@ export default {
     title: 'End to end testing',
     href: '/developer-guide/testing'
   },
+  pipelines: {
+    title: 'Build pipelines',
+    href: '/operations-guide/build-pipelines'
+  },
 
   '---operate': { type: 'separator', title: 'Operate ARK (operators / SRE)' },
   provisioning: {
@@ -87,10 +91,6 @@ export default {
   'operate-marketplace': {
     title: 'Marketplace',
     href: '/operations-guide/marketplace'
-  },
-  pipelines: {
-    title: 'Build pipelines',
-    href: '/operations-guide/build-pipelines'
   },
   'pen-testing': {
     title: 'Penetration testing',

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -31,6 +31,7 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
   - [Work with services](/developer-guide/services).
   - [Use the ARK API](/developer-guide/services/ark-api).
 - [Run end-to-end tests](/developer-guide/testing).
+- [Configure build pipelines](/operations-guide/build-pipelines).
 
 ## Operate ARK (operators, SRE, and security)
 
@@ -38,9 +39,6 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 - [Provision cloud infrastructure](/operations-guide/provisioning).
 - [Deploy ARK](/operations-guide/deploying-ark).
 - [Marketplace](/operations-guide/marketplace).
-
-### CI/CD and supply chain
-- [Configure build pipelines](/operations-guide/build-pipelines).
 
 ### Security and assurance
 - [Review penetration testing reports](/operations-guide/penetration-testing-reports).


### PR DESCRIPTION
## Summary
Move **Build pipelines** from the **Operate ARK** section into **Develop ARK** in the how-to-guides nav (`_meta.js`) and the index page. CI/CD pipelines are a development concern, so they sit better alongside local dev, build system, services, and testing.

The now-empty "CI/CD and supply chain" subsection is removed from the index page.