### PR TITLE
fix(controller): bound Query goroutines and enable parallel reconciles

### DIFF
--- a/ark/Makefile
+++ b/ark/Makefile
@@ -93,7 +93,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 ##@ Build
 
 .PHONY: build
-build: validate-chart-crds validate-chart-webhooks manifests generate fmt vet ## Build manager binary.
+build: validate-chart-crds validate-chart-webhooks validate-chart-values manifests generate fmt vet ## Build manager binary.
 	go build $(LDFLAGS) -o bin/manager cmd/main.go
 
 .PHONY: build-completions
@@ -142,6 +142,10 @@ validate-chart-crds: ## Validate that CRDs in Helm chart match source CRDs
 .PHONY: validate-chart-webhooks
 validate-chart-webhooks: ## Validate that webhooks in Helm chart match source webhooks
 	@./scripts/validate-chart-webhooks.sh
+
+.PHONY: validate-chart-values
+validate-chart-values: ## Validate that key chart values render into the manager Deployment as expected
+	@./scripts/validate-chart-values.sh
 
 .PHONY: build-container
 build-container: ## Build the ark-controller

--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -68,6 +68,7 @@ type config struct {
 	completionsAddr                                  string
 	role                                             string
 	maxConcurrentQueries                             int
+	maxConcurrentReconciles                          int
 }
 
 const (
@@ -167,6 +168,10 @@ func parseFlags() struct {
 		"Maximum number of Query executions running concurrently in goroutines. "+
 			"When the cap is reached, Reconcile requeues so the workqueue holds the backlog "+
 			"instead of the controller heap. Set to 0 to disable enforcement (not recommended).")
+	flag.IntVar(&cfg.maxConcurrentReconciles, "max-concurrent-reconciles", 4,
+		"Maximum number of Query reconciles running in parallel. The workqueue dedupes per-key, "+
+			"so this only enables concurrency across different Query objects. Set to 0 to use "+
+			"the controller-runtime default (1).")
 
 	zapOpts := zap.Options{Development: false}
 	zapOpts.BindFlags(flag.CommandLine)
@@ -291,12 +296,13 @@ func setupControllers(mgr ctrl.Manager, telemetryProvider *telemetryconfig.Provi
 			Eventing: eventingProvider,
 		}},
 		{"Query", &controller.QueryReconciler{
-			Client:               mgr.GetClient(),
-			Scheme:               mgr.GetScheme(),
-			Telemetry:            telemetryProvider,
-			Eventing:             eventingProvider,
-			CompletionsAddr:      cfg.completionsAddr,
-			MaxConcurrentQueries: cfg.maxConcurrentQueries,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Telemetry:               telemetryProvider,
+			Eventing:                eventingProvider,
+			CompletionsAddr:         cfg.completionsAddr,
+			MaxConcurrentQueries:    cfg.maxConcurrentQueries,
+			MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
 		}},
 		{"Tool", &controller.ToolReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}},
 		{"Team", &controller.TeamReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Recorder: mgr.GetEventRecorderFor("team-controller")}},

--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -67,6 +67,7 @@ type config struct {
 	enableHTTP2                                      bool
 	completionsAddr                                  string
 	role                                             string
+	maxConcurrentQueries                             int
 }
 
 const (
@@ -162,6 +163,10 @@ func parseFlags() struct {
 		"Address of the completions engine for A2A communication")
 	flag.StringVar(&cfg.role, "role", "",
 		"Required: process role — 'apiserver' (runs only the aggregated API server) or 'controller' (runs only reconcilers and webhooks)")
+	flag.IntVar(&cfg.maxConcurrentQueries, "max-concurrent-queries", 32,
+		"Maximum number of Query executions running concurrently in goroutines. "+
+			"When the cap is reached, Reconcile requeues so the workqueue holds the backlog "+
+			"instead of the controller heap. Set to 0 to disable enforcement (not recommended).")
 
 	zapOpts := zap.Options{Development: false}
 	zapOpts.BindFlags(flag.CommandLine)
@@ -286,11 +291,12 @@ func setupControllers(mgr ctrl.Manager, telemetryProvider *telemetryconfig.Provi
 			Eventing: eventingProvider,
 		}},
 		{"Query", &controller.QueryReconciler{
-			Client:          mgr.GetClient(),
-			Scheme:          mgr.GetScheme(),
-			Telemetry:       telemetryProvider,
-			Eventing:        eventingProvider,
-			CompletionsAddr: cfg.completionsAddr,
+			Client:               mgr.GetClient(),
+			Scheme:               mgr.GetScheme(),
+			Telemetry:            telemetryProvider,
+			Eventing:             eventingProvider,
+			CompletionsAddr:      cfg.completionsAddr,
+			MaxConcurrentQueries: cfg.maxConcurrentQueries,
 		}},
 		{"Tool", &controller.ToolReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}},
 		{"Team", &controller.TeamReconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Recorder: mgr.GetEventRecorderFor("team-controller")}},

--- a/ark/cmd/main_test.go
+++ b/ark/cmd/main_test.go
@@ -3,8 +3,12 @@
 package main
 
 import (
+	"flag"
+	"os"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestValidateRole(t *testing.T) {
@@ -34,6 +38,102 @@ func TestValidateRole(t *testing.T) {
 		if !strings.Contains(err.Error(), c.wantErr) {
 			t.Errorf("validateRole(%q) error = %q, want substring %q", c.role, err.Error(), c.wantErr)
 		}
+	}
+}
+
+// runParseFlags resets flag state, sets os.Args, and invokes parseFlags so each
+// subtest gets an isolated FlagSet.
+func runParseFlags(t *testing.T, args []string) struct {
+	config
+	zapOpts     zap.Options
+	showVersion bool
+} {
+	t.Helper()
+	oldArgs := os.Args
+	oldFlagSet := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldFlagSet
+	})
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	os.Args = args
+	return parseFlags()
+}
+
+func TestParseFlags(t *testing.T) {
+	cases := []struct {
+		name            string
+		args            []string
+		wantConfig      config
+		wantShowVersion bool
+	}{
+		{
+			name: "defaults when flags omitted",
+			args: []string{"cmd"},
+			wantConfig: config{
+				metricsAddr:             "0",
+				probeAddr:               ":8081",
+				secureMetrics:           true,
+				webhookCertName:         "tls.crt",
+				webhookCertKey:          "tls.key",
+				metricsCertName:         "tls.crt",
+				metricsCertKey:          "tls.key",
+				completionsAddr:         "http://ark-completions.ark-system",
+				maxConcurrentQueries:    32,
+				maxConcurrentReconciles: 4,
+			},
+		},
+		{
+			name: "every flag overridden",
+			args: []string{
+				"cmd",
+				"--metrics-bind-address=:9000",
+				"--health-probe-bind-address=:9001",
+				"--leader-elect=true",
+				"--metrics-secure=false",
+				"--webhook-cert-path=/tmp/webhook",
+				"--webhook-cert-name=webhook.crt",
+				"--webhook-cert-key=webhook.key",
+				"--metrics-cert-path=/tmp/metrics",
+				"--metrics-cert-name=metrics.crt",
+				"--metrics-cert-key=metrics.key",
+				"--enable-http2=true",
+				"--version=true",
+				"--completions-addr=http://example.local",
+				"--role=apiserver",
+				"--max-concurrent-queries=10",
+				"--max-concurrent-reconciles=5",
+			},
+			wantConfig: config{
+				metricsAddr:             ":9000",
+				probeAddr:               ":9001",
+				enableLeaderElection:    true,
+				secureMetrics:           false,
+				webhookCertPath:         "/tmp/webhook",
+				webhookCertName:         "webhook.crt",
+				webhookCertKey:          "webhook.key",
+				metricsCertPath:         "/tmp/metrics",
+				metricsCertName:         "metrics.crt",
+				metricsCertKey:          "metrics.key",
+				enableHTTP2:             true,
+				completionsAddr:         "http://example.local",
+				role:                    "apiserver",
+				maxConcurrentQueries:    10,
+				maxConcurrentReconciles: 5,
+			},
+			wantShowVersion: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := runParseFlags(t, c.args)
+			if result.config != c.wantConfig {
+				t.Errorf("config mismatch\n got: %+v\nwant: %+v", result.config, c.wantConfig)
+			}
+			if result.showVersion != c.wantShowVersion {
+				t.Errorf("showVersion = %v, want %v", result.showVersion, c.wantShowVersion)
+			}
+		})
 	}
 }
 

--- a/ark/dist/chart/templates/manager/manager.yaml
+++ b/ark/dist/chart/templates/manager/manager.yaml
@@ -33,8 +33,8 @@ spec:
             - {{ . }}
             {{- end }}
             - "--completions-addr={{ .Values.completions.addr }}"
-            - "--max-concurrent-queries={{ .Values.controllerManager.maxConcurrentQueries | default 32 }}"
-            - "--max-concurrent-reconciles={{ .Values.controllerManager.maxConcurrentReconciles | default 4 }}"
+            - "--max-concurrent-queries={{ .Values.controllerManager.maxConcurrentQueries }}"
+            - "--max-concurrent-reconciles={{ .Values.controllerManager.maxConcurrentReconciles }}"
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag | default .Chart.AppVersion }}

--- a/ark/dist/chart/templates/manager/manager.yaml
+++ b/ark/dist/chart/templates/manager/manager.yaml
@@ -34,6 +34,7 @@ spec:
             {{- end }}
             - "--completions-addr={{ .Values.completions.addr }}"
             - "--max-concurrent-queries={{ .Values.controllerManager.maxConcurrentQueries | default 32 }}"
+            - "--max-concurrent-reconciles={{ .Values.controllerManager.maxConcurrentReconciles | default 4 }}"
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag | default .Chart.AppVersion }}

--- a/ark/dist/chart/templates/manager/manager.yaml
+++ b/ark/dist/chart/templates/manager/manager.yaml
@@ -33,6 +33,7 @@ spec:
             - {{ . }}
             {{- end }}
             - "--completions-addr={{ .Values.completions.addr }}"
+            - "--max-concurrent-queries={{ .Values.controllerManager.maxConcurrentQueries | default 32 }}"
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag | default .Chart.AppVersion }}

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -1,6 +1,12 @@
 # [MANAGER]: Manager Deployment Configurations
 controllerManager:
   replicas: 1
+  # Maximum number of Query executions running concurrently in goroutines.
+  # When the cap is reached, Reconcile requeues so the workqueue holds the
+  # backlog instead of the controller heap. Set to 0 to disable enforcement
+  # (not recommended — historical default behaviour, susceptible to OOM
+  # under burst load, see issue #2597).
+  maxConcurrentQueries: 32
   container:
     image:
       repository: ghcr.io/mckinsey/agents-at-scale-ark/ark-controller

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -7,6 +7,11 @@ controllerManager:
   # (not recommended — historical default behaviour, susceptible to OOM
   # under burst load, see issue #2597).
   maxConcurrentQueries: 32
+  # Maximum number of Query reconciles running in parallel. The workqueue
+  # dedupes per-key, so this only enables concurrency across different Query
+  # objects. Set to 0 to use the controller-runtime default (1). See issue
+  # #2609.
+  maxConcurrentReconciles: 4
   container:
     image:
       repository: ghcr.io/mckinsey/agents-at-scale-ark/ark-controller

--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -16,14 +16,14 @@ import (
 )
 
 const (
-	DefaultTimeoutSeconds    = 30 // Default timeout in seconds
-	ContentTypeJSON          = "application/json"
-	MessagesEndpoint         = "/messages"
-	ConversationsEndpoint    = "/conversations"
-	CompletionEndpoint       = "/stream/%s/complete"
-	MaxRetries               = 3
-	RetryDelay               = 100 * time.Millisecond
-	UserAgent                = "ark-memory-client/1.0"
+	DefaultTimeoutSeconds = 30 // Default timeout in seconds
+	ContentTypeJSON       = "application/json"
+	MessagesEndpoint      = "/messages"
+	ConversationsEndpoint = "/conversations"
+	CompletionEndpoint    = "/stream/%s/complete"
+	MaxRetries            = 3
+	RetryDelay            = 100 * time.Millisecond
+	UserAgent             = "ark-memory-client/1.0"
 )
 
 // getMemoryTimeout reads ARK_MEMORY_HTTP_TIMEOUT_SECONDS env var or returns default

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,11 @@ const (
 
 	messageCleanupGracePeriod   = 5 * time.Minute
 	messageCleanupRetryInterval = 15 * time.Second
+
+	// queryCapacityRequeueDelay is how long Reconcile waits before retrying
+	// when MaxConcurrentQueries is reached. Short enough to be responsive,
+	// long enough to avoid a busy-loop while in-flight queries drain.
+	queryCapacityRequeueDelay = 250 * time.Millisecond
 )
 
 type QueryReconciler struct {
@@ -54,7 +60,15 @@ type QueryReconciler struct {
 	Telemetry       *telemetryconfig.Provider
 	Eventing        *eventingconfig.Provider
 	CompletionsAddr string
-	operations      sync.Map
+
+	// MaxConcurrentQueries caps the number of Query executions running in
+	// goroutines at once. When the cap is reached, Reconcile() requeues so
+	// the workqueue (cheap, object keys only) holds the backlog instead of
+	// the controller heap. Set to 0 to disable enforcement.
+	MaxConcurrentQueries int
+
+	sem        *semaphore.Weighted
+	operations sync.Map
 }
 
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=queries,verbs=get;list;watch;create;update;patch;delete
@@ -190,6 +204,11 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
+	if r.sem != nil && !r.sem.TryAcquire(1) {
+		log.V(1).Info("query execution capacity reached, requeuing", "query", req.NamespacedName.String(), "cap", r.MaxConcurrentQueries)
+		return ctrl.Result{RequeueAfter: queryCapacityRequeueDelay}, nil
+	}
+
 	opCtx, cancel := context.WithTimeout(ctx, remaining)
 	r.operations.Store(req.NamespacedName, cancel)
 
@@ -203,11 +222,14 @@ func (r *QueryReconciler) executeQueryAsync(opCtx context.Context, obj arkv1alph
 	startTime := time.Now()
 
 	defer func() {
-		if r := recover(); r != nil {
-			log.Error(fmt.Errorf("query execution goroutine panic: %v", r), "Query execution goroutine panicked")
+		if rec := recover(); rec != nil {
+			log.Error(fmt.Errorf("query execution goroutine panic: %v", rec), "Query execution goroutine panicked")
 		}
 		if cleanupCache {
 			r.operations.Delete(namespacedName)
+		}
+		if r.sem != nil {
+			r.sem.Release(1)
 		}
 	}()
 
@@ -228,7 +250,8 @@ func (r *QueryReconciler) executeQueryAsync(opCtx context.Context, obj arkv1alph
 
 	queryInput := extractUserInput(opCtx, obj, r.Client)
 
-	opCtx, dispatchSpan := r.Telemetry.Tracer().Start(opCtx, fmt.Sprintf("query.%s.dispatch", obj.Name),
+	opCtx, dispatchSpan := r.Telemetry.Tracer().Start(
+		opCtx, fmt.Sprintf("query.%s.dispatch", obj.Name),
 		telemetry.WithSpanKind(telemetry.SpanKindChain),
 		telemetry.WithAttributes(
 			telemetry.String(telemetry.AttrQueryName, obj.Name),
@@ -889,6 +912,9 @@ func (r *QueryReconciler) cleanupExistingOperation(namespacedName types.Namespac
 }
 
 func (r *QueryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.MaxConcurrentQueries > 0 {
+		r.sem = semaphore.NewWeighted(int64(r.MaxConcurrentQueries))
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arkv1alpha1.Query{}).
 		Named("query").

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -66,6 +67,13 @@ type QueryReconciler struct {
 	// the workqueue (cheap, object keys only) holds the backlog instead of
 	// the controller heap. Set to 0 to disable enforcement.
 	MaxConcurrentQueries int
+
+	// MaxConcurrentReconciles sets how many Query keys can be reconciled in
+	// parallel. The controller-runtime workqueue dedupes per-key, so concurrent
+	// reconciles only run for different Query objects — Reconcile() for the
+	// same key is still serialized. Set to 0 to use the controller-runtime
+	// default (1).
+	MaxConcurrentReconciles int
 
 	sem        *semaphore.Weighted
 	operations sync.Map
@@ -915,8 +923,13 @@ func (r *QueryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.MaxConcurrentQueries > 0 {
 		r.sem = semaphore.NewWeighted(int64(r.MaxConcurrentQueries))
 	}
+	opts := controller.Options{}
+	if r.MaxConcurrentReconciles > 0 {
+		opts.MaxConcurrentReconciles = r.MaxConcurrentReconciles
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arkv1alpha1.Query{}).
 		Named("query").
+		WithOptions(opts).
 		Complete(r)
 }

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -226,20 +226,9 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 
 func (r *QueryReconciler) executeQueryAsync(opCtx context.Context, obj arkv1alpha1.Query, namespacedName types.NamespacedName) {
 	log := logf.FromContext(opCtx)
-	cleanupCache := true
 	startTime := time.Now()
 
-	defer func() {
-		if rec := recover(); rec != nil {
-			log.Error(fmt.Errorf("query execution goroutine panic: %v", rec), "Query execution goroutine panicked")
-		}
-		if cleanupCache {
-			r.operations.Delete(namespacedName)
-		}
-		if r.sem != nil {
-			r.sem.Release(1)
-		}
-	}()
+	defer r.finishExecuteQueryAsync(opCtx, namespacedName)
 
 	opCtx = r.Eventing.QueryRecorder().InitializeQueryContext(opCtx, &obj)
 	opCtx = r.Eventing.QueryRecorder().StartTokenCollection(opCtx)
@@ -331,6 +320,16 @@ func (r *QueryReconciler) executeQueryAsync(opCtx context.Context, obj arkv1alph
 
 	operationData := buildOperationData(target, queryInput)
 	r.Eventing.QueryRecorder().Complete(opCtx, "QueryExecution", "Query execution completed", operationData)
+}
+
+func (r *QueryReconciler) finishExecuteQueryAsync(ctx context.Context, namespacedName types.NamespacedName) {
+	if rec := recover(); rec != nil {
+		logf.FromContext(ctx).Error(fmt.Errorf("query execution goroutine panic: %v", rec), "Query execution goroutine panicked")
+	}
+	r.operations.Delete(namespacedName)
+	if r.sem != nil {
+		r.sem.Release(1)
+	}
 }
 
 func buildOperationData(target *arkv1alpha1.QueryTarget, queryInput string) map[string]string {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -213,7 +213,7 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 	}
 
 	if r.sem != nil && !r.sem.TryAcquire(1) {
-		log.V(1).Info("query execution capacity reached, requeuing", "query", req.NamespacedName.String(), "cap", r.MaxConcurrentQueries)
+		log.V(1).Info("query execution capacity reached, requeuing", "query", req.String(), "cap", r.MaxConcurrentQueries)
 		return ctrl.Result{RequeueAfter: queryCapacityRequeueDelay}, nil
 	}
 
@@ -920,16 +920,24 @@ func (r *QueryReconciler) cleanupExistingOperation(namespacedName types.Namespac
 }
 
 func (r *QueryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.initSemaphore()
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arkv1alpha1.Query{}).
+		Named("query").
+		WithOptions(r.buildControllerOptions()).
+		Complete(r)
+}
+
+func (r *QueryReconciler) initSemaphore() {
 	if r.MaxConcurrentQueries > 0 {
 		r.sem = semaphore.NewWeighted(int64(r.MaxConcurrentQueries))
 	}
+}
+
+func (r *QueryReconciler) buildControllerOptions() controller.Options {
 	opts := controller.Options{}
 	if r.MaxConcurrentReconciles > 0 {
 		opts.MaxConcurrentReconciles = r.MaxConcurrentReconciles
 	}
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&arkv1alpha1.Query{}).
-		Named("query").
-		WithOptions(opts).
-		Complete(r)
+	return opts
 }

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -359,6 +359,30 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Expect(result).To(Equal(ctrl.Result{}))
 		})
 	})
+
+	Context("initSemaphore", func() {
+		It("creates a semaphore sized to MaxConcurrentQueries", func() {
+			r := &QueryReconciler{MaxConcurrentQueries: 3}
+			r.initSemaphore()
+			Expect(r.sem).NotTo(BeNil())
+			Expect(r.sem.TryAcquire(3)).To(BeTrue(), "should permit MaxConcurrentQueries acquisitions")
+			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "should deny the next acquisition once the cap is reached")
+		})
+
+		It("leaves the semaphore nil when MaxConcurrentQueries is 0", func() {
+			r := &QueryReconciler{MaxConcurrentQueries: 0}
+			r.initSemaphore()
+			Expect(r.sem).To(BeNil())
+		})
+	})
+
+	Context("buildControllerOptions", func() {
+		It("propagates MaxConcurrentReconciles when set", func() {
+			r := &QueryReconciler{MaxConcurrentReconciles: 7}
+			opts := r.buildControllerOptions()
+			Expect(opts.MaxConcurrentReconciles).To(Equal(7))
+		})
+	})
 })
 
 var _ = Describe("Query Controller Fallback Raw", func() {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -346,7 +346,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "capacity-disabled-query",
 					Namespace:         "default",
-					CreationTimestamp: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+					CreationTimestamp: metav1.Time{Time: time.Now()},
 				},
 				Spec: arkv1alpha1.QuerySpec{
 					TTL: &metav1.Duration{Duration: time.Hour},
@@ -357,7 +357,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			result, err := r.handleRunningPhase(context.Background(), req, query)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result.RequeueAfter).To(BeZero(), "must not requeue with capacity delay when enforcement is disabled")
+			_, exists := r.operations.Load(req.NamespacedName)
+			Expect(exists).To(BeTrue(), "should register the operation, proving execution branch was taken despite no semaphore")
 		})
 	})
 

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -381,6 +382,26 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			r := &QueryReconciler{MaxConcurrentReconciles: 7}
 			opts := r.buildControllerOptions()
 			Expect(opts.MaxConcurrentReconciles).To(Equal(7))
+		})
+	})
+
+	Context("SetupWithManager", func() {
+		It("registers the controller and sizes the semaphore from MaxConcurrentQueries", func() {
+			mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			r := &QueryReconciler{
+				Client:                  mgr.GetClient(),
+				Scheme:                  mgr.GetScheme(),
+				MaxConcurrentQueries:    2,
+				MaxConcurrentReconciles: 2,
+			}
+
+			Expect(r.SetupWithManager(mgr)).To(Succeed())
+
+			Expect(r.sem).NotTo(BeNil(), "initSemaphore should have run via SetupWithManager")
+			Expect(r.sem.TryAcquire(2)).To(BeTrue(), "semaphore should permit MaxConcurrentQueries acquisitions")
+			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "semaphore should refuse the next acquisition once the cap is reached")
 		})
 	})
 

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -290,6 +291,64 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 					CreationTimestamp: metav1.Time{
 						Time: time.Now().Add(-2 * time.Hour),
 					},
+				},
+			}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: query.Name, Namespace: query.Namespace}}
+
+			result, err := r.handleRunningPhase(context.Background(), req, query)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+	})
+
+	Context("MaxConcurrentQueries enforcement", func() {
+		It("requeues without spawning execution when the semaphore is full", func() {
+			r := &QueryReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				MaxConcurrentQueries: 1,
+				sem:                  semaphore.NewWeighted(1),
+			}
+			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "pre-condition: semaphore should start drainable")
+
+			query := arkv1alpha1.Query{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "capacity-requeue-query",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+				},
+				Spec: arkv1alpha1.QuerySpec{
+					TTL: &metav1.Duration{Duration: time.Hour},
+				},
+			}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: query.Name, Namespace: query.Namespace}}
+
+			result, err := r.handleRunningPhase(context.Background(), req, query)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(queryCapacityRequeueDelay))
+
+			_, exists := r.operations.Load(req.NamespacedName)
+			Expect(exists).To(BeFalse(), "should not register an operation when capacity is exhausted")
+		})
+
+		It("does not enforce a cap when MaxConcurrentQueries is 0", func() {
+			r := &QueryReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				MaxConcurrentQueries: 0,
+			}
+			Expect(r.sem).To(BeNil(), "nil semaphore means enforcement is disabled")
+
+			query := arkv1alpha1.Query{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "capacity-disabled-query",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+				},
+				Spec: arkv1alpha1.QuerySpec{
+					TTL: &metav1.Duration{Duration: time.Hour},
 				},
 			}
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: query.Name, Namespace: query.Namespace}}

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			namespacedName := types.NamespacedName{Name: "finish-query", Namespace: "default"}
 			_, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			r.operations.Store(namespacedName, context.CancelFunc(cancel))
+			r.operations.Store(namespacedName, cancel)
 
 			r.finishExecuteQueryAsync(context.Background(), namespacedName)
 

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -383,6 +383,61 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Expect(opts.MaxConcurrentReconciles).To(Equal(7))
 		})
 	})
+
+	Context("finishExecuteQueryAsync", func() {
+		It("deletes the operation entry and releases the semaphore", func() {
+			r := &QueryReconciler{
+				MaxConcurrentQueries: 1,
+				sem:                  semaphore.NewWeighted(1),
+			}
+			// Saturate the semaphore to model "a query is already in flight"; the
+			// next TryAcquire fails until something releases the slot.
+			Expect(r.sem.TryAcquire(1)).To(BeTrue())
+			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "semaphore should now be full")
+
+			namespacedName := types.NamespacedName{Name: "finish-query", Namespace: "default"}
+			_, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			r.operations.Store(namespacedName, context.CancelFunc(cancel))
+
+			r.finishExecuteQueryAsync(context.Background(), namespacedName)
+
+			_, exists := r.operations.Load(namespacedName)
+			Expect(exists).To(BeFalse(), "operations entry should be cleared")
+			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "semaphore slot should have been released")
+		})
+
+		It("does not panic when the semaphore is nil", func() {
+			r := &QueryReconciler{}
+			namespacedName := types.NamespacedName{Name: "no-sem-query", Namespace: "default"}
+			r.operations.Store(namespacedName, context.CancelFunc(func() {}))
+
+			Expect(func() { r.finishExecuteQueryAsync(context.Background(), namespacedName) }).NotTo(Panic())
+
+			_, exists := r.operations.Load(namespacedName)
+			Expect(exists).To(BeFalse())
+		})
+
+		It("recovers from a panic in the goroutine and still cleans up", func() {
+			r := &QueryReconciler{
+				MaxConcurrentQueries: 1,
+				sem:                  semaphore.NewWeighted(1),
+			}
+			Expect(r.sem.TryAcquire(1)).To(BeTrue())
+
+			namespacedName := types.NamespacedName{Name: "panic-query", Namespace: "default"}
+			r.operations.Store(namespacedName, context.CancelFunc(func() {}))
+
+			Expect(func() {
+				defer r.finishExecuteQueryAsync(context.Background(), namespacedName)
+				panic("simulated execution panic")
+			}).NotTo(Panic())
+
+			_, exists := r.operations.Load(namespacedName)
+			Expect(exists).To(BeFalse(), "cleanup must run even on panic")
+			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "semaphore must be released even on panic")
+		})
+	})
 })
 
 var _ = Describe("Query Controller Fallback Raw", func() {

--- a/ark/scripts/validate-chart-values.sh
+++ b/ark/scripts/validate-chart-values.sh
@@ -2,9 +2,7 @@
 #
 # validate-chart-values.sh
 # Validates that key values in dist/chart/values.yaml render into the
-# manager Deployment as expected. Regression guard for cases like
-# https://github.com/mckinsey/agents-at-scale-ark/pull/2717 where
-# `| default 32` silently swallowed `--set ...=0`.
+# manager Deployment as expected. 
 #
 
 set -euo pipefail
@@ -26,6 +24,7 @@ render() {
     helm template test-release "$CHART_DIR" \
         --show-only "$MANAGER_TEMPLATE" \
         "$@"
+    return $?
 }
 
 # expect_arg <name> <expected-arg> <set-args...>
@@ -39,7 +38,7 @@ expect_arg() {
         echo -e "${YELLOW}  helm template failed:${NC}"
         echo "$output" | sed 's/^/    /'
         FAILED=$((FAILED + 1))
-        return
+        return 0
     fi
     if echo "$output" | grep -qF -- "$expected"; then
         echo -e "${GREEN}OK${NC}   $name (found: $expected)"
@@ -50,6 +49,7 @@ expect_arg() {
         echo "$output" | grep -E -- '--max-concurrent-(queries|reconciles)=' | sed 's/^/    /' || true
         FAILED=$((FAILED + 1))
     fi
+    return 0
 }
 
 echo "Validating chart value rendering for $MANAGER_TEMPLATE..."
@@ -75,7 +75,7 @@ expect_arg "override maxConcurrentReconciles=0" \
     --set controllerManager.maxConcurrentReconciles=0
 
 echo ""
-if [ "$FAILED" -eq 0 ]; then
+if [[ "$FAILED" -eq 0 ]]; then
     echo -e "${GREEN}All chart value checks passed${NC}"
     exit 0
 fi

--- a/ark/scripts/validate-chart-values.sh
+++ b/ark/scripts/validate-chart-values.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# validate-chart-values.sh
+# Validates that key values in dist/chart/values.yaml render into the
+# manager Deployment as expected. Regression guard for cases like
+# https://github.com/mckinsey/agents-at-scale-ark/pull/2717 where
+# `| default 32` silently swallowed `--set ...=0`.
+#
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHART_DIR="$ARK_DIR/dist/chart"
+MANAGER_TEMPLATE="templates/manager/manager.yaml"
+
+FAILED=0
+
+# render <set-args...> -> stdout (just the manager Deployment)
+render() {
+    helm template test-release "$CHART_DIR" \
+        --show-only "$MANAGER_TEMPLATE" \
+        "$@"
+}
+
+# expect_arg <name> <expected-arg> <set-args...>
+expect_arg() {
+    local name="$1"
+    local expected="$2"
+    shift 2
+    local output
+    if ! output=$(render "$@" 2>&1); then
+        echo -e "${RED}FAIL${NC} $name"
+        echo -e "${YELLOW}  helm template failed:${NC}"
+        echo "$output" | sed 's/^/    /'
+        FAILED=$((FAILED + 1))
+        return
+    fi
+    if echo "$output" | grep -qF -- "$expected"; then
+        echo -e "${GREEN}OK${NC}   $name (found: $expected)"
+    else
+        echo -e "${RED}FAIL${NC} $name"
+        echo -e "${YELLOW}  expected to find:${NC} $expected"
+        echo -e "${YELLOW}  rendered args:${NC}"
+        echo "$output" | grep -E -- '--max-concurrent-(queries|reconciles)=' | sed 's/^/    /' || true
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+echo "Validating chart value rendering for $MANAGER_TEMPLATE..."
+
+# Defaults from values.yaml.
+expect_arg "default maxConcurrentQueries"     '"--max-concurrent-queries=32"'
+expect_arg "default maxConcurrentReconciles"  '"--max-concurrent-reconciles=4"'
+
+# Explicit non-zero overrides.
+expect_arg "override maxConcurrentQueries=64" \
+    '"--max-concurrent-queries=64"' \
+    --set controllerManager.maxConcurrentQueries=64
+expect_arg "override maxConcurrentReconciles=8" \
+    '"--max-concurrent-reconciles=8"' \
+    --set controllerManager.maxConcurrentReconciles=8
+
+# Zero must flow through (regression guard against Sprig `default` swallowing 0).
+expect_arg "override maxConcurrentQueries=0" \
+    '"--max-concurrent-queries=0"' \
+    --set controllerManager.maxConcurrentQueries=0
+expect_arg "override maxConcurrentReconciles=0" \
+    '"--max-concurrent-reconciles=0"' \
+    --set controllerManager.maxConcurrentReconciles=0
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    echo -e "${GREEN}All chart value checks passed${NC}"
+    exit 0
+fi
+echo -e "${RED}$FAILED chart value check(s) failed${NC}"
+exit 1

--- a/docs/content/reference/core-architecture.mdx
+++ b/docs/content/reference/core-architecture.mdx
@@ -44,7 +44,7 @@ sequenceDiagram
     KubeAPI->>etcd: Store Query status
 ```
 
-In the current architecture, queries are processed sequentially by controller reconciliation loops. This limits horizontal scalability for query workloads.
+In the current architecture, the controller processes queries through its reconciliation loop. The Query reconciler runs up to `maxConcurrentReconciles` worker goroutines in parallel (default 4) and caps concurrent in-flight executions at `maxConcurrentQueries` (default 32). Because reconciliation runs only on the leader, query throughput does not scale horizontally with replica count — production tuning is done by adjusting these limits and the controller's resource allocation. See [Scalability](/reference/scalability) for details.
 
 ## Aggregated Architecture
 

--- a/docs/content/reference/scalability.mdx
+++ b/docs/content/reference/scalability.mdx
@@ -13,9 +13,18 @@ Ark's control plane runs on Kubernetes and inherits its scaling primitives. The 
 
 ### Controller
 
-The controller reconciles all Ark custom resources across the cluster. It runs with leader election enabled by default, so multiple replicas can be deployed for availability — only the leader actively reconciles. Reconciler concurrency uses controller-runtime defaults and is not currently configurable via Helm values.
+The controller reconciles all Ark custom resources across the cluster. It runs with leader election enabled by default, so multiple replicas can be deployed for availability — only the leader actively reconciles.
 
 The controller's default resource allocation is intentionally conservative. Production deployments with a high volume of concurrent queries or large numbers of resources should increase CPU and memory limits based on observed usage.
+
+#### Query concurrency tuning
+
+The Query controller exposes two knobs via Helm values under `controllerManager`:
+
+- **`maxConcurrentQueries`** (default `32`) — caps the number of Query executions running concurrently as in-process goroutines. When the cap is reached, the reconciler requeues so the backlog stays in the workqueue instead of the controller heap. This bounds memory under burst load. Set to `0` to disable the cap (not recommended — susceptible to OOM under burst load).
+- **`maxConcurrentReconciles`** (default `4`) — caps the number of Query reconciles running in parallel. The workqueue dedupes per-key, so this only enables concurrency *across different* Query objects, not faster repeats of the same one. Set to `0` to use the controller-runtime default (1).
+
+The two knobs are independent and both effective at the defaults. `maxConcurrentReconciles` controls how fast queued queries are picked up; `maxConcurrentQueries` bounds how many of them can be in-flight at once. Raise both together if the controller has spare CPU/memory headroom and queue depth is growing. Lower `maxConcurrentQueries` if the controller pod is near its memory limit during bursts.
 
 ### API and dashboard
 


### PR DESCRIPTION
## Summary

Two related fixes for #2597 (controller OOM under burst load), plus docs.

- **#2692** — `Query` reconciler now caps in-flight executions via a `semaphore.Weighted`. When the cap is reached, reconciles requeue so the backlog stays in the workqueue (bounded by the K8s API server) instead of the controller heap. New flag/Helm value `maxConcurrentQueries` (default `32`, `0` disables — restores the pre-fix unbounded behaviour).
- **#2609** — `Query` controller now opts in to controller-runtime's `MaxConcurrentReconciles` so different Query objects can reconcile in parallel. New flag/Helm value `maxConcurrentReconciles` (default `4`, `0` falls back to controller-runtime's default of 1). The workqueue still dedupes per-key, so the same Query never reconciles concurrently with itself.
- **Docs** — updated `reference/scalability.mdx` and `reference/core-architecture.mdx` so the two knobs and their `0` semantics are documented. `dist/chart/values.yaml` comments already cover them inline.

These two fixes needed to be done at the same time - requeuing without upping concurrent reconciles meant that while the controller didn't OOM, it did still take a long time to clear. These default values seem to work well at the default memory values, and can be tuned for other setups.

Also adds some tests covering flag parsing in main, to get coverage up enough to satisfy codecov (but probably a good thing to have anyway).

## What we tested

Stress cluster (`eks-stress`), `stress-tenant` namespace, 5000-query bursts at 200 concurrency, 128 MiB controller memory limit (Helm default).

| Run | Args | Outcome | Drain time | done @ end | Peak goroutines | Peak Go sys | Peak cgroup working_set |
|---|---|---|---|---|---|---|---|
| `v0.1.64` baseline | controller-runtime defaults | OOMKilled | n/a | ~27% drained | 350 | 67.6 MB | 128 MB (limit) |
| `v0.1.65` baseline | controller-runtime defaults | OOMKilled | n/a | ~27% drained | 350 | 67.6 MB | 128 MB (limit) |
| Fix, **defaults** (4 reconcilers, sema=32) | this branch | drained cleanly | 7m 40s | 5000/5000 | 100 | 79 MB | 109 MB |
| Fix, 1 reconciler, sema=32 | this branch | drained cleanly | 14m 06s | 5000/5000 | 75 | 73 MB | 102 MB |
| Fix, **both flags = 0** | this branch | OOMKilled | n/a | ~26% drained | 322 | 67.7 MB | 128 MB (limit) |

The last row was the equivalence check: with both knobs disabled, the fix branch should behave like `v0.1.65`. Goroutine peak (322 vs 350), Go sys peak (67.7 MB vs 67.6 MB), and drain-before-OOM (~26% vs ~27%) match closely, confirming the `0` escape hatch is honoured and the fix's improvement comes from the semaphore + reconciler parallelism (not unrelated changes).

### Notes on the metric gap

Go `runtime/metrics` reported only ~67 MB at the moment of OOM, while the cgroup hit the 128 MiB limit. The gap is off-heap memory (cgo allocations, mmap arenas, scratch buffers) that the Go runtime doesn't account for. Operators monitoring controller memory should rely on container-level `working_set_bytes` (cAdvisor) rather than Go runtime metrics alone.

Closes #2692
Closes #2609
Refs #2597