### PR TITLE
ci: drop unused k9s install from e2e-ark-cli action

### DIFF
--- a/.github/actions/test-ark-cli/action.yaml
+++ b/.github/actions/test-ark-cli/action.yaml
@@ -45,7 +45,6 @@ runs:
         sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
         sudo chmod +x /usr/local/bin/yq
         curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-        curl -sS https://webinstall.dev/k9s | bash
         export PATH="$HOME/.local/bin:$PATH"
         sudo apt-get update && sudo apt-get install -y gettext
 


### PR DESCRIPTION
## Summary
- Remove `curl -sS https://webinstall.dev/k9s | bash` from `.github/actions/test-ark-cli/action.yaml`
- k9s is not invoked by the action, by ark-cli, or by any test — it's only mentioned in developer docs (`docs/content/developer-guide/cli-tools.mdx`, `logging-and-events.mdx`) as an interactive tool developers install themselves
- `webinstall.dev` has been unreachable for hours, timing out the TLS handshake (curl exit 28, ~5 min hang), which was failing `e2e-ark-cli` on every branch including `main`

## Evidence
Sampled recent CI runs (each hit the same line at ~5 min):

| Run | Branch |
|---|---|
| 28517594115 | feat/ark-broker-phase-3-events-postgres |
| 28517129055 | feat/qb-design-migration |
| 28516170935 | fix/2693-query-ttl-post-completion |
| 28515970698 | main |

All failed with:
```
curl -sS https://webinstall.dev/k9s | bash
...
curl: (28) SSL connection timeout
##[error]Process completed with exit code 28.
```