### PR TITLE
fix(apiserver): honor field selectors and set-based label selectors

### DIFF
--- a/ark/internal/apiserver/registry/storage.go
+++ b/ark/internal/apiserver/registry/storage.go
@@ -126,6 +126,9 @@ func (s *GenericStorage) List(ctx context.Context, options *metainternalversion.
 	if err != nil {
 		metrics.RecordStorageOperation("list", s.config.Kind, "error")
 		metrics.RecordStorageLatency("list", s.config.Kind, start)
+		if errors.Is(err, storage.ErrInvalidRequest) {
+			return nil, apierrors.NewBadRequest(err.Error())
+		}
 		return nil, apierrors.NewInternalError(fmt.Errorf("failed to list %s: %w", s.config.Resource, err))
 	}
 
@@ -342,7 +345,14 @@ func (s *GenericStorage) Watch(ctx context.Context, options *metainternalversion
 		opts.ResourceVersion = options.ResourceVersion
 	}
 
-	return s.backend.Watch(ctx, s.config.Kind, namespace, opts)
+	watcher, err := s.backend.Watch(ctx, s.config.Kind, namespace, opts)
+	if err != nil {
+		if errors.Is(err, storage.ErrInvalidRequest) {
+			return nil, apierrors.NewBadRequest(err.Error())
+		}
+		return nil, err
+	}
+	return watcher, nil
 }
 
 func (s *GenericStorage) ConvertToTable(ctx context.Context, obj, tableOptions runtime.Object) (*metav1.Table, error) {

--- a/ark/internal/apiserver/registry/storage_test.go
+++ b/ark/internal/apiserver/registry/storage_test.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -276,6 +277,24 @@ func TestGenericStorage_List_WithLabelSelector(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("List() with selector error = %v", err)
+	}
+}
+
+func TestGenericStorage_List_FieldSelectorReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+	gs, _ := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	fs, err := fields.ParseSelector("status.phase=Running")
+	if err != nil {
+		t.Fatalf("ParseSelector() error = %v", err)
+	}
+	_, err = gs.List(ctx, &metainternalversion.ListOptions{FieldSelector: fs})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest, got %T: %v", err, err)
 	}
 }
 
@@ -595,6 +614,24 @@ func TestGenericStorage_Watch(t *testing.T) {
 		t.Error("expected non-nil watcher")
 	}
 	watcher.Stop()
+}
+
+func TestGenericStorage_Watch_FieldSelectorReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+	gs, _ := newTestStorage()
+	ctx := contextWithNamespace(testNS())
+
+	fs, err := fields.ParseSelector("status.phase=Running")
+	if err != nil {
+		t.Fatalf("ParseSelector() error = %v", err)
+	}
+	_, err = gs.Watch(ctx, &metainternalversion.ListOptions{FieldSelector: fs})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest, got %T: %v", err, err)
+	}
 }
 
 func TestGenericStorage_ConvertToTable_Single(t *testing.T) {

--- a/ark/internal/apiserver/registry/testhelpers_test.go
+++ b/ark/internal/apiserver/registry/testhelpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,9 @@ func (m *mockBackend) List(ctx context.Context, kind, namespace string, opts sto
 	if m.err != nil {
 		return nil, "", m.err
 	}
+	if opts.FieldSelector != "" {
+		return nil, "", fmt.Errorf("%w: field selector %q not yet implemented", storage.ErrInvalidRequest, opts.FieldSelector)
+	}
 	var result []runtime.Object
 	prefix := kind + "/"
 	if namespace != "" {
@@ -104,6 +108,9 @@ func (m *mockBackend) Delete(ctx context.Context, kind, namespace, name string) 
 }
 
 func (m *mockBackend) Watch(ctx context.Context, kind, namespace string, opts storage.WatchOptions) (watch.Interface, error) {
+	if opts.FieldSelector != "" {
+		return nil, fmt.Errorf("%w: field selector %q not yet implemented", storage.ErrInvalidRequest, opts.FieldSelector)
+	}
 	return &mockWatcher{ch: make(chan watch.Event)}, nil
 }
 

--- a/ark/internal/storage/interface.go
+++ b/ark/internal/storage/interface.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	ErrNotFound      = errors.New("not found")
-	ErrConflict      = errors.New("conflict: resource version mismatch")
-	ErrAlreadyExists = errors.New("already exists")
+	ErrNotFound       = errors.New("not found")
+	ErrConflict       = errors.New("conflict: resource version mismatch")
+	ErrAlreadyExists  = errors.New("already exists")
+	ErrInvalidRequest = errors.New("invalid request")
 )
 
 type ListOptions struct {

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -37,28 +37,20 @@ type fieldPredicate struct {
 	value  string
 }
 
-// supportedFieldColumns maps the well-known Kubernetes field selectors this
-// backend understands to the resources table column they filter on. Only the
-// two universally-defined metadata fields are wired up so far; resource-specific
-// fields (e.g. status.phase) are rejected pending typed field indexers — the
-// intent is to add them, not to forbid them.
+// supportedFieldColumns maps k8s field selectors to the resources table
+// column they filter on. Resource-specific fields (e.g. status.phase) are
+// rejected pending typed field indexers — not permanently forbidden.
 var supportedFieldColumns = map[string]string{
 	"metadata.name":      "name",
 	"metadata.namespace": "namespace",
 }
 
-// supportedFieldOps maps a Kubernetes field-selector operator to the SQL
-// operator it translates to. Adding a new operator here also updates the
-// error message via supportedFieldOpsList.
 var supportedFieldOps = map[selection.Operator]string{
 	selection.Equals:       "=",
 	selection.DoubleEquals: "=",
 	selection.NotEquals:    "<>",
 }
 
-// supportedFieldsList returns the currently-supported field selector fields,
-// sorted alphabetically, for inclusion in error messages. Derived from
-// supportedFieldColumns so the two stay in lockstep as fields are added.
 func supportedFieldsList() string {
 	keys := make([]string, 0, len(supportedFieldColumns))
 	for k := range supportedFieldColumns {
@@ -68,9 +60,6 @@ func supportedFieldsList() string {
 	return strings.Join(keys, ", ")
 }
 
-// supportedFieldOpsList returns the currently-supported field selector
-// operators (in their k8s user-visible form), sorted for determinism.
-// Derived from supportedFieldOps so the two stay in lockstep.
 func supportedFieldOpsList() string {
 	keys := make([]string, 0, len(supportedFieldOps))
 	for k := range supportedFieldOps {
@@ -81,9 +70,7 @@ func supportedFieldOpsList() string {
 }
 
 // parseFieldSelector validates opts.FieldSelector and returns SQL predicates for
-// the currently supported metadata fields. Fields that aren't wired up yet, and
-// operators other than =/==/!=, produce storage.ErrInvalidRequest so the registry
-// surfaces them as 400 Bad Request rather than returning an unfiltered result set.
+// supported metadata fields. Unsupported fields or operators produce storage.ErrInvalidRequest.
 // Additional fields can be added by extending supportedFieldColumns.
 func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 	if selector == "" {
@@ -112,10 +99,6 @@ func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 	return preds, nil
 }
 
-// parseLabelSelector parses a Kubernetes label selector expression. The full
-// selector language is supported: equality (=, ==), inequality (!=), set-based
-// (in, notin), and existence (key, !key). Invalid expressions produce a
-// storage.ErrInvalidRequest so the registry surfaces them as 400 Bad Request.
 func parseLabelSelector(selector string) (labels.Selector, error) {
 	if selector == "" {
 		return nil, nil
@@ -130,70 +113,44 @@ func parseLabelSelector(selector string) (labels.Selector, error) {
 	return sel, nil
 }
 
-// buildLabelSelectorSQL translates a parsed label selector into a SQL fragment
-// (a series of " AND ..." clauses) and the arguments to bind. startArgIndex is
-// the $N placeholder to use for the first bound arg; callers should advance
-// their own arg index by len(args) after appending.
-//
-// The labels column is jsonb; we read individual values via labels->>$N and use
-// NULL-safe operators so k8s semantics are preserved:
-//   - Equals/DoubleEquals match when the key exists AND the value matches.
-//   - NotEquals matches when the key is absent OR the value differs.
-//   - In matches when the key exists AND the value is in the set.
-//   - NotIn matches when the key is absent OR the value is not in the set.
-//   - Exists/DoesNotExist require only the key's presence/absence.
-//
-// Operator SQL is fixed text (no client-controlled strings), and every value
-// crosses the boundary as a bound parameter, so no injection surface.
-//
-// The selector must have come from parseLabelSelector (i.e. labels.Parse) — an
-// unsupported operator or malformed requirement is treated as an unreachable
-// invariant violation and panics rather than silently returning over-broad SQL.
-func buildLabelSelectorSQL(sel labels.Selector, startArgIndex int) (string, []interface{}) {
+// labelSelectorSQL emits " AND ..." clauses and appends bind values to *args.
+// Placeholders are len(*args)+1 at each use, so the caller passes the same
+// slice and doesn't track an index. Values are bound; operators are fixed.
+func labelSelectorSQL(sel labels.Selector, args *[]interface{}) string {
 	if sel == nil || sel.Empty() {
-		return "", nil
+		return ""
 	}
 	reqs, _ := sel.Requirements()
 	var sb strings.Builder
-	var args []interface{}
-	argIndex := startArgIndex
 	for _, req := range reqs {
 		key := req.Key()
 		op := req.Operator()
-		// .List() (not UnsortedList) so the emitted SQL is deterministic —
-		// labels.Parse already sorts requirements by key, and this sorts values
-		// within each requirement, so equivalent selectors produce identical SQL.
 		vals := req.Values().List()
+		p := len(*args) + 1
 		switch op {
 		case selection.Equals, selection.DoubleEquals:
-			fmt.Fprintf(&sb, ` AND labels->>$%d = $%d`, argIndex, argIndex+1)
-			args = append(args, key, vals[0])
-			argIndex += 2
+			fmt.Fprintf(&sb, ` AND labels->>$%d = $%d`, p, p+1)
+			*args = append(*args, key, vals[0])
 		case selection.NotEquals:
-			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> $%d)`, argIndex, argIndex, argIndex+1)
-			args = append(args, key, vals[0])
-			argIndex += 2
+			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> $%d)`, p, p, p+1)
+			*args = append(*args, key, vals[0])
 		case selection.In:
-			fmt.Fprintf(&sb, ` AND labels->>$%d = ANY($%d::text[])`, argIndex, argIndex+1)
-			args = append(args, key, pq.Array(vals))
-			argIndex += 2
+			fmt.Fprintf(&sb, ` AND labels->>$%d = ANY($%d::text[])`, p, p+1)
+			*args = append(*args, key, pq.Array(vals))
 		case selection.NotIn:
-			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> ALL($%d::text[]))`, argIndex, argIndex, argIndex+1)
-			args = append(args, key, pq.Array(vals))
-			argIndex += 2
+			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> ALL($%d::text[]))`, p, p, p+1)
+			*args = append(*args, key, pq.Array(vals))
 		case selection.Exists:
-			fmt.Fprintf(&sb, ` AND labels->>$%d IS NOT NULL`, argIndex)
-			args = append(args, key)
-			argIndex++
+			fmt.Fprintf(&sb, ` AND labels->>$%d IS NOT NULL`, p)
+			*args = append(*args, key)
 		case selection.DoesNotExist:
-			fmt.Fprintf(&sb, ` AND labels->>$%d IS NULL`, argIndex)
-			args = append(args, key)
-			argIndex++
+			fmt.Fprintf(&sb, ` AND labels->>$%d IS NULL`, p)
+			*args = append(*args, key)
 		default:
-			panic(fmt.Sprintf("buildLabelSelectorSQL: unhandled operator %q from labels.Parse output", op))
+			panic(fmt.Sprintf("labelSelectorSQL: unhandled operator %q from labels.Parse output", op))
 		}
 	}
-	return sb.String(), args
+	return sb.String()
 }
 
 type Config struct {
@@ -483,10 +440,8 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 		return nil, "", err
 	}
 	if labelSel != nil {
-		clause, labelArgs := buildLabelSelectorSQL(labelSel, argIndex)
-		query += clause
-		args = append(args, labelArgs...)
-		argIndex += len(labelArgs)
+		query += labelSelectorSQL(labelSel, &args)
+		argIndex = len(args) + 1
 	}
 
 	fieldPreds, err := parseFieldSelector(opts.FieldSelector)
@@ -1062,10 +1017,8 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 		argIndex++
 	}
 	if w.labelSel != nil {
-		clause, labelArgs := buildLabelSelectorSQL(w.labelSel, argIndex)
-		query += clause
-		args = append(args, labelArgs...)
-		argIndex += len(labelArgs)
+		query += labelSelectorSQL(w.labelSel, &args)
+		argIndex = len(args) + 1
 	}
 	for _, p := range w.fieldPreds {
 		query += fmt.Sprintf(` AND %s %s $%d`, p.column, p.op, argIndex)

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,6 +47,18 @@ var supportedFieldColumns = map[string]string{
 	"metadata.namespace": "namespace",
 }
 
+// supportedFieldsList returns the currently-supported field selector fields,
+// sorted alphabetically, for inclusion in error messages. Derived from
+// supportedFieldColumns so the two stay in lockstep as fields are added.
+func supportedFieldsList() string {
+	keys := make([]string, 0, len(supportedFieldColumns))
+	for k := range supportedFieldColumns {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
 // parseFieldSelector validates opts.FieldSelector and returns SQL predicates for
 // the currently supported metadata fields. Fields that aren't wired up yet, and
 // operators other than =/==/!=, produce storage.ErrInvalidRequest so the registry
@@ -67,7 +80,7 @@ func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 	for _, req := range reqs {
 		col, ok := supportedFieldColumns[req.Field]
 		if !ok {
-			return nil, fmt.Errorf("%w: field selector on %q is not yet implemented for the PostgreSQL backend (currently supported: metadata.name, metadata.namespace)", storage.ErrInvalidRequest, req.Field)
+			return nil, fmt.Errorf("%w: field selector on %q is not yet implemented for the PostgreSQL backend (currently supported: %s)", storage.ErrInvalidRequest, req.Field, supportedFieldsList())
 		}
 		var op string
 		switch req.Operator {

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/lib/pq"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 
@@ -23,6 +25,62 @@ import (
 )
 
 const jsonNull = "null"
+
+// fieldPredicate is a validated (column, op, value) triple derived from a client-
+// supplied field selector. columns come from supportedFieldColumns (never client
+// input), so composing SQL by concatenating column and op is safe from injection.
+type fieldPredicate struct {
+	column string
+	op     string
+	value  string
+}
+
+// supportedFieldColumns maps the well-known Kubernetes field selectors this
+// backend understands to the resources table column they filter on. Only the
+// two universally-defined metadata fields are wired up so far; resource-specific
+// fields (e.g. status.phase) are rejected pending typed field indexers — the
+// intent is to add them, not to forbid them.
+var supportedFieldColumns = map[string]string{
+	"metadata.name":      "name",
+	"metadata.namespace": "namespace",
+}
+
+// parseFieldSelector validates opts.FieldSelector and returns SQL predicates for
+// the currently supported metadata fields. Fields that aren't wired up yet, and
+// operators other than =/==/!=, produce storage.ErrInvalidRequest so the registry
+// surfaces them as 400 Bad Request rather than returning an unfiltered result set.
+// Additional fields can be added by extending supportedFieldColumns.
+func parseFieldSelector(selector string) ([]fieldPredicate, error) {
+	if selector == "" {
+		return nil, nil
+	}
+	sel, err := fields.ParseSelector(selector)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid field selector %q: %v", storage.ErrInvalidRequest, selector, err)
+	}
+	if sel.Empty() {
+		return nil, nil
+	}
+	reqs := sel.Requirements()
+	preds := make([]fieldPredicate, 0, len(reqs))
+	for _, req := range reqs {
+		col, ok := supportedFieldColumns[req.Field]
+		if !ok {
+			return nil, fmt.Errorf("%w: field selector on %q is not yet implemented for the PostgreSQL backend (currently supported: metadata.name, metadata.namespace)", storage.ErrInvalidRequest, req.Field)
+		}
+		var op string
+		switch req.Operator {
+		case selection.Equals, selection.DoubleEquals:
+			op = "="
+		case selection.NotEquals:
+			op = "<>"
+		default:
+			return nil, fmt.Errorf("%w: field selector operator %q is not yet implemented (currently supported: =, ==, !=)", storage.ErrInvalidRequest, req.Operator)
+		}
+		preds = append(preds, fieldPredicate{column: col, op: op, value: req.Value})
+	}
+	return preds, nil
+}
 
 func parseLabelSelector(selector string) (map[string]string, error) {
 	if selector == "" {
@@ -345,6 +403,16 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 		}
 	}
 
+	fieldPreds, err := parseFieldSelector(opts.FieldSelector)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, p := range fieldPreds {
+		query += fmt.Sprintf(" AND %s %s $%d", p.column, p.op, argIndex)
+		args = append(args, p.value)
+		argIndex++
+	}
+
 	if opts.Continue != "" {
 		cursor, err := strconv.ParseInt(opts.Continue, 10, 64)
 		if err == nil && cursor > 0 {
@@ -593,6 +661,11 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 		return nil, fmt.Errorf("failed to parse label selector: %w", err)
 	}
 
+	fieldPreds, err := parseFieldSelector(opts.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+
 	w := &postgresWatcher{
 		outCh:       make(chan watch.Event, 100),
 		nudgeCh:     make(chan struct{}, 1),
@@ -601,6 +674,7 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 		kind:        kind,
 		ns:          namespace,
 		labelFilter: labelFilter,
+		fieldPreds:  fieldPreds,
 		ctx:         ctx,
 		done:        make(chan struct{}),
 		initialList: true,
@@ -753,6 +827,7 @@ type postgresWatcher struct {
 	kind            string
 	ns              string
 	labelFilter     map[string]string
+	fieldPreds      []fieldPredicate
 	ctx             context.Context
 	done            chan struct{}
 	stopped         atomic.Bool
@@ -904,7 +979,12 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 		labelJSON, _ := json.Marshal(w.labelFilter)
 		query += fmt.Sprintf(` AND labels @> $%d::jsonb`, argIndex)
 		args = append(args, string(labelJSON))
-		_ = argIndex
+		argIndex++
+	}
+	for _, p := range w.fieldPreds {
+		query += fmt.Sprintf(` AND %s %s $%d`, p.column, p.op, argIndex)
+		args = append(args, p.value)
+		argIndex++
 	}
 	query += ` ORDER BY resource_version ASC`
 	return query, args

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -17,7 +17,7 @@ import (
 	"github.com/lib/pq"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
@@ -99,11 +99,11 @@ func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 	return preds, nil
 }
 
-func parseLabelSelector(selector string) (labels.Selector, error) {
+func parseLabelSelector(selector string) (k8slabels.Selector, error) {
 	if selector == "" {
 		return nil, nil
 	}
-	sel, err := labels.Parse(selector)
+	sel, err := k8slabels.Parse(selector)
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid label selector %q: %v", storage.ErrInvalidRequest, selector, err)
 	}
@@ -116,7 +116,7 @@ func parseLabelSelector(selector string) (labels.Selector, error) {
 // labelSelectorSQL emits " AND ..." clauses and appends bind values to *args.
 // Placeholders are len(*args)+1 at each use, so the caller passes the same
 // slice and doesn't track an index. Values are bound; operators are fixed.
-func labelSelectorSQL(sel labels.Selector, args *[]interface{}) string {
+func labelSelectorSQL(sel k8slabels.Selector, args *[]interface{}) string {
 	if sel == nil || sel.Empty() {
 		return ""
 	}
@@ -147,7 +147,7 @@ func labelSelectorSQL(sel labels.Selector, args *[]interface{}) string {
 			fmt.Fprintf(&sb, ` AND labels->>$%d IS NULL`, p)
 			*args = append(*args, key)
 		default:
-			panic(fmt.Sprintf("labelSelectorSQL: unhandled operator %q from labels.Parse output", op))
+			panic(fmt.Sprintf("labelSelectorSQL: unhandled operator %q from k8slabels.Parse output", op))
 		}
 	}
 	return sb.String()
@@ -407,18 +407,18 @@ func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name strin
 
 	var rv, generation int64
 	var uid string
-	var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
+	var spec, status, labels, annotations, finalizers, ownerRefs []byte
 	var createdAt, updatedAt time.Time
 	var deletionTimestamp sql.NullTime
 
-	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt, &deletionTimestamp); err != nil {
+	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt, &deletionTimestamp); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, storage.ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to scan row: %w", err)
 	}
 
-	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 }
 
 func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, opts storage.ListOptions) ([]runtime.Object, string, error) {
@@ -488,15 +488,15 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 	for rows.Next() {
 		var rv, generation int64
 		var ns, name, uid string
-		var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
+		var spec, status, labels, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
 		var deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &deletionTimestamp); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletionTimestamp); err != nil {
 			return nil, "", fmt.Errorf("failed to scan row: %w", err)
 		}
 
-		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 		if err != nil {
 			klog.Warningf("Failed to reconstruct object %s/%s: %v", ns, name, err)
 			continue
@@ -751,12 +751,12 @@ func nullTimePtr(t sql.NullTime) *time.Time {
 	return &t.Time
 }
 
-func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labelsJSON, annotations, finalizers, ownerRefs string, createdAt time.Time, deletionTimestamp *time.Time) (runtime.Object, error) {
+func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labels, annotations, finalizers, ownerRefs string, createdAt time.Time, deletionTimestamp *time.Time) (runtime.Object, error) {
 	var labelsMap map[string]string
 	var annotationsMap map[string]string
 	var finalizersList []string
 	var ownerRefsList []interface{}
-	_ = json.Unmarshal([]byte(labelsJSON), &labelsMap)
+	_ = json.Unmarshal([]byte(labels), &labelsMap)
 	_ = json.Unmarshal([]byte(annotations), &annotationsMap)
 	_ = json.Unmarshal([]byte(finalizers), &finalizersList)
 	_ = json.Unmarshal([]byte(ownerRefs), &ownerRefsList)
@@ -867,7 +867,7 @@ type postgresWatcher struct {
 	key             string
 	kind            string
 	ns              string
-	labelSel        labels.Selector
+	labelSel        k8slabels.Selector
 	fieldPreds      []fieldPredicate
 	ctx             context.Context
 	done            chan struct{}
@@ -1031,12 +1031,12 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 
 // emitRow sends a single relist row downstream. Returns false if the watcher
 // should stop iterating (done/cancelled).
-func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt, deletionTimestamp sql.NullTime) bool {
+func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labels, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt, deletionTimestamp sql.NullTime) bool {
 	uidNew := !w.hasSeenUID(uid)
 	if w.markSeen(uid, rv) {
 		return true
 	}
-	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 	if err != nil {
 		return true
 	}
@@ -1076,14 +1076,14 @@ func (w *postgresWatcher) relist() {
 	for rows.Next() {
 		var rv, generation int64
 		var ns, name, uid string
-		var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
+		var spec, status, labels, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
 		var deletedAt, deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt, &deletionTimestamp); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt, &deletionTimestamp); err != nil {
 			return
 		}
-		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labelsJSON, annotations, finalizers, ownerRefs, createdAt, deletedAt, deletionTimestamp) {
+		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labels, annotations, finalizers, ownerRefs, createdAt, deletedAt, deletionTimestamp) {
 			return
 		}
 	}

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -47,6 +47,15 @@ var supportedFieldColumns = map[string]string{
 	"metadata.namespace": "namespace",
 }
 
+// supportedFieldOps maps a Kubernetes field-selector operator to the SQL
+// operator it translates to. Adding a new operator here also updates the
+// error message via supportedFieldOpsList.
+var supportedFieldOps = map[selection.Operator]string{
+	selection.Equals:       "=",
+	selection.DoubleEquals: "=",
+	selection.NotEquals:    "<>",
+}
+
 // supportedFieldsList returns the currently-supported field selector fields,
 // sorted alphabetically, for inclusion in error messages. Derived from
 // supportedFieldColumns so the two stay in lockstep as fields are added.
@@ -54,6 +63,18 @@ func supportedFieldsList() string {
 	keys := make([]string, 0, len(supportedFieldColumns))
 	for k := range supportedFieldColumns {
 		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+// supportedFieldOpsList returns the currently-supported field selector
+// operators (in their k8s user-visible form), sorted for determinism.
+// Derived from supportedFieldOps so the two stay in lockstep.
+func supportedFieldOpsList() string {
+	keys := make([]string, 0, len(supportedFieldOps))
+	for k := range supportedFieldOps {
+		keys = append(keys, string(k))
 	}
 	sort.Strings(keys)
 	return strings.Join(keys, ", ")
@@ -82,14 +103,9 @@ func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 		if !ok {
 			return nil, fmt.Errorf("%w: field selector on %q is not yet implemented for the PostgreSQL backend (currently supported: %s)", storage.ErrInvalidRequest, req.Field, supportedFieldsList())
 		}
-		var op string
-		switch req.Operator {
-		case selection.Equals, selection.DoubleEquals:
-			op = "="
-		case selection.NotEquals:
-			op = "<>"
-		default:
-			return nil, fmt.Errorf("%w: field selector operator %q is not yet implemented (currently supported: =, ==, !=)", storage.ErrInvalidRequest, req.Operator)
+		op, ok := supportedFieldOps[req.Operator]
+		if !ok {
+			return nil, fmt.Errorf("%w: field selector operator %q is not yet implemented (currently supported: %s)", storage.ErrInvalidRequest, req.Operator, supportedFieldOpsList())
 		}
 		preds = append(preds, fieldPredicate{column: col, op: op, value: req.Value})
 	}

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lib/pq"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
@@ -82,30 +83,88 @@ func parseFieldSelector(selector string) ([]fieldPredicate, error) {
 	return preds, nil
 }
 
-func parseLabelSelector(selector string) (map[string]string, error) {
+// parseLabelSelector parses a Kubernetes label selector expression. The full
+// selector language is supported: equality (=, ==), inequality (!=), set-based
+// (in, notin), and existence (key, !key). Invalid expressions produce a
+// storage.ErrInvalidRequest so the registry surfaces them as 400 Bad Request.
+func parseLabelSelector(selector string) (labels.Selector, error) {
 	if selector == "" {
 		return nil, nil
 	}
-	result := map[string]string{}
-	for _, part := range strings.Split(selector, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		if strings.Contains(part, "!=") || strings.Contains(part, " in ") || strings.Contains(part, " notin ") || strings.HasPrefix(part, "!") {
-			return nil, fmt.Errorf("unsupported label selector operator in %q, only equality (=, ==) is supported", part)
-		}
-		kv := strings.SplitN(part, "=", 2)
-		if len(kv) != 2 {
-			return nil, fmt.Errorf("invalid label selector %q", part)
-		}
-		key := strings.TrimSuffix(strings.TrimSpace(kv[0]), "=")
-		result[strings.TrimSpace(key)] = strings.TrimSpace(kv[1])
+	sel, err := labels.Parse(selector)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid label selector %q: %v", storage.ErrInvalidRequest, selector, err)
 	}
-	if len(result) == 0 {
+	if sel.Empty() {
 		return nil, nil
 	}
-	return result, nil
+	return sel, nil
+}
+
+// buildLabelSelectorSQL translates a parsed label selector into a SQL fragment
+// (a series of " AND ..." clauses) and the arguments to bind. startArgIndex is
+// the $N placeholder to use for the first bound arg; callers should advance
+// their own arg index by len(args) after appending.
+//
+// The labels column is jsonb; we read individual values via labels->>$N and use
+// NULL-safe operators so k8s semantics are preserved:
+//   - Equals/DoubleEquals match when the key exists AND the value matches.
+//   - NotEquals matches when the key is absent OR the value differs.
+//   - In matches when the key exists AND the value is in the set.
+//   - NotIn matches when the key is absent OR the value is not in the set.
+//   - Exists/DoesNotExist require only the key's presence/absence.
+//
+// Operator SQL is fixed text (no client-controlled strings), and every value
+// crosses the boundary as a bound parameter, so no injection surface.
+//
+// The selector must have come from parseLabelSelector (i.e. labels.Parse) — an
+// unsupported operator or malformed requirement is treated as an unreachable
+// invariant violation and panics rather than silently returning over-broad SQL.
+func buildLabelSelectorSQL(sel labels.Selector, startArgIndex int) (string, []interface{}) {
+	if sel == nil || sel.Empty() {
+		return "", nil
+	}
+	reqs, _ := sel.Requirements()
+	var sb strings.Builder
+	var args []interface{}
+	argIndex := startArgIndex
+	for _, req := range reqs {
+		key := req.Key()
+		op := req.Operator()
+		// .List() (not UnsortedList) so the emitted SQL is deterministic —
+		// labels.Parse already sorts requirements by key, and this sorts values
+		// within each requirement, so equivalent selectors produce identical SQL.
+		vals := req.Values().List()
+		switch op {
+		case selection.Equals, selection.DoubleEquals:
+			fmt.Fprintf(&sb, ` AND labels->>$%d = $%d`, argIndex, argIndex+1)
+			args = append(args, key, vals[0])
+			argIndex += 2
+		case selection.NotEquals:
+			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> $%d)`, argIndex, argIndex, argIndex+1)
+			args = append(args, key, vals[0])
+			argIndex += 2
+		case selection.In:
+			fmt.Fprintf(&sb, ` AND labels->>$%d = ANY($%d::text[])`, argIndex, argIndex+1)
+			args = append(args, key, pq.Array(vals))
+			argIndex += 2
+		case selection.NotIn:
+			fmt.Fprintf(&sb, ` AND (labels->>$%d IS NULL OR labels->>$%d <> ALL($%d::text[]))`, argIndex, argIndex, argIndex+1)
+			args = append(args, key, pq.Array(vals))
+			argIndex += 2
+		case selection.Exists:
+			fmt.Fprintf(&sb, ` AND labels->>$%d IS NOT NULL`, argIndex)
+			args = append(args, key)
+			argIndex++
+		case selection.DoesNotExist:
+			fmt.Fprintf(&sb, ` AND labels->>$%d IS NULL`, argIndex)
+			args = append(args, key)
+			argIndex++
+		default:
+			panic(fmt.Sprintf("buildLabelSelectorSQL: unhandled operator %q from labels.Parse output", op))
+		}
+	}
+	return sb.String(), args
 }
 
 type Config struct {
@@ -390,17 +449,15 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 		argIndex++
 	}
 
-	if opts.LabelSelector != "" {
-		labelMap, err := parseLabelSelector(opts.LabelSelector)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to parse label selector: %w", err)
-		}
-		if labelMap != nil {
-			labelJSON, _ := json.Marshal(labelMap)
-			query += fmt.Sprintf(" AND labels @> $%d::jsonb", argIndex)
-			args = append(args, string(labelJSON))
-			argIndex++
-		}
+	labelSel, err := parseLabelSelector(opts.LabelSelector)
+	if err != nil {
+		return nil, "", err
+	}
+	if labelSel != nil {
+		clause, labelArgs := buildLabelSelectorSQL(labelSel, argIndex)
+		query += clause
+		args = append(args, labelArgs...)
+		argIndex += len(labelArgs)
 	}
 
 	fieldPreds, err := parseFieldSelector(opts.FieldSelector)
@@ -656,9 +713,9 @@ func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name st
 func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, opts storage.WatchOptions) (watch.Interface, error) {
 	key := fmt.Sprintf("%s/%s", kind, namespace)
 
-	labelFilter, err := parseLabelSelector(opts.LabelSelector)
+	labelSel, err := parseLabelSelector(opts.LabelSelector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse label selector: %w", err)
+		return nil, err
 	}
 
 	fieldPreds, err := parseFieldSelector(opts.FieldSelector)
@@ -673,7 +730,7 @@ func (p *PostgreSQLBackend) Watch(ctx context.Context, kind, namespace string, o
 		key:         key,
 		kind:        kind,
 		ns:          namespace,
-		labelFilter: labelFilter,
+		labelSel:    labelSel,
 		fieldPreds:  fieldPreds,
 		ctx:         ctx,
 		done:        make(chan struct{}),
@@ -826,7 +883,7 @@ type postgresWatcher struct {
 	key             string
 	kind            string
 	ns              string
-	labelFilter     map[string]string
+	labelSel        labels.Selector
 	fieldPreds      []fieldPredicate
 	ctx             context.Context
 	done            chan struct{}
@@ -975,11 +1032,11 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 		args = append(args, w.ns)
 		argIndex++
 	}
-	if w.labelFilter != nil {
-		labelJSON, _ := json.Marshal(w.labelFilter)
-		query += fmt.Sprintf(` AND labels @> $%d::jsonb`, argIndex)
-		args = append(args, string(labelJSON))
-		argIndex++
+	if w.labelSel != nil {
+		clause, labelArgs := buildLabelSelectorSQL(w.labelSel, argIndex)
+		query += clause
+		args = append(args, labelArgs...)
+		argIndex += len(labelArgs)
 	}
 	for _, p := range w.fieldPreds {
 		query += fmt.Sprintf(` AND %s %s $%d`, p.column, p.op, argIndex)

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -421,18 +421,18 @@ func (p *PostgreSQLBackend) Get(ctx context.Context, kind, namespace, name strin
 
 	var rv, generation int64
 	var uid string
-	var spec, status, labels, annotations, finalizers, ownerRefs []byte
+	var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
 	var createdAt, updatedAt time.Time
 	var deletionTimestamp sql.NullTime
 
-	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt, &deletionTimestamp); err != nil {
+	if err := row.Scan(&rv, &generation, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &updatedAt, &deletionTimestamp); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, storage.ErrNotFound
 		}
 		return nil, fmt.Errorf("failed to scan row: %w", err)
 	}
 
-	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+	return p.reconstructObject(kind, namespace, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 }
 
 func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, opts storage.ListOptions) ([]runtime.Object, string, error) {
@@ -504,15 +504,15 @@ func (p *PostgreSQLBackend) List(ctx context.Context, kind, namespace string, op
 	for rows.Next() {
 		var rv, generation int64
 		var ns, name, uid string
-		var spec, status, labels, annotations, finalizers, ownerRefs []byte
+		var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
 		var deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletionTimestamp); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &deletionTimestamp); err != nil {
 			return nil, "", fmt.Errorf("failed to scan row: %w", err)
 		}
 
-		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+		obj, err := p.reconstructObject(kind, ns, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 		if err != nil {
 			klog.Warningf("Failed to reconstruct object %s/%s: %v", ns, name, err)
 			continue
@@ -767,12 +767,12 @@ func nullTimePtr(t sql.NullTime) *time.Time {
 	return &t.Time
 }
 
-func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labels, annotations, finalizers, ownerRefs string, createdAt time.Time, deletionTimestamp *time.Time) (runtime.Object, error) {
+func (p *PostgreSQLBackend) reconstructObject(kind, namespace, name string, rv, generation int64, uid, spec, status, labelsJSON, annotations, finalizers, ownerRefs string, createdAt time.Time, deletionTimestamp *time.Time) (runtime.Object, error) {
 	var labelsMap map[string]string
 	var annotationsMap map[string]string
 	var finalizersList []string
 	var ownerRefsList []interface{}
-	_ = json.Unmarshal([]byte(labels), &labelsMap)
+	_ = json.Unmarshal([]byte(labelsJSON), &labelsMap)
 	_ = json.Unmarshal([]byte(annotations), &annotationsMap)
 	_ = json.Unmarshal([]byte(finalizers), &finalizersList)
 	_ = json.Unmarshal([]byte(ownerRefs), &ownerRefsList)
@@ -1049,12 +1049,12 @@ func (w *postgresWatcher) buildRelistQuery() (string, []interface{}) {
 
 // emitRow sends a single relist row downstream. Returns false if the watcher
 // should stop iterating (done/cancelled).
-func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labels, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt, deletionTimestamp sql.NullTime) bool {
+func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte, createdAt time.Time, deletedAt, deletionTimestamp sql.NullTime) bool {
 	uidNew := !w.hasSeenUID(uid)
 	if w.markSeen(uid, rv) {
 		return true
 	}
-	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labels), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
+	obj, err := w.backend.reconstructObject(w.kind, ns, name, rv, generation, uid, string(spec), string(status), string(labelsJSON), string(annotations), string(finalizers), string(ownerRefs), createdAt, nullTimePtr(deletionTimestamp))
 	if err != nil {
 		return true
 	}
@@ -1094,14 +1094,14 @@ func (w *postgresWatcher) relist() {
 	for rows.Next() {
 		var rv, generation int64
 		var ns, name, uid string
-		var spec, status, labels, annotations, finalizers, ownerRefs []byte
+		var spec, status, labelsJSON, annotations, finalizers, ownerRefs []byte
 		var createdAt time.Time
 		var deletedAt, deletionTimestamp sql.NullTime
 
-		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labels, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt, &deletionTimestamp); err != nil {
+		if err := rows.Scan(&rv, &generation, &ns, &name, &uid, &spec, &status, &labelsJSON, &annotations, &finalizers, &ownerRefs, &createdAt, &deletedAt, &deletionTimestamp); err != nil {
 			return
 		}
-		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labels, annotations, finalizers, ownerRefs, createdAt, deletedAt, deletionTimestamp) {
+		if !w.emitRow(rv, generation, ns, name, uid, spec, status, labelsJSON, annotations, finalizers, ownerRefs, createdAt, deletedAt, deletionTimestamp) {
 			return
 		}
 	}

--- a/ark/internal/storage/postgresql/selectors_test.go
+++ b/ark/internal/storage/postgresql/selectors_test.go
@@ -3,9 +3,12 @@
 package postgresql
 
 import (
+	"database/sql/driver"
 	"errors"
+	"reflect"
 	"testing"
 
+	"github.com/lib/pq"
 	"mckinsey.com/ark/internal/storage"
 )
 
@@ -104,5 +107,189 @@ func TestParseFieldSelector(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseLabelSelector_AcceptsSetBased(t *testing.T) {
+	t.Parallel()
+	// These selectors were rejected by the old equality-only parser. Confirm
+	// each parses cleanly now, exposing the shape client-go and kubectl use.
+	inputs := []string{
+		"app=web",
+		"app==web",
+		"app!=web",
+		"tier in (frontend, backend)",
+		"tier notin (frontend, backend)",
+		"tier",
+		"!tier",
+		"app=web,tier in (frontend, backend),!temporary",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			sel, err := parseLabelSelector(in)
+			if err != nil {
+				t.Fatalf("parseLabelSelector(%q) error = %v", in, err)
+			}
+			if sel == nil {
+				t.Fatalf("parseLabelSelector(%q) returned nil", in)
+			}
+		})
+	}
+}
+
+func TestParseLabelSelector_InvalidReturnsInvalidRequest(t *testing.T) {
+	t.Parallel()
+	_, err := parseLabelSelector("this is not a selector")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, storage.ErrInvalidRequest) {
+		t.Errorf("expected ErrInvalidRequest, got %v", err)
+	}
+}
+
+// normalizedArg collapses pq.Array (which wraps a slice into a driver.Valuer)
+// into the equivalent []string, so tests can compare arg slices directly.
+func normalizedArg(a interface{}) interface{} {
+	if v, ok := a.(driver.Valuer); ok {
+		// pq.Array over []string is comparable by falling back to the underlying
+		// value; use reflection to unwrap without invoking Value() (which
+		// produces a Postgres array literal string, not the input slice).
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
+		if rv.Kind() == reflect.Struct && rv.NumField() > 0 {
+			inner := rv.Field(0)
+			if inner.CanInterface() {
+				return inner.Interface()
+			}
+		}
+	}
+	return a
+}
+
+func TestBuildLabelSelectorSQL(t *testing.T) {
+	t.Parallel()
+
+	// Every case starts the arg index at 5 to exercise the offset logic that
+	// callers rely on (labels are added after kind/namespace/etc.).
+	const start = 5
+
+	tests := []struct {
+		name       string
+		selector   string
+		wantClause string
+		wantArgs   []interface{}
+	}{
+		{
+			name:       "equals",
+			selector:   "app=web",
+			wantClause: " AND labels->>$5 = $6",
+			wantArgs:   []interface{}{"app", "web"},
+		},
+		{
+			name:       "double equals",
+			selector:   "app==web",
+			wantClause: " AND labels->>$5 = $6",
+			wantArgs:   []interface{}{"app", "web"},
+		},
+		{
+			name:       "not equals — must match when label absent",
+			selector:   "app!=web",
+			wantClause: " AND (labels->>$5 IS NULL OR labels->>$5 <> $6)",
+			wantArgs:   []interface{}{"app", "web"},
+		},
+		{
+			name:       "in",
+			selector:   "tier in (frontend, backend)",
+			wantClause: " AND labels->>$5 = ANY($6::text[])",
+			wantArgs:   []interface{}{"tier", pq.Array([]string{"backend", "frontend"})},
+		},
+		{
+			name:       "notin — must match when label absent",
+			selector:   "tier notin (frontend, backend)",
+			wantClause: " AND (labels->>$5 IS NULL OR labels->>$5 <> ALL($6::text[]))",
+			wantArgs:   []interface{}{"tier", pq.Array([]string{"backend", "frontend"})},
+		},
+		{
+			name:       "exists",
+			selector:   "app",
+			wantClause: " AND labels->>$5 IS NOT NULL",
+			wantArgs:   []interface{}{"app"},
+		},
+		{
+			name:       "does not exist",
+			selector:   "!temporary",
+			wantClause: " AND labels->>$5 IS NULL",
+			wantArgs:   []interface{}{"temporary"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sel, err := parseLabelSelector(tt.selector)
+			if err != nil {
+				t.Fatalf("parseLabelSelector(%q) error = %v", tt.selector, err)
+			}
+			clause, args := buildLabelSelectorSQL(sel, start)
+			if clause != tt.wantClause {
+				t.Errorf("clause = %q, want %q", clause, tt.wantClause)
+			}
+			if len(args) != len(tt.wantArgs) {
+				t.Fatalf("got %d args, want %d: %+v", len(args), len(tt.wantArgs), args)
+			}
+			for i := range args {
+				got := normalizedArg(args[i])
+				want := normalizedArg(tt.wantArgs[i])
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("arg[%d] = %#v, want %#v", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildLabelSelectorSQL_NilAndEmpty(t *testing.T) {
+	t.Parallel()
+	clause, args := buildLabelSelectorSQL(nil, 1)
+	if clause != "" || args != nil {
+		t.Errorf("nil selector: clause=%q args=%v; want empty", clause, args)
+	}
+}
+
+func TestBuildLabelSelectorSQL_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	// Equivalent selectors written in a different order (both requirement order
+	// and value order within a set) must produce identical SQL and args.
+	pairs := []struct {
+		a, b string
+	}{
+		{"app=web,tier=frontend", "tier=frontend,app=web"},
+		{"tier in (b, a)", "tier in (a, b)"},
+		{"a=1,b in (y, x),!c", "!c,b in (x, y),a=1"},
+	}
+	for _, p := range pairs {
+		a, err := parseLabelSelector(p.a)
+		if err != nil {
+			t.Fatalf("parse(%q) err=%v", p.a, err)
+		}
+		b, err := parseLabelSelector(p.b)
+		if err != nil {
+			t.Fatalf("parse(%q) err=%v", p.b, err)
+		}
+		clauseA, argsA := buildLabelSelectorSQL(a, 1)
+		clauseB, argsB := buildLabelSelectorSQL(b, 1)
+		if clauseA != clauseB {
+			t.Errorf("%q vs %q: clause differs\n  a=%q\n  b=%q", p.a, p.b, clauseA, clauseB)
+		}
+		if len(argsA) != len(argsB) {
+			t.Fatalf("%q vs %q: arg count differs %d vs %d", p.a, p.b, len(argsA), len(argsB))
+		}
+		for i := range argsA {
+			if !reflect.DeepEqual(normalizedArg(argsA[i]), normalizedArg(argsB[i])) {
+				t.Errorf("%q vs %q: arg[%d] differs: %#v vs %#v", p.a, p.b, i, argsA[i], argsB[i])
+			}
+		}
 	}
 }

--- a/ark/internal/storage/postgresql/selectors_test.go
+++ b/ark/internal/storage/postgresql/selectors_test.go
@@ -155,12 +155,11 @@ func normalizedArg(a interface{}) interface{} {
 	return a
 }
 
-func TestBuildLabelSelectorSQL(t *testing.T) {
+func TestLabelSelectorSQL(t *testing.T) {
 	t.Parallel()
 
-	// Every case starts the arg index at 5 to exercise the offset logic that
-	// callers rely on (labels are added after kind/namespace/etc.).
-	const start = 5
+	// Pre-seed args with 4 pads so the first emitted placeholder is $5.
+	const preExistingArgs = 4
 
 	tests := []struct {
 		name       string
@@ -218,15 +217,18 @@ func TestBuildLabelSelectorSQL(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseLabelSelector(%q) error = %v", tt.selector, err)
 			}
-			clause, args := buildLabelSelectorSQL(sel, start)
+			args := make([]interface{}, preExistingArgs)
+			clause := labelSelectorSQL(sel, &args)
+			gotArgs := args[preExistingArgs:]
+
 			if clause != tt.wantClause {
 				t.Errorf("clause = %q, want %q", clause, tt.wantClause)
 			}
-			if len(args) != len(tt.wantArgs) {
-				t.Fatalf("got %d args, want %d: %+v", len(args), len(tt.wantArgs), args)
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Fatalf("got %d args, want %d: %+v", len(gotArgs), len(tt.wantArgs), gotArgs)
 			}
-			for i := range args {
-				got := normalizedArg(args[i])
+			for i := range gotArgs {
+				got := normalizedArg(gotArgs[i])
 				want := normalizedArg(tt.wantArgs[i])
 				if !reflect.DeepEqual(got, want) {
 					t.Errorf("arg[%d] = %#v, want %#v", i, got, want)
@@ -236,15 +238,16 @@ func TestBuildLabelSelectorSQL(t *testing.T) {
 	}
 }
 
-func TestBuildLabelSelectorSQL_NilAndEmpty(t *testing.T) {
+func TestLabelSelectorSQL_NilAndEmpty(t *testing.T) {
 	t.Parallel()
-	clause, args := buildLabelSelectorSQL(nil, 1)
-	if clause != "" || args != nil {
+	args := make([]interface{}, 0)
+	clause := labelSelectorSQL(nil, &args)
+	if clause != "" || len(args) != 0 {
 		t.Errorf("nil selector: clause=%q args=%v; want empty", clause, args)
 	}
 }
 
-func TestBuildLabelSelectorSQL_IsDeterministic(t *testing.T) {
+func TestLabelSelectorSQL_IsDeterministic(t *testing.T) {
 	t.Parallel()
 	// Equivalent selectors written in a different order (both requirement order
 	// and value order within a set) must produce identical SQL and args.
@@ -264,8 +267,10 @@ func TestBuildLabelSelectorSQL_IsDeterministic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse(%q) err=%v", p.b, err)
 		}
-		clauseA, argsA := buildLabelSelectorSQL(a, 1)
-		clauseB, argsB := buildLabelSelectorSQL(b, 1)
+		argsA := make([]interface{}, 0)
+		argsB := make([]interface{}, 0)
+		clauseA := labelSelectorSQL(a, &argsA)
+		clauseB := labelSelectorSQL(b, &argsB)
 		if clauseA != clauseB {
 			t.Errorf("%q vs %q: clause differs\n  a=%q\n  b=%q", p.a, p.b, clauseA, clauseB)
 		}

--- a/ark/internal/storage/postgresql/selectors_test.go
+++ b/ark/internal/storage/postgresql/selectors_test.go
@@ -12,15 +12,13 @@ import (
 	"mckinsey.com/ark/internal/storage"
 )
 
-func TestParseFieldSelector(t *testing.T) {
+func TestParseFieldSelector_Supported(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		selector    string
-		wantPreds   []fieldPredicate
-		wantErr     bool
-		wantInvalid bool
+		name      string
+		selector  string
+		wantPreds []fieldPredicate
 	}{
 		{
 			name:      "empty selector returns no predicates",
@@ -63,48 +61,36 @@ func TestParseFieldSelector(t *testing.T) {
 				{column: "namespace", op: "=", value: "prod"},
 			},
 		},
-		{
-			name:        "unsupported field",
-			selector:    "status.phase=Running",
-			wantErr:     true,
-			wantInvalid: true,
-		},
-		{
-			name:        "unsupported field metadata.uid",
-			selector:    "metadata.uid=abc123",
-			wantErr:     true,
-			wantInvalid: true,
-		},
-		{
-			name:        "malformed selector",
-			selector:    "metadata.name",
-			wantErr:     true,
-			wantInvalid: true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			preds, err := parseFieldSelector(tt.selector)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil (preds=%v)", preds)
-				}
-				if tt.wantInvalid && !errors.Is(err, storage.ErrInvalidRequest) {
-					t.Errorf("expected ErrInvalidRequest, got %v", err)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(preds) != len(tt.wantPreds) {
-				t.Fatalf("got %d predicates, want %d: %+v", len(preds), len(tt.wantPreds), preds)
+			if !reflect.DeepEqual(preds, tt.wantPreds) {
+				t.Errorf("preds = %+v, want %+v", preds, tt.wantPreds)
 			}
-			for i, p := range preds {
-				if p != tt.wantPreds[i] {
-					t.Errorf("predicate[%d] = %+v, want %+v", i, p, tt.wantPreds[i])
-				}
+		})
+	}
+}
+
+func TestParseFieldSelector_Rejects(t *testing.T) {
+	t.Parallel()
+
+	for _, selector := range []string{
+		"status.phase=Running",
+		"metadata.uid=abc123",
+		"metadata.name",
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := parseFieldSelector(selector)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, storage.ErrInvalidRequest) {
+				t.Errorf("expected ErrInvalidRequest, got %v", err)
 			}
 		})
 	}

--- a/ark/internal/storage/postgresql/selectors_test.go
+++ b/ark/internal/storage/postgresql/selectors_test.go
@@ -1,0 +1,108 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"errors"
+	"testing"
+
+	"mckinsey.com/ark/internal/storage"
+)
+
+func TestParseFieldSelector(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		selector    string
+		wantPreds   []fieldPredicate
+		wantErr     bool
+		wantInvalid bool
+	}{
+		{
+			name:      "empty selector returns no predicates",
+			selector:  "",
+			wantPreds: nil,
+		},
+		{
+			name:     "metadata.name equality",
+			selector: "metadata.name=my-agent",
+			wantPreds: []fieldPredicate{
+				{column: "name", op: "=", value: "my-agent"},
+			},
+		},
+		{
+			name:     "metadata.name double-equals",
+			selector: "metadata.name==my-agent",
+			wantPreds: []fieldPredicate{
+				{column: "name", op: "=", value: "my-agent"},
+			},
+		},
+		{
+			name:     "metadata.name inequality",
+			selector: "metadata.name!=my-agent",
+			wantPreds: []fieldPredicate{
+				{column: "name", op: "<>", value: "my-agent"},
+			},
+		},
+		{
+			name:     "metadata.namespace equality",
+			selector: "metadata.namespace=prod",
+			wantPreds: []fieldPredicate{
+				{column: "namespace", op: "=", value: "prod"},
+			},
+		},
+		{
+			name:     "combined name and namespace",
+			selector: "metadata.name=foo,metadata.namespace=prod",
+			wantPreds: []fieldPredicate{
+				{column: "name", op: "=", value: "foo"},
+				{column: "namespace", op: "=", value: "prod"},
+			},
+		},
+		{
+			name:        "unsupported field",
+			selector:    "status.phase=Running",
+			wantErr:     true,
+			wantInvalid: true,
+		},
+		{
+			name:        "unsupported field metadata.uid",
+			selector:    "metadata.uid=abc123",
+			wantErr:     true,
+			wantInvalid: true,
+		},
+		{
+			name:        "malformed selector",
+			selector:    "metadata.name",
+			wantErr:     true,
+			wantInvalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preds, err := parseFieldSelector(tt.selector)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (preds=%v)", preds)
+				}
+				if tt.wantInvalid && !errors.Is(err, storage.ErrInvalidRequest) {
+					t.Errorf("expected ErrInvalidRequest, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(preds) != len(tt.wantPreds) {
+				t.Fatalf("got %d predicates, want %d: %+v", len(preds), len(tt.wantPreds), preds)
+			}
+			for i, p := range preds {
+				if p != tt.wantPreds[i] {
+					t.Errorf("predicate[%d] = %+v, want %+v", i, p, tt.wantPreds[i])
+				}
+			}
+		})
+	}
+}

--- a/tests/field-selector-metadata-name/README.md
+++ b/tests/field-selector-metadata-name/README.md
@@ -1,0 +1,24 @@
+# Field selector on metadata.name
+
+Verifies that `--field-selector metadata.name=X` actually filters against the
+aggregated PostgreSQL apiserver (rather than silently returning every item).
+
+## What it tests
+- Create three Models with distinct names
+- List with `--field-selector metadata.name=<one>` and assert exactly one item
+  comes back, with the requested name
+- List with an unsupported field selector and assert a 400 Bad Request
+
+Under the pre-fix backend, `opts.FieldSelector` was silently dropped: the
+list returned every item regardless of the requested filter — a correctness
+bug (over-broad response, potential cross-tenant leak in a multi-tenant
+setup). The fix translates supported fields to SQL and rejects the rest.
+
+## Running
+
+```bash
+chainsaw test tests/field-selector-metadata-name/
+```
+
+Successful completion confirms field selectors are honoured (for supported
+fields) and rejected loudly (for unsupported ones), rather than ignored.

--- a/tests/field-selector-metadata-name/chainsaw-test.yaml
+++ b/tests/field-selector-metadata-name/chainsaw-test.yaml
@@ -1,0 +1,101 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: field-selector-metadata-name
+  labels:
+    postgresql: "true"
+spec:
+  description: |
+    The aggregated PostgreSQL apiserver's storage backend used to silently
+    drop opts.FieldSelector: a request for "the Model named X" returned
+    every Model in the namespace. Verify that supported fields are now
+    honoured and unsupported ones are rejected loudly.
+  steps:
+    - name: create-models
+      try:
+      - script:
+          content: |
+            set -eu
+            for n in fs-model-alpha fs-model-beta fs-model-gamma; do
+              cat <<MANIFEST | kubectl apply -n "$NAMESPACE" -f -
+            apiVersion: ark.mckinsey.com/v1alpha1
+            kind: Model
+            metadata:
+              name: $n
+            spec:
+              provider: openai
+              model:
+                value: rv-test
+              config:
+                openai:
+                  baseUrl:
+                    value: https://localhost:9999/v1
+                  apiKey:
+                    value: rv-test-key
+            MANIFEST
+            done
+            echo "OK created 3 Models"
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 60s
+
+    - name: metadata-name-filter-returns-one
+      try:
+      - script:
+          content: |
+            set -eu
+            NAMES=$(kubectl get models -n "$NAMESPACE" \
+              --field-selector metadata.name=fs-model-beta \
+              -o jsonpath='{.items[*].metadata.name}')
+            echo "returned: '$NAMES'"
+
+            # Under the pre-fix backend this returned all three names.
+            if [ "$NAMES" != "fs-model-beta" ]; then
+              echo "FAIL expected only 'fs-model-beta', got '$NAMES'"
+              exit 1
+            fi
+            echo "OK metadata.name field selector filters correctly"
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 30s
+
+    - name: unsupported-field-selector-rejected
+      try:
+      - script:
+          content: |
+            set -eu
+            # kubectl should surface the server's 400. `set +e` around the
+            # call so we can capture both stdout and the exit code.
+            set +e
+            OUT=$(kubectl get models -n "$NAMESPACE" \
+              --field-selector status.phase=Ready \
+              -o jsonpath='{.items[*].metadata.name}' 2>&1)
+            RC=$?
+            set -e
+            echo "exit=$RC output: $OUT"
+            if [ $RC -eq 0 ]; then
+              echo "FAIL expected non-zero exit for unsupported field selector"
+              exit 1
+            fi
+            case "$OUT" in
+              *"BadRequest"*|*"400"*|*"not a known field selector"*|*"not yet implemented"*)
+                echo "OK unsupported field selector rejected with 400"
+                ;;
+              *)
+                echo "FAIL expected BadRequest/400 in error, got: $OUT"
+                exit 1
+                ;;
+            esac
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 30s
+      cleanup:
+      - script:
+          content: |
+            kubectl delete models -n "$NAMESPACE" --all --ignore-not-found >/dev/null 2>&1 || true
+          env:
+          - name: NAMESPACE
+            value: ($namespace)

--- a/tests/query-label-selector-set-based/README.md
+++ b/tests/query-label-selector-set-based/README.md
@@ -1,0 +1,26 @@
+# Query with set-based label selector
+
+Verifies that a Query using `spec.selector.matchExpressions` (the set-based
+form of a `LabelSelector`) dispatches correctly through the aggregated
+PostgreSQL apiserver.
+
+## What it tests
+- Creating a Query with `matchExpressions: In` / `NotIn` and a set of labeled
+  Agents (specialist vs generalist, production vs development)
+- The Query controller lists Agents through the aggregated apiserver using
+  the parsed selector
+- The apiserver's PostgreSQL storage backend translates set-based operators
+  into jsonb SQL and returns the matching Agent
+- The Query reaches `Completed` and targets a specialist, not the generalist
+
+The pre-fix backend rejected anything other than equality, so this Query
+would never have dispatched.
+
+## Running
+
+```bash
+chainsaw test tests/query-label-selector-set-based/
+```
+
+Successful completion confirms set-based label selectors flow end-to-end from
+Query CR through the controller to the apiserver's storage layer.

--- a/tests/query-label-selector-set-based/chainsaw-test.yaml
+++ b/tests/query-label-selector-set-based/chainsaw-test.yaml
@@ -1,0 +1,84 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: query-label-selector-set-based
+  labels:
+    postgresql: "true"
+spec:
+  description: |
+    Query dispatch using a set-based LabelSelector (matchExpressions).
+    The old PostgreSQL storage backend rejected anything but equality, so a
+    Query with matchExpressions never resolved a target. This exercises the
+    fix end-to-end: Query.spec.selector -> controller LabelSelectorAsSelector
+    -> client-go List against the aggregated apiserver -> storage-layer SQL
+    filter.
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query
+    try:
+    - apply:
+        file: manifests/*.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: test-query-set-based-selector
+        timeout: 60s
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - assert:
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: test-query-set-based-selector
+          status:
+            # Under the pre-fix backend, the impersonated List with a
+            # set-based selector errors at the storage layer and the Query
+            # ends up in phase=error. Assert on phase=done explicitly so a
+            # regression there fails loudly rather than passing through the
+            # weaker Completed=True condition.
+            phase: done
+            (response != null): true
+            # `type in (specialist)` matches weather + math; `environment
+            # notin (development)` excludes general. Whichever specialist the
+            # controller lists first wins — assert we picked a specialist and
+            # not the generalist.
+            (response.target.name == 'test-agent-math' || response.target.name == 'test-agent-weather'): true
+            (response.target.name != 'test-agent-general'): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: test-query-set-based-selector
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/query-label-selector-set-based/chainsaw-test.yaml
+++ b/tests/query-label-selector-set-based/chainsaw-test.yaml
@@ -5,13 +5,7 @@ metadata:
   labels:
     postgresql: "true"
 spec:
-  description: |
-    Query dispatch using a set-based LabelSelector (matchExpressions).
-    The old PostgreSQL storage backend rejected anything but equality, so a
-    Query with matchExpressions never resolved a target. This exercises the
-    fix end-to-end: Query.spec.selector -> controller LabelSelectorAsSelector
-    -> client-go List against the aggregated apiserver -> storage-layer SQL
-    filter.
+  description: Query dispatch with a set-based LabelSelector (matchExpressions).
   steps:
   - name: setup-mock-llm
     try:
@@ -55,17 +49,9 @@ spec:
           metadata:
             name: test-query-set-based-selector
           status:
-            # Under the pre-fix backend, the impersonated List with a
-            # set-based selector errors at the storage layer and the Query
-            # ends up in phase=error. Assert on phase=done explicitly so a
-            # regression there fails loudly rather than passing through the
-            # weaker Completed=True condition.
+            # phase=done (not just Completed=True): pre-fix code errored the query.
             phase: done
             (response != null): true
-            # `type in (specialist)` matches weather + math; `environment
-            # notin (development)` excludes general. Whichever specialist the
-            # controller lists first wins — assert we picked a specialist and
-            # not the generalist.
             (response.target.name == 'test-agent-math' || response.target.name == 'test-agent-weather'): true
             (response.target.name != 'test-agent-general'): true
     catch:

--- a/tests/query-label-selector-set-based/manifests/a00-rbac.yaml
+++ b/tests/query-label-selector-set-based/manifests/a00-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: query-selector-sa
+---
+# When a Query has spec.serviceAccount set, the Query controller creates an
+# uncached, impersonated client for that SA (rather than using the manager's
+# cached client). The uncached client pushes label selectors to the API
+# server — which is what we need to exercise the aggregated apiserver's
+# storage-layer selector translation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: query-selector-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["agents", "teams", "models", "tools", "queries"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: query-selector-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: query-selector-sa
+roleRef:
+  kind: Role
+  name: query-selector-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/query-label-selector-set-based/manifests/a00-rbac.yaml
+++ b/tests/query-label-selector-set-based/manifests/a00-rbac.yaml
@@ -3,11 +3,6 @@ kind: ServiceAccount
 metadata:
   name: query-selector-sa
 ---
-# When a Query has spec.serviceAccount set, the Query controller creates an
-# uncached, impersonated client for that SA (rather than using the manager's
-# cached client). The uncached client pushes label selectors to the API
-# server — which is what we need to exercise the aggregated apiserver's
-# storage-layer selector translation.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/tests/query-label-selector-set-based/manifests/a03-agent-weather.yaml
+++ b/tests/query-label-selector-set-based/manifests/a03-agent-weather.yaml
@@ -1,0 +1,14 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: test-agent-weather
+  labels:
+    category: weather
+    environment: production
+    type: specialist
+spec:
+  modelRef:
+    name: test-model-mock
+  prompt: |
+    You are a weather specialist agent.
+    Provide accurate weather information and forecasts.

--- a/tests/query-label-selector-set-based/manifests/a04-agent-math.yaml
+++ b/tests/query-label-selector-set-based/manifests/a04-agent-math.yaml
@@ -1,0 +1,14 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: test-agent-math
+  labels:
+    category: math
+    environment: production
+    type: specialist
+spec:
+  modelRef:
+    name: test-model-mock
+  prompt: |
+    You are a mathematics specialist agent.
+    Solve mathematical problems and provide detailed explanations.

--- a/tests/query-label-selector-set-based/manifests/a05-agent-general.yaml
+++ b/tests/query-label-selector-set-based/manifests/a05-agent-general.yaml
@@ -1,0 +1,14 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: test-agent-general
+  labels:
+    category: general
+    environment: development
+    type: generalist
+spec:
+  modelRef:
+    name: test-model-mock
+  prompt: |
+    You are a general purpose agent.
+    Provide helpful responses on a wide range of topics.

--- a/tests/query-label-selector-set-based/manifests/a06-query.yaml
+++ b/tests/query-label-selector-set-based/manifests/a06-query.yaml
@@ -1,0 +1,26 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: test-query-set-based-selector
+spec:
+  input: What is the weather like today and what mathematical concepts should I know?
+  # serviceAccount forces the Query controller to build an uncached impersonated
+  # client (see getClientForQuery in query_controller.go). Without this the
+  # controller uses its default cached client, which applies label selectors
+  # against the local informer cache and never sends them to the API server —
+  # so the aggregated apiserver storage-layer selector translation this test
+  # is trying to exercise would be bypassed.
+  serviceAccount: query-selector-sa
+  selector:
+    # matchExpressions is the set-based form of a LabelSelector. Under the
+    # pre-fix PostgreSQL storage backend, `parseLabelSelector` rejected the
+    # `In` operator ("only equality is supported"), so the Query controller's
+    # List call failed and the Query never dispatched. The fix routes label
+    # selectors through k8s labels.Parse so all operators are honoured.
+    matchExpressions:
+    - key: type
+      operator: In
+      values: [specialist]
+    - key: environment
+      operator: NotIn
+      values: [development]

--- a/tests/query-label-selector-set-based/manifests/a06-query.yaml
+++ b/tests/query-label-selector-set-based/manifests/a06-query.yaml
@@ -4,19 +4,9 @@ metadata:
   name: test-query-set-based-selector
 spec:
   input: What is the weather like today and what mathematical concepts should I know?
-  # serviceAccount forces the Query controller to build an uncached impersonated
-  # client (see getClientForQuery in query_controller.go). Without this the
-  # controller uses its default cached client, which applies label selectors
-  # against the local informer cache and never sends them to the API server —
-  # so the aggregated apiserver storage-layer selector translation this test
-  # is trying to exercise would be bypassed.
+  # Forces the uncached impersonated client so the selector reaches the server.
   serviceAccount: query-selector-sa
   selector:
-    # matchExpressions is the set-based form of a LabelSelector. Under the
-    # pre-fix PostgreSQL storage backend, `parseLabelSelector` rejected the
-    # `In` operator ("only equality is supported"), so the Query controller's
-    # List call failed and the Query never dispatched. The fix routes label
-    # selectors through k8s labels.Parse so all operators are honoured.
     matchExpressions:
     - key: type
       operator: In

--- a/tests/query-label-selector-set-based/mock-llm-values.yaml
+++ b/tests/query-label-selector-set-based/mock-llm-values.yaml
@@ -1,0 +1,40 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "gpt-4.1-mini",
+              "object": "model",
+              "owned_by": "openai"
+            }
+          ]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{
+            "message": {
+              "role": "assistant",
+              "content": "Some specialist knowledge would go here."
+            },
+            "finish_reason": "stop"
+          }],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 20,
+            "total_tokens": 70
+          }
+        }


### PR DESCRIPTION
## Summary
- **Field selectors**: the aggregated PostgreSQL apiserver silently dropped `opts.FieldSelector`, so a request for "the Model named X" returned every Model in the namespace. Now translates `metadata.name` and `metadata.namespace` with `=`/`==`/`!=` into SQL predicates; rejects unsupported fields with 400 Bad Request via a new `storage.ErrInvalidRequest`. Supported set can be extended by adding to `supportedFieldColumns`.
- **Label selectors**: `parseLabelSelector` was equality-only and errored on inequality, set-based, and existence forms. Now routes through `k8s.io/apimachinery/pkg/labels` and emits jsonb SQL using NULL-safe operators so k8s semantics are preserved (notably: `NotEquals`/`NotIn` match when the label is absent).
- **e2e**: two chainsaw tests (`postgresql: "true"` matrix) verify the fix end-to-end.

Refs #2680 (items 2 and 3).

## Verification
Both e2e tests verified locally against a real aggregated apiserver on minikube:

| Apiserver | field-selector-metadata-name | query-label-selector-set-based |
|---|---|---|
| main (pre-fix) | FAIL — returned all 3 items | FAIL — Query landed in `phase=error` |
| build of this branch | PASS — returned only the requested item | PASS — Query completed on a specialist Agent |

The Query dispatch test uses `spec.serviceAccount` deliberately: without it the Query controller uses controller-runtime's cached client which applies selectors client-side against the informer cache and never hits the server-side translation. The serviceAccount forces the uncached impersonated path so the storage-layer fix is actually exercised.

## Scope
- Only the aggregated PostgreSQL apiserver is affected. Etcd/CRD backend implements the real k8s contract natively.
- Deterministic SQL emission (labels.Parse sorts requirements by key, `.List()` sorts values within each requirement).
- Values are always bound parameters; operators/column names are fixed text — no injection surface.