### PR TITLE
 fix: restore auth gate for proxied API and pages (SSO bypass)

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequestWithAuth } from '@/auth';
+import middleware from '@/middleware';
+
+// Mock NextResponse's static helpers so we can assert on redirect/next.
+vi.mock('next/server', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockNextResponse: any = vi.fn((body, init) => ({
+    body,
+    status: init?.status,
+    statusText: init?.statusText,
+    headers: init?.headers,
+  }));
+  MockNextResponse.next = vi.fn(() => ({ type: 'next' }));
+  MockNextResponse.redirect = vi.fn(url => ({ type: 'redirect', url }));
+
+  return { NextResponse: MockNextResponse };
+});
+
+// The auth() wrapper just hands our callback the request in tests, so we can
+// drive req.auth directly (sso: NextAuth populates it; open: openauth injects a
+// dummy session — both reduce to "is req.auth truthy" here).
+vi.mock('@/auth', () => ({
+  auth: vi.fn(callback => callback),
+}));
+
+const BASE_URL = 'https://example.com';
+
+const createMockRequest = (pathname: string): NextRequestWithAuth => {
+  const url = new URL(`${BASE_URL}${pathname}`);
+  const headers = new Headers();
+  headers.set('host', 'example.com');
+
+  return {
+    nextUrl: {
+      pathname,
+      search: '',
+      protocol: 'https:',
+      origin: url.origin,
+      href: url.toString(),
+    },
+    url: url.toString(),
+    headers,
+    method: 'GET',
+    body: null,
+    auth: null,
+  } as unknown as NextRequestWithAuth;
+};
+
+describe('middleware (auth gate)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.BASE_URL = BASE_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.BASE_URL;
+  });
+
+  describe('unauthenticated requests are redirected to sign-in', () => {
+    // Regression guard: the proxied API must be gated, not just UI pages.
+    // Before the middleware was restored, GET /api/v1/* returned 200 + data
+    // to anonymous callers.
+    it('redirects the proxied API route /api/v1/context', async () => {
+      const request = createMockRequest('/api/v1/context');
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        new URL(
+          '/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fcontext',
+          BASE_URL,
+        ),
+      );
+      expect(NextResponse.next).not.toHaveBeenCalled();
+    });
+
+    it('redirects a UI page route', async () => {
+      const request = createMockRequest('/dashboard');
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        new URL(
+          '/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com%2Fdashboard',
+          BASE_URL,
+        ),
+      );
+    });
+  });
+
+  describe('authenticated requests pass through', () => {
+    it('calls NextResponse.next() and does not redirect', async () => {
+      const request = createMockRequest('/api/v1/context');
+      request.auth = {
+        user: { id: 'user123', email: 'test@example.com' },
+        expires: '',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.next).toHaveBeenCalled();
+      expect(NextResponse.redirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('excluded paths are never gated', () => {
+    // These must pass through even with no session, or the auth flow and
+    // static assets break. (Replaces the old config.matcher, which compiles to
+    // an invalid RegExp under Next.js 16.)
+    it.each([
+      '/api/auth/signin',
+      '/api/auth/providers',
+      '/api/auth/session',
+      '/signout',
+      '/_next/static/chunk.js',
+      '/_next/image',
+      '/favicon.ico',
+    ])('passes through %s without a session', async pathname => {
+      const request = createMockRequest(pathname);
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled();
+      expect(NextResponse.next).toHaveBeenCalled();
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+
+import { auth, type NextRequestWithAuth } from './auth';
+import { SIGNIN_PATH } from './lib/constants/auth';
+
+// Auth-only edge gate. The proxy logic that used to live here now lives in
+// app/api/v1/[...proxy]/route.ts; this file restores the authentication gate
+// that was lost when the original middleware.ts was renamed (commit 001616dd9).
+//
+// In open mode, auth.ts's openauth wrapper injects a dummy session, so req.auth
+// is always truthy and nothing is redirected. In sso mode NextAuth populates
+// req.auth from the session; an unauthenticated request is redirected to the
+// sign-in page.
+//
+// NB: we deliberately do NOT use `export const config = { matcher }`. The
+// negative-lookahead matcher string that worked on the pre-16 build compiles to
+// an invalid RegExp under Next.js 16 ("Unmatched ')'"), crashing the server on
+// every request. Filtering excluded paths in-code is version-robust and matches
+// the same exclusions the old matcher expressed.
+const PUBLIC_PREFIXES = [
+  '/api/auth',
+  '/signout',
+  '/_next/static',
+  '/_next/image',
+];
+
+export default auth(async (req: NextRequestWithAuth) => {
+  const { pathname } = req.nextUrl;
+
+  if (
+    pathname === '/favicon.ico' ||
+    PUBLIC_PREFIXES.some((p) => pathname.startsWith(p))
+  ) {
+    return NextResponse.next();
+  }
+
+  if (!req.auth && pathname !== SIGNIN_PATH) {
+    const signInUrl = new URL(
+      `${SIGNIN_PATH}?callbackUrl=${encodeURIComponent(req.nextUrl.href)}`,
+      process.env.BASE_URL,
+    );
+    return NextResponse.redirect(signInUrl);
+  }
+  return NextResponse.next();
+});


### PR DESCRIPTION
## Summary

In SSO mode the dashboard no longer enforces authentication on the `/api/v1/*`
proxy or on page routes. An unauthenticated request to any proxied endpoint
(e.g. `GET /api/v1/context`, `/models`, `/agents`, `/queries`) returns `200`
with live ark-api data instead of redirecting to sign-in.

This restores the auth gate as a Next.js middleware, written to be compatible
with Next.js 16.

## Root cause

The dashboard used to ship a root `middleware.ts` whose `auth()` wrapper
redirected unauthenticated requests to the sign-in page, with a matcher that
covered everything except the auth/static paths — **including `/api/v1/*`**.

- `001616dd9` renamed `middleware.ts` → `proxy.ts` "to avoid a warning". Next.js
  only auto-runs a root file literally named `middleware.ts`, so from that commit
  on the edge middleware never executed — both the auth redirect and the proxy
  stopped running.
- The proxy was later reimplemented as the route handler
  `app/api/v1/[...proxy]/route.ts`, which preserved proxying + bearer-minting but
  dropped the `if (!req.auth) redirect` enforcement. It forwards every request to
  ark-api and only *conditionally* attaches `Authorization` when a session token
  exists.

Net effect: with ark-api in its usual `open` mode, anonymous calls are proxied
straight through and served. The `authorized` callback and `pages.signIn` in
`authConfig` are still defined but dead, because nothing wires `auth` up as
middleware.

## Fix

Re-add `services/ark-dashboard/ark-dashboard/middleware.ts` containing only the
auth gate (proxying stays in the route handler — that's what avoids the original
warning):

- Open mode: `auth.ts`'s `openauth` wrapper injects a dummy session, so `req.auth`
  is truthy and nothing is redirected — open mode is unaffected.
- SSO mode: NextAuth populates `req.auth`; unauthenticated requests are redirected
  to `SIGNIN_PATH` with a `callbackUrl`.

**Next.js 16 note:** the pre-16 negative-lookahead `config.matcher` string
(`/((?!api/auth|...).*)`) compiles to an invalid RegExp under Next 16
("Unmatched ')'") and 500s every request. This change drops `config.matcher` and
filters excluded prefixes (`/api/auth`, `/signout`, `/_next/static`,
`/_next/image`, `/favicon.ico`) inside the middleware function, which is robust
across versions.