### PR TITLE
fix(apiserver): drop PostgreSQL replication slot and publication on uninstall

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -33,6 +35,7 @@ import (
 	"mckinsey.com/ark/internal/apiserver"
 	"mckinsey.com/ark/internal/controller"
 	eventingconfig "mckinsey.com/ark/internal/eventing/config"
+	"mckinsey.com/ark/internal/storage/postgresql"
 	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
 	webhookv1 "mckinsey.com/ark/internal/webhook/v1"
 	webhookv1prealpha1 "mckinsey.com/ark/internal/webhook/v1prealpha1"
@@ -72,19 +75,21 @@ type config struct {
 }
 
 const (
-	RoleAPIServer  = "apiserver"
-	RoleController = "controller"
+	RoleAPIServer       = "apiserver"
+	RoleController      = "controller"
+	RolePostgresCleanup = "postgres-cleanup"
 )
 
+var validRoles = []string{RoleAPIServer, RoleController, RolePostgresCleanup}
+
 func validateRole(role string) error {
-	switch role {
-	case RoleAPIServer, RoleController:
+	if slices.Contains(validRoles, role) {
 		return nil
-	case "":
-		return fmt.Errorf("--role is required; must be %q or %q", RoleAPIServer, RoleController)
-	default:
-		return fmt.Errorf("--role=%q is invalid; must be %q or %q", role, RoleAPIServer, RoleController)
 	}
+	if role == "" {
+		return fmt.Errorf("--role is required; must be one of %q", validRoles)
+	}
+	return fmt.Errorf("--role=%q is invalid; must be one of %q", role, validRoles)
 }
 
 func leaderElectionID(role string) string {
@@ -106,6 +111,11 @@ func main() {
 	}
 
 	setupLog.Info("starting ark controller", "version", Version, "commit", GitCommit, "role", result.role)
+
+	if result.role == RolePostgresCleanup {
+		runPostgresCleanup()
+		return
+	}
 
 	mgr, metricsCertWatcher, webhookCertWatcher := setupManager(result.config)
 
@@ -163,7 +173,7 @@ func parseFlags() struct {
 	flag.StringVar(&cfg.completionsAddr, "completions-addr", "http://ark-completions.ark-system",
 		"Address of the completions engine for A2A communication")
 	flag.StringVar(&cfg.role, "role", "",
-		"Required: process role — 'apiserver' (runs only the aggregated API server) or 'controller' (runs only reconcilers and webhooks)")
+		"Required: process role — 'apiserver' (runs only the aggregated API server), 'controller' (runs only reconcilers and webhooks) or 'postgres-cleanup' (drops the PostgreSQL replication slot and publication, then exits)")
 	flag.IntVar(&cfg.maxConcurrentQueries, "max-concurrent-queries", 32,
 		"Maximum number of Query executions running concurrently in goroutines. "+
 			"When the cap is reached, Reconcile requeues so the workqueue holds the backlog "+
@@ -370,6 +380,37 @@ func setupWebhooks(mgr ctrl.Manager) {
 			os.Exit(1)
 		}
 	}
+}
+
+func postgresCleanupConfig() postgresql.Config {
+	cfg := postgresql.Config{
+		Host:        os.Getenv("ARK_POSTGRES_HOST"),
+		Database:    os.Getenv("ARK_POSTGRES_DATABASE"),
+		User:        os.Getenv("ARK_POSTGRES_USER"),
+		Password:    os.Getenv("ARK_POSTGRES_PASSWORD"),
+		SSLMode:     os.Getenv("ARK_POSTGRES_SSL_MODE"),
+		SSLRootCert: os.Getenv("ARK_POSTGRES_SSL_ROOT_CERT"),
+		SSLCert:     os.Getenv("ARK_POSTGRES_SSL_CERT"),
+		SSLKey:      os.Getenv("ARK_POSTGRES_SSL_KEY"),
+	}
+	if portStr := os.Getenv("ARK_POSTGRES_PORT"); portStr != "" {
+		port, _ := strconv.Atoi(portStr)
+		cfg.Port = port
+	}
+	return cfg
+}
+
+func runPostgresCleanup() {
+	cfg := postgresCleanupConfig()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	err := postgresql.DropReplicationArtifacts(ctx, cfg)
+	cancel()
+	if err != nil {
+		setupLog.Error(err, "postgres cleanup failed")
+		os.Exit(1)
+	}
+	setupLog.Info("postgres cleanup complete")
 }
 
 func apiserverConfigFromEnv() (apiserver.Config, error) {

--- a/ark/cmd/main_test.go
+++ b/ark/cmd/main_test.go
@@ -19,6 +19,7 @@ func TestValidateRole(t *testing.T) {
 	}{
 		{"apiserver", ""},
 		{"controller", ""},
+		{"postgres-cleanup", ""},
 		{"", "is required"},
 		{"combined", "is invalid"},
 		{"APISERVER", "is invalid"},
@@ -231,6 +232,48 @@ func TestApiserverConfigFromEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPostgresCleanupConfig(t *testing.T) {
+	for _, k := range []string{
+		"ARK_POSTGRES_HOST", "ARK_POSTGRES_DATABASE", "ARK_POSTGRES_USER",
+		"ARK_POSTGRES_PASSWORD", "ARK_POSTGRES_SSL_MODE", "ARK_POSTGRES_PORT",
+		"ARK_POSTGRES_SSL_ROOT_CERT", "ARK_POSTGRES_SSL_CERT", "ARK_POSTGRES_SSL_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+
+	t.Run("reads env", func(t *testing.T) {
+		t.Setenv("ARK_POSTGRES_HOST", "db")
+		t.Setenv("ARK_POSTGRES_DATABASE", "ark")
+		t.Setenv("ARK_POSTGRES_USER", "ark")
+		t.Setenv("ARK_POSTGRES_PASSWORD", "pw")
+		t.Setenv("ARK_POSTGRES_SSL_MODE", "verify-full")
+		t.Setenv("ARK_POSTGRES_PORT", "6000")
+		t.Setenv("ARK_POSTGRES_SSL_ROOT_CERT", "/etc/ark/postgres-tls/ca.crt")
+		t.Setenv("ARK_POSTGRES_SSL_CERT", "/etc/ark/postgres-tls/tls.crt")
+		t.Setenv("ARK_POSTGRES_SSL_KEY", "/etc/ark/postgres-tls/tls.key")
+
+		cfg := postgresCleanupConfig()
+		if cfg.Host != "db" || cfg.Database != "ark" || cfg.User != "ark" ||
+			cfg.Password != "pw" || cfg.SSLMode != "verify-full" || cfg.Port != 6000 ||
+			cfg.SSLRootCert != "/etc/ark/postgres-tls/ca.crt" ||
+			cfg.SSLCert != "/etc/ark/postgres-tls/tls.crt" ||
+			cfg.SSLKey != "/etc/ark/postgres-tls/tls.key" {
+			t.Errorf("unexpected config: %+v", cfg)
+		}
+	})
+
+	t.Run("port left zero when unset or invalid", func(t *testing.T) {
+		t.Setenv("ARK_POSTGRES_PORT", "")
+		if cfg := postgresCleanupConfig(); cfg.Port != 0 {
+			t.Errorf("Port = %d, want 0 (defaulted downstream)", cfg.Port)
+		}
+		t.Setenv("ARK_POSTGRES_PORT", "not-a-number")
+		if cfg := postgresCleanupConfig(); cfg.Port != 0 {
+			t.Errorf("Port = %d, want 0 for invalid input", cfg.Port)
+		}
+	})
 }
 
 func TestLeaderElectionID(t *testing.T) {

--- a/ark/dist/chart-apiserver/templates/_helpers.tpl
+++ b/ark/dist/chart-apiserver/templates/_helpers.tpl
@@ -23,3 +23,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}
+
+{{- define "ark-apiserver.postgresEnv" -}}
+- name: ARK_POSTGRES_HOST
+  value: {{ required "postgresql.host is required" .Values.postgresql.host | quote }}
+- name: ARK_POSTGRES_PORT
+  value: {{ .Values.postgresql.port | quote }}
+- name: ARK_POSTGRES_DATABASE
+  value: {{ .Values.postgresql.database | quote }}
+- name: ARK_POSTGRES_USER
+  value: {{ required "postgresql.user is required" .Values.postgresql.user | quote }}
+- name: ARK_POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ required "postgresql.passwordSecretName is required" .Values.postgresql.passwordSecretName }}
+      key: {{ .Values.postgresql.passwordSecretKey }}
+- name: ARK_POSTGRES_SSL_MODE
+  value: {{ .Values.postgresql.sslMode | quote }}
+{{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslRootCertKey }}
+- name: ARK_POSTGRES_SSL_ROOT_CERT
+  value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslRootCertKey }}
+{{- end }}
+{{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslClientCertKey }}
+- name: ARK_POSTGRES_SSL_CERT
+  value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslClientCertKey }}
+{{- end }}
+{{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslClientKeyKey }}
+- name: ARK_POSTGRES_SSL_KEY
+  value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslClientKeyKey }}
+{{- end }}
+{{- end }}

--- a/ark/dist/chart-apiserver/templates/deployment.yaml
+++ b/ark/dist/chart-apiserver/templates/deployment.yaml
@@ -42,38 +42,12 @@ spec:
               value: postgresql
             - name: ARK_APISERVER_PORT
               value: {{ .Values.apiserver.port | quote }}
-            - name: ARK_POSTGRES_HOST
-              value: {{ required "postgresql.host is required" .Values.postgresql.host | quote }}
-            - name: ARK_POSTGRES_PORT
-              value: {{ .Values.postgresql.port | quote }}
-            - name: ARK_POSTGRES_DATABASE
-              value: {{ .Values.postgresql.database | quote }}
-            - name: ARK_POSTGRES_USER
-              value: {{ required "postgresql.user is required" .Values.postgresql.user | quote }}
-            - name: ARK_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ required "postgresql.passwordSecretName is required" .Values.postgresql.passwordSecretName }}
-                  key: {{ .Values.postgresql.passwordSecretKey }}
-            - name: ARK_POSTGRES_SSL_MODE
-              value: {{ .Values.postgresql.sslMode | quote }}
+            {{- include "ark-apiserver.postgresEnv" . | nindent 12 }}
             {{- if .Values.certManager.enabled }}
             - name: ARK_APISERVER_TLS_CERT_FILE
               value: /etc/ark/apiserver-tls/tls.crt
             - name: ARK_APISERVER_TLS_KEY_FILE
               value: /etc/ark/apiserver-tls/tls.key
-            {{- end }}
-            {{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslRootCertKey }}
-            - name: ARK_POSTGRES_SSL_ROOT_CERT
-              value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslRootCertKey }}
-            {{- end }}
-            {{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslClientCertKey }}
-            - name: ARK_POSTGRES_SSL_CERT
-              value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslClientCertKey }}
-            {{- end }}
-            {{- if and .Values.postgresql.sslSecretName .Values.postgresql.sslClientKeyKey }}
-            - name: ARK_POSTGRES_SSL_KEY
-              value: /etc/ark/postgres-tls/{{ .Values.postgresql.sslClientKeyKey }}
             {{- end }}
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/ark/dist/chart-apiserver/templates/postgres-cleanup-job.yaml
+++ b/ark/dist/chart-apiserver/templates/postgres-cleanup-job.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ark-apiserver-postgres-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "ark-apiserver.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- if .Values.postgresql.sslSecretName }}
+        fsGroup: {{ .Values.containerSecurityContext.runAsGroup | default .Values.postgresql.sslFsGroup }}
+        {{- end }}
+      containers:
+        - name: postgres-cleanup
+          image: {{ include "ark-apiserver.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --role=postgres-cleanup
+          env:
+            {{- include "ark-apiserver.postgresEnv" . | nindent 12 }}
+          {{- if .Values.postgresql.sslSecretName }}
+          volumeMounts:
+            - name: postgres-tls
+              mountPath: /etc/ark/postgres-tls
+              readOnly: true
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- if .Values.postgresql.sslSecretName }}
+      volumes:
+        - name: postgres-tls
+          secret:
+            secretName: {{ .Values.postgresql.sslSecretName }}
+            defaultMode: 0640
+      {{- end }}

--- a/ark/go.mod
+++ b/ark/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26

--- a/ark/go.sum
+++ b/ark/go.sum
@@ -12,6 +12,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
@@ -203,6 +205,7 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/ark/internal/storage/postgresql/cleanup.go
+++ b/ark/internal/storage/postgresql/cleanup.go
@@ -1,0 +1,85 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+var cleanupRetryInterval = 3 * time.Second
+
+func cleanupConnString(cfg Config) string {
+	if cfg.SSLMode == "" {
+		cfg.SSLMode = "require"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 5432
+	}
+	return buildConnString(cfg) + " connect_timeout=10"
+}
+
+// DropReplicationArtifacts removes the logical replication slot and publication
+// created by the backend. Without this, an uninstalled deployment leaves an
+// inactive slot behind that pins WAL segments until the disk fills up.
+//
+// A still-terminating apiserver pod can hold the slot active or recreate it
+// right after a drop (the WAL consumer reconnects and re-creates the slot), so
+// the drop is retried until it outlasts the pod's termination grace period.
+func DropReplicationArtifacts(ctx context.Context, cfg Config) error {
+	db, err := sql.Open("postgres", cleanupConnString(cfg))
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	return dropReplicationArtifacts(ctx, db)
+}
+
+func dropReplicationArtifacts(ctx context.Context, db *sql.DB) error {
+	for {
+		if _, err := db.ExecContext(ctx,
+			"SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = $1 AND active_pid IS NOT NULL",
+			walSlotName); err != nil {
+			return fmt.Errorf("terminate slot consumer: %w", err)
+		}
+
+		_, dropErr := db.ExecContext(ctx,
+			"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1",
+			walSlotName)
+		var stillPresent bool
+		if dropErr == nil {
+			var n int
+			if err := db.QueryRowContext(ctx,
+				"SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
+				walSlotName).Scan(&n); err != nil {
+				return fmt.Errorf("verify slot dropped: %w", err)
+			}
+			stillPresent = n > 0
+		}
+		if dropErr == nil && !stillPresent {
+			break
+		}
+
+		reason := fmt.Sprintf("slot %s was recreated by a live consumer", walSlotName)
+		if dropErr != nil {
+			reason = dropErr.Error()
+		}
+		klog.Infof("replication slot busy, retrying: %s", reason)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("drop replication slot (%s): %w", reason, ctx.Err())
+		case <-time.After(cleanupRetryInterval):
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, "DROP PUBLICATION IF EXISTS "+walPublicationName); err != nil {
+		return fmt.Errorf("drop publication: %w", err)
+	}
+
+	klog.Infof("dropped replication slot and publication %s", walSlotName)
+	return nil
+}

--- a/ark/internal/storage/postgresql/cleanup_integration_test.go
+++ b/ark/internal/storage/postgresql/cleanup_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+// +build integration
+
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestDropReplicationArtifacts_Integration(t *testing.T) {
+	host := os.Getenv("POSTGRES_HOST")
+	if host == "" {
+		t.Skip("POSTGRES_HOST not set, skipping integration test")
+	}
+
+	port := 5432
+	if p := os.Getenv("POSTGRES_PORT"); p != "" {
+		port, _ = strconv.Atoi(p)
+	}
+
+	cfg := Config{
+		Host:     host,
+		Port:     port,
+		Database: "ark",
+		User:     "ark",
+		Password: os.Getenv("POSTGRES_PASSWORD"),
+		SSLMode:  "disable",
+	}
+
+	ctx := context.Background()
+	checker, err := sql.Open("postgres", cleanupConnString(cfg))
+	if err != nil {
+		t.Fatalf("open checker connection: %v", err)
+	}
+	defer checker.Close()
+
+	slotCount := func() int {
+		var n int
+		if err := checker.QueryRowContext(ctx,
+			"SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1", walSlotName).Scan(&n); err != nil {
+			t.Fatalf("query pg_replication_slots: %v", err)
+		}
+		return n
+	}
+	publicationCount := func() int {
+		var n int
+		if err := checker.QueryRowContext(ctx,
+			"SELECT count(*) FROM pg_publication WHERE pubname = $1", walPublicationName).Scan(&n); err != nil {
+			t.Fatalf("query pg_publication: %v", err)
+		}
+		return n
+	}
+
+	backend, err := New(cfg, &integrationMockConverter{})
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+
+	deadline := time.Now().Add(15 * time.Second)
+	for slotCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("replication slot was not created within 15s")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if publicationCount() == 0 {
+		t.Fatal("publication was not created")
+	}
+
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	if err := DropReplicationArtifacts(ctx, cfg); err != nil {
+		t.Fatalf("DropReplicationArtifacts failed: %v", err)
+	}
+
+	if n := slotCount(); n != 0 {
+		t.Errorf("replication slot still present after cleanup: count = %d", n)
+	}
+	if n := publicationCount(); n != 0 {
+		t.Errorf("publication still present after cleanup: count = %d", n)
+	}
+
+	if err := DropReplicationArtifacts(ctx, cfg); err != nil {
+		t.Errorf("second DropReplicationArtifacts should be idempotent, got: %v", err)
+	}
+}

--- a/ark/internal/storage/postgresql/cleanup_test.go
+++ b/ark/internal/storage/postgresql/cleanup_test.go
@@ -5,6 +5,7 @@ package postgresql
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -124,6 +125,62 @@ func TestDropReplicationArtifacts_PublicationError(t *testing.T) {
 	}
 }
 
+func TestDropReplicationArtifacts_VerifyError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnError(errors.New("boom"))
+
+	err = dropReplicationArtifacts(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "verify slot dropped") {
+		t.Fatalf("expected verify error, got %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_RetriesOnDropError(t *testing.T) {
+	withFastRetry(t)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// First pass: drop fails while a consumer still holds the slot.
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnError(errors.New("slot is active"))
+	// Second pass: gone.
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("DROP PUBLICATION").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := dropReplicationArtifacts(context.Background(), db); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_UnreachableDatabase(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	err = DropReplicationArtifacts(context.Background(), Config{Host: "127.0.0.1", Port: port, Database: "ark", User: "ark", Password: "pw", SSLMode: "disable"})
+	if err == nil || !strings.Contains(err.Error(), "terminate slot consumer") {
+		t.Fatalf("expected connection failure from terminate step, got %v", err)
+	}
+}
+
 func TestDropReplicationArtifacts_DeadlineExceeded(t *testing.T) {
 	withFastRetry(t)
 	db, mock, err := sqlmock.New()
@@ -143,8 +200,11 @@ func TestDropReplicationArtifacts_DeadlineExceeded(t *testing.T) {
 	defer cancel()
 
 	err = dropReplicationArtifacts(ctx, db)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	if err == nil {
+		t.Fatal("expected error after deadline, got nil")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("loop ended before deadline: %v", err)
 	}
 }
 

--- a/ark/internal/storage/postgresql/cleanup_test.go
+++ b/ark/internal/storage/postgresql/cleanup_test.go
@@ -1,0 +1,168 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestCleanupConnString(t *testing.T) {
+	got := cleanupConnString(Config{Host: "h", User: "u", Password: "p", Database: "d"})
+	for _, want := range []string{"host='h'", "user='u'", "dbname='d'", "port=5432", "sslmode='require'", "connect_timeout=10"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("conn string %q missing %q", got, want)
+		}
+	}
+
+	got = cleanupConnString(Config{Host: "h", Port: 6000, SSLMode: "disable"})
+	if !strings.Contains(got, "port=6000") || !strings.Contains(got, "sslmode='disable'") {
+		t.Errorf("explicit port/sslmode not honored: %q", got)
+	}
+
+	got = cleanupConnString(Config{Host: "h", SSLMode: "verify-full", SSLRootCert: "/c/ca.crt", SSLCert: "/c/tls.crt", SSLKey: "/c/tls.key"})
+	for _, want := range []string{"sslrootcert='/c/ca.crt'", "sslcert='/c/tls.crt'", "sslkey='/c/tls.key'"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("conn string %q missing %q", got, want)
+		}
+	}
+
+	got = cleanupConnString(Config{Host: "h", Password: `p' \x`})
+	if !strings.Contains(got, `password='p\' \\x'`) {
+		t.Errorf("password not escaped: %q", got)
+	}
+}
+
+func withFastRetry(t *testing.T) {
+	t.Helper()
+	old := cleanupRetryInterval
+	cleanupRetryInterval = time.Millisecond
+	t.Cleanup(func() { cleanupRetryInterval = old })
+}
+
+func TestDropReplicationArtifacts_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("DROP PUBLICATION").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := dropReplicationArtifacts(context.Background(), db); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_RetriesWhenRecreated(t *testing.T) {
+	withFastRetry(t)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// First pass: slot still present after drop (recreated by a live consumer).
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	// Second pass: gone.
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("DROP PUBLICATION").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := dropReplicationArtifacts(context.Background(), db); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_TerminateError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnError(errors.New("boom"))
+
+	err = dropReplicationArtifacts(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "terminate slot consumer") {
+		t.Fatalf("expected terminate error, got %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_PublicationError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec("DROP PUBLICATION").WillReturnError(errors.New("nope"))
+
+	err = dropReplicationArtifacts(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "drop publication") {
+		t.Fatalf("expected publication error, got %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_DeadlineExceeded(t *testing.T) {
+	withFastRetry(t)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Slot keeps coming back; the caller's context deadline must end the loop.
+	for i := 0; i < 200; i++ {
+		mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err = dropReplicationArtifacts(ctx, db)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestDropReplicationArtifacts_ContextCanceled(t *testing.T) {
+	withFastRetry(t)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mock.ExpectExec("pg_terminate_backend").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("pg_drop_replication_slot").WithArgs(walSlotName).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("count").WithArgs(walSlotName).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	cancel()
+
+	if err := dropReplicationArtifacts(ctx, db); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -230,9 +230,9 @@ Treat the `resources` table like any other application table:
 
 ## Uninstall and cleanup
 
-`helm uninstall` removes the apiserver Deployment and APIService but does **not** drop the publication or the replication slot. An orphaned slot will pin WAL retention and can fill the disk.
+`helm uninstall` runs a `post-delete` hook Job that drops the `ark_cdc` replication slot and publication. Without this cleanup, an orphaned slot would pin WAL retention and can fill the disk. The Job connects with the same credentials as the apiserver, so the password secret must still exist when you uninstall.
 
-After uninstalling, drop the slot manually:
+If the hook Job could not run (for example the database was unreachable, or you removed the release with `--no-hooks`), drop the slot manually:
 
 ```sql
 SELECT pg_drop_replication_slot('ark_cdc');


### PR DESCRIPTION
## Summary
- `helm uninstall` of chart-apiserver left the `ark_cdc` logical replication slot (and publication) behind; an orphaned inactive slot pins WAL retention indefinitely and eventually fills the database disk. The operations guide documented this as a manual SQL step.
- Adds a `post-delete` hook Job to chart-apiserver that runs the controller image with a new `--role=postgres-cleanup`, which drops the replication slot and publication, then exits. The Job reuses the same `ARK_POSTGRES_*` env wiring as the deployment (factored into a shared `ark-apiserver.postgresEnv` helper; the rendered deployment is unchanged).
- A pod still terminating during the hook can hold the slot active — or its WAL consumer can recreate the slot right after a drop (it reconnects with 1-30s backoff and re-creates the slot). `DropReplicationArtifacts` therefore terminates any active walsender, drops the slot, verifies it stayed gone, and retries for up to 60s before dropping the publication. The operation is idempotent, so a re-run after a partial failure is safe.
- The cleanup role exits before manager setup, so the Job needs no kube API access; the hook uses `hook-delete-policy: before-hook-creation,hook-succeeded` so a failed Job is kept for inspection.
- Docs: the uninstall section now describes the automatic cleanup; the manual SQL is kept for `--no-hooks` uninstalls or an unreachable database. Since the chart does not own the password secret, the secret is still present when the post-delete hook runs.
- Integration test covers slot+publication removal and idempotency; `TestValidateRole` covers the new role.

@Nab-0


Fixes #2803.
