### PR TITLE
feat(broker): propagate Query TTL to operation events

### DIFF
--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -19,6 +19,7 @@ import (
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arka2a "mckinsey.com/ark/internal/a2a"
 	"mckinsey.com/ark/internal/annotations"
+	"mckinsey.com/ark/internal/common"
 	"mckinsey.com/ark/internal/eventing"
 	"mckinsey.com/ark/internal/telemetry"
 )
@@ -253,7 +254,7 @@ func (h *Handler) setupExecution(ctx context.Context, query *arkv1alpha1.Query, 
 	if conversationId == "" {
 		conversationId = query.Spec.ConversationId
 	}
-	memory, err := NewMemoryForQuery(ctx, h.k8sClient, query.Spec.Memory, query.Namespace, conversationId, query.Name, ttlSecondsFromQuery(query), h.eventing.MemoryRecorder())
+	memory, err := NewMemoryForQuery(ctx, h.k8sClient, query.Spec.Memory, query.Namespace, conversationId, query.Name, common.TtlSecondsFromQuery(query), h.eventing.MemoryRecorder())
 	if err != nil {
 		querySpan.End()
 		return ctx, nil, fmt.Errorf("failed to create memory client: %w", err)

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -813,50 +813,6 @@ func TestCheckResumption(t *testing.T) {
 	}
 }
 
-func TestTtlSecondsFromQuery(t *testing.T) {
-	tests := []struct {
-		name        string
-		queryTTL    *metav1.Duration
-		expectNil   bool
-		expectedSec int64
-	}{
-		{
-			name:        "1 hour TTL converts to 3600 seconds",
-			queryTTL:    &metav1.Duration{Duration: time.Hour},
-			expectNil:   false,
-			expectedSec: 3600,
-		},
-		{
-			name:        "30 days converts to 2592000 seconds",
-			queryTTL:    &metav1.Duration{Duration: 30 * 24 * time.Hour},
-			expectNil:   false,
-			expectedSec: 2592000,
-		},
-		{
-			name:      "nil TTL stays nil",
-			queryTTL:  nil,
-			expectNil: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			query := &arkv1alpha1.Query{
-				Spec: arkv1alpha1.QuerySpec{TTL: tt.queryTTL},
-			}
-
-			result := ttlSecondsFromQuery(query)
-
-			if tt.expectNil {
-				require.Nil(t, result)
-			} else {
-				require.NotNil(t, result)
-				require.Equal(t, tt.expectedSec, *result)
-			}
-		})
-	}
-}
-
 func TestParseApprovalDecision(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -83,14 +83,6 @@ func DefaultConfig() Config {
 	}
 }
 
-func ttlSecondsFromQuery(query *arkv1alpha1.Query) *int64 {
-	if query.Spec.TTL == nil {
-		return nil
-	}
-	secs := int64(query.Spec.TTL.Seconds())
-	return &secs
-}
-
 func NewMemory(ctx context.Context, k8sClient client.Client, memoryName, namespace string, memoryRecorder eventing.MemoryRecorder) (MemoryInterface, error) {
 	return NewMemoryWithConfig(ctx, k8sClient, memoryName, namespace, DefaultConfig(), memoryRecorder)
 }

--- a/ark/internal/common/ttl.go
+++ b/ark/internal/common/ttl.go
@@ -1,0 +1,15 @@
+/* Copyright 2025. McKinsey & Company */
+
+package common
+
+import (
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TtlSecondsFromQuery(query *arkv1alpha1.Query) *int64 {
+	if query.Spec.TTL == nil {
+		return nil
+	}
+	secs := int64(query.Spec.TTL.Seconds())
+	return &secs
+}

--- a/ark/internal/common/ttl_test.go
+++ b/ark/internal/common/ttl_test.go
@@ -1,0 +1,57 @@
+/* Copyright 2025. McKinsey & Company */
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestTtlSecondsFromQuery(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryTTL    *metav1.Duration
+		expectNil   bool
+		expectedSec int64
+	}{
+		{
+			name:        "1 hour TTL converts to 3600 seconds",
+			queryTTL:    &metav1.Duration{Duration: time.Hour},
+			expectNil:   false,
+			expectedSec: 3600,
+		},
+		{
+			name:        "30 days converts to 2592000 seconds",
+			queryTTL:    &metav1.Duration{Duration: 30 * 24 * time.Hour},
+			expectNil:   false,
+			expectedSec: 2592000,
+		},
+		{
+			name:      "nil TTL stays nil",
+			queryTTL:  nil,
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := &arkv1alpha1.Query{
+				Spec: arkv1alpha1.QuerySpec{TTL: tt.queryTTL},
+			}
+
+			result := TtlSecondsFromQuery(query)
+
+			if tt.expectNil {
+				require.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				require.Equal(t, tt.expectedSec, *result)
+			}
+		})
+	}
+}

--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -14,6 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	"mckinsey.com/ark/internal/common"
 	"mckinsey.com/ark/internal/eventing"
 	"mckinsey.com/ark/internal/telemetry/routing"
 )
@@ -48,14 +49,6 @@ func NewBrokerEventEmitter(endpoints []routing.BrokerEndpoint) eventing.EventEmi
 		endpoints: endpointMap,
 		sem:       semaphore.NewWeighted(64),
 	}
-}
-
-func ttlSecondsFromQuery(query *arkv1alpha1.Query) *int64 {
-	if query.Spec.TTL == nil {
-		return nil
-	}
-	secs := int64(query.Spec.TTL.Seconds())
-	return &secs
 }
 
 func (e *BrokerEventEmitter) getEndpointForNamespace(namespace string) string {
@@ -104,7 +97,7 @@ func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Obj
 		Reason:     reason,
 		Message:    message,
 		Data:       eventData,
-		TtlSeconds: ttlSecondsFromQuery(query),
+		TtlSeconds: common.TtlSecondsFromQuery(query),
 	}
 
 	if e.sem.TryAcquire(1) {

--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -21,11 +21,12 @@ import (
 var log = logf.Log.WithName("eventing.broker")
 
 type Event struct {
-	Timestamp string                 `json:"timestamp"`
-	EventType string                 `json:"eventType"`
-	Reason    string                 `json:"reason"`
-	Message   string                 `json:"message"`
-	Data      map[string]interface{} `json:"data"`
+	Timestamp  string                 `json:"timestamp"`
+	EventType  string                 `json:"eventType"`
+	Reason     string                 `json:"reason"`
+	Message    string                 `json:"message"`
+	Data       map[string]interface{} `json:"data"`
+	TtlSeconds *int64                 `json:"ttl_seconds,omitempty"`
 }
 
 type BrokerEventEmitter struct {
@@ -47,6 +48,14 @@ func NewBrokerEventEmitter(endpoints []routing.BrokerEndpoint) eventing.EventEmi
 		endpoints: endpointMap,
 		sem:       semaphore.NewWeighted(64),
 	}
+}
+
+func ttlSecondsFromQuery(query *arkv1alpha1.Query) *int64 {
+	if query.Spec.TTL == nil {
+		return nil
+	}
+	secs := int64(query.Spec.TTL.Seconds())
+	return &secs
 }
 
 func (e *BrokerEventEmitter) getEndpointForNamespace(namespace string) string {
@@ -90,11 +99,12 @@ func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Obj
 	}
 
 	event := Event{
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		EventType: eventType,
-		Reason:    reason,
-		Message:   message,
-		Data:      eventData,
+		Timestamp:  time.Now().Format(time.RFC3339Nano),
+		EventType:  eventType,
+		Reason:     reason,
+		Message:    message,
+		Data:       eventData,
+		TtlSeconds: ttlSecondsFromQuery(query),
 	}
 
 	if e.sem.TryAcquire(1) {

--- a/ark/internal/eventing/broker/emitter_test.go
+++ b/ark/internal/eventing/broker/emitter_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/semaphore"
@@ -100,6 +101,66 @@ func TestEmitStructured_SendsEventToMatchingNamespace(t *testing.T) {
 
 	assert.Equal(t, "QueryExecutionStart", received.Reason)
 	assert.Equal(t, "test-uid", received.Data["queryId"])
+}
+
+func TestEmitStructured_IncludesTtlSecondsWhenQueryHasTTL(t *testing.T) {
+	var rawBody []byte
+	var received Event
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		_ = json.Unmarshal(rawBody, &received)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	query := newTestQuery("test-ns")
+	query.Spec.TTL = &metav1.Duration{Duration: time.Hour}
+
+	done := make(chan struct{})
+	origClient := e.httpClient
+	e.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := origClient.Do(req)
+			close(done)
+			return resp, err
+		}),
+	}
+
+	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", map[string]string{"queryId": "test-uid"})
+	<-done
+
+	assert.Contains(t, string(rawBody), `"ttl_seconds":3600`)
+	if assert.NotNil(t, received.TtlSeconds) {
+		assert.Equal(t, int64(3600), *received.TtlSeconds)
+	}
+}
+
+func TestEmitStructured_OmitsTtlSecondsWhenQueryHasNoTTL(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	query := newTestQuery("test-ns")
+
+	done := make(chan struct{})
+	origClient := e.httpClient
+	e.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := origClient.Do(req)
+			close(done)
+			return resp, err
+		}),
+	}
+
+	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", map[string]string{"queryId": "test-uid"})
+	<-done
+
+	assert.NotContains(t, string(rawBody), "ttl_seconds")
 }
 
 func TestEmitStructured_FallsBackToAnyEndpoint(t *testing.T) {

--- a/tests/event-broker-postgres/README.md
+++ b/tests/event-broker-postgres/README.md
@@ -1,10 +1,11 @@
 # event-broker-postgres
 
-Verifies that operation events from a completed query land in the Postgres `events` table with `expires_at` set.
+Verifies that operation events from a completed query land in the Postgres `events` table with `expires_at` set from the query's `spec.ttl`.
 
 ## What it tests
 - A query completes with `phase: done`
-- The broker writes at least one event to the Postgres `events` table with `query_id='events-broker-query'` and a non-null `expires_at`
+- The broker writes at least one event to the Postgres `events` table with `query_id=<query UID>` and a non-null `expires_at`
+- `expires_at - created_at` equals the query's `spec.ttl` (1h0m0s → 3600s)
 - `GET /events/:queryId` returns those events via the broker HTTP API
 - Requires the broker running with postgres event backend (`postgresql: "true"` label)
 

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     postgresql: "true"
 spec:
-  description: Operation events from a completed query land in the Postgres events table with expires_at set; GET /events/:queryId returns them
+  description: Operation events from a completed query land in the Postgres events table with expires_at set from Query.spec.ttl; GET /events/:queryId returns them
   steps:
   - name: setup-mock-llm
     try:
@@ -91,6 +91,28 @@ spec:
           done
           echo "events in Postgres: ${COUNT}"
           [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event, got ${COUNT}"; exit 1; }
+    catch:
+    - events: {}
+
+  - name: verify-event-ttl-in-postgres
+    try:
+    - script:
+        timeout: 30s
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: |
+          QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
+          TTL=""
+          for i in $(seq 1 10); do
+            TTL=$(bash ../shared/psql-query.sh \
+              "SELECT EXTRACT(EPOCH FROM (expires_at - created_at))::int FROM events WHERE query_id='${QUERY_UID}' LIMIT 1;" \
+              | tr -d ' \n')
+            [ -n "${TTL}" ] && break
+            sleep 1
+          done
+          echo "DB ttl_seconds: ${TTL}"
+          [ "${TTL}" = "3600" ] || { echo "expected 3600, got '${TTL}'"; exit 1; }
     catch:
     - events: {}
 

--- a/tests/event-broker-postgres/manifests/a02-query.yaml
+++ b/tests/event-broker-postgres/manifests/a02-query.yaml
@@ -7,3 +7,4 @@ spec:
   target:
     type: agent
     name: events-broker-agent
+  ttl: "1h0m0s"


### PR DESCRIPTION
## Summary

Follow-up to Phase 3 (#2737, part of the umbrella #2728) of the broker backend roadmap (#2153). Operation events now carry the originating Query's `spec.ttl` to the broker, so an event's Postgres retention (`expires_at`) matches its query's own TTL instead of always falling back to the broker's global `EVENT_VISIBILITY_TTL_SECONDS` default (720h). This mirrors the TTL wiring messages already got in #2508 — that PR did the same for `POST /messages`; this one closes the same gap for `POST /events`, which #2728 explicitly called out as deferred:

> Propagating the per-query TTL in the `POST /events` payload requires a controller-side change to the emitter and is deferred to a follow-up, mirroring how the message TTL wiring (#2508) followed the initial messages-on-Postgres work (#2424). This phase uses the env-default TTL.

## Problem

`ark/internal/eventing/broker/emitter.go` is the sole producer of `POST /events` requests — both the controller and the `ark-completions` executor pod build the same `eventing.Provider` and route every structured event through `BrokerEventEmitter.EmitStructured`. That struct never set `ttl_seconds` in the request body, even though the broker-side schema and `PostgresEventStream.append(event, ttlSeconds)` have accepted it since Phase 3 landed. The practical effect: with `EVENT_BACKEND=postgres`, every event's `expires_at` was `created_at + 720h`, regardless of whether the query itself had a much shorter (or longer) `spec.ttl`. Retention was decoupled from the thing it's supposed to track.

Before writing any code I re-verified (grepping the whole repo, not just the broker package) that `emitter.go`'s `sendEvent` is genuinely the only writer of `POST /events` — the ark-api `broker.py` and dashboard `useSSEStream` only read (`GET`/SSE), and the Python SDK's `BrokerClient` has `send_messages` but no `send_events` at all. So this is a single-file change on the Go side, no broker changes needed (broker-side `ttl_seconds` handling was already shipped in Phase 3).

## Fix

- `ark/internal/eventing/broker/emitter.go`: added `TtlSeconds *int64 \`json:"ttl_seconds,omitempty"\`` to the `Event` struct, and a small `ttlSecondsFromQuery` helper (mirroring the equivalent helper in `ark/executors/completions/memory.go`, unexported there so not reusable directly) that converts `query.Spec.TTL` (a `*metav1.Duration`) to seconds. `EmitStructured` now sets `event.TtlSeconds = ttlSecondsFromQuery(query)` before dispatch.
- `omitempty` on a `*int64` means a query with no `spec.ttl` produces a payload with the key absent entirely, not `"ttl_seconds":0` or `null` — the broker's existing `ttlSeconds ?? this.ttlSeconds` fallback then applies the global default exactly as it does today. Backward compatible, no behaviour change for queries without a TTL.
- `ark/internal/eventing/broker/emitter_test.go`: two new tests, `TestEmitStructured_IncludesTtlSecondsWhenQueryHasTTL` (query with `Spec.TTL = 1h` → body contains `"ttl_seconds":3600`) and `TestEmitStructured_OmitsTtlSecondsWhenQueryHasNoTTL` (no TTL → key absent from the body), following the existing test-server pattern in the file.
- `tests/event-broker-postgres/`: extended the existing Phase 3 chainsaw test rather than adding a new one, since it already covers the events-on-Postgres path end to end. `manifests/a02-query.yaml` now sets `spec.ttl: "1h0m0s"`; a new `verify-event-ttl-in-postgres` step queries `EXTRACT(EPOCH FROM (expires_at - created_at))` directly against the `events` table and asserts it equals `3600`, on top of the pre-existing existence/HTTP checks.

## Verification

- `cd ark && make lint && make test` — green (per CLAUDE.md pre-push gate).
- `go test ./internal/eventing/broker/...` — all unit tests pass, including the two new ones.
- Full local chainsaw run on a dedicated, disposable `ark-e2e` Kind cluster (not `kind-ark-local`), built from this branch's code, configured to match `.github/actions/setup-e2e/setup-local.sh` (Postgres + TLS, broker with `backends.message=postgres` + `backends.event=postgres`):
  - All 5 `postgresql: "true"` tests pass, including `event-broker-postgres`'s new step — `DB ttl_seconds: 3600` confirmed against a query with `spec.ttl: "1h0m0s"`, both via direct SQL and via `GET /events/:queryId`.
  - All 40 standard (non-labelled) tests pass.
  - All 4 `requires-images: "true"` tests pass (built `ark-dashboard`/`ark-mcp` images locally for this; `ark-broker`/`ark-completions`/`ark-controller` were already built for the earlier stages).
  - The 8 `tests/llm-tests/` tests were not run — no real LLM API key was available in this environment.
  - Cluster torn down after the run; no changes were left on `kind-ark-local`.

## Review guide

- `ark/internal/eventing/broker/emitter.go:23-30` — new field on the wire struct.
- `ark/internal/eventing/broker/emitter.go:53-59` — `ttlSecondsFromQuery` helper.
- `ark/internal/eventing/broker/emitter.go:101-108` — where it's wired into `EmitStructured`.
- `ark/internal/eventing/broker/emitter_test.go:106-164` — the two new tests.
- `tests/event-broker-postgres/chainsaw-test.yaml:97-117` — the new `verify-event-ttl-in-postgres` step.
- `tests/event-broker-postgres/manifests/a02-query.yaml:10` — `ttl: "1h0m0s"` addition.

## Out of scope

Everything else #2728 lists as a Phase 3 follow-up remains untouched here: `DELETE /events/:queryId` + finalizer cascade cleanup, the Postgres read-path perf follow-up (#2736), and Phase 4 (sessions on Postgres). This PR is scoped to the single TTL-propagation gap.

Closes part of #2728.