### PR TITLE
fix: TTL should be counted from completion, not creation

### DIFF
--- a/ark/api/v1alpha1/query_types.go
+++ b/ark/api/v1alpha1/query_types.go
@@ -78,6 +78,7 @@ type QuerySpec struct {
 	// Engines use it for conversation threading (e.g., memory lookup, session management).
 	ConversationId string `json:"conversationId,omitempty"`
 	// +kubebuilder:validation:Optional
+	// Time to retain Query after completion.
 	// Default is resolved by the mutating webhook from ArkConfig/default
 	// (spec.queryTTL), falling back to 720h when ArkConfig is absent.
 	TTL *metav1.Duration `json:"ttl,omitempty"`

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -101,17 +101,16 @@ func (r *QueryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Check TTL expiry if TTL is set.
-	// TTL may be nil when using aggregated API server (non-CRD storage)
-	// because the field is omitempty and may not be initialized.
-	if obj.Spec.TTL != nil {
-		expiry := obj.CreationTimestamp.Add(obj.Spec.TTL.Duration)
-		if time.Now().After(expiry) {
-			if err := r.Delete(ctx, &obj); err != nil {
-				log.Error(err, "unable to delete object")
-				return ctrl.Result{}, err
-			}
+	// Garbage-collect the Query once it has been in a terminal phase for
+	// longer than its TTL. TTL is measured from completion, not creation,
+	// so long-running or queued queries are never reaped mid-flight.
+	// TTL may be nil when using aggregated API server (non-CRD storage).
+	if ttlRemaining(&obj) < 0 && isTerminalPhase(obj.Status.Phase) {
+		if err := r.Delete(ctx, &obj); err != nil {
+			log.Error(err, "unable to delete object")
+			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, nil
 	}
 
 	if result, err := r.handleFinalizer(ctx, &obj); result != nil {
@@ -160,39 +159,52 @@ func (r *QueryReconciler) handleFinalizer(ctx context.Context, obj *arkv1alpha1.
 }
 
 func (r *QueryReconciler) handleQueryExecution(ctx context.Context, req ctrl.Request, obj arkv1alpha1.Query) (ctrl.Result, error) {
-	// Calculate expiry time for requeue. Use 1 hour default if TTL is not set.
-	// TTL may be nil when using aggregated API server (non-CRD storage).
-	ttl := time.Hour
-	if obj.Spec.TTL != nil {
-		ttl = obj.Spec.TTL.Duration
-	}
-	expiry := obj.CreationTimestamp.Add(ttl)
-
 	if obj.Spec.Cancel && obj.Status.Phase != statusCanceled {
 		r.cleanupExistingOperation(req.NamespacedName)
 		if err := r.updateStatus(ctx, &obj, statusCanceled); err != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Until(expiry),
-			}, err
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
 
 	switch obj.Status.Phase {
 	case statusDone, statusError, statusCanceled:
-		return ctrl.Result{
-			RequeueAfter: time.Until(expiry),
-		}, nil
+		remaining := ttlRemaining(&obj)
+		if remaining == 0 {
+			return ctrl.Result{}, nil
+		}
+		if remaining < 0 {
+			// RequeueAfter requires a positive time: 1ns means it will be
+			// requeued for GC almost immediately
+			remaining = time.Nanosecond
+		}
+		return ctrl.Result{RequeueAfter: remaining}, nil
 	case statusProvisioning, statusRunning:
 		return r.handleRunningPhase(ctx, req, obj)
 	default:
 		if err := r.updateStatus(ctx, &obj, statusRunning); err != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Until(expiry),
-			}, err
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
+}
+
+// ttlRemaining returns the time left until the Query's post-completion TTL
+// elapses: zero means TTL is not configured, negative means TTL has already
+// elapsed, positive means time left until expiry. The anchor is the
+// QueryCompleted condition's LastTransitionTime; if that condition is
+// missing on a terminal-phase Query (a corrupt state our updater should
+// not produce), the anchor falls back to CreationTimestamp so GC still
+// fires eventually instead of stranding the object.
+func ttlRemaining(obj *arkv1alpha1.Query) time.Duration {
+	if obj.Spec.TTL == nil {
+		return 0
+	}
+	anchor := obj.CreationTimestamp.Time
+	if completedAt := queryCompletedAt(obj); completedAt != nil {
+		anchor = *completedAt
+	}
+	return time.Until(anchor.Add(obj.Spec.TTL.Duration))
 }
 
 func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Request, obj arkv1alpha1.Query) (ctrl.Result, error) {
@@ -203,21 +215,15 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	queryTimeout := time.Hour
-	if obj.Spec.TTL != nil {
-		queryTimeout = obj.Spec.TTL.Duration
-	}
-	remaining := time.Until(obj.CreationTimestamp.Add(queryTimeout))
-	if remaining <= 0 {
-		return ctrl.Result{}, nil
-	}
-
 	if r.sem != nil && !r.sem.TryAcquire(1) {
 		log.V(1).Info("query execution capacity reached, requeuing", "query", req.String(), "cap", r.MaxConcurrentQueries)
 		return ctrl.Result{RequeueAfter: queryCapacityRequeueDelay}, nil
 	}
 
-	opCtx, cancel := context.WithTimeout(ctx, remaining)
+	// Execution deadline is governed by Spec.Timeout, applied per-A2A-call in
+	// sendQueryA2A. The cancel handle is stored so Spec.Cancel can interrupt
+	// the goroutine via cleanupExistingOperation.
+	opCtx, cancel := context.WithCancel(ctx)
 	r.operations.Store(req.NamespacedName, cancel)
 
 	go r.executeQueryAsync(opCtx, obj, req.NamespacedName)
@@ -693,6 +699,28 @@ func (r *QueryReconciler) resolveSelector(ctx context.Context, selector *metav1.
 	}
 
 	return nil, fmt.Errorf("no matching resources found for selector")
+}
+
+func isTerminalPhase(phase string) bool {
+	switch phase {
+	case statusDone, statusError, statusCanceled:
+		return true
+	}
+	return false
+}
+
+// queryCompletedAt returns the timestamp when the Query reached a terminal
+// phase, or nil if it has not. The QueryCompleted condition flips to
+// Status=True only on terminal phases (Done/Error/Canceled), and
+// setConditionCompleted writes LastTransitionTime explicitly each time, so
+// the field is a reliable post-terminal anchor for TTL retention.
+func queryCompletedAt(obj *arkv1alpha1.Query) *time.Time {
+	cond := meta.FindStatusCondition(obj.Status.Conditions, string(arkv1alpha1.QueryCompleted))
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		return nil
+	}
+	t := cond.LastTransitionTime.Time
+	return &t
 }
 
 func (r *QueryReconciler) setConditionCompleted(query *arkv1alpha1.Query, status metav1.ConditionStatus, reason, message string) {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -254,55 +255,6 @@ var _ = Describe("Query Controller", func() {
 })
 
 var _ = Describe("Query Controller handleRunningPhase", func() {
-	Context("TTL handling", func() {
-		It("returns immediately when the query TTL has already expired", func() {
-			r := &QueryReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-			query := arkv1alpha1.Query{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "expired-ttl-query",
-					Namespace: "default",
-					CreationTimestamp: metav1.Time{
-						Time: time.Now().Add(-2 * time.Hour),
-					},
-				},
-				Spec: arkv1alpha1.QuerySpec{
-					TTL: &metav1.Duration{Duration: 1 * time.Hour},
-				},
-			}
-			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: query.Name, Namespace: query.Namespace}}
-
-			result, err := r.handleRunningPhase(context.Background(), req, query)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
-		})
-
-		It("returns immediately when the query has no TTL and uses default 1h but is already 2h old", func() {
-			r := &QueryReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-			query := arkv1alpha1.Query{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-ttl-old-query",
-					Namespace: "default",
-					CreationTimestamp: metav1.Time{
-						Time: time.Now().Add(-2 * time.Hour),
-					},
-				},
-			}
-			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: query.Name, Namespace: query.Namespace}}
-
-			result, err := r.handleRunningPhase(context.Background(), req, query)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
-		})
-	})
-
 	Context("MaxConcurrentQueries enforcement", func() {
 		It("requeues without spawning execution when the semaphore is full", func() {
 			r := &QueryReconciler{
@@ -460,6 +412,261 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Expect(exists).To(BeFalse(), "cleanup must run even on panic")
 			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "semaphore must be released even on panic")
 		})
+	})
+})
+
+var _ = Describe("Query TTL helpers", func() {
+	Describe("ttlRemaining", func() {
+		It("returns 0 when TTL is not configured", func() {
+			q := &arkv1alpha1.Query{}
+			Expect(ttlRemaining(q)).To(BeZero())
+		})
+
+		It("returns a positive duration when terminal and completion is recent", func() {
+			q := &arkv1alpha1.Query{
+				Spec: arkv1alpha1.QuerySpec{TTL: &metav1.Duration{Duration: time.Hour}},
+				Status: arkv1alpha1.QueryStatus{
+					Phase: statusDone,
+					Conditions: []metav1.Condition{{
+						Type:               string(arkv1alpha1.QueryCompleted),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+					}},
+				},
+			}
+			Expect(ttlRemaining(q)).To(BeNumerically("~", 50*time.Minute, time.Minute))
+		})
+
+		It("returns a negative duration when TTL has elapsed since completion", func() {
+			q := &arkv1alpha1.Query{
+				Spec: arkv1alpha1.QuerySpec{TTL: &metav1.Duration{Duration: time.Hour}},
+				Status: arkv1alpha1.QueryStatus{
+					Phase: statusDone,
+					Conditions: []metav1.Condition{{
+						Type:               string(arkv1alpha1.QueryCompleted),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+					}},
+				},
+			}
+			Expect(ttlRemaining(q)).To(BeNumerically("<", 0))
+		})
+
+		It("falls back to CreationTimestamp when no QueryCompleted condition is set", func() {
+			q := &arkv1alpha1.Query{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
+				Spec:       arkv1alpha1.QuerySpec{TTL: &metav1.Duration{Duration: time.Hour}},
+			}
+			Expect(ttlRemaining(q)).To(BeNumerically("<", 0))
+		})
+
+		It("falls back to CreationTimestamp when QueryCompleted has Status=False (in-flight)", func() {
+			q := &arkv1alpha1.Query{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
+				Spec:       arkv1alpha1.QuerySpec{TTL: &metav1.Duration{Duration: time.Hour}},
+				Status: arkv1alpha1.QueryStatus{
+					Phase: statusRunning,
+					Conditions: []metav1.Condition{{
+						Type:               string(arkv1alpha1.QueryCompleted),
+						Status:             metav1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					}},
+				},
+			}
+			Expect(ttlRemaining(q)).To(BeNumerically("<", 0))
+		})
+	})
+
+	Describe("queryCompletedAt", func() {
+		It("returns nil when no QueryCompleted condition is set", func() {
+			Expect(queryCompletedAt(&arkv1alpha1.Query{})).To(BeNil())
+		})
+
+		It("returns nil when QueryCompleted is Status=False", func() {
+			q := &arkv1alpha1.Query{
+				Status: arkv1alpha1.QueryStatus{
+					Conditions: []metav1.Condition{{
+						Type:   string(arkv1alpha1.QueryCompleted),
+						Status: metav1.ConditionFalse,
+					}},
+				},
+			}
+			Expect(queryCompletedAt(q)).To(BeNil())
+		})
+
+		It("returns LastTransitionTime when QueryCompleted is Status=True", func() {
+			at := time.Now().Add(-time.Hour).Truncate(time.Second)
+			q := &arkv1alpha1.Query{
+				Status: arkv1alpha1.QueryStatus{
+					Conditions: []metav1.Condition{{
+						Type:               string(arkv1alpha1.QueryCompleted),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(at),
+					}},
+				},
+			}
+			got := queryCompletedAt(q)
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(at))
+		})
+	})
+
+	Describe("isTerminalPhase", func() {
+		It("returns true for done/error/canceled", func() {
+			Expect(isTerminalPhase(statusDone)).To(BeTrue())
+			Expect(isTerminalPhase(statusError)).To(BeTrue())
+			Expect(isTerminalPhase(statusCanceled)).To(BeTrue())
+		})
+		It("returns false for in-flight or unknown phases", func() {
+			Expect(isTerminalPhase(statusRunning)).To(BeFalse())
+			Expect(isTerminalPhase(statusProvisioning)).To(BeFalse())
+			Expect(isTerminalPhase(statusPending)).To(BeFalse())
+			Expect(isTerminalPhase("")).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
+	ctx := context.Background()
+
+	It("deletes a terminal-phase Query whose TTL has elapsed since completion", func() {
+		name := "ttl-elapsed-terminal-query"
+		key := types.NamespacedName{Name: name, Namespace: "default"}
+
+		query := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				TTL:    &metav1.Duration{Duration: time.Nanosecond},
+			},
+		}
+		Expect(query.Spec.SetInputString("hello")).To(Succeed())
+		Expect(k8sClient.Create(ctx, query)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		query.Status.Phase = statusDone
+		query.Status.Conditions = []metav1.Condition{{
+			Type:               string(arkv1alpha1.QueryCompleted),
+			Status:             metav1.ConditionTrue,
+			Reason:             "QuerySucceeded",
+			Message:            "Query completed successfully",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+		}}
+		Expect(k8sClient.Status().Update(ctx, query)).To(Succeed())
+
+		r := &QueryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Get(ctx, key, &arkv1alpha1.Query{})
+		Expect(errors.IsNotFound(err)).To(BeTrue(), "Query should be deleted when terminal phase + TTL elapsed since completion")
+	})
+
+	It("does NOT delete a non-terminal Query even when its TTL has elapsed since creation", func() {
+		// Regression test for #2693: the old controller measured TTL from
+		// CreationTimestamp regardless of phase, which would reap a long-
+		// running or queue-backlogged Query mid-flight.
+		name := "ttl-elapsed-running-query"
+		key := types.NamespacedName{Name: name, Namespace: "default"}
+
+		query := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				TTL:    &metav1.Duration{Duration: time.Nanosecond},
+			},
+		}
+		Expect(query.Spec.SetInputString("hello")).To(Succeed())
+		Expect(k8sClient.Create(ctx, query)).To(Succeed())
+
+		// Sleep so time.Since(CreationTimestamp) > TTL (1ns). Without the
+		// fix, ttlRemaining would be negative and the guard would delete.
+		time.Sleep(10 * time.Millisecond)
+
+		// Pre-add the finalizer so Reconcile reaches handleQueryExecution
+		// in a single pass instead of returning early to write it first.
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		controllerutil.AddFinalizer(query, finalizer)
+		Expect(k8sClient.Update(ctx, query)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		query.Status.Phase = statusRunning
+		query.Status.Conditions = []metav1.Condition{{
+			Type:               string(arkv1alpha1.QueryCompleted),
+			Status:             metav1.ConditionFalse,
+			Reason:             "QueryRunning",
+			Message:            "Query is running",
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}}
+		Expect(k8sClient.Status().Update(ctx, query)).To(Succeed())
+
+		r := &QueryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		// Pre-register an operation so handleRunningPhase short-circuits
+		// instead of spawning an executor goroutine we'd have to drain.
+		_, cancel := context.WithCancel(ctx)
+		defer cancel()
+		r.operations.Store(key, context.CancelFunc(cancel))
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		var refetched arkv1alpha1.Query
+		Expect(k8sClient.Get(ctx, key, &refetched)).To(Succeed())
+		Expect(refetched.DeletionTimestamp.IsZero()).To(BeTrue(), "in-flight Query must not be GC'd even when TTL has elapsed since creation")
+
+		// Cleanup: remove finalizer so Delete actually removes the object.
+		r.operations.Delete(key)
+		controllerutil.RemoveFinalizer(&refetched, finalizer)
+		Expect(k8sClient.Update(ctx, &refetched)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &refetched)).To(Succeed())
+	})
+
+	It("requeues a terminal Query for GC at completedAt + TTL when TTL has not yet elapsed", func() {
+		name := "ttl-pending-terminal-query"
+		key := types.NamespacedName{Name: name, Namespace: "default"}
+
+		query := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				TTL:    &metav1.Duration{Duration: time.Hour},
+			},
+		}
+		Expect(query.Spec.SetInputString("hello")).To(Succeed())
+		Expect(k8sClient.Create(ctx, query)).To(Succeed())
+
+		// Pre-add the finalizer so Reconcile reaches handleQueryExecution
+		// in a single pass instead of returning early to write it first.
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		controllerutil.AddFinalizer(query, finalizer)
+		Expect(k8sClient.Update(ctx, query)).To(Succeed())
+
+		completedAt := time.Now().Add(-10 * time.Minute)
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		query.Status.Phase = statusDone
+		query.Status.Conditions = []metav1.Condition{{
+			Type:               string(arkv1alpha1.QueryCompleted),
+			Status:             metav1.ConditionTrue,
+			Reason:             "QuerySucceeded",
+			Message:            "Query completed successfully",
+			LastTransitionTime: metav1.NewTime(completedAt),
+		}}
+		Expect(k8sClient.Status().Update(ctx, query)).To(Succeed())
+
+		r := &QueryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		var refetched arkv1alpha1.Query
+		Expect(k8sClient.Get(ctx, key, &refetched)).To(Succeed())
+		Expect(refetched.DeletionTimestamp.IsZero()).To(BeTrue(), "terminal Query with TTL still remaining must not be GC'd yet")
+		Expect(result.RequeueAfter).To(BeNumerically("~", 50*time.Minute, time.Minute), "RequeueAfter should target completedAt + TTL")
+
+		// Cleanup: remove finalizer so Delete actually removes the object.
+		Expect(k8sClient.Get(ctx, key, &refetched)).To(Succeed())
+		controllerutil.RemoveFinalizer(&refetched, finalizer)
+		Expect(k8sClient.Update(ctx, &refetched)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &refetched)).To(Succeed())
 	})
 })
 

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -605,7 +605,7 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		// instead of spawning an executor goroutine we'd have to drain.
 		_, cancel := context.WithCancel(ctx)
 		defer cancel()
-		r.operations.Store(key, context.CancelFunc(cancel))
+		r.operations.Store(key, cancel)
 
 		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Previously, the TTL on a query spec was measured from query *creation*, not from query *completion*. Queries with a short TTL could time out before even being run if the server was busy. This is contrary to what the docs say, which describes TTL as "How long the Query resource lingers after completion."

This changes TTL calculations to bring them in line with the documentation and presumed intent. We already have Timeout to bound query runtime.

Closes #2693 .

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 