### PR TITLE
feat(apiserver): enforce delegated authn/authz and verified serving TLS

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -402,6 +402,9 @@ func setupEmbeddedApiserver(mgr ctrl.Manager) {
 	if cfg.PostgresSSL == "" {
 		cfg.PostgresSSL = "disable"
 	}
+	cfg.AuthMode = os.Getenv("ARK_APISERVER_AUTH_MODE")
+	cfg.TLSCertFile = os.Getenv("ARK_APISERVER_TLS_CERT_FILE")
+	cfg.TLSKeyFile = os.Getenv("ARK_APISERVER_TLS_KEY_FILE")
 	cfg.K8sClient = mgr.GetClient()
 
 	server := apiserver.New(cfg)

--- a/ark/dist/chart-apiserver/README.md
+++ b/ark/dist/chart-apiserver/README.md
@@ -17,6 +17,14 @@ helm upgrade --install ark-apiserver ./dist/chart-apiserver \
 
 ## Operational notes
 
+### Authentication, authorization and TLS
+
+Requests are authenticated and authorized against the kube-apiserver (TokenReview + SubjectAccessReview), so Kubernetes RBAC applies to direct service access, not only to the kubectl path. The chart ships the required `system:auth-delegator` and `extension-apiserver-authentication-reader` bindings.
+
+With `certManager.enabled` (default `true`, requires cert-manager) the serving certificate is issued by cert-manager and its CA is injected into the APIServices, so the kube-apiserver verifies the aggregated apiserver's identity. Set `certManager.enabled=false` to fall back to an ephemeral self-signed certificate with `insecureSkipTLSVerify` on the APIServices.
+
+`networkPolicy.enabled=true` adds an ingress policy for the serving and health ports; restrict serving-port sources with `networkPolicy.extraIngressFrom`.
+
 ### Replication slot lifecycle
 
 The apiserver creates a **persistent** logical replication slot named `ark_cdc` on the configured PostgreSQL database to drive its watch stream. The slot survives apiserver pod restarts, which is what lets watchers resume from the last confirmed WAL position rather than missing events from the restart gap.

--- a/ark/dist/chart-apiserver/templates/apiservice.yaml
+++ b/ark/dist/chart-apiserver/templates/apiservice.yaml
@@ -4,6 +4,10 @@ metadata:
   name: v1alpha1.ark.mckinsey.com
   labels:
     {{- include "ark-apiserver.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/ark-apiserver-serving-cert
+  {{- end }}
 spec:
   group: ark.mckinsey.com
   version: v1alpha1
@@ -13,7 +17,9 @@ spec:
     port: {{ .Values.apiserver.port }}
   groupPriorityMinimum: 1000
   versionPriority: 15
+  {{- if not .Values.certManager.enabled }}
   insecureSkipTLSVerify: true
+  {{- end }}
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -21,6 +27,10 @@ metadata:
   name: v1prealpha1.ark.mckinsey.com
   labels:
     {{- include "ark-apiserver.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/ark-apiserver-serving-cert
+  {{- end }}
 spec:
   group: ark.mckinsey.com
   version: v1prealpha1
@@ -30,4 +40,6 @@ spec:
     port: {{ .Values.apiserver.port }}
   groupPriorityMinimum: 1000
   versionPriority: 10
+  {{- if not .Values.certManager.enabled }}
   insecureSkipTLSVerify: true
+  {{- end }}

--- a/ark/dist/chart-apiserver/templates/certificate.yaml
+++ b/ark/dist/chart-apiserver/templates/certificate.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ark-apiserver-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ark-apiserver-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - ark-apiserver.{{ .Release.Namespace }}.svc
+    - ark-apiserver.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: ark-apiserver-selfsigned-issuer
+  secretName: ark-apiserver-tls
+{{- end }}

--- a/ark/dist/chart-apiserver/templates/deployment.yaml
+++ b/ark/dist/chart-apiserver/templates/deployment.yaml
@@ -50,10 +50,22 @@ spec:
                   key: {{ .Values.postgresql.passwordSecretKey }}
             - name: ARK_POSTGRES_SSL_MODE
               value: {{ .Values.postgresql.sslMode | quote }}
+            {{- if .Values.certManager.enabled }}
+            - name: ARK_APISERVER_TLS_CERT_FILE
+              value: /etc/ark/apiserver-tls/tls.crt
+            - name: ARK_APISERVER_TLS_KEY_FILE
+              value: /etc/ark/apiserver-tls/tls.key
+            {{- end }}
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.certManager.enabled }}
+          volumeMounts:
+            - name: apiserver-tls
+              mountPath: /etc/ark/apiserver-tls
+              readOnly: true
+          {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.apiserver.port }}
@@ -69,3 +81,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- if .Values.certManager.enabled }}
+      volumes:
+        - name: apiserver-tls
+          secret:
+            secretName: ark-apiserver-tls
+      {{- end }}

--- a/ark/dist/chart-apiserver/templates/networkpolicy.yaml
+++ b/ark/dist/chart-apiserver/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ark-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "ark-apiserver.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.apiserver.port }}
+          protocol: TCP
+      {{- with .Values.networkPolicy.extraIngressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    - ports:
+        - port: 8081
+          protocol: TCP
+{{- end }}

--- a/ark/dist/chart-apiserver/values.yaml
+++ b/ark/dist/chart-apiserver/values.yaml
@@ -59,3 +59,10 @@ containerSecurityContext:
 terminationGracePeriodSeconds: 10
 
 extraEnv: {}
+
+certManager:
+  enabled: true
+
+networkPolicy:
+  enabled: false
+  extraIngressFrom: []

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -89,6 +89,11 @@ func init() {
 	)
 }
 
+const (
+	AuthModeDelegated = "delegated"
+	AuthModeOff       = "off"
+)
+
 type Config struct {
 	PostgresHost string
 	PostgresPort int
@@ -97,6 +102,9 @@ type Config struct {
 	PostgresPass string
 	PostgresSSL  string
 	BindPort     int
+	AuthMode     string
+	TLSCertFile  string
+	TLSKeyFile   string
 	K8sClient    client.Client
 }
 
@@ -110,6 +118,9 @@ func New(cfg Config) *Server {
 	if cfg.BindPort == 0 {
 		cfg.BindPort = 6443
 	}
+	if cfg.AuthMode == "" {
+		cfg.AuthMode = AuthModeDelegated
+	}
 	return &Server{
 		config: cfg,
 		stopCh: make(chan struct{}),
@@ -117,6 +128,10 @@ func New(cfg Config) *Server {
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	if s.config.AuthMode != AuthModeDelegated && s.config.AuthMode != AuthModeOff {
+		return fmt.Errorf("invalid auth mode %q: must be %q or %q", s.config.AuthMode, AuthModeDelegated, AuthModeOff)
+	}
+
 	klog.Info("Starting embedded Ark API Server")
 
 	converter := NewRegistryTypeConverter()
@@ -140,6 +155,8 @@ func (s *Server) Start(ctx context.Context) error {
 	secureServing.BindPort = s.config.BindPort
 	secureServing.HTTP2MaxStreamsPerConnection = 1000
 	secureServing.ServerCert.CertDirectory = "/tmp/ark-apiserver-certs"
+	secureServing.ServerCert.CertKey.CertFile = s.config.TLSCertFile
+	secureServing.ServerCert.CertKey.KeyFile = s.config.TLSKeyFile
 
 	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
@@ -164,6 +181,20 @@ func (s *Server) Start(ctx context.Context) error {
 
 	if err := secureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
 		return err
+	}
+
+	if s.config.AuthMode == AuthModeDelegated {
+		authn := genericoptions.NewDelegatingAuthenticationOptions()
+		if err := authn.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, serverConfig.OpenAPIConfig); err != nil {
+			return fmt.Errorf("failed to apply delegated authentication: %w", err)
+		}
+		authz := genericoptions.NewDelegatingAuthorizationOptions()
+		if err := authz.ApplyTo(&serverConfig.Authorization); err != nil {
+			return fmt.Errorf("failed to apply delegated authorization: %w", err)
+		}
+		klog.Info("Delegated authentication and authorization enabled")
+	} else {
+		klog.Warning("Request authentication and authorization are DISABLED (auth mode 'off'); any client that can reach the service can read and write all Ark resources")
 	}
 
 	completedConfig := serverConfig.Complete(nil)

--- a/ark/internal/apiserver/server_test.go
+++ b/ark/internal/apiserver/server_test.go
@@ -3,6 +3,8 @@
 package apiserver
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +14,31 @@ import (
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arkv1prealpha1 "mckinsey.com/ark/api/v1prealpha1"
 )
+
+func TestNew_Defaults(t *testing.T) {
+	t.Parallel()
+
+	s := New(Config{})
+	if s.config.BindPort != 6443 {
+		t.Errorf("BindPort = %d, want 6443", s.config.BindPort)
+	}
+	if s.config.AuthMode != AuthModeDelegated {
+		t.Errorf("AuthMode = %q, want %q", s.config.AuthMode, AuthModeDelegated)
+	}
+}
+
+func TestServer_Start_InvalidAuthMode(t *testing.T) {
+	t.Parallel()
+
+	s := New(Config{AuthMode: "bogus"})
+	err := s.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid auth mode")
+	}
+	if !strings.Contains(err.Error(), "auth mode") {
+		t.Errorf("error = %q, want mention of auth mode", err.Error())
+	}
+}
 
 func TestScheme_InternalVersionsRegistered(t *testing.T) {
 	t.Parallel()

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -177,6 +177,14 @@ Then connect to Postgres and confirm the row exists:
 SELECT kind, namespace, name, uid FROM resources WHERE kind = 'Agent';
 ```
 
+## Security model
+
+The aggregated apiserver enforces the same access control as the rest of the cluster:
+
+- **Delegated authentication and authorization.** Every request is authenticated against the kube-apiserver (TokenReview and requestheader/front-proxy identity) and authorized via SubjectAccessReview, so Kubernetes RBAC on `ark.mckinsey.com` resources applies to direct service access as well as to the kubectl path. Health endpoints (`/healthz`, `/readyz`, `/livez`) stay unauthenticated. Set `ARK_APISERVER_AUTH_MODE=off` (for example via `extraEnv`) only for local development outside a cluster.
+- **Verified serving TLS.** With `certManager.enabled` (the default), cert-manager issues the serving certificate for the `ark-apiserver` service, mounts it into the pod, and injects the CA into both APIServices — the kube-apiserver verifies the aggregated apiserver's identity instead of `insecureSkipTLSVerify`. The certificate rotates through cert-manager and the server reloads it without a restart. Setting `certManager.enabled=false` restores the previous behavior (ephemeral self-signed certificate, unverified proxy channel) for clusters without cert-manager.
+- **Optional NetworkPolicy.** `networkPolicy.enabled=true` restricts ingress to the serving and health ports; use `networkPolicy.extraIngressFrom` to pin the allowed sources for the serving port (the origin of kube-apiserver traffic depends on your CNI, which is why this is off by default).
+
 ## Multi-replica behaviour
 
 The `ark-apiserver` chart defaults to a single replica. The chart wires the RBAC needed for controller-runtime leader election on a `Lease` named `ark-apiserver-leader`.

--- a/tests/apiserver-auth/README.md
+++ b/tests/apiserver-auth/README.md
@@ -1,0 +1,16 @@
+# Apiserver Auth
+
+Validates that the aggregated apiserver enforces delegated authentication and authorization on direct service access.
+
+## What it tests
+- An unauthenticated request straight to the ark-apiserver service is rejected (401/403), not served.
+- A valid service account token without RBAC on Ark resources is denied (403) via delegated SubjectAccessReview.
+- Granting a Role on agents makes the same direct request succeed, proving Kubernetes RBAC governs the direct path.
+- kubectl through the aggregation layer keeps working under delegated auth.
+
+## Running
+```bash
+chainsaw test
+```
+
+Successful completion validates that direct access to the aggregated apiserver cannot bypass Kubernetes RBAC.

--- a/tests/apiserver-auth/chainsaw-test.yaml
+++ b/tests/apiserver-auth/chainsaw-test.yaml
@@ -1,0 +1,125 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: apiserver-auth
+  labels:
+    postgresql: "true"
+spec:
+  steps:
+    - name: setup-curl-pod
+      try:
+      - apply:
+          resource:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: authcheck
+            spec:
+              containers:
+                - name: curl
+                  image: curlimages/curl:8.11.1
+                  command: ["sleep", "300"]
+              restartPolicy: Never
+              terminationGracePeriodSeconds: 0
+      - wait:
+          apiVersion: v1
+          kind: Pod
+          name: authcheck
+          timeout: 120s
+          for:
+            condition:
+              name: Ready
+              value: 'True'
+
+    - name: anonymous-direct-access-denied
+      try:
+      - script:
+          content: |
+            set -eu
+            URL="https://ark-apiserver.ark-system.svc.cluster.local:6443/apis/ark.mckinsey.com/v1alpha1/namespaces/${NAMESPACE}/agents"
+            CODE=$(kubectl exec authcheck -n $NAMESPACE -- curl -sk -o /dev/null -w '%{http_code}' "$URL")
+            echo "anonymous request returned HTTP $CODE"
+            case "$CODE" in
+              401|403) echo "OK direct unauthenticated access is rejected" ;;
+              *) echo "FAIL expected 401 or 403, got $CODE"; exit 1 ;;
+            esac
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 60s
+
+    - name: authenticated-without-rbac-denied
+      try:
+      - script:
+          content: |
+            set -eu
+            TOKEN=$(kubectl create token default -n $NAMESPACE)
+            URL="https://ark-apiserver.ark-system.svc.cluster.local:6443/apis/ark.mckinsey.com/v1alpha1/namespaces/${NAMESPACE}/agents"
+            CODE=$(kubectl exec authcheck -n $NAMESPACE -- curl -sk -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$URL")
+            echo "authenticated request without RBAC returned HTTP $CODE"
+            if [ "$CODE" = "403" ]; then
+              echo "OK authenticated but unauthorized access is denied by delegated RBAC"
+            else
+              echo "FAIL expected 403, got $CODE"
+              exit 1
+            fi
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 60s
+
+    - name: rbac-granted-direct-access-allowed
+      try:
+      - apply:
+          resource:
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: apiserver-auth-reader
+            rules:
+              - apiGroups: ["ark.mckinsey.com"]
+                resources: ["agents"]
+                verbs: ["get", "list"]
+      - apply:
+          resource:
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: apiserver-auth-reader
+            subjects:
+              - kind: ServiceAccount
+                name: default
+                namespace: ($namespace)
+            roleRef:
+              kind: Role
+              name: apiserver-auth-reader
+              apiGroup: rbac.authorization.k8s.io
+      - script:
+          content: |
+            set -eu
+            TOKEN=$(kubectl create token default -n $NAMESPACE)
+            URL="https://ark-apiserver.ark-system.svc.cluster.local:6443/apis/ark.mckinsey.com/v1alpha1/namespaces/${NAMESPACE}/agents"
+            CODE=$(kubectl exec authcheck -n $NAMESPACE -- curl -sk -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$URL")
+            echo "authorized request returned HTTP $CODE"
+            if [ "$CODE" = "200" ]; then
+              echo "OK delegated RBAC allows the granted service account"
+            else
+              echo "FAIL expected 200, got $CODE"
+              exit 1
+            fi
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 60s
+
+    - name: aggregation-path-still-works
+      try:
+      - script:
+          content: |
+            set -eu
+            kubectl get agents -n $NAMESPACE
+            echo "OK kubectl via the aggregation layer works under delegated auth"
+          env:
+          - name: NAMESPACE
+            value: ($namespace)
+          timeout: 60s


### PR DESCRIPTION
Fixes #2672.

## Summary
- The aggregated apiserver accepted any request from any pod that could reach its ClusterIP service — no authentication, no authorization — bypassing Kubernetes RBAC for all Ark resources, and the kube-apiserver proxied to it with `insecureSkipTLSVerify: true` against an ephemeral self-signed cert. This wires the standard aggregated-apiserver security stack.
- **Delegated authn/authz**: requests are authenticated against the kube-apiserver (TokenReview + requestheader/front-proxy identity) and authorized via SubjectAccessReview, so RBAC on `ark.mckinsey.com` resources now governs direct service access as well as the kubectl path. The chart already shipped the required `system:auth-delegator` and `extension-apiserver-authentication-reader` bindings — only the server wiring was missing. Health endpoints stay open; `ARK_APISERVER_AUTH_MODE=off` is an escape hatch for local development outside a cluster.
- **Verified serving TLS**: with `certManager.enabled` (default), cert-manager issues the serving certificate for the service, the pod serves it from a mounted secret (hot-reloaded on renewal via the dynamic serving controller, no restart), and cainjector injects the CA into both APIServices, which drop `insecureSkipTLSVerify`. `certManager.enabled=false` restores the previous behavior for clusters without cert-manager — note cert-manager is already a dependency of every documented install path.
- **Optional NetworkPolicy** (`networkPolicy.enabled`, default off): restricts ingress to the serving and health ports; `networkPolicy.extraIngressFrom` pins allowed sources for the serving port. Off by default because the origin of kube-apiserver traffic is CNI-dependent.
- New postgresql-labeled chainsaw test `tests/apiserver-auth`: an anonymous direct request to the service is rejected; a valid service-account token without RBAC gets 403 via delegated SAR; granting a Role makes the same request return 200; kubectl through the aggregation layer keeps working.
- Verified end-to-end on a local kind cluster: APIServices report Available with the injected caBundle (no insecure verify), the new chainsaw test and `aggregation-smoke` pass, and OpenAPI aggregation / `kubectl explain` work under delegated auth with no aggregator denials.

@Nab-0