### PR TITLE
fix(security): bump fast-uri to 3.1.3 to address CVE-2026-13676

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3793,9 +3793,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -93,7 +93,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": "^3.1.1",
+    "fast-uri": "^3.1.3",
     "ws": "^8.21.0",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6"


### PR DESCRIPTION
## Summary
- Bump `fast-uri` override in `tools/ark-cli/package.json` from `^3.1.1` to `^3.1.3` and refresh the lockfile to resolve fast-uri to 3.1.3
- Clears CVE-2026-13676 (HIGH, CVSS 7.5, CWE-436) in ark-cli

## Vulnerability

| Field | Value |
|-------|-------|
| CVE | CVE-2026-13676 |
| Severity | HIGH (CVSS 7.5, `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N`) |
| Component | `fast-uri` (npm) |
| Vulnerable | 2.3.1–3.1.2, 4.0.0 |
| Patched | 3.1.3 (also 4.0.1) |

fast-uri fails to canonicalize IDN hostnames for HTTP URLs; `normalize()`/`equal()` can diverge from the WHATWG URL parser, allowing host-based policy checks (denylists, loopback filtering, redirect validation, proxy routing) to be bypassed when the same input is later handed to Node's `URL`/`fetch`.

## Impact on Ark
- Only `tools/ark-cli/` is affected. `fast-uri` is a transitive dep via `ajv` (JSON schema validation).
- ark-cli does not use `fast-uri` for host-based policy enforcement on user-supplied URLs, so realistic risk is low — but the CVE is cleared regardless.

## References
- Advisory: https://github.com/fastify/fast-uri/security/advisories/GHSA-4c8g-83qw-93j6
- CVE: https://cve.circl.lu/cve/CVE-2026-13676