### PR TITLE
feat(broker): Phase 3 — durable Postgres backend for operation events

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -249,6 +249,7 @@ if [ "${INSTALL_BROKER}" = "true" ]; then
     BROKER_HELM_ARGS+=(
       --set memory.createMemoryCRD=false
       --set backends.message=postgres
+      --set backends.event=postgres
       --set "database.url=postgres://postgres:${POSTGRES_PASSWORD}@ark-storage-dev.ark-system.svc.cluster.local:5432/ark?sslmode=verify-full"
       --set "database.migrateUrl=postgres://postgres:${POSTGRES_PASSWORD}@ark-storage-dev.ark-system.svc.cluster.local:5432/ark?sslmode=verify-full&sslrootcert=/etc/pg-ssl/ca.crt"
       --set database.tls.enabled=true

--- a/ark/internal/eventing/recorder/operations/operation_tracker.go
+++ b/ark/internal/eventing/recorder/operations/operation_tracker.go
@@ -52,7 +52,7 @@ func (ot *OperationTracker) InitializeQueryContext(ctx context.Context, query *a
 
 	qd := &QueryDetails{
 		Query:          query,
-		QueryID:        query.Name,
+		QueryID:        string(query.UID),
 		QueryName:      query.Name,
 		Namespace:      query.Namespace,
 		SessionID:      sessionID,

--- a/ark/internal/eventing/recorder/operations/operation_tracker.go
+++ b/ark/internal/eventing/recorder/operations/operation_tracker.go
@@ -52,7 +52,7 @@ func (ot *OperationTracker) InitializeQueryContext(ctx context.Context, query *a
 
 	qd := &QueryDetails{
 		Query:          query,
-		QueryID:        string(query.UID),
+		QueryID:        query.Name,
 		QueryName:      query.Name,
 		Namespace:      query.Namespace,
 		SessionID:      sessionID,

--- a/ark/internal/eventing/recorder/operations/operation_tracker_test.go
+++ b/ark/internal/eventing/recorder/operations/operation_tracker_test.go
@@ -36,7 +36,7 @@ func TestOperationTracker_InitializeQueryContext(t *testing.T) {
 	assert.NotNil(t, qd)
 	assert.Equal(t, "test-query", qd.QueryName)
 	assert.Equal(t, "test-ns", qd.Namespace)
-	assert.Equal(t, "test-uid", qd.QueryID)
+	assert.Equal(t, "test-query", qd.QueryID)
 	assert.Equal(t, "session-123", qd.SessionID)
 	assert.Equal(t, query, qd.Query)
 }
@@ -112,7 +112,7 @@ func TestOperationTracker_Start(t *testing.T) {
 	assert.NotNil(t, event.Data)
 	data, ok := (*event.Data).(map[string]string)
 	assert.True(t, ok)
-	assert.Equal(t, "test-uid", data["queryId"])
+	assert.Equal(t, "test-query", data["queryId"])
 	assert.Equal(t, "test-query", data["queryName"])
 	assert.Equal(t, "test-ns", data["queryNamespace"])
 	assert.Equal(t, "session-123", data["sessionId"])

--- a/ark/internal/eventing/recorder/operations/operation_tracker_test.go
+++ b/ark/internal/eventing/recorder/operations/operation_tracker_test.go
@@ -36,7 +36,7 @@ func TestOperationTracker_InitializeQueryContext(t *testing.T) {
 	assert.NotNil(t, qd)
 	assert.Equal(t, "test-query", qd.QueryName)
 	assert.Equal(t, "test-ns", qd.Namespace)
-	assert.Equal(t, "test-query", qd.QueryID)
+	assert.Equal(t, "test-uid", qd.QueryID)
 	assert.Equal(t, "session-123", qd.SessionID)
 	assert.Equal(t, query, qd.Query)
 }
@@ -112,7 +112,7 @@ func TestOperationTracker_Start(t *testing.T) {
 	assert.NotNil(t, event.Data)
 	data, ok := (*event.Data).(map[string]string)
 	assert.True(t, ok)
-	assert.Equal(t, "test-query", data["queryId"])
+	assert.Equal(t, "test-uid", data["queryId"])
 	assert.Equal(t, "test-query", data["queryName"])
 	assert.Equal(t, "test-ns", data["queryNamespace"])
 	assert.Equal(t, "session-123", data["sessionId"])

--- a/docs/content/developer-guide/services/ark-broker.mdx
+++ b/docs/content/developer-guide/services/ark-broker.mdx
@@ -51,7 +51,7 @@ The Helm chart can optionally configure a persistent volume for data storage by 
 
 ## Message backend (Postgres)
 
-By default the broker keeps all stores in memory. The **messages** store can opt in to Postgres so messages survive pod restarts. Only the messages store is affected — chunks, traces, events, and sessions remain in memory (or file-based, as above). The events store has its own Postgres backend (`EVENT_BACKEND=postgres`), described in the [Events backend](#events-backend-postgres) section below.
+By default the broker keeps all stores in memory. The **messages** store can opt in to Postgres so messages survive pod restarts. Only the messages store is affected — chunks, traces, events, and sessions remain in memory (or file-based, as above).
 
 This is separate from the controller's [PostgreSQL storage backend](/operations-guide/postgres-storage-backend), which stores Ark resources (CRDs) via the aggregated API server. The two use different databases and serve different purposes.
 
@@ -239,53 +239,6 @@ redis:
 ```
 
 The password can also be supplied separately from the URL via `redis.passwordSecretRef`, sourced into `REDIS_PASSWORD`.
-
-## Events backend (Postgres)
-
-Operation events (`QueryExecutionComplete`, `AgentExecutionStart`, and similar lifecycle events emitted by the controller) are stored in-memory by default. With `EVENT_BACKEND=postgres` they are persisted to Postgres, surviving pod restarts and enabling durable event history.
-
-The events store uses the same `DATABASE_URL` and connection pool as the messages backend. Both can be enabled independently or together — no separate database or credentials are needed.
-
-Enable it in the Helm chart:
-
-```yaml
-backends:
-  event: postgres
-
-database:
-  url: "postgres://user:password@host:5432/ark_broker"
-```
-
-Key environment variables:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `EVENT_BACKEND` | `memory` | Event storage backend: `memory` or `postgres` |
-| `DATABASE_URL` | — | Postgres connection string. Required when `EVENT_BACKEND=postgres` (shared with `MESSAGE_BACKEND`). |
-| `EVENT_VISIBILITY_TTL_SECONDS` | `2592000` | Default event TTL (30 days) |
-
-Events are written with an `expires_at` snapshot at insert time and filtered out once it elapses. The per-event TTL can be overridden at write time by including `ttl_seconds` in the `POST /events` body:
-
-```json
-{
-  "eventType": "QueryExecutionComplete",
-  "reason": "Completed",
-  "timestamp": "...",
-  "message": "...",
-  "data": { "queryId": "my-query", ... },
-  "ttl_seconds": 3600
-}
-```
-
-When `ttl_seconds` is absent the global `EVENT_VISIBILITY_TTL_SECONDS` applies. Events are append-only and immutable; there is no per-query delete endpoint yet (follow-up).
-
-<Callout type="warning">
-  Apply the same database isolation rules as for messages: each broker release must use its own database. The `events` table has no tenant separation. See [Broker storage isolation](/operations-guide/tenant-namespace-management#broker-storage-isolation).
-</Callout>
-
-The same TLS and `urlSecretRef` options from the messages backend apply here — see [Securing the Postgres connection](#securing-the-postgres-connection).
-
-See the [service README](https://github.com/mckinsey/agents-at-scale-ark/blob/main/services/ark-broker/README.md) for local development with devspace and integration tests.
 
 ## Sessions Endpoint
 

--- a/docs/content/developer-guide/services/ark-broker.mdx
+++ b/docs/content/developer-guide/services/ark-broker.mdx
@@ -51,7 +51,7 @@ The Helm chart can optionally configure a persistent volume for data storage by 
 
 ## Message backend (Postgres)
 
-By default the broker keeps all stores in memory. The **messages** store can opt in to Postgres so messages survive pod restarts. Only the messages store is affected — chunks, traces, events, and sessions remain in memory (or file-based, as above).
+By default the broker keeps all stores in memory. The **messages** store can opt in to Postgres so messages survive pod restarts. Only the messages store is affected — chunks, traces, events, and sessions remain in memory (or file-based, as above). The events store has its own Postgres backend (`EVENT_BACKEND=postgres`), described in the [Events backend](#events-backend-postgres) section below.
 
 This is separate from the controller's [PostgreSQL storage backend](/operations-guide/postgres-storage-backend), which stores Ark resources (CRDs) via the aggregated API server. The two use different databases and serve different purposes.
 
@@ -239,6 +239,53 @@ redis:
 ```
 
 The password can also be supplied separately from the URL via `redis.passwordSecretRef`, sourced into `REDIS_PASSWORD`.
+
+## Events backend (Postgres)
+
+Operation events (`QueryExecutionComplete`, `AgentExecutionStart`, and similar lifecycle events emitted by the controller) are stored in-memory by default. With `EVENT_BACKEND=postgres` they are persisted to Postgres, surviving pod restarts and enabling durable event history.
+
+The events store uses the same `DATABASE_URL` and connection pool as the messages backend. Both can be enabled independently or together — no separate database or credentials are needed.
+
+Enable it in the Helm chart:
+
+```yaml
+backends:
+  event: postgres
+
+database:
+  url: "postgres://user:password@host:5432/ark_broker"
+```
+
+Key environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EVENT_BACKEND` | `memory` | Event storage backend: `memory` or `postgres` |
+| `DATABASE_URL` | — | Postgres connection string. Required when `EVENT_BACKEND=postgres` (shared with `MESSAGE_BACKEND`). |
+| `EVENT_VISIBILITY_TTL_SECONDS` | `2592000` | Default event TTL (30 days) |
+
+Events are written with an `expires_at` snapshot at insert time and filtered out once it elapses. The per-event TTL can be overridden at write time by including `ttl_seconds` in the `POST /events` body:
+
+```json
+{
+  "eventType": "QueryExecutionComplete",
+  "reason": "Completed",
+  "timestamp": "...",
+  "message": "...",
+  "data": { "queryId": "my-query", ... },
+  "ttl_seconds": 3600
+}
+```
+
+When `ttl_seconds` is absent the global `EVENT_VISIBILITY_TTL_SECONDS` applies. Events are append-only and immutable; there is no per-query delete endpoint yet (follow-up).
+
+<Callout type="warning">
+  Apply the same database isolation rules as for messages: each broker release must use its own database. The `events` table has no tenant separation. See [Broker storage isolation](/operations-guide/tenant-namespace-management#broker-storage-isolation).
+</Callout>
+
+The same TLS and `urlSecretRef` options from the messages backend apply here — see [Securing the Postgres connection](#securing-the-postgres-connection).
+
+See the [service README](https://github.com/mckinsey/agents-at-scale-ark/blob/main/services/ark-broker/README.md) for local development with devspace and integration tests.
 
 ## Sessions Endpoint
 

--- a/services/ark-broker/README.md
+++ b/services/ark-broker/README.md
@@ -1,6 +1,6 @@
 # Ark Broker
 
-Event bus for Ark cluster communication. Stores messages, chunks, traces, events, and sessions. Default backend is in-memory; messages can be persisted to Postgres and completion chunks to Redis Streams.
+Event bus for Ark cluster communication. Stores messages, chunks, traces, events, and sessions. Default backend is in-memory; messages and events can be persisted to Postgres, and completion chunks to Redis Streams.
 
 ## Quickstart
 
@@ -17,11 +17,14 @@ devspace dev
 # Run with Postgres message backend.
 BROKER_MESSAGE_BACKEND=postgres devspace dev
 
+# Run with Postgres event backend.
+BROKER_EVENT_BACKEND=postgres devspace dev
+
 # Run with Redis chunks backend.
 BROKER_CHUNK_BACKEND=redis devspace dev
 
-# Run with both backends active.
-BROKER_MESSAGE_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
+# All backends active at once (profiles are combinable).
+BROKER_MESSAGE_BACKEND=postgres BROKER_EVENT_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
 ```
 
 ## Configuration
@@ -36,11 +39,13 @@ BROKER_MESSAGE_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
 | `MAX_SPANS` | `0` | Max trace spans to persist (0 = unlimited) |
 | `MAX_EVENTS` | `0` | Max events to persist (0 = unlimited) |
 | `MESSAGE_BACKEND` | `memory` | Message storage backend: `memory` or `postgres` |
-| `DATABASE_URL` | — | Postgres connection string. Required when `MESSAGE_BACKEND=postgres`. |
+| `EVENT_BACKEND` | `memory` | Event storage backend: `memory` or `postgres` |
+| `DATABASE_URL` | — | Postgres connection string. Required when `MESSAGE_BACKEND=postgres` or `EVENT_BACKEND=postgres`. Both backends share the same pool. |
 | `DATABASE_POOL_MAX` | `10` | Max connections in the pool |
 | `DATABASE_CONNECT_TIMEOUT_MS` | `10000` | Connection timeout |
 | `DATABASE_STATEMENT_TIMEOUT_MS` | `30000` | Per-statement timeout |
 | `MESSAGE_VISIBILITY_TTL_SECONDS` | `2592000` | Default message TTL (30 days) |
+| `EVENT_VISIBILITY_TTL_SECONDS` | `2592000` | Default event TTL (30 days) |
 | `DATABASE_DEBUG_QUERIES` | `false` | Log SQL queries at debug level (SQL text + param count, never values) |
 | `DATABASE_SSL_ROOT_CERT_PATH` | — | Path to the Postgres CA certificate file. When set, the broker passes it to the Postgres driver for server certificate verification. Set automatically by the Helm chart when `database.tls.enabled=true`. |
 | `CHUNK_BACKEND` | `memory` | Completion chunk storage backend: `memory` or `redis` |
@@ -53,35 +58,43 @@ BROKER_MESSAGE_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
 | `REDIS_CONNECT_TIMEOUT_MS` | `10000` | Redis connection timeout |
 | `REDIS_DEBUG_COMMANDS` | `false` | Log Redis connection lifecycle events at debug level (never logs payloads) |
 
-## Database backend
+## Database backend (messages and events)
 
-Messages can survive pod restarts by opting in to Postgres storage.
+Messages and operation events can survive pod restarts by opting in to Postgres storage. Both backends share a single `DATABASE_URL` and connection pool. You can enable one or both independently.
 
 ### Local development with devspace
 
 ```bash
+# Messages only.
 BROKER_MESSAGE_BACKEND=postgres devspace dev
+
+# Events only.
+BROKER_EVENT_BACKEND=postgres devspace dev
+
+# Both.
+BROKER_MESSAGE_BACKEND=postgres BROKER_EVENT_BACKEND=postgres devspace dev
 ```
 
-This activates the `broker-postgres` profile, which:
+Activating either backend (or both) triggers the shared `postgres-infra` DevSpace profile, which:
 - Deploys `ark-storage-dev` (Postgres 16-alpine, service `ark-storage-dev`, database `ark`) in the `default` namespace and waits for it to be ready.
 - Builds the `ark-broker-migrate` init container image locally.
 - Sets `DATABASE_URL=postgres://postgres:arkdev123@ark-storage-dev:5432/ark?sslmode=disable` on the broker deployment.
 - Runs `golang-migrate` as an init container before the broker starts.
 
-The same var works standalone: `BROKER_MESSAGE_BACKEND=postgres devspace deploy`.
+The same vars work standalone: `BROKER_MESSAGE_BACKEND=postgres devspace deploy`.
 
 ### Enabling in Helm
 
 ```yaml
 backends:
-  message: postgres
+  message: postgres   # or: event: postgres, or both
+  event: postgres
 
 database:
   url: "postgres://user:password@host:5432/ark_broker"
 ```
 
-The chart deploys a `migrate/migrate` init container that applies pending migrations before the broker starts.
+The chart deploys a `migrate/migrate` init container that applies all pending migrations before the broker starts. The `messages` and `events` tables share the same schema.
 
 ### Running migrations locally
 
@@ -122,10 +135,10 @@ This activates the `broker-redis` profile, which:
 - Deploys `ark-redis-dev` (Redis 7-alpine, service `ark-redis-dev`, port 6379) in the `default` namespace and waits for it to be ready.
 - Sets `REDIS_URL=redis://:arkredisdev123@ark-redis-dev:6379` on the broker deployment.
 
-Both backends can be activated together:
+All three backends can be activated together:
 
 ```bash
-BROKER_MESSAGE_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
+BROKER_MESSAGE_BACKEND=postgres BROKER_EVENT_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev
 ```
 
 ### Enabling in Helm

--- a/services/ark-broker/ark-broker/src/brokers/event-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/event-broker.ts
@@ -30,8 +30,11 @@ export class EventBroker {
     this.stream = stream;
   }
 
-  async addEvent(event: EventData): Promise<BrokerItem<EventData>> {
-    return this.stream.append(event);
+  async addEvent(
+    event: EventData,
+    ttlSeconds?: number
+  ): Promise<BrokerItem<EventData>> {
+    return this.stream.append(event, ttlSeconds);
   }
 
   async getByQuery(queryId: string): Promise<BrokerItem<EventData>[]> {

--- a/services/ark-broker/ark-broker/src/brokers/event-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/event-broker.ts
@@ -1,5 +1,4 @@
 import {BrokerItem} from './stream/broker-item.js';
-import {InMemoryStream} from './stream/in-memory-stream.js';
 import type {Stream} from './stream/stream.js';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import {PaginatedList, PaginationParams} from './pagination.js';
@@ -22,16 +21,13 @@ export interface EventData {
   };
 }
 
+export type EventStream = Stream<EventData>;
+
 export class EventBroker {
   private readonly stream: Stream<EventData>;
 
-  constructor(logger: Logger, path?: string, maxItems?: number) {
-    this.stream = new InMemoryStream<EventData>(
-      logger,
-      'Event',
-      path,
-      maxItems
-    );
+  constructor(stream: EventStream, _logger?: Logger) {
+    this.stream = stream;
   }
 
   async addEvent(event: EventData): Promise<BrokerItem<EventData>> {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
@@ -1,0 +1,213 @@
+import {createLogger} from '@ark-broker/logging/logger.js';
+import {usePgContainer} from '../../../db/__tests__/testHelpers/pg-testcontainer.js';
+import {PostgresEventStream} from '../postgres-event-stream.js';
+import {makeEventData} from './testHelpers/event-data-factory.js';
+
+jest.setTimeout(120_000);
+
+const silentLogger = createLogger({level: 'silent', pretty: false});
+
+describe('PostgresEventStream', () => {
+  const {db} = usePgContainer();
+  let stream: PostgresEventStream;
+
+  beforeAll(() => {
+    stream = new PostgresEventStream(silentLogger, db(), 3600);
+  });
+
+  describe('append', () => {
+    it('assigns sequenceNumber starting at 1', async () => {
+      const item = await stream.append(makeEventData());
+      expect(item.sequenceNumber).toBe(1);
+    });
+
+    it('increments sequenceNumber monotonically', async () => {
+      const a = await stream.append(makeEventData());
+      const b = await stream.append(makeEventData());
+      const c = await stream.append(makeEventData());
+      expect(a.sequenceNumber).toBe(1);
+      expect(b.sequenceNumber).toBe(2);
+      expect(c.sequenceNumber).toBe(3);
+    });
+
+    it('returns item with timestamp as Date', async () => {
+      const item = await stream.append(makeEventData());
+      expect(item.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('round-trips EventData through JSONB', async () => {
+      const event = makeEventData({eventType: 'AgentExecutionStart'});
+      const item = await stream.append(event);
+      expect(item.data.eventType).toBe('AgentExecutionStart');
+      expect(item.data.data.queryId).toBe(event.data.queryId);
+    });
+
+    it('fires subscribe callback during append', async () => {
+      const received: number[] = [];
+      stream.subscribe((item) => received.push(item.sequenceNumber));
+      await stream.append(makeEventData());
+      expect(received).toHaveLength(1);
+    });
+  });
+
+  describe('all', () => {
+    it('returns empty array initially', async () => {
+      expect(await stream.all()).toEqual([]);
+    });
+
+    it('returns all appended items in order', async () => {
+      await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      const all = await stream.all();
+      expect(all).toHaveLength(2);
+      expect(all[0].sequenceNumber).toBe(1);
+      expect(all[1].sequenceNumber).toBe(2);
+    });
+  });
+
+  describe('filter', () => {
+    it('returns only matching items', async () => {
+      const a = await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      const result = await stream.filter(
+        (item) => item.sequenceNumber === a.sequenceNumber
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].sequenceNumber).toBe(a.sequenceNumber);
+    });
+
+    it('filters by queryId via EventData.data.queryId', async () => {
+      const target = 'q-' + Math.random().toString(36).slice(2);
+      const event = makeEventData();
+      event.data.queryId = target;
+      await stream.append(event);
+      await stream.append(makeEventData());
+
+      const result = await stream.filter(
+        (item) => item.data.data.queryId === target
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].data.data.queryId).toBe(target);
+    });
+  });
+
+  describe('paginate', () => {
+    beforeEach(async () => {
+      for (let i = 0; i < 5; i++) {
+        await stream.append(makeEventData());
+      }
+    });
+
+    it('returns up to limit items', async () => {
+      const result = await stream.paginate({limit: 2});
+      expect(result.items).toHaveLength(2);
+      expect(result.total).toBe(5);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).toBe(2);
+    });
+
+    it('applies cursor to skip already-seen items', async () => {
+      const result = await stream.paginate({limit: 2, cursor: 2});
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].sequenceNumber).toBe(3);
+    });
+
+    it('sets hasMore=false and nextCursor=undefined on last page', async () => {
+      const result = await stream.paginate({limit: 10});
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('applies predicate before pagination', async () => {
+      const result = await stream.paginate(
+        {limit: 10},
+        (item) => item.sequenceNumber % 2 === 1
+      );
+      expect(result.items).toHaveLength(3);
+      expect(result.total).toBe(3);
+    });
+  });
+
+  describe('delete', () => {
+    it('removes all items when called without predicate', async () => {
+      await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      await stream.delete();
+      expect(await stream.all()).toHaveLength(0);
+      const next = await stream.append(makeEventData());
+      expect(next.sequenceNumber).toBe(3);
+    });
+
+    it('removes only matching items when predicate is provided', async () => {
+      const a = await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      await stream.delete((item) => item.sequenceNumber === a.sequenceNumber);
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0].sequenceNumber).toBe(2);
+    });
+  });
+
+  describe('getCurrentSequence', () => {
+    it('returns 0 when stream is empty', async () => {
+      expect(await stream.getCurrentSequence()).toBe(0);
+    });
+
+    it('returns last assigned sequence number', async () => {
+      await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      expect(await stream.getCurrentSequence()).toBe(2);
+    });
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('notifies subscriber for each append', async () => {
+      const seqs: number[] = [];
+      stream.subscribe((item) => seqs.push(item.sequenceNumber));
+      await stream.append(makeEventData());
+      await stream.append(makeEventData());
+      expect(seqs).toEqual([1, 2]);
+    });
+
+    it('stops notifying after returned unsubscribe is called', async () => {
+      const seqs: number[] = [];
+      const unsubscribe = stream.subscribe((item) =>
+        seqs.push(item.sequenceNumber)
+      );
+      await stream.append(makeEventData());
+      unsubscribe();
+      await stream.append(makeEventData());
+      expect(seqs).toEqual([1]);
+    });
+  });
+
+  describe('TTL', () => {
+    const CLOCK_SKEW_MS = 100;
+
+    it('uses constructor ttlSeconds as default expires_at', async () => {
+      const before = Date.now();
+      const item = await stream.append(makeEventData());
+      const after = Date.now();
+
+      const pgDb = db();
+      const rows = await pgDb<{expires_at: Date}[]>`
+        SELECT expires_at FROM events WHERE sequence_number = ${item.sequenceNumber}
+      `;
+      const expiresAt = rows[0]!.expires_at.getTime();
+      expect(expiresAt).toBeGreaterThanOrEqual(
+        before - CLOCK_SKEW_MS + 3600 * 1000
+      );
+      expect(expiresAt).toBeLessThanOrEqual(after + 3600 * 1000 + 2000);
+    });
+
+    it('expired items are invisible to all and getCurrentSequence', async () => {
+      await stream.append(makeEventData(), 1);
+      expect(await stream.all()).toHaveLength(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      expect(await stream.all()).toHaveLength(0);
+      expect(await stream.getCurrentSequence()).toBe(0);
+    });
+  });
+});

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/testHelpers/event-data-factory.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/testHelpers/event-data-factory.ts
@@ -1,0 +1,19 @@
+import {faker} from '@faker-js/faker';
+import type {EventData} from '../../../event-broker.js';
+
+const defaults = (): EventData => ({
+  timestamp: new Date().toISOString(),
+  eventType: 'QueryExecutionComplete',
+  reason: 'Completed',
+  message: faker.lorem.sentence(),
+  data: {
+    queryId: faker.string.uuid(),
+    queryName: faker.lorem.word(),
+    queryNamespace: 'default',
+    sessionId: faker.string.uuid(),
+  },
+});
+
+export function makeEventData(overrides?: Partial<EventData>): EventData {
+  return {...defaults(), ...overrides};
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
@@ -1,0 +1,18 @@
+import type {AppConfig} from '@ark-broker/config/index.js';
+import type {Db} from '@ark-broker/db/db.js';
+import type {Logger} from '@ark-broker/logging/logger.js';
+import type {EventData, EventStream} from '../event-broker.js';
+import {InMemoryStream} from './in-memory-stream.js';
+
+export function createEventStream(
+  config: AppConfig,
+  logger: Logger,
+  _db?: Db
+): EventStream {
+  return new InMemoryStream<EventData>(
+    logger.child({broker: 'memory-events'}),
+    'Event',
+    config.persistence.eventFilePath,
+    config.limits.maxEvents
+  );
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
@@ -3,12 +3,20 @@ import type {Db} from '@ark-broker/db/db.js';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {EventData, EventStream} from '../event-broker.js';
 import {InMemoryStream} from './in-memory-stream.js';
+import {PostgresEventStream} from './postgres-event-stream.js';
 
 export function createEventStream(
   config: AppConfig,
   logger: Logger,
-  _db?: Db
+  db?: Db
 ): EventStream {
+  if (config.backends.event === 'postgres') {
+    return new PostgresEventStream(
+      logger.child({broker: 'postgres-events'}),
+      db!,
+      config.backends.eventVisibilityTtlSeconds
+    );
+  }
   return new InMemoryStream<EventData>(
     logger.child({broker: 'memory-events'}),
     'Event',

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
@@ -1,0 +1,130 @@
+import {EventEmitter} from 'events';
+import type postgres from 'postgres';
+import type {Logger} from '@ark-broker/logging/logger.js';
+import type {Db} from '@ark-broker/db/db.js';
+import type {EventData} from '../event-broker.js';
+import {BrokerItem} from './broker-item.js';
+import {
+  DEFAULT_LIMIT,
+  type PaginatedList,
+  type PaginationParams,
+} from '../pagination.js';
+import type {Predicate, Stream} from './stream.js';
+
+type EventRow = {
+  sequence_number: string;
+  query_id: string;
+  session_id: string | null;
+  reason: string | null;
+  event: unknown;
+  created_at: Date;
+};
+
+function rowToBrokerItem(row: EventRow): BrokerItem<EventData> {
+  return {
+    sequenceNumber: Number(row.sequence_number),
+    timestamp: row.created_at,
+    data: row.event as EventData,
+  };
+}
+
+export class PostgresEventStream implements Stream<EventData> {
+  private readonly emitter = new EventEmitter();
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly db: Db,
+    private readonly ttlSeconds: number
+  ) {}
+
+  async append(
+    data: EventData,
+    ttlSeconds?: number
+  ): Promise<BrokerItem<EventData>> {
+    const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
+    const rows = await this.db<EventRow[]>`
+      INSERT INTO events (query_id, session_id, reason, event, expires_at)
+      VALUES (
+        ${data.data.queryId},
+        ${data.data.sessionId ?? null},
+        ${data.reason ?? null},
+        ${this.db.json(data as unknown as postgres.JSONValue)},
+        now() + make_interval(secs => ${effectiveTtl})
+      )
+      RETURNING sequence_number, query_id, session_id, reason, event, created_at
+    `;
+    const item = rowToBrokerItem(rows[0]!);
+    this.emitter.emit('item', item);
+    return item;
+  }
+
+  async all(): Promise<BrokerItem<EventData>[]> {
+    const rows = await this.db<EventRow[]>`
+      SELECT sequence_number, query_id, session_id, reason, event, created_at
+      FROM events
+      WHERE expires_at > now()
+      ORDER BY sequence_number ASC
+    `;
+    return rows.map(rowToBrokerItem);
+  }
+
+  async filter(
+    predicate: Predicate<EventData>
+  ): Promise<BrokerItem<EventData>[]> {
+    return (await this.all()).filter(predicate);
+  }
+
+  async paginate(
+    params: PaginationParams,
+    predicate?: Predicate<EventData>
+  ): Promise<PaginatedList<BrokerItem<EventData>>> {
+    const limit = params.limit ?? DEFAULT_LIMIT;
+    const cursor = params.cursor;
+
+    const all = await this.all();
+    let filtered = predicate ? all.filter(predicate) : all;
+    const total = filtered.length;
+
+    if (cursor !== undefined) {
+      filtered = filtered.filter((item) => item.sequenceNumber > cursor);
+    }
+
+    const items = filtered.slice(0, limit);
+    const hasMore = filtered.length > limit;
+
+    return {
+      items,
+      total,
+      hasMore,
+      nextCursor: hasMore ? items.at(-1)!.sequenceNumber : undefined,
+    };
+  }
+
+  async delete(predicate?: Predicate<EventData>): Promise<void> {
+    if (!predicate) {
+      this.logger.info('deleting all events');
+      await this.db`DELETE FROM events`;
+      return;
+    }
+    const items = await this.all();
+    const toDelete = items.filter(predicate).map((item) => item.sequenceNumber);
+    if (toDelete.length === 0) return;
+    await this.db`DELETE FROM events WHERE sequence_number = ANY(${toDelete})`;
+  }
+
+  async save(): Promise<void> {}
+
+  async getCurrentSequence(): Promise<number> {
+    const [{seq}] = await this.db<[{seq: string | null}]>`
+      SELECT MAX(sequence_number) as seq FROM events WHERE expires_at > now()
+    `;
+    return seq === null ? 0 : Number(seq);
+  }
+
+  subscribe(callback: (item: BrokerItem<EventData>) => void): () => void {
+    this.emitter.on('item', callback);
+    return (): void => {
+      this.emitter.off('item', callback);
+    };
+  }
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
@@ -1,15 +1,10 @@
-import {EventEmitter} from 'events';
 import type postgres from 'postgres';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {Db} from '@ark-broker/db/db.js';
 import type {EventData} from '../event-broker.js';
 import {BrokerItem} from './broker-item.js';
-import {
-  DEFAULT_LIMIT,
-  type PaginatedList,
-  type PaginationParams,
-} from '../pagination.js';
-import type {Predicate, Stream} from './stream.js';
+import type {Predicate} from './stream.js';
+import {PostgresStreamBase} from './postgres-stream-base.js';
 
 type EventRow = {
   sequence_number: string;
@@ -28,14 +23,14 @@ function rowToBrokerItem(row: EventRow): BrokerItem<EventData> {
   };
 }
 
-export class PostgresEventStream implements Stream<EventData> {
-  private readonly emitter = new EventEmitter();
-
+export class PostgresEventStream extends PostgresStreamBase<EventData> {
   constructor(
     private readonly logger: Logger,
     private readonly db: Db,
     private readonly ttlSeconds: number
-  ) {}
+  ) {
+    super();
+  }
 
   async append(
     data: EventData,
@@ -68,38 +63,6 @@ export class PostgresEventStream implements Stream<EventData> {
     return rows.map(rowToBrokerItem);
   }
 
-  async filter(
-    predicate: Predicate<EventData>
-  ): Promise<BrokerItem<EventData>[]> {
-    return (await this.all()).filter(predicate);
-  }
-
-  async paginate(
-    params: PaginationParams,
-    predicate?: Predicate<EventData>
-  ): Promise<PaginatedList<BrokerItem<EventData>>> {
-    const limit = params.limit ?? DEFAULT_LIMIT;
-    const cursor = params.cursor;
-
-    const all = await this.all();
-    let filtered = predicate ? all.filter(predicate) : all;
-    const total = filtered.length;
-
-    if (cursor !== undefined) {
-      filtered = filtered.filter((item) => item.sequenceNumber > cursor);
-    }
-
-    const items = filtered.slice(0, limit);
-    const hasMore = filtered.length > limit;
-
-    return {
-      items,
-      total,
-      hasMore,
-      nextCursor: hasMore ? items.at(-1)!.sequenceNumber : undefined,
-    };
-  }
-
   async delete(predicate?: Predicate<EventData>): Promise<void> {
     if (!predicate) {
       this.logger.info('deleting all events');
@@ -112,19 +75,10 @@ export class PostgresEventStream implements Stream<EventData> {
     await this.db`DELETE FROM events WHERE sequence_number = ANY(${toDelete})`;
   }
 
-  async save(): Promise<void> {}
-
   async getCurrentSequence(): Promise<number> {
     const [{seq}] = await this.db<[{seq: string | null}]>`
       SELECT MAX(sequence_number) as seq FROM events WHERE expires_at > now()
     `;
     return seq === null ? 0 : Number(seq);
-  }
-
-  subscribe(callback: (item: BrokerItem<EventData>) => void): () => void {
-    this.emitter.on('item', callback);
-    return (): void => {
-      this.emitter.off('item', callback);
-    };
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -1,16 +1,11 @@
-import {EventEmitter} from 'events';
 import type postgres from 'postgres';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {Db} from '@ark-broker/db/db.js';
 import type {MessageData} from '../memory-broker.js';
 import {BrokerItem} from './broker-item.js';
-import {
-  DEFAULT_LIMIT,
-  type PaginatedList,
-  type PaginationParams,
-} from '../pagination.js';
 import type {Predicate} from './stream.js';
 import type {MessageStream} from './message-stream.js';
+import {PostgresStreamBase} from './postgres-stream-base.js';
 
 type MessageRow = {
   sequence_number: string;
@@ -32,14 +27,17 @@ function rowToBrokerItem(row: MessageRow): BrokerItem<MessageData> {
   };
 }
 
-export class PostgresMessageStream implements MessageStream {
-  private readonly emitter = new EventEmitter();
-
+export class PostgresMessageStream
+  extends PostgresStreamBase<MessageData>
+  implements MessageStream
+{
   constructor(
     private readonly logger: Logger,
     private readonly db: Db,
     private readonly ttlSeconds: number
-  ) {}
+  ) {
+    super();
+  }
 
   async append(
     data: MessageData,
@@ -71,38 +69,6 @@ export class PostgresMessageStream implements MessageStream {
     return rows.map(rowToBrokerItem);
   }
 
-  async filter(
-    predicate: Predicate<MessageData>
-  ): Promise<BrokerItem<MessageData>[]> {
-    return (await this.all()).filter(predicate);
-  }
-
-  async paginate(
-    params: PaginationParams,
-    predicate?: Predicate<MessageData>
-  ): Promise<PaginatedList<BrokerItem<MessageData>>> {
-    const limit = params.limit ?? DEFAULT_LIMIT;
-    const cursor = params.cursor;
-
-    const all = await this.all();
-    let filtered = predicate ? all.filter(predicate) : all;
-    const total = filtered.length;
-
-    if (cursor !== undefined) {
-      filtered = filtered.filter((item) => item.sequenceNumber > cursor);
-    }
-
-    const items = filtered.slice(0, limit);
-    const hasMore = filtered.length > limit;
-
-    return {
-      items,
-      total,
-      hasMore,
-      nextCursor: hasMore ? items.at(-1)!.sequenceNumber : undefined,
-    };
-  }
-
   async delete(predicate?: Predicate<MessageData>): Promise<void> {
     if (!predicate) {
       this.logger.info('deleting all messages');
@@ -121,19 +87,10 @@ export class PostgresMessageStream implements MessageStream {
     await this.db`DELETE FROM messages WHERE query_id = ${queryId}`;
   }
 
-  async save(): Promise<void> {}
-
   async getCurrentSequence(): Promise<number> {
     const [{seq}] = await this.db<[{seq: string | null}]>`
       SELECT MAX(sequence_number) as seq FROM messages WHERE expires_at > now()
     `;
     return seq === null ? 0 : Number(seq);
-  }
-
-  subscribe(callback: (item: BrokerItem<MessageData>) => void): () => void {
-    this.emitter.on('item', callback);
-    return (): void => {
-      this.emitter.off('item', callback);
-    };
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
@@ -1,0 +1,59 @@
+import {EventEmitter} from 'node:events';
+import {BrokerItem} from './broker-item.js';
+import {
+  DEFAULT_LIMIT,
+  type PaginatedList,
+  type PaginationParams,
+} from '../pagination.js';
+import type {Predicate, Stream} from './stream.js';
+
+export abstract class PostgresStreamBase<T> implements Stream<T> {
+  protected readonly emitter = new EventEmitter();
+
+  abstract append(data: T, ttlSeconds?: number): Promise<BrokerItem<T>>;
+  abstract all(): Promise<BrokerItem<T>[]>;
+  abstract delete(predicate?: Predicate<T>): Promise<void>;
+  abstract getCurrentSequence(): Promise<number>;
+
+  async filter(predicate: Predicate<T>): Promise<BrokerItem<T>[]> {
+    return (await this.all()).filter(predicate);
+  }
+
+  async paginate(
+    params: PaginationParams,
+    predicate?: Predicate<T>
+  ): Promise<PaginatedList<BrokerItem<T>>> {
+    const limit = params.limit ?? DEFAULT_LIMIT;
+    const cursor = params.cursor;
+
+    const all = await this.all();
+    let filtered = predicate ? all.filter(predicate) : all;
+    const total = filtered.length;
+
+    if (cursor !== undefined) {
+      filtered = filtered.filter((item) => item.sequenceNumber > cursor);
+    }
+
+    const items = filtered.slice(0, limit);
+    const hasMore = filtered.length > limit;
+    const lastItem = items.at(-1);
+
+    return {
+      items,
+      total,
+      hasMore,
+      nextCursor: hasMore && lastItem ? lastItem.sequenceNumber : undefined,
+    };
+  }
+
+  async save(): Promise<void> {
+    // no-op: Postgres persists synchronously on append, no separate flush step
+  }
+
+  subscribe(callback: (item: BrokerItem<T>) => void): () => void {
+    this.emitter.on('item', callback);
+    return (): void => {
+      this.emitter.off('item', callback);
+    };
+  }
+}

--- a/services/ark-broker/ark-broker/src/config/load.ts
+++ b/services/ark-broker/ark-broker/src/config/load.ts
@@ -27,6 +27,8 @@ export function loadConfig(env: Record<string, string | undefined>): AppConfig {
     backends: Object.freeze({
       message: parsed.MESSAGE_BACKEND,
       messageVisibilityTtlSeconds: parsed.MESSAGE_VISIBILITY_TTL_SECONDS,
+      event: parsed.EVENT_BACKEND,
+      eventVisibilityTtlSeconds: parsed.EVENT_VISIBILITY_TTL_SECONDS,
       chunk: parsed.CHUNK_BACKEND,
     }),
     database: Object.freeze({

--- a/services/ark-broker/ark-broker/src/config/schema.ts
+++ b/services/ark-broker/ark-broker/src/config/schema.ts
@@ -38,6 +38,12 @@ export const envSchema = z
       .int()
       .positive()
       .default(2592000),
+    EVENT_BACKEND: z.enum(['memory', 'postgres']).default('memory'),
+    EVENT_VISIBILITY_TTL_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(2592000),
     DATABASE_DEBUG_QUERIES: z
       .string()
       .default('false')
@@ -57,10 +63,15 @@ export const envSchema = z
       .transform((v) => v === 'true'),
   })
   .superRefine((data, ctx) => {
-    if (data.MESSAGE_BACKEND === 'postgres' && !data.DATABASE_URL) {
+    if (
+      (data.MESSAGE_BACKEND === 'postgres' ||
+        data.EVENT_BACKEND === 'postgres') &&
+      !data.DATABASE_URL
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'DATABASE_URL is required when MESSAGE_BACKEND=postgres',
+        message:
+          'DATABASE_URL is required when MESSAGE_BACKEND=postgres or EVENT_BACKEND=postgres',
         path: ['DATABASE_URL'],
       });
     }

--- a/services/ark-broker/ark-broker/src/config/types.ts
+++ b/services/ark-broker/ark-broker/src/config/types.ts
@@ -32,11 +32,15 @@ export type PersistenceConfig = Readonly<{
 
 export type MessageBackend = 'memory' | 'postgres';
 
+export type EventBackend = 'memory' | 'postgres';
+
 export type ChunkBackend = 'memory' | 'redis';
 
 export type BackendsConfig = Readonly<{
   message: MessageBackend;
   messageVisibilityTtlSeconds: number;
+  event: EventBackend;
+  eventVisibilityTtlSeconds: number;
   chunk: ChunkBackend;
 }>;
 

--- a/services/ark-broker/ark-broker/src/db/migrations/000002_create_events.down.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000002_create_events.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS events;
+DROP SEQUENCE IF EXISTS events_seq;

--- a/services/ark-broker/ark-broker/src/db/migrations/000002_create_events.up.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000002_create_events.up.sql
@@ -1,0 +1,17 @@
+CREATE SEQUENCE IF NOT EXISTS events_seq AS BIGINT START WITH 1;
+
+CREATE TABLE IF NOT EXISTS events (
+  sequence_number BIGINT      PRIMARY KEY DEFAULT nextval('events_seq'),
+  query_id        TEXT        NOT NULL,
+  session_id      TEXT,
+  reason          TEXT,
+  event           JSONB       NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ NOT NULL
+);
+
+ALTER SEQUENCE events_seq OWNED BY events.sequence_number;
+
+CREATE INDEX events_query_idx      ON events (query_id, sequence_number);
+CREATE INDEX events_session_idx    ON events (session_id, sequence_number);
+CREATE INDEX events_expires_at_idx ON events (expires_at);

--- a/services/ark-broker/ark-broker/src/http/routes/events/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/events/index.ts
@@ -81,10 +81,10 @@ export function createEventsRouter(
         sendValidationError(res, parse.error, req.id);
         return;
       }
-      const event: PostEventBody = parse.data;
+      const {ttl_seconds: ttlSeconds, ...event}: PostEventBody = parse.data;
 
       try {
-        await events.addEvent(event as unknown as EventData);
+        await events.addEvent(event as unknown as EventData, ttlSeconds);
         await events.save();
 
         sessions.applyEvent({

--- a/services/ark-broker/ark-broker/src/http/routes/events/schemas.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/events/schemas.ts
@@ -23,6 +23,7 @@ export type GetEventsQueryRaw = {
 export const postEventBodySchema = z
   .object({
     data: z.object({queryId: z.string().min(1)}).passthrough(),
+    ttl_seconds: z.coerce.number().int().positive().optional(),
   })
   .passthrough();
 export type PostEventBody = z.infer<typeof postEventBodySchema>;

--- a/services/ark-broker/ark-broker/src/index.ts
+++ b/services/ark-broker/ark-broker/src/index.ts
@@ -4,6 +4,7 @@ import {createLogger} from './logging/logger.js';
 import {buildApp} from './server.js';
 import {createMessageStream} from './brokers/stream/message-stream-factory.js';
 import {createChunkStream} from './brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from './brokers/stream/event-stream-factory.js';
 import {createDb} from './db/db.js';
 import {createRedis} from './redis/redis.js';
 
@@ -28,23 +29,26 @@ const main = async (): Promise<void> => {
 
   logger.info({backend: config.backends.message}, 'message backend');
   logger.info({backend: config.backends.chunk}, 'chunk backend');
+  logger.info({backend: config.backends.event}, 'event backend');
 
-  const db =
-    config.backends.message === 'postgres'
-      ? createDb(config, logger)
-      : undefined;
+  const needsDb =
+    config.backends.message === 'postgres' ||
+    config.backends.event === 'postgres';
+  const db = needsDb ? createDb(config, logger) : undefined;
 
   const redis =
     config.backends.chunk === 'redis' ? createRedis(config, logger) : undefined;
 
   const messageStream = createMessageStream(config, logger, db);
   const chunkStream = createChunkStream(config, logger, redis);
+  const eventStream = createEventStream(config, logger, db);
   const {app, brokers} = buildApp({
     config,
     logger,
     version,
     messageStream,
     chunkStream,
+    eventStream,
     db,
     redis,
   });

--- a/services/ark-broker/ark-broker/src/server.ts
+++ b/services/ark-broker/ark-broker/src/server.ts
@@ -10,6 +10,7 @@ import {createHttpLogger} from './http/middleware/http-logger.js';
 import {requestId} from './http/middleware/request-id.js';
 import {MemoryBroker} from './brokers/memory-broker.js';
 import type {MessageStream} from './brokers/stream/message-stream.js';
+import type {EventStream} from './brokers/event-broker.js';
 import {type Db, pingDb} from './db/db.js';
 import type {RedisClient} from './redis/redis.js';
 import {pingRedis} from './redis/redis.js';
@@ -45,10 +46,20 @@ export function buildApp(deps: {
   version: string;
   messageStream: MessageStream;
   chunkStream: ChunkStream;
+  eventStream: EventStream;
   db?: Db;
   redis?: RedisClient;
 }): AppBundle {
-  const {config, logger, version, messageStream, chunkStream, db, redis} = deps;
+  const {
+    config,
+    logger,
+    version,
+    messageStream,
+    chunkStream,
+    eventStream,
+    db,
+    redis,
+  } = deps;
   const app = express();
 
   const memory = new MemoryBroker(messageStream);
@@ -58,11 +69,7 @@ export function buildApp(deps: {
     config.persistence.traceFilePath,
     config.limits.maxSpans
   );
-  const events = new EventBroker(
-    logger.child({broker: 'events'}),
-    config.persistence.eventFilePath,
-    config.limits.maxEvents
-  );
+  const events = new EventBroker(eventStream);
   const sessions = new SessionsBroker(
     logger.child({broker: 'sessions'}),
     config.persistence.sessionsFilePath

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -6,6 +6,7 @@ import {buildApp} from '../src/server.js';
 import {createDb} from '../src/db/db.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 import {usePgContainer} from '../src/db/__tests__/testHelpers/pg-testcontainer.js';
 
 jest.setTimeout(120_000);
@@ -31,6 +32,7 @@ describeIntegration('postgres backend — HTTP integration', () => {
       version: 'test',
       messageStream: stream,
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
       db: db(),
     }));
   });
@@ -73,6 +75,7 @@ describeIntegration('postgres backend — HTTP integration', () => {
       version: 'test',
       messageStream: freshStream,
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
       db: freshDb,
     });
 

--- a/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
@@ -1,0 +1,133 @@
+import type {Express} from 'express';
+import request from 'supertest';
+import {loadConfig} from '../src/config/index.js';
+import {createLogger} from '../src/logging/logger.js';
+import {buildApp} from '../src/server.js';
+import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
+import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
+import {usePgContainer} from '../src/db/__tests__/testHelpers/pg-testcontainer.js';
+
+jest.setTimeout(120_000);
+
+const logger = createLogger({level: 'silent', pretty: false});
+
+const describeIntegration =
+  process.env.SKIP_INTEGRATION === 'true' ? describe.skip : describe;
+
+const baseEvent = {
+  timestamp: new Date().toISOString(),
+  eventType: 'QueryExecutionComplete',
+  reason: 'Completed',
+  message: 'query finished',
+  data: {
+    queryId: 'q-pg-events-1',
+    queryName: 'test-query',
+    queryNamespace: 'default',
+    sessionId: 'sess-1',
+  },
+};
+
+describeIntegration('postgres event backend — HTTP integration', () => {
+  const {db, connectionUrl} = usePgContainer();
+  let app: Express;
+
+  beforeAll(() => {
+    const config = loadConfig({
+      EVENT_BACKEND: 'postgres',
+      DATABASE_URL: connectionUrl(),
+    });
+    ({app} = buildApp({
+      config,
+      logger,
+      version: 'test',
+      messageStream: createMessageStream(config, logger),
+      chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger, db()),
+      db: db(),
+    }));
+  });
+
+  it('POST /events stores and GET /events retrieves from Postgres', async () => {
+    await request(app).post('/events').send(baseEvent).expect(201);
+
+    const res = await request(app).get('/events').expect(200);
+    expect(res.body.items).toHaveLength(1);
+    const item = res.body.items[0] as typeof baseEvent;
+    expect(item.eventType).toBe('QueryExecutionComplete');
+    expect(item.data.queryId).toBe('q-pg-events-1');
+  });
+
+  it('GET /events/:queryId returns only events for that query', async () => {
+    await request(app).post('/events').send(baseEvent).expect(201);
+    await request(app)
+      .post('/events')
+      .send({...baseEvent, data: {...baseEvent.data, queryId: 'q-other'}})
+      .expect(201);
+
+    const res = await request(app).get('/events/q-pg-events-1').expect(200);
+    expect(res.body.items.length).toBeGreaterThanOrEqual(1);
+    for (const item of res.body.items as {data: {queryId: string}}[]) {
+      expect(item.data.queryId).toBe('q-pg-events-1');
+    }
+  });
+
+  it('events survive a stream instance restart against the same database', async () => {
+    await request(app).post('/events').send(baseEvent).expect(201);
+
+    const config = loadConfig({
+      EVENT_BACKEND: 'postgres',
+      DATABASE_URL: connectionUrl(),
+    });
+    const freshDb = db();
+    const {app: freshApp} = buildApp({
+      config,
+      logger,
+      version: 'test',
+      messageStream: createMessageStream(config, logger),
+      chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger, freshDb),
+      db: freshDb,
+    });
+
+    const res = await request(freshApp).get('/events').expect(200);
+    expect(res.body.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('expired events are not returned (short-ttl config)', async () => {
+    const config = loadConfig({
+      EVENT_BACKEND: 'postgres',
+      DATABASE_URL: connectionUrl(),
+      EVENT_VISIBILITY_TTL_SECONDS: '1',
+    });
+    const shortTtlDb = db();
+    const {app: shortTtlApp} = buildApp({
+      config,
+      logger,
+      version: 'test',
+      messageStream: createMessageStream(config, logger),
+      chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger, shortTtlDb),
+      db: shortTtlDb,
+    });
+
+    const ttlEvent = {
+      ...baseEvent,
+      data: {...baseEvent.data, queryId: 'q-ttl-test'},
+    };
+
+    await request(shortTtlApp).post('/events').send(ttlEvent).expect(201);
+
+    const before = await request(shortTtlApp)
+      .get('/events/q-ttl-test')
+      .expect(200);
+    expect(before.body.items).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    const after = await request(shortTtlApp)
+      .get('/events/q-ttl-test')
+      .expect(200);
+    expect(after.body.items).toHaveLength(0);
+  });
+});

--- a/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
@@ -94,40 +94,21 @@ describeIntegration('postgres event backend — HTTP integration', () => {
     expect(res.body.items.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('expired events are not returned (short-ttl config)', async () => {
-    const config = loadConfig({
-      EVENT_BACKEND: 'postgres',
-      DATABASE_URL: connectionUrl(),
-      EVENT_VISIBILITY_TTL_SECONDS: '1',
-    });
-    const shortTtlDb = db();
-    const {app: shortTtlApp} = buildApp({
-      config,
-      logger,
-      version: 'test',
-      messageStream: createMessageStream(config, logger),
-      chunkStream: createChunkStream(config, logger),
-      eventStream: createEventStream(config, logger, shortTtlDb),
-      db: shortTtlDb,
-    });
-
+  it('expired events are not returned (body ttl_seconds override)', async () => {
     const ttlEvent = {
       ...baseEvent,
       data: {...baseEvent.data, queryId: 'q-ttl-test'},
+      ttl_seconds: 1,
     };
 
-    await request(shortTtlApp).post('/events').send(ttlEvent).expect(201);
+    await request(app).post('/events').send(ttlEvent).expect(201);
 
-    const before = await request(shortTtlApp)
-      .get('/events/q-ttl-test')
-      .expect(200);
+    const before = await request(app).get('/events/q-ttl-test').expect(200);
     expect(before.body.items).toHaveLength(1);
 
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    const after = await request(shortTtlApp)
-      .get('/events/q-ttl-test')
-      .expect(200);
+    const after = await request(app).get('/events/q-ttl-test').expect(200);
     expect(after.body.items).toHaveLength(0);
   });
 });

--- a/services/ark-broker/ark-broker/test/postgres-ssl.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-ssl.integration.test.ts
@@ -5,6 +5,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 import {usePgContainerSsl} from '../src/db/__tests__/testHelpers/pg-testcontainer.js';
 
 jest.setTimeout(120_000);
@@ -30,6 +31,7 @@ describeIntegration('postgres backend — SSL connection', () => {
       version: 'test',
       messageStream: stream,
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
       db: db(),
     }));
   });

--- a/services/ark-broker/ark-broker/test/redis-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/redis-backend.integration.test.ts
@@ -5,6 +5,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 import {createRedis} from '../src/redis/redis.js';
 import {useRedisContainer} from '../src/redis/__tests__/testHelpers/redis-testcontainer.js';
 
@@ -74,6 +75,7 @@ describeIntegration('redis chunk backend — HTTP parity', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger, redis),
+      eventStream: createEventStream(config, logger),
       redis,
     }).app;
   });

--- a/services/ark-broker/ark-broker/test/redis-cross-replica.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/redis-cross-replica.integration.test.ts
@@ -5,6 +5,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 import {createRedis} from '../src/redis/redis.js';
 import {useRedisContainer} from '../src/redis/__tests__/testHelpers/redis-testcontainer.js';
 
@@ -76,6 +77,7 @@ describeIntegration('redis chunk backend — cross-replica', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger, redisA),
+      eventStream: createEventStream(config, logger),
       redis: redisA,
     }).app;
 
@@ -85,6 +87,7 @@ describeIntegration('redis chunk backend — cross-replica', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger, redisB),
+      eventStream: createEventStream(config, logger),
       redis: redisB,
     }).app;
   });

--- a/services/ark-broker/ark-broker/test/request-id.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/request-id.integration.test.ts
@@ -5,6 +5,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 
 class MemorySink extends Writable {
   public readonly lines: string[] = [];
@@ -25,6 +26,7 @@ describe('request-id middleware', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
     });
 
     const res = await request(app)
@@ -44,6 +46,7 @@ describe('request-id middleware', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
     });
 
     const res = await request(app).get('/health');
@@ -64,6 +67,7 @@ describe('request-id middleware', () => {
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger),
+      eventStream: createEventStream(config, logger),
     });
 
     await request(app).get('/health').set('X-Request-ID', 'log-correlation-1');

--- a/services/ark-broker/ark-broker/test/server.test.ts
+++ b/services/ark-broker/ark-broker/test/server.test.ts
@@ -4,6 +4,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 
 const config = loadConfig({});
 const logger = createLogger({level: 'silent', pretty: false});
@@ -13,6 +14,7 @@ const {app} = buildApp({
   version: 'test',
   messageStream: createMessageStream(config, logger),
   chunkStream: createChunkStream(config, logger),
+  eventStream: createEventStream(config, logger),
 });
 
 describe('ARK Broker API', () => {

--- a/services/ark-broker/ark-broker/test/session-filter.test.ts
+++ b/services/ark-broker/ark-broker/test/session-filter.test.ts
@@ -4,6 +4,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 import {OTELSpan} from '../src/brokers/trace-broker.js';
 import {EventData} from '../src/brokers/event-broker.js';
 
@@ -18,6 +19,7 @@ const {
   version: 'test',
   messageStream: createMessageStream(config, logger),
   chunkStream: createChunkStream(config, logger),
+  eventStream: createEventStream(config, logger),
 });
 
 describe('Session ID Filtering', () => {

--- a/services/ark-broker/ark-broker/test/stream-timeout.test.ts
+++ b/services/ark-broker/ark-broker/test/stream-timeout.test.ts
@@ -4,6 +4,7 @@ import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
 
 const config = loadConfig({});
 const logger = createLogger({level: 'silent', pretty: false});
@@ -13,6 +14,7 @@ const {app} = buildApp({
   version: 'test',
   messageStream: createMessageStream(config, logger),
   chunkStream: createChunkStream(config, logger),
+  eventStream: createEventStream(config, logger),
 });
 
 describe('Stream Timeout', () => {

--- a/services/ark-broker/chart/templates/deployment.yaml
+++ b/services/ark-broker/chart/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "ark-broker.serviceAccountName" . }}
-      {{- if eq .Values.backends.message "postgres" }}
+      {{- if or (eq .Values.backends.message "postgres") (eq .Values.backends.event "postgres") }}
       initContainers:
         - name: migrate
           image: "{{ .Values.migrate.image.repository }}:{{ .Values.migrate.image.tag | default .Values.app.image.tag | default .Chart.AppVersion }}"
@@ -79,6 +79,8 @@ spec:
             {{- end }}
             - name: MESSAGE_BACKEND
               value: {{ .Values.backends.message | quote }}
+            - name: EVENT_BACKEND
+              value: {{ .Values.backends.event | quote }}
             - name: CHUNK_BACKEND
               value: {{ .Values.backends.chunk | quote }}
             {{- if eq .Values.backends.chunk "redis" }}
@@ -113,7 +115,7 @@ spec:
               value: {{ printf "%s/ca.crt" .Values.redis.tls.mountPath | quote }}
             {{- end }}
             {{- end }}
-            {{- if eq .Values.backends.message "postgres" }}
+            {{- if or (eq .Values.backends.message "postgres") (eq .Values.backends.event "postgres") }}
             - name: DATABASE_URL
               {{- if .Values.database.urlSecretRef.name }}
               valueFrom:
@@ -130,7 +132,9 @@ spec:
             - name: DATABASE_STATEMENT_TIMEOUT_MS
               value: {{ .Values.database.statementTimeoutMs | quote }}
             - name: MESSAGE_VISIBILITY_TTL_SECONDS
-              value: {{ .Values.database.visibilityTtlSeconds | int | quote }}
+              value: {{ .Values.database.messageVisibilityTtlSeconds | int | quote }}
+            - name: EVENT_VISIBILITY_TTL_SECONDS
+              value: {{ .Values.database.eventVisibilityTtlSeconds | int | quote }}
             {{- if .Values.database.debugQueries }}
             - name: DATABASE_DEBUG_QUERIES
               value: "true"

--- a/services/ark-broker/chart/values.yaml
+++ b/services/ark-broker/chart/values.yaml
@@ -1,9 +1,11 @@
 # ARK Broker chart values
 
 # Message backend: memory (default) or postgres
+# Event backend: memory (default) or postgres
 # Chunk backend: memory (default) or redis
 backends:
   message: memory
+  event: memory
   chunk: memory
 
 # PostgreSQL connection — required when backends.message=postgres
@@ -35,7 +37,8 @@ database:
   poolMax: 10
   connectTimeoutMs: 10000
   statementTimeoutMs: 30000
-  visibilityTtlSeconds: 2592000
+  messageVisibilityTtlSeconds: 2592000
+  eventVisibilityTtlSeconds: 2592000
   debugQueries: false
 
 # Redis connection — required when backends.chunk=redis

--- a/services/ark-broker/devspace.yaml
+++ b/services/ark-broker/devspace.yaml
@@ -3,7 +3,7 @@ version: v2beta1
 
 pipelines:
   deploy: |-
-    if [ "${BROKER_MESSAGE_BACKEND}" == "postgres" ]; then
+    if [ "${BROKER_MESSAGE_BACKEND}" == "postgres" ] || [ "${BROKER_EVENT_BACKEND}" == "postgres" ]; then
       create_deployments ark-storage-dev
       kubectl rollout status deployment/ark-storage-dev -n default --timeout=120s
     fi
@@ -14,7 +14,7 @@ pipelines:
     build_images --all
     create_deployments --all
   dev: |-
-    if [ "${BROKER_MESSAGE_BACKEND}" == "postgres" ]; then
+    if [ "${BROKER_MESSAGE_BACKEND}" == "postgres" ] || [ "${BROKER_EVENT_BACKEND}" == "postgres" ]; then
       create_deployments ark-storage-dev
       kubectl rollout status deployment/ark-storage-dev -n default --timeout=120s
     fi
@@ -29,9 +29,9 @@ pipelines:
     kubectl wait --for=condition=complete job -l app.kubernetes.io/component=restart-hook -n ${DEVSPACE_NAMESPACE:-default} --timeout=120s 2>/dev/null || true
 
     # Patch deployment to add PVC for node modules.
-    # Skip in postgres mode: the PVC shadows the image's node_modules before the dev
-    # container swap, causing a transient crash. The dev container runs npm install anyway.
-    if [ "${BROKER_MESSAGE_BACKEND}" != "postgres" ]; then
+    # Skip when any postgres backend is active: the PVC shadows the image's node_modules
+    # before the dev container swap, causing a transient crash.
+    if [ "${BROKER_MESSAGE_BACKEND}" != "postgres" ] && [ "${BROKER_EVENT_BACKEND}" != "postgres" ]; then
       kubectl patch deployment ark-broker -n ${DEVSPACE_NAMESPACE:-default} --type=strategic -p \
         '{"spec":{"template":{"spec":{"volumes":[{"name":"node-modules","persistentVolumeClaim":{"claimName":"ark-broker-node-modules"}}],"containers":[{"name":"ark-broker","volumeMounts":[{"name":"node-modules","mountPath":"/app/node_modules"}]}]}}}}' || true
     fi
@@ -45,6 +45,9 @@ vars:
   BROKER_REDIS_PASSWORD:
     source: env
     default: arkredisdev123
+  BROKER_EVENT_BACKEND:
+    source: env
+    default: memory
 
 images:
   ark-broker:
@@ -90,6 +93,7 @@ deployments:
               - DAC_OVERRIDE
         backends:
           message: memory
+          event: memory
           chunk: memory
         memory:
           setAsDefault: true
@@ -124,10 +128,12 @@ dev:
       enabled: true
 
 profiles:
-  - name: broker-postgres
+  - name: postgres-infra
     activation:
       - vars:
           BROKER_MESSAGE_BACKEND: postgres
+      - vars:
+          BROKER_EVENT_BACKEND: postgres
     patches:
       - op: add
         path: images.ark-broker-migrate
@@ -145,9 +151,6 @@ profiles:
             chart:
               path: ../../charts/ark-storage-dev
             releaseName: ark-storage-dev
-      - op: replace
-        path: deployments.ark-broker.helm.values.backends.message
-        value: postgres
       - op: add
         path: deployments.ark-broker.helm.values.database
         value:
@@ -158,6 +161,22 @@ profiles:
           image:
             repository: ${runtime.images.ark-broker-migrate.image}
             tag: ${runtime.images.ark-broker-migrate.tag}
+  - name: broker-postgres
+    activation:
+      - vars:
+          BROKER_MESSAGE_BACKEND: postgres
+    patches:
+      - op: replace
+        path: deployments.ark-broker.helm.values.backends.message
+        value: postgres
+  - name: broker-events-postgres
+    activation:
+      - vars:
+          BROKER_EVENT_BACKEND: postgres
+    patches:
+      - op: replace
+        path: deployments.ark-broker.helm.values.backends.event
+        value: postgres
   - name: broker-redis
     activation:
       - vars:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1001,9 +1001,9 @@ If options are still detaching after this, the likely cause is a parent componen
 
 ## PostgreSQL Broker Tests
 
-Tests labeled `postgresql: "true"` run in the `storage-backend: postgresql` CI matrix, where the broker uses a Postgres backend (MESSAGE_BACKEND=postgres). This means broker messages are persisted in the `messages` table of the `ark-storage-dev` Postgres instance in `ark-system`.
+Tests labeled `postgresql: "true"` run in the `storage-backend: postgresql` CI matrix, where the broker uses Postgres for both messages and events (`backends.message=postgres`, `backends.event=postgres`). This means broker messages and events are persisted in the `messages` and `events` tables of the `ark-storage-dev` Postgres instance in `ark-system`.
 
-Use this label when a test needs to verify broker message persistence, `expires_at`, or other Postgres-specific behavior.
+Use this label when a test needs to verify broker message/event persistence, `expires_at`, or other Postgres-specific behavior.
 
 ### Querying Postgres from a chainsaw test
 

--- a/tests/event-broker-postgres/README.md
+++ b/tests/event-broker-postgres/README.md
@@ -1,0 +1,16 @@
+# event-broker-postgres
+
+Verifies that operation events from a completed query land in the Postgres `events` table with `expires_at` set.
+
+## What it tests
+- A query completes with `phase: done`
+- The broker writes at least one event to the Postgres `events` table with `query_id='events-broker-query'` and a non-null `expires_at`
+- `GET /events/:queryId` returns those events via the broker HTTP API
+- Requires the broker running with postgres event backend (`postgresql: "true"` label)
+
+## Running
+```bash
+chainsaw test
+```
+
+Requires a cluster set up with `--storage-backend postgresql` (which configures the broker with `EVENT_BACKEND=postgres`).

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -1,0 +1,109 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: event-broker-postgres
+  labels:
+    postgresql: "true"
+spec:
+  description: Operation events from a completed query land in the Postgres events table with expires_at set; GET /events/:queryId returns them
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query
+    try:
+    - apply:
+        file: manifests/a00-rbac.yaml
+    - apply:
+        file: manifests/a00-memory.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Memory
+        name: default
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.lastResolvedAddress}'
+    - apply:
+        file: manifests/a01-agent.yaml
+    - apply:
+        file: manifests/a02-query.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: events-broker-query
+        timeout: 4m
+        for:
+          jsonPath:
+            path: '{.status.response.content}'
+    - assert:
+        timeout: 1s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: events-broker-query
+          status:
+            phase: done
+            (response != null): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: events-broker-query
+
+  - name: verify-events-in-postgres
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT count(*) FROM events WHERE query_id='events-broker-query' AND expires_at IS NOT NULL;" \
+            | tr -d ' \n')
+          echo "events in Postgres: ${COUNT}"
+          [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event, got ${COUNT}"; exit 1; }
+    catch:
+    - events: {}
+
+  - name: verify-events-via-http
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          BROKER_NS=$(kubectl get deployment --all-namespaces \
+            -o jsonpath='{range .items[?(@.metadata.name=="ark-broker")]}{.metadata.namespace}{end}' 2>/dev/null)
+          BROKER_NS=${BROKER_NS:-default}
+          COUNT=$(kubectl exec -n "$BROKER_NS" deployment/ark-broker -- \
+            node -e 'const h=require("http");h.get("http://localhost:8080/events/events-broker-query",r=>{let d="";r.on("data",c=>{d+=c});r.on("end",()=>{const b=JSON.parse(d);process.stdout.write(String(b.items?b.items.length:0));process.exit(b.items&&b.items.length>=1?0:1)})}).on("error",e=>{process.stderr.write(e.message);process.exit(1)})')
+          echo "HTTP events count: ${COUNT}"
+          [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event via HTTP, got ${COUNT}"; exit 1; }
+    catch:
+    - events: {}
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -77,9 +77,14 @@ spec:
     - script:
         timeout: 30s
         content: |
-          COUNT=$(bash ../shared/psql-query.sh \
-            "SELECT count(*) FROM events WHERE query_id='events-broker-query' AND expires_at IS NOT NULL;" \
-            | tr -d ' \n')
+          COUNT=0
+          for i in $(seq 1 10); do
+            COUNT=$(bash ../shared/psql-query.sh \
+              "SELECT count(*) FROM events WHERE query_id='events-broker-query' AND expires_at IS NOT NULL;" \
+              | tr -d ' \n')
+            [ "${COUNT}" -ge 1 ] && break
+            sleep 1
+          done
           echo "events in Postgres: ${COUNT}"
           [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event, got ${COUNT}"; exit 1; }
     catch:

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -76,11 +76,15 @@ spec:
     try:
     - script:
         timeout: 30s
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
         content: |
+          QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
           COUNT=0
           for i in $(seq 1 10); do
             COUNT=$(bash ../shared/psql-query.sh \
-              "SELECT count(*) FROM events WHERE query_id='events-broker-query' AND expires_at IS NOT NULL;" \
+              "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
               | tr -d ' \n')
             [ "${COUNT}" -ge 1 ] && break
             sleep 1
@@ -94,12 +98,16 @@ spec:
     try:
     - script:
         timeout: 30s
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
         content: |
+          QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
           BROKER_NS=$(kubectl get deployment --all-namespaces \
             -o jsonpath='{range .items[?(@.metadata.name=="ark-broker")]}{.metadata.namespace}{end}' 2>/dev/null)
           BROKER_NS=${BROKER_NS:-default}
           COUNT=$(kubectl exec -n "$BROKER_NS" deployment/ark-broker -- \
-            node -e 'const h=require("http");h.get("http://localhost:8080/events/events-broker-query",r=>{let d="";r.on("data",c=>{d+=c});r.on("end",()=>{const b=JSON.parse(d);process.stdout.write(String(b.items?b.items.length:0));process.exit(b.items&&b.items.length>=1?0:1)})}).on("error",e=>{process.stderr.write(e.message);process.exit(1)})')
+            node -e "const h=require('http');h.get('http://localhost:8080/events/${QUERY_UID}',r=>{let d='';r.on('data',c=>{d+=c});r.on('end',()=>{const b=JSON.parse(d);process.stdout.write(String(b.items?b.items.length:0));process.exit(b.items&&b.items.length>=1?0:1)})}).on('error',e=>{process.stderr.write(e.message);process.exit(1)})")
           echo "HTTP events count: ${COUNT}"
           [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event via HTTP, got ${COUNT}"; exit 1; }
     catch:

--- a/tests/event-broker-postgres/manifests/a00-memory.yaml
+++ b/tests/event-broker-postgres/manifests/a00-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Memory
+metadata:
+  name: default
+spec:
+  address:
+    valueFrom:
+      serviceRef:
+        name: ark-broker
+        namespace: default
+        port: http

--- a/tests/event-broker-postgres/manifests/a00-rbac.yaml
+++ b/tests/event-broker-postgres/manifests/a00-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: event-broker-postgres-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: event-broker-postgres-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ($namespace)
+roleRef:
+  kind: Role
+  name: event-broker-postgres-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/event-broker-postgres/manifests/a01-agent.yaml
+++ b/tests/event-broker-postgres/manifests/a01-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: events-broker-agent
+spec:
+  prompt: You are a helpful assistant.
+  modelRef:
+    name: test-model-mock

--- a/tests/event-broker-postgres/manifests/a02-query.yaml
+++ b/tests/event-broker-postgres/manifests/a02-query.yaml
@@ -1,0 +1,9 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: events-broker-query
+spec:
+  input: What is 2+2?
+  target:
+    type: agent
+    name: events-broker-agent

--- a/tests/event-broker-postgres/mock-llm-values.yaml
+++ b/tests/event-broker-postgres/mock-llm-values.yaml
@@ -1,0 +1,24 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [{"id": "gpt-4.1-mini", "object": "model", "owned_by": "openai"}]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+        }

--- a/tests/query-event-recorder/chainsaw-test.yaml
+++ b/tests/query-event-recorder/chainsaw-test.yaml
@@ -71,13 +71,19 @@ spec:
           if [ -z "$BROKER_PORT" ] || [ "$BROKER_PORT" = "http" ]; then BROKER_PORT=80; fi
           BROKER_URL="http://${BROKER_SVC}.${BROKER_NS}.svc.cluster.local:${BROKER_PORT}"
 
+          EXPECTED_REASONS="QueryExecutionStart AgentExecutionStart LLMCallStart LLMCallComplete AgentExecutionComplete QueryExecutionComplete"
+
           events='[]'
           for attempt in $(seq 1 10); do
             BROKER_RESPONSE=$(kubectl run broker-query-$$ --image=curlimages/curl:8.11.1 --restart=Never --rm -i -n "$NAMESPACE" \
               -- curl -s "$BROKER_URL/events/$QUERY_UID" 2>/dev/null | grep '^{' | sed 's/pod ".*$//')
             events=$(echo "$BROKER_RESPONSE" | jq '.items // []')
-            count=$(echo "$events" | jq 'length')
-            if [ "$count" -gt 0 ] 2>/dev/null; then break; fi
+            missing=0
+            for reason in $EXPECTED_REASONS; do
+              count=$(echo "$events" | jq "[.[] | select(.reason == \"$reason\")] | length")
+              [ "$count" -gt 0 ] 2>/dev/null || missing=1
+            done
+            [ "$missing" -eq 0 ] && break
             sleep 2
           done
 


### PR DESCRIPTION
## Context

This is Phase 3 of the ark-broker durability roadmap tracked in #2153, implementing #2728. Phase 0 (#2377) extracted the async `Stream<T>` storage interface, Phase 1 (#2418) moved messages to an opt-in Postgres backend, and Phase 2 (#2654) moved completion chunks to Redis Streams. This PR does the same for operation events: `QueryExecutionStart`, `LLMCallComplete`, etc., emitted by the controller via `POST /events`.

## Problem

Events were in-memory only, so they were lost on every pod restart or redeploy — the same durability gap messages had before Phase 1. There was also no way to override an event's TTL per-request, unlike messages, which already support a body-level `ttl_seconds` override from #2507.

## What changes

- **`EVENT_BACKEND` config** (`memory` | `postgres`, default `memory`) and `EVENT_VISIBILITY_TTL_SECONDS` (default 30 days), sharing `DATABASE_URL` and the connection pool with the message backend (`src/config/schema.ts`).
- **DI seam for events**: `EventBroker` now takes an injected `Stream<EventData>` instead of owning storage directly, mirroring the Phase 0 pattern already used for messages (`src/brokers/event-broker.ts`).
- **`PostgresEventStream`**, a new `Stream<EventData>` implementation backed by a dedicated `events` table (migration `000002_create_events`), sharing schema shape and pool with `messages`.
- **Helm + devspace wiring**: `backends.event: postgres` in the chart, and a `broker-events-postgres` devspace profile that reuses the shared `postgres-infra` profile — combinable independently or together with the existing message/chunk profiles (`BROKER_MESSAGE_BACKEND=postgres BROKER_EVENT_BACKEND=postgres BROKER_CHUNK_BACKEND=redis devspace dev` all work together).
- **`ttl_seconds` in `POST /events`**: the broker-side plumbing only (schema, route, `EventBroker.addEvent`) — `PostgresEventStream.append` already accepted an optional per-call TTL override from the start, so no stream change was needed here. Analogous to messages' `ttl_seconds`, this lets a caller override the default 30-day event TTL per event.
- **Chainsaw e2e test** (`tests/event-broker-postgres/`) verifying events land in Postgres with `expires_at` populated and are retrievable via `GET /events/:queryId`, mirroring the pattern in `tests/query-broker-ttl/`.
- **README** updated to document `EVENT_BACKEND`, `EVENT_VISIBILITY_TTL_SECONDS`, the shared `DATABASE_URL`/pool semantics between messages and events, and the combinable devspace profile examples.

## Intentionally out of scope

- **Caller-side `ttl_seconds` wiring**: the Go controller doesn't yet pass `ttl_seconds` in `POST /events` from `Query.spec.ttl`. This PR only adds the broker's ability to accept and honor it, mirroring how #2507 (caller-side for messages) was a separate PR from the message backend itself. Tracked as a follow-up.
- **`DELETE /events/:queryId` + finalizer cleanup on Query deletion**, analogous to #2557 for messages. Events aren't part of the Memory API contract, so this needs a separate cleanup path and is deferred.
- **The `all()`-then-filter-in-JS pattern** used by `paginate`/`filter`/`paginateByQuery`/`paginateBySessionId` on both `PostgresEventStream` and the pre-existing `PostgresMessageStream`. This predates this PR (inherited from Phase 1's message stream, faithfully mirrored here for consistency) and is tracked as a dedicated follow-up in #2736, since fixing it properly means pushing predicates into SQL for both streams together rather than patching one.
- **Cross-replica live push**: Postgres-backed `subscribe()` is in-process (`EventEmitter`) only, so SSE live updates for Postgres-backed events don't propagate across broker replicas the way Redis Streams `XREAD` does for chunks (Phase 2). Same pre-existing gap as messages, not introduced here.

## Review guide

1. `src/brokers/stream/postgres-event-stream.ts:37-44` — `append()` already took an optional `ttlSeconds` and fell back to the configured default; confirms Commit 9 (`ttl_seconds` wiring) only needed changes above this layer.
2. `src/brokers/event-broker.ts:33-38` — `addEvent` forwards the optional TTL override straight to the stream.
3. `src/http/routes/events/schemas.ts:26` and `src/http/routes/events/index.ts:84-87` — `ttl_seconds` parsed out of the body and passed separately from the event payload, so it's never persisted as part of the event data itself.
4. `src/config/schema.ts:41-42,68-74` — `EVENT_BACKEND` validation and the cross-field rule requiring `DATABASE_URL` when either `MESSAGE_BACKEND` or `EVENT_BACKEND` is `postgres`.
5. `test/postgres-events.integration.test.ts` — the `ttl_seconds` expiry test uses the body-level override directly rather than a second short-TTL app instance, keeping the test focused on the new feature.
6. `tests/event-broker-postgres/chainsaw-test.yaml` — end-to-end assertion path: Postgres row count with non-null `expires_at`, then an HTTP round-trip via `GET /events/:queryId` from inside the broker pod.

## Issue reference

Implements #2728, part of the broker durability roadmap in #2153. Follow-ups: #2736 (Postgres stream read performance, covers this PR's `PostgresEventStream` and the pre-existing `PostgresMessageStream` together).
