### PR TITLE
fix: implement failure requeue interval logic in MCPServer controller

### DIFF
--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -145,6 +145,10 @@ func failureRequeueInterval(mcpServer *arkv1alpha1.MCPServer, wasAvailable bool)
 }
 
 func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1alpha1.MCPServer) (ctrl.Result, error) {
+	// Snapshot the last persisted Available state before any condition mutation
+	// in this cycle. The failure paths below flip Available to False, so reading
+	// it up front is what lets them distinguish first-time convergence from
+	// steady-state re-discovery.
 	wasAvailable := meta.IsStatusConditionTrue(mcpServer.Status.Conditions, MCPServerAvailable)
 
 	resolver := r.getResolver()

--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -56,6 +56,12 @@ const (
 	MCPServerReasonAuthorized = "Authorized"
 )
 
+// initialConvergenceRetry bounds how long a freshly deployed MCPServer waits
+// between discovery attempts before it first reaches Available. The poll
+// interval governs steady-state re-discovery and is too long for first-time
+// bring-up, where the endpoint may be Ready but not yet serving tools/list.
+const initialConvergenceRetry = 5 * time.Second
+
 type MCPServerReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
@@ -126,14 +132,28 @@ func (r *MCPServerReconciler) deleteAllMCPTools(ctx context.Context, mcpServerNa
 	return r.DeleteAllOf(ctx, &arkv1alpha1.Tool{}, deleteOpts...)
 }
 
+// failureRequeueInterval returns the retry delay after a transient discovery
+// failure: a short interval while the server has never reached Available
+// (initial convergence, endpoint still starting), the steady-state poll
+// interval once it has been Available at least once.
+func failureRequeueInterval(mcpServer *arkv1alpha1.MCPServer, wasAvailable bool) time.Duration {
+	poll := getPollInterval(mcpServer.Spec.PollInterval)
+	if !wasAvailable && initialConvergenceRetry < poll {
+		return initialConvergenceRetry
+	}
+	return poll
+}
+
 func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1alpha1.MCPServer) (ctrl.Result, error) {
+	wasAvailable := meta.IsStatusConditionTrue(mcpServer.Status.Conditions, MCPServerAvailable)
+
 	resolver := r.getResolver()
 	resolvedAddress, err := resolver.ResolveValueSource(ctx, mcpServer.Spec.Address, mcpServer.Namespace)
 	if err != nil {
 		if err := r.reconcileConditionsAddressResolutionFailed(ctx, &mcpServer, err); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: getPollInterval(mcpServer.Spec.PollInterval)}, nil
+		return ctrl.Result{RequeueAfter: failureRequeueInterval(&mcpServer, wasAvailable)}, nil
 	}
 
 	mcpServer.Status.ResolvedAddress = resolvedAddress
@@ -145,7 +165,7 @@ func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1
 
 	mcpClient, err := r.createMCPClient(ctx, &mcpServer, authMaterial)
 	if err != nil {
-		return r.handleClientCreationError(ctx, &mcpServer, err)
+		return r.handleClientCreationError(ctx, &mcpServer, err, wasAvailable)
 	}
 	defer func() {
 		if err := mcpClient.Client.Close(); err != nil {
@@ -158,7 +178,7 @@ func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1
 		if err := r.reconcileConditionsToolListingFailed(ctx, &mcpServer, err); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: getPollInterval(mcpServer.Spec.PollInterval)}, nil
+		return ctrl.Result{RequeueAfter: failureRequeueInterval(&mcpServer, wasAvailable)}, nil
 	}
 
 	r.applyAuthorizationSuccess(&mcpServer, authMaterial)
@@ -168,7 +188,7 @@ func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1
 		if err := r.reconcileConditionsToolCreationFailed(ctx, &mcpServer, err); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: getPollInterval(mcpServer.Spec.PollInterval)}, nil
+		return ctrl.Result{RequeueAfter: failureRequeueInterval(&mcpServer, wasAvailable)}, nil
 	}
 
 	return r.finalizeMCPServerProcessing(ctx, mcpServer, len(mcpTools), toolsChanged)
@@ -379,8 +399,8 @@ func (r *MCPServerReconciler) reconcileConditionsToolCreationFailed(ctx context.
 // the appropriate condition handler — the OAuth discovery path for a
 // 401 response, the generic client-creation path otherwise — and
 // cleans up any tools owned by the server.
-func (r *MCPServerReconciler) handleClientCreationError(ctx context.Context, mcpServer *arkv1alpha1.MCPServer, err error) (ctrl.Result, error) {
-	requeue := ctrl.Result{RequeueAfter: getPollInterval(mcpServer.Spec.PollInterval)}
+func (r *MCPServerReconciler) handleClientCreationError(ctx context.Context, mcpServer *arkv1alpha1.MCPServer, err error, wasAvailable bool) (ctrl.Result, error) {
+	requeue := ctrl.Result{RequeueAfter: failureRequeueInterval(mcpServer, wasAvailable)}
 
 	if ue, ok := arkmcp.IsUnauthorizedError(err); ok {
 		if err := r.handleAuthorizationRequired(ctx, mcpServer, ue); err != nil {

--- a/ark/internal/controller/mcpserver_controller_test.go
+++ b/ark/internal/controller/mcpserver_controller_test.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,3 +54,19 @@ var _ = Describe("MCPServer Controller", func() {
 		Expect(controllerReconciler.updateStatus(ctx, deletedMCPServer)).To(Succeed())
 	})
 })
+
+var _ = DescribeTable(
+	"failureRequeueInterval",
+	func(pollInterval *metav1.Duration, wasAvailable bool, expected time.Duration) {
+		mcpServer := &arkv1alpha1.MCPServer{
+			Spec: arkv1alpha1.MCPServerSpec{PollInterval: pollInterval},
+		}
+		Expect(failureRequeueInterval(mcpServer, wasAvailable)).To(Equal(expected))
+	},
+	Entry("never available, default poll -> fast retry", nil, false, initialConvergenceRetry),
+	Entry("already available, default poll -> steady poll", nil, true, time.Minute),
+	Entry("never available, poll shorter than fast retry -> poll",
+		&metav1.Duration{Duration: 2 * time.Second}, false, 2*time.Second),
+	Entry("already available, custom poll -> custom poll",
+		&metav1.Duration{Duration: 10 * time.Second}, true, 10*time.Second),
+)

--- a/tests/mcp-ark/chainsaw-test.yaml
+++ b/tests/mcp-ark/chainsaw-test.yaml
@@ -47,7 +47,7 @@ spec:
         apiVersion: ark.mckinsey.com/v1alpha1
         kind: MCPServer
         name: ark-mcp
-        timeout: 2m
+        timeout: 4m
         for:
           condition:
             name: Available

--- a/tests/mcp-ark/chainsaw-test.yaml
+++ b/tests/mcp-ark/chainsaw-test.yaml
@@ -47,7 +47,7 @@ spec:
         apiVersion: ark.mckinsey.com/v1alpha1
         kind: MCPServer
         name: ark-mcp
-        timeout: 4m
+        timeout: 2m
         for:
           condition:
             name: Available


### PR DESCRIPTION
## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 