### PR TITLE
feat(broker): cascade-delete operation events when a Query is deleted

### DIFF
--- a/ark/internal/common/transport.go
+++ b/ark/internal/common/transport.go
@@ -14,7 +14,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const QueryMessagesEndpointFmt = "/queries/%s/messages"
+const (
+	QueryMessagesEndpointFmt = "/queries/%s/messages"
+	QueryEventsEndpointFmt   = "/events/%s"
+)
 
 // LoggingTransport wraps an http.RoundTripper to provide optional HTTP request/response logging.
 type LoggingTransport struct {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -42,6 +42,7 @@ import (
 	"mckinsey.com/ark/internal/telemetry"
 	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
 	otelimpl "mckinsey.com/ark/internal/telemetry/otel"
+	"mckinsey.com/ark/internal/telemetry/routing"
 )
 
 // maxApprovalCascades caps the number of times the agent can be resumed after
@@ -87,6 +88,11 @@ type QueryReconciler struct {
 
 	sem        *semaphore.Weighted
 	operations sync.Map
+
+	// brokerEventsEndpoint resolves the broker endpoint for a namespace, used
+	// by deleteBrokerEvents. Defaults to routing.ResolveBrokerEndpoint when
+	// nil; tests override it to avoid depending on real cluster DNS.
+	brokerEventsEndpoint func(ctx context.Context, namespace string) (string, error)
 }
 
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=queries,verbs=get;list;watch;create;update;patch;delete
@@ -948,7 +954,7 @@ func (r *QueryReconciler) finalize(ctx context.Context, query *arkv1alpha1.Query
 		log.Info("cancelled running operation for query", "name", query.Name, "namespace", query.Namespace)
 	}
 
-	return r.deleteBrokerMessages(ctx, query)
+	return stderrors.Join(r.deleteBrokerMessages(ctx, query), r.deleteBrokerEvents(ctx, query))
 }
 
 func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1alpha1.Query) error {
@@ -1011,6 +1017,59 @@ func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1
 	}
 
 	log.Info("deleted broker messages for query", "query", query.Name)
+	return nil
+}
+
+// resolveBrokerEventsEndpoint resolves the broker endpoint for namespace,
+// returning "" when no broker is configured there.
+func (r *QueryReconciler) resolveBrokerEventsEndpoint(ctx context.Context, namespace string) (string, error) {
+	if r.brokerEventsEndpoint != nil {
+		return r.brokerEventsEndpoint(ctx, namespace)
+	}
+	return routing.ResolveBrokerEndpoint(ctx, r.Client, namespace)
+}
+
+// deleteBrokerEvents removes the broker's operation events for query. Unlike
+// deleteBrokerMessages, this does not go through the Memory contract: events
+// are emitted directly to the broker endpoint discovered via the
+// ark-config-broker ConfigMap (see internal/eventing/broker), keyed by the
+// Query's UID rather than its name (see operation_tracker.go).
+func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1alpha1.Query) error {
+	log := logf.FromContext(ctx)
+
+	endpoint, err := r.resolveBrokerEventsEndpoint(ctx, query.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to resolve broker endpoint: %w", err)
+	}
+	if endpoint == "" {
+		log.Info("no broker configured for namespace, skipping broker event cleanup", "namespace", query.Namespace, "query", query.Name)
+		return nil
+	}
+
+	requestURL := strings.TrimSuffix(endpoint, "/") + fmt.Sprintf(common.QueryEventsEndpointFmt, url.PathEscape(string(query.UID)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+	req.Header.Set("User-Agent", "ark-controller/1.0")
+
+	httpClient := common.NewHTTPClientWithLogging()
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		log.Info("broker does not support delete query events, skipping", "query", query.Name, "status", resp.StatusCode)
+		return nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("broker at %s returned HTTP %d deleting events for query %s", endpoint, resp.StatusCode, query.Name)
+	}
+
+	log.Info("deleted broker events for query", "query", query.Name)
 	return nil
 }
 

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -993,7 +993,19 @@ func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1
 		baseURL = strings.TrimSuffix(resolved, "/")
 	}
 
-	requestURL := fmt.Sprintf("%s"+common.QueryMessagesEndpointFmt, baseURL, url.PathEscape(query.Name))
+	path := fmt.Sprintf(common.QueryMessagesEndpointFmt, url.PathEscape(query.Name))
+	return deleteBrokerResource(ctx, baseURL, path, "messages", query.Name)
+}
+
+// deleteBrokerResource issues a DELETE for path against baseURL and interprets
+// the response the way every broker cleanup call needs to: 404/405 means the
+// broker doesn't support this delete (skip, not an error), any other non-2xx
+// is a real failure the finalizer should retry. resource is used only for
+// logging (e.g. "messages", "events").
+func deleteBrokerResource(ctx context.Context, baseURL, path, resource, queryName string) error {
+	log := logf.FromContext(ctx)
+
+	requestURL := strings.TrimSuffix(baseURL, "/") + path
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete request: %w", err)
@@ -1008,15 +1020,15 @@ func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
-		log.Info("broker does not support delete query messages, skipping", "query", query.Name, "status", resp.StatusCode)
+		log.Info("broker does not support delete request, skipping", "resource", resource, "query", queryName, "status", resp.StatusCode)
 		return nil
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("broker at %s returned HTTP %d deleting messages for query %s", baseURL, resp.StatusCode, query.Name)
+		return fmt.Errorf("broker at %s returned HTTP %d deleting %s for query %s", baseURL, resp.StatusCode, resource, queryName)
 	}
 
-	log.Info("deleted broker messages for query", "query", query.Name)
+	log.Info("deleted broker resource for query", "resource", resource, "query", queryName)
 	return nil
 }
 
@@ -1046,31 +1058,8 @@ func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1al
 		return nil
 	}
 
-	requestURL := strings.TrimSuffix(endpoint, "/") + fmt.Sprintf(common.QueryEventsEndpointFmt, url.PathEscape(string(query.UID)))
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create delete request: %w", err)
-	}
-	req.Header.Set("User-Agent", "ark-controller/1.0")
-
-	httpClient := common.NewHTTPClientWithLogging()
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("HTTP request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
-		log.Info("broker does not support delete query events, skipping", "query", query.Name, "status", resp.StatusCode)
-		return nil
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("broker at %s returned HTTP %d deleting events for query %s", endpoint, resp.StatusCode, query.Name)
-	}
-
-	log.Info("deleted broker events for query", "query", query.Name)
-	return nil
+	path := fmt.Sprintf(common.QueryEventsEndpointFmt, url.PathEscape(string(query.UID)))
+	return deleteBrokerResource(ctx, endpoint, path, "events", query.Name)
 }
 
 func (r *QueryReconciler) getClientForQuery(query arkv1alpha1.Query) (client.Client, error) {

--- a/ark/internal/controller/query_delete_broker_test.go
+++ b/ark/internal/controller/query_delete_broker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -183,7 +184,12 @@ func TestHandleFinalizer_BrokerFailure_RequeuesUntilGrace(t *testing.T) {
 
 	memory := memoryWithAddress("my-memory", srv.URL)
 	fc := fake.NewClientBuilder().
-		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
+		WithScheme(func() *runtime.Scheme {
+			s := runtime.NewScheme()
+			_ = arkv1alpha1.AddToScheme(s)
+			_ = corev1.AddToScheme(s)
+			return s
+		}()).
 		WithObjects(memory).
 		Build()
 
@@ -227,6 +233,7 @@ func TestHandleFinalizer_GracePeriodExpired_RemovesFinalizer(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	_ = arkv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	fc := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(memory, query).
@@ -238,4 +245,89 @@ func TestHandleFinalizer_GracePeriodExpired_RemovesFinalizer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &ctrl.Result{}, result)
 	assert.Empty(t, query.Finalizers)
+}
+
+func TestDeleteBrokerEvents_EndpointResolved(t *testing.T) {
+	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
+
+	r := &QueryReconciler{
+		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.deleteBrokerEvents(context.Background(), query)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, *capturedMethod)
+	assert.Equal(t, "/events/query-uid-123", *capturedPath)
+}
+
+func TestDeleteBrokerEvents_NoBrokerConfigured(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := &QueryReconciler{
+		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+			return "", nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.deleteBrokerEvents(context.Background(), query)
+	require.NoError(t, err)
+	assert.False(t, called, "should not call broker when no broker is configured for the namespace")
+}
+
+func TestDeleteBrokerEvents_Broker500ReturnsError(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
+
+	r := &QueryReconciler{
+		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.deleteBrokerEvents(context.Background(), query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestDeleteBrokerEvents_Broker404IsSkipped(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
+
+	r := &QueryReconciler{
+		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.deleteBrokerEvents(context.Background(), query)
+	require.NoError(t, err)
+}
+
+func TestResolveBrokerEventsEndpoint_DefaultUsesRoutingDiscovery(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &QueryReconciler{Client: fc}
+
+	endpoint, err := r.resolveBrokerEventsEndpoint(context.Background(), "default")
+	require.NoError(t, err)
+	assert.Empty(t, endpoint, "no ark-config-broker ConfigMap exists, so no endpoint should resolve")
 }

--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
@@ -32,33 +33,29 @@ type Event struct {
 
 type BrokerEventEmitter struct {
 	httpClient *http.Client
-	endpoints  map[string]string
+	k8sClient  client.Client
 	sem        *semaphore.Weighted
+
+	// resolveEndpoint resolves the broker base URL for a namespace. Defaults
+	// to routing.ResolveBrokerEndpoint when nil; tests override it to avoid
+	// depending on real cluster DNS.
+	resolveEndpoint func(ctx context.Context, namespace string) (string, error)
 }
 
-func NewBrokerEventEmitter(endpoints []routing.BrokerEndpoint) eventing.EventEmitter {
-	endpointMap := make(map[string]string)
-	for _, ep := range endpoints {
-		endpointMap[ep.Namespace] = ep.Endpoint + "/events"
-	}
-
+// NewBrokerEventEmitter resolves the broker endpoint live, per event, via
+// routing.ResolveBrokerEndpoint — no endpoint list is cached up front, so a
+// namespace's ark-config-broker ConfigMap takes effect immediately, and a
+// namespace with no ConfigMap of its own gets no broker (see
+// ResolveBrokerEndpoint's doc comment for why there's no cross-namespace
+// fallback).
+func NewBrokerEventEmitter(k8sClient client.Client) eventing.EventEmitter {
 	return &BrokerEventEmitter{
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		endpoints: endpointMap,
+		k8sClient: k8sClient,
 		sem:       semaphore.NewWeighted(64),
 	}
-}
-
-func (e *BrokerEventEmitter) getEndpointForNamespace(namespace string) string {
-	if endpoint, ok := e.endpoints[namespace]; ok {
-		return endpoint
-	}
-	for _, endpoint := range e.endpoints {
-		return endpoint
-	}
-	return ""
 }
 
 func (e *BrokerEventEmitter) EmitNormal(ctx context.Context, obj runtime.Object, reason, message string) {
@@ -72,12 +69,6 @@ func (e *BrokerEventEmitter) EmitWarning(ctx context.Context, obj runtime.Object
 func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Object, eventType, reason, message string, data any) {
 	query, ok := obj.(*arkv1alpha1.Query)
 	if !ok {
-		return
-	}
-
-	endpoint := e.getEndpointForNamespace(query.Namespace)
-	if endpoint == "" {
-		log.V(1).Info("no broker endpoint for namespace, dropping event", "namespace", query.Namespace, "reason", reason)
 		return
 	}
 
@@ -103,14 +94,32 @@ func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Obj
 	if e.sem.TryAcquire(1) {
 		go func() {
 			defer e.sem.Release(1)
-			e.sendEvent(context.WithoutCancel(ctx), endpoint, event)
+			e.sendEvent(context.WithoutCancel(ctx), query.Namespace, event)
 		}()
 	} else {
 		log.V(1).Info("semaphore full, dropping event", "namespace", query.Namespace, "reason", reason)
 	}
 }
 
-func (e *BrokerEventEmitter) sendEvent(ctx context.Context, endpoint string, event Event) {
+func (e *BrokerEventEmitter) getEndpointForNamespace(ctx context.Context, namespace string) (string, error) {
+	if e.resolveEndpoint != nil {
+		return e.resolveEndpoint(ctx, namespace)
+	}
+	return routing.ResolveBrokerEndpoint(ctx, e.k8sClient, namespace)
+}
+
+func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, event Event) {
+	baseURL, err := e.getEndpointForNamespace(ctx, namespace)
+	if err != nil {
+		log.Error(err, "failed to resolve broker endpoint", "namespace", namespace, "reason", event.Reason)
+		return
+	}
+	if baseURL == "" {
+		log.V(1).Info("no broker endpoint for namespace, dropping event", "namespace", namespace, "reason", event.Reason)
+		return
+	}
+	endpoint := baseURL + "/events"
+
 	body, err := json.Marshal(event)
 	if err != nil {
 		log.Error(err, "failed to marshal event")

--- a/ark/internal/eventing/broker/emitter_test.go
+++ b/ark/internal/eventing/broker/emitter_test.go
@@ -10,13 +10,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
-	"mckinsey.com/ark/internal/telemetry/routing"
 )
 
 func newTestQuery(namespace string) *arkv1alpha1.Query {
@@ -29,49 +30,72 @@ func newTestQuery(namespace string) *arkv1alpha1.Query {
 	}
 }
 
+// newTestEmitter builds an emitter whose endpoint resolution is a plain
+// namespace->URL lookup, standing in for routing.ResolveBrokerEndpoint so
+// tests don't depend on real cluster DNS.
 func newTestEmitter(endpoints map[string]string) *BrokerEventEmitter {
 	return &BrokerEventEmitter{
 		httpClient: &http.Client{},
-		endpoints:  endpoints,
 		sem:        semaphore.NewWeighted(64),
+		resolveEndpoint: func(_ context.Context, namespace string) (string, error) {
+			return endpoints[namespace], nil
+		},
 	}
 }
 
 func TestGetEndpointForNamespace_ExactMatch(t *testing.T) {
 	e := newTestEmitter(map[string]string{
-		"default": "http://broker.default/events",
-		"other":   "http://broker.other/events",
+		"default": "http://broker.default",
+		"other":   "http://broker.other",
 	})
 
-	assert.Equal(t, "http://broker.default/events", e.getEndpointForNamespace("default"))
-	assert.Equal(t, "http://broker.other/events", e.getEndpointForNamespace("other"))
+	got, err := e.getEndpointForNamespace(context.Background(), "default")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://broker.default", got)
+
+	got, err = e.getEndpointForNamespace(context.Background(), "other")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://broker.other", got)
 }
 
-func TestGetEndpointForNamespace_FallbackToAny(t *testing.T) {
+func TestGetEndpointForNamespace_NoFallback(t *testing.T) {
 	e := newTestEmitter(map[string]string{
-		"default": "http://broker.default/events",
+		"default": "http://broker.default",
 	})
 
-	assert.Equal(t, "http://broker.default/events", e.getEndpointForNamespace("chainsaw-test-ns"))
+	got, err := e.getEndpointForNamespace(context.Background(), "chainsaw-test-ns")
+	assert.NoError(t, err)
+	assert.Empty(t, got, "should not fall back to another namespace's broker")
 }
 
 func TestGetEndpointForNamespace_NoEndpoints(t *testing.T) {
 	e := newTestEmitter(map[string]string{})
 
-	assert.Equal(t, "", e.getEndpointForNamespace("any-namespace"))
+	got, err := e.getEndpointForNamespace(context.Background(), "any-namespace")
+	assert.NoError(t, err)
+	assert.Empty(t, got)
 }
 
-func TestNewBrokerEventEmitter(t *testing.T) {
-	endpoints := []routing.BrokerEndpoint{
-		{Namespace: "default", Endpoint: "http://broker.default"},
-		{Namespace: "other", Endpoint: "http://broker.other"},
-	}
+func TestNewBrokerEventEmitter_ResolvesLiveViaRouting(t *testing.T) {
+	fc := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "ark-config-broker", Namespace: "test-ns"},
+		Data: map[string]string{
+			"enabled":    "true",
+			"serviceRef": "name: ark-broker\nport: \"80\"",
+		},
+	}).Build()
 
-	emitter := NewBrokerEventEmitter(endpoints)
-	be := emitter.(*BrokerEventEmitter)
+	emitter := NewBrokerEventEmitter(fc)
+	e, ok := emitter.(*BrokerEventEmitter)
+	require.True(t, ok)
 
-	assert.Equal(t, "http://broker.default/events", be.endpoints["default"])
-	assert.Equal(t, "http://broker.other/events", be.endpoints["other"])
+	endpoint, err := e.getEndpointForNamespace(context.Background(), "test-ns")
+	require.NoError(t, err)
+	assert.Equal(t, "http://ark-broker.test-ns.svc.cluster.local:80", endpoint)
+
+	endpoint, err = e.getEndpointForNamespace(context.Background(), "other-ns")
+	require.NoError(t, err)
+	assert.Empty(t, endpoint, "should not fall back to test-ns's broker")
 }
 
 func TestEmitStructured_SendsEventToMatchingNamespace(t *testing.T) {
@@ -83,7 +107,7 @@ func TestEmitStructured_SendsEventToMatchingNamespace(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL})
 	query := newTestQuery("test-ns")
 
 	done := make(chan struct{})
@@ -113,7 +137,7 @@ func TestEmitStructured_IncludesTtlSecondsWhenQueryHasTTL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL})
 	query := newTestQuery("test-ns")
 	query.Spec.TTL = &metav1.Duration{Duration: time.Hour}
 
@@ -144,7 +168,7 @@ func TestEmitStructured_OmitsTtlSecondsWhenQueryHasNoTTL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL})
 	query := newTestQuery("test-ns")
 
 	done := make(chan struct{})
@@ -163,32 +187,22 @@ func TestEmitStructured_OmitsTtlSecondsWhenQueryHasNoTTL(t *testing.T) {
 	assert.NotContains(t, string(rawBody), "ttl_seconds")
 }
 
-func TestEmitStructured_FallsBackToAnyEndpoint(t *testing.T) {
-	var received Event
+func TestEmitStructured_DropsEventWhenNamespaceHasNoEndpoint(t *testing.T) {
+	called := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(body, &received)
+		called = true
 		w.WriteHeader(http.StatusCreated)
 	}))
 	defer srv.Close()
 
-	e := newTestEmitter(map[string]string{"default": srv.URL + "/events"})
+	// A broker exists for "default", but the query runs in a different
+	// namespace with no ConfigMap of its own — no fallback, drop the event.
+	e := newTestEmitter(map[string]string{"default": srv.URL})
 	query := newTestQuery("chainsaw-test-ns")
 
-	done := make(chan struct{})
-	origClient := e.httpClient
-	e.httpClient = &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			resp, err := origClient.Do(req)
-			close(done)
-			return resp, err
-		}),
-	}
-
 	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", map[string]string{"queryId": "test-uid"})
-	<-done
 
-	assert.Equal(t, "QueryExecutionStart", received.Reason)
+	assert.False(t, called, "should not fall back to another namespace's broker")
 }
 
 func TestEmitStructured_DropsEventWhenNoEndpoints(t *testing.T) {
@@ -215,7 +229,7 @@ func TestEmitStructured_IgnoresNonQueryObjects(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := newTestEmitter(map[string]string{"test-ns": srv.URL + "/events"})
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL})
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "test-ns"}}
 
 	e.EmitStructured(context.Background(), obj, corev1.EventTypeNormal, "SomeEvent", "msg", nil)
@@ -231,11 +245,8 @@ func TestEmitStructured_DropsEventWhenSemaphoreFull(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := &BrokerEventEmitter{
-		httpClient: &http.Client{},
-		endpoints:  map[string]string{"test-ns": srv.URL + "/events"},
-		sem:        semaphore.NewWeighted(0),
-	}
+	e := newTestEmitter(map[string]string{"test-ns": srv.URL})
+	e.sem = semaphore.NewWeighted(0)
 	query := newTestQuery("test-ns")
 
 	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", nil)

--- a/ark/internal/eventing/config/provider.go
+++ b/ark/internal/eventing/config/provider.go
@@ -50,7 +50,7 @@ func NewProvider(mgr ctrl.Manager, k8sClient client.Client) *Provider {
 				namespaces = append(namespaces, ep.Namespace)
 			}
 			log.Info("broker endpoints discovered, using broker for operation events", "count", len(endpoints), "namespaces", namespaces)
-			operationEmitter = brokereventing.NewBrokerEventEmitter(endpoints)
+			operationEmitter = brokereventing.NewBrokerEventEmitter(k8sClient)
 		default:
 			log.Info("no broker endpoints found, using Kubernetes events for operations")
 		}
@@ -84,7 +84,7 @@ func NewProviderWithClient(ctx context.Context, k8sClient client.Client) *Provid
 				namespaces = append(namespaces, ep.Namespace)
 			}
 			log.Info("broker endpoints discovered, using broker for operation events", "count", len(endpoints), "namespaces", namespaces)
-			operationEmitter = brokereventing.NewBrokerEventEmitter(endpoints)
+			operationEmitter = brokereventing.NewBrokerEventEmitter(k8sClient)
 		default:
 			log.Info("no broker endpoints found, using noop emitter for operations")
 		}

--- a/ark/internal/telemetry/routing/broker_discovery.go
+++ b/ark/internal/telemetry/routing/broker_discovery.go
@@ -75,16 +75,25 @@ func DiscoverBrokerEndpoints(ctx context.Context, k8sClient client.Client) ([]Br
 }
 
 // ResolveBrokerEndpoint returns the broker endpoint for namespace, or "" when
-// no ark-config-broker ConfigMap exists there or the broker is not enabled.
+// no enabled ark-config-broker ConfigMap exists in the cluster. Mirrors
+// BrokerEventEmitter.getEndpointForNamespace: an exact namespace match wins,
+// otherwise it falls back to any other enabled broker — the same broker that
+// receives this namespace's operation events when it has no dedicated
+// ark-config-broker ConfigMap of its own.
 func ResolveBrokerEndpoint(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
-	config, err := GetBrokerConfig(ctx, k8sClient, namespace)
+	endpoints, err := DiscoverBrokerEndpoints(ctx, k8sClient)
 	if err != nil {
 		return "", err
 	}
-	if config == nil || config.Enabled != "true" {
+	if len(endpoints) == 0 {
 		return "", nil
 	}
-	return buildEndpoint(namespace, config.ServiceRef)
+	for _, ep := range endpoints {
+		if ep.Namespace == namespace {
+			return ep.Endpoint, nil
+		}
+	}
+	return endpoints[0].Endpoint, nil
 }
 
 func GetBrokerConfig(ctx context.Context, k8sClient client.Client, namespace string) (*BrokerConfig, error) {

--- a/ark/internal/telemetry/routing/broker_discovery.go
+++ b/ark/internal/telemetry/routing/broker_discovery.go
@@ -28,6 +28,13 @@ type BrokerConfig struct {
 type ServiceRef struct {
 	Name string
 	Port string
+	// Namespace overrides the namespace the Service is looked up in. When
+	// empty, the Service is assumed to live in the same namespace as the
+	// ark-config-broker ConfigMap that declared it — the common case for a
+	// per-tenant broker announcing itself. Set it to point a namespace's
+	// ConfigMap at a broker Service that lives elsewhere (e.g. a shared
+	// cluster-wide broker in another namespace).
+	Namespace string
 }
 
 func DiscoverBrokerEndpoints(ctx context.Context, k8sClient client.Client) ([]BrokerEndpoint, error) {
@@ -75,25 +82,24 @@ func DiscoverBrokerEndpoints(ctx context.Context, k8sClient client.Client) ([]Br
 }
 
 // ResolveBrokerEndpoint returns the broker endpoint for namespace, or "" when
-// no enabled ark-config-broker ConfigMap exists in the cluster. Mirrors
-// BrokerEventEmitter.getEndpointForNamespace: an exact namespace match wins,
-// otherwise it falls back to any other enabled broker — the same broker that
-// receives this namespace's operation events when it has no dedicated
-// ark-config-broker ConfigMap of its own.
+// namespace has no enabled ark-config-broker ConfigMap of its own. This is a
+// deliberate exact match with no cross-namespace fallback — matching how
+// messages (Memory), chunks (ark-config-streaming), and OTEL trace routing
+// already resolve a broker: a namespace either declares its broker
+// explicitly or gets none, never another tenant's by accident. A namespace
+// that wants to point at a broker living elsewhere sets ServiceRef.Namespace
+// in its own ConfigMap rather than relying on discovery to guess.
 func ResolveBrokerEndpoint(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
 	endpoints, err := DiscoverBrokerEndpoints(ctx, k8sClient)
 	if err != nil {
 		return "", err
-	}
-	if len(endpoints) == 0 {
-		return "", nil
 	}
 	for _, ep := range endpoints {
 		if ep.Namespace == namespace {
 			return ep.Endpoint, nil
 		}
 	}
-	return endpoints[0].Endpoint, nil
+	return "", nil
 }
 
 func GetBrokerConfig(ctx context.Context, k8sClient client.Client, namespace string) (*BrokerConfig, error) {
@@ -157,6 +163,8 @@ func parseServiceRef(data string) (ServiceRef, error) {
 			ref.Name = value
 		case "port":
 			ref.Port = value
+		case "namespace":
+			ref.Namespace = value
 		}
 	}
 
@@ -167,9 +175,17 @@ func parseServiceRef(data string) (ServiceRef, error) {
 	return ref, nil
 }
 
-func buildEndpoint(namespace string, serviceRef ServiceRef) (string, error) {
+// buildEndpoint builds the Service DNS endpoint for serviceRef. The Service
+// is looked up in configMapNamespace (the namespace of the ark-config-broker
+// ConfigMap that declared serviceRef) unless serviceRef.Namespace overrides it.
+func buildEndpoint(configMapNamespace string, serviceRef ServiceRef) (string, error) {
 	if serviceRef.Name == "" {
 		return "", fmt.Errorf("serviceRef.name is empty")
+	}
+
+	namespace := configMapNamespace
+	if serviceRef.Namespace != "" {
+		namespace = serviceRef.Namespace
 	}
 
 	port := serviceRef.Port

--- a/ark/internal/telemetry/routing/broker_discovery.go
+++ b/ark/internal/telemetry/routing/broker_discovery.go
@@ -74,6 +74,19 @@ func DiscoverBrokerEndpoints(ctx context.Context, k8sClient client.Client) ([]Br
 	return endpoints, nil
 }
 
+// ResolveBrokerEndpoint returns the broker endpoint for namespace, or "" when
+// no ark-config-broker ConfigMap exists there or the broker is not enabled.
+func ResolveBrokerEndpoint(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
+	config, err := GetBrokerConfig(ctx, k8sClient, namespace)
+	if err != nil {
+		return "", err
+	}
+	if config == nil || config.Enabled != "true" {
+		return "", nil
+	}
+	return buildEndpoint(namespace, config.ServiceRef)
+}
+
 func GetBrokerConfig(ctx context.Context, k8sClient client.Client, namespace string) (*BrokerConfig, error) {
 	if k8sClient == nil {
 		return nil, nil

--- a/ark/internal/telemetry/routing/broker_discovery_test.go
+++ b/ark/internal/telemetry/routing/broker_discovery_test.go
@@ -224,7 +224,7 @@ func TestResolveBrokerEndpoint(t *testing.T) {
 			want: "http://ark-broker.tenant-a.svc.cluster.local:80",
 		},
 		{
-			name:      "falls back to the only enabled broker when namespace has no ConfigMap of its own",
+			name:      "no fallback: other namespaces' brokers are ignored when this namespace has none",
 			namespace: "team-namespace",
 			configMaps: []client.Object{
 				&corev1.ConfigMap{
@@ -232,6 +232,22 @@ func TestResolveBrokerEndpoint(t *testing.T) {
 					Data: map[string]string{
 						"enabled":    "true",
 						"serviceRef": `name: "ark-broker"` + "\n" + `port: "80"`,
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name:      "explicit serviceRef.namespace points at a broker in another namespace",
+			namespace: "team-namespace",
+			configMaps: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ark-config-broker", Namespace: "team-namespace"},
+					Data: map[string]string{
+						"enabled": "true",
+						"serviceRef": `name: "ark-broker"` + "\n" +
+							`namespace: "default"` + "\n" +
+							`port: "80"`,
 					},
 				},
 			},
@@ -259,17 +275,25 @@ func TestResolveBrokerEndpoint(t *testing.T) {
 
 func TestParseServiceRef(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		wantName string
-		wantPort string
-		wantErr  bool
+		name          string
+		input         string
+		wantName      string
+		wantPort      string
+		wantNamespace string
+		wantErr       bool
 	}{
 		{
 			name:     "parses name and port",
 			input:    "name: \"collector\"\nport: \"4318\"",
 			wantName: "collector",
 			wantPort: "4318",
+		},
+		{
+			name:          "parses namespace override",
+			input:         "name: collector\nnamespace: default\nport: 4318",
+			wantName:      "collector",
+			wantPort:      "4318",
+			wantNamespace: "default",
 		},
 		{
 			name:     "parses without quotes",
@@ -314,6 +338,9 @@ func TestParseServiceRef(t *testing.T) {
 			if ref.Port != tt.wantPort {
 				t.Errorf("Port = %s, want %s", ref.Port, tt.wantPort)
 			}
+			if ref.Namespace != tt.wantNamespace {
+				t.Errorf("Namespace = %s, want %s", ref.Namespace, tt.wantNamespace)
+			}
 		})
 	}
 }
@@ -355,6 +382,12 @@ func TestBuildEndpoint(t *testing.T) {
 			namespace:  "tenant-a",
 			serviceRef: ServiceRef{Name: "", Port: "4318"},
 			wantErr:    true,
+		},
+		{
+			name:       "serviceRef.Namespace overrides the configmap namespace",
+			namespace:  "tenant-a",
+			serviceRef: ServiceRef{Name: "collector", Port: "4318", Namespace: "shared"},
+			want:       "http://collector.shared.svc.cluster.local:4318",
 		},
 	}
 

--- a/ark/internal/telemetry/routing/broker_discovery_test.go
+++ b/ark/internal/telemetry/routing/broker_discovery_test.go
@@ -223,6 +223,20 @@ func TestResolveBrokerEndpoint(t *testing.T) {
 			},
 			want: "http://ark-broker.tenant-a.svc.cluster.local:80",
 		},
+		{
+			name:      "falls back to the only enabled broker when namespace has no ConfigMap of its own",
+			namespace: "team-namespace",
+			configMaps: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ark-config-broker", Namespace: "default"},
+					Data: map[string]string{
+						"enabled":    "true",
+						"serviceRef": `name: "ark-broker"` + "\n" + `port: "80"`,
+					},
+				},
+			},
+			want: "http://ark-broker.default.svc.cluster.local:80",
+		},
 	}
 
 	for _, tt := range tests {

--- a/ark/internal/telemetry/routing/broker_discovery_test.go
+++ b/ark/internal/telemetry/routing/broker_discovery_test.go
@@ -177,6 +177,72 @@ port: "4318"`,
 	}
 }
 
+func TestResolveBrokerEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		configMaps []client.Object
+		want       string
+	}{
+		{
+			name:      "nil client returns empty",
+			namespace: "default",
+			want:      "",
+		},
+		{
+			name:       "missing configmap returns empty",
+			namespace:  "default",
+			configMaps: []client.Object{},
+			want:       "",
+		},
+		{
+			name:      "disabled broker returns empty",
+			namespace: "tenant-a",
+			configMaps: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ark-config-broker", Namespace: "tenant-a"},
+					Data: map[string]string{
+						"enabled":    "false",
+						"serviceRef": `name: "ark-broker"` + "\n" + `port: "80"`,
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name:      "enabled broker returns built endpoint",
+			namespace: "tenant-a",
+			configMaps: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ark-config-broker", Namespace: "tenant-a"},
+					Data: map[string]string{
+						"enabled":    "true",
+						"serviceRef": `name: "ark-broker"` + "\n" + `port: "80"`,
+					},
+				},
+			},
+			want: "http://ark-broker.tenant-a.svc.cluster.local:80",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var k8sClient client.Client
+			if tt.configMaps != nil {
+				k8sClient = fake.NewClientBuilder().WithObjects(tt.configMaps...).Build()
+			}
+
+			got, err := ResolveBrokerEndpoint(context.Background(), k8sClient, tt.namespace)
+			if err != nil {
+				t.Fatalf("ResolveBrokerEndpoint() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseServiceRef(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/docs/content/developer-guide/services/ark-broker.mdx
+++ b/docs/content/developer-guide/services/ark-broker.mdx
@@ -88,6 +88,8 @@ Messages carry a TTL-based expiry: each message is written with an `expires_at` 
 
 Messages are also removed when their originating `Query` is deleted: the controller issues `DELETE /queries/{queryId}/messages`, which hard-deletes every message for that query across all conversations. On the Postgres backend this is a single indexed delete. This complements the TTL above — TTL is time-based, this is triggered by the Query's removal. See [Query → Deletion and cleanup](/reference/resources/query#deletion-and-cleanup).
 
+Operation events are cleaned up the same way, but through a separate path: events aren't part of the [Memory API](/reference/resources/memory#memory-api-specification), so the controller calls `DELETE /events/{queryId}` directly on the broker endpoint discovered via the `ark-config-broker` ConfigMap, rather than going through a `Memory` resource. Events are keyed by the Query's UID rather than its name, so `{queryId}` here is the UID.
+
 See the [service README](https://github.com/mckinsey/agents-at-scale-ark/blob/main/services/ark-broker/README.md) for local development with devspace, running migrations, and integration tests.
 
 ### Securing the Postgres connection

--- a/docs/content/reference/broker.mdx
+++ b/docs/content/reference/broker.mdx
@@ -206,6 +206,7 @@ GET    /events
 GET    /events/{queryId}
 POST   /events
 DELETE /events
+DELETE /events/{queryId}
 ```
 
 | Parameter | Description |
@@ -264,6 +265,6 @@ curl "http://localhost:8080/sessions?limit=10&status=active"
 | Conversations | `GET`/`POST`/`DELETE` `/conversations`, `GET`/`DELETE` `/conversations/{id}`, `DELETE /queries/{queryId}/messages`, `DELETE /conversations/{id}/queries/{queryId}/messages` |
 | Chunks | `GET`/`DELETE` `/stream`, `GET /stream/{query_name}`, `POST /stream/{query_id}`, `POST /stream/{query_id}/complete` |
 | Traces | `POST /v1/traces` (OTLP), `GET`/`DELETE` `/traces`, `GET /traces/{traceId}` |
-| Events | `GET`/`POST`/`DELETE` `/events`, `GET /events/{queryId}` |
+| Events | `GET`/`POST`/`DELETE` `/events`, `GET`/`DELETE` `/events/{queryId}` |
 | Sessions | `GET`/`POST`/`DELETE` `/sessions`, `GET /sessions/{sessionId}` |
 | Health | `GET /health` (liveness), `GET /readyz` (readiness) |

--- a/docs/content/reference/resources/query.mdx
+++ b/docs/content/reference/resources/query.mdx
@@ -220,12 +220,17 @@ The controller transitions the query to `phase: canceled` once the in-flight dis
 
 ## Deletion and cleanup
 
-When a `Query` is deleted, a controller finalizer removes the messages that query wrote to its `Memory` backend, so deleting a Query does not leave orphaned history behind.
+When a `Query` is deleted, a controller finalizer removes the messages and operation events that query wrote to the broker, so deleting a Query does not leave orphaned history behind.
 
+**Messages** go through the `Memory` contract:
 - **Memory resolution** mirrors execution: the controller uses `spec.memory` if set, otherwise a `Memory` named `default` in the query's namespace. If neither exists, cleanup is skipped.
 - The controller resolves the backend address from the `Memory` resource (`status.lastResolvedAddress`, falling back to `spec.address`) and issues `DELETE /queries/{queryId}/messages` against it — see the [Memory delete endpoint](/reference/resources/memory#delete-query-messages).
-- **Scope:** messages only. Events, chunks, and traces are not affected. A backend that does not implement the delete endpoint returns `404`/`405`, which the controller treats as "not supported" and skips.
-- **Failure policy:** if the backend is unreachable the finalizer retries every 15s; after a 5-minute grace period it gives up and removes itself, so a Query is never stuck in `Deleting`.
+
+**Operation events** are not part of the Memory contract, so they use a separate path:
+- The controller discovers the broker endpoint from the `ark-config-broker` ConfigMap and issues `DELETE /events/{queryId}` directly against it. If no broker is configured for the namespace, cleanup is skipped.
+- Events are keyed by the Query's **UID**, not its name (unlike messages), so `{queryId}` here is the UID.
+
+Both cleanups run independently and either can fail without blocking the other. A backend that does not implement a delete endpoint returns `404`/`405`, which the controller treats as "not supported" and skips. **Scope:** messages and events only — chunks and traces are not affected. **Failure policy:** if a backend is unreachable the finalizer retries every 15s; after a 5-minute grace period it gives up and removes itself, so a Query is never stuck in `Deleting`.
 
 This is complementary to `spec.ttl`: TTL expires history on a timer, while deletion cleans it up immediately when the Query is removed.
 

--- a/services/ark-broker/ark-broker/src/brokers/event-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/event-broker.ts
@@ -21,10 +21,12 @@ export interface EventData {
   };
 }
 
-export type EventStream = Stream<EventData>;
+export interface EventStream extends Stream<EventData> {
+  deleteByQuery(queryId: string): Promise<void>;
+}
 
 export class EventBroker {
-  private readonly stream: Stream<EventData>;
+  private readonly stream: EventStream;
 
   constructor(stream: EventStream, _logger?: Logger) {
     this.stream = stream;
@@ -55,6 +57,10 @@ export class EventBroker {
 
   async delete(): Promise<void> {
     return this.stream.delete();
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    return this.stream.deleteByQuery(queryId);
   }
 
   subscribe(callback: (item: BrokerItem<EventData>) => void): () => void {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
@@ -1,0 +1,37 @@
+import {createLogger} from '@ark-broker/logging/logger.js';
+import {InMemoryEventStream} from '../in-memory-event-stream.js';
+import {makeEventData} from './testHelpers/event-data-factory.js';
+
+const silentLogger = createLogger({level: 'silent', pretty: false});
+
+describe('InMemoryEventStream', () => {
+  let stream: InMemoryEventStream;
+
+  beforeEach(() => {
+    stream = new InMemoryEventStream(silentLogger, 'test-events');
+  });
+
+  describe('deleteByQuery', () => {
+    it('removes only items with the given queryId', async () => {
+      const eventA = makeEventData();
+      eventA.data.queryId = 'query-a';
+      const eventB = makeEventData();
+      eventB.data.queryId = 'query-b';
+      await stream.append(eventA);
+      await stream.append({...eventA});
+      await stream.append(eventB);
+
+      await stream.deleteByQuery('query-a');
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0].data.data.queryId).toBe('query-b');
+    });
+
+    it('is a no-op when no items match', async () => {
+      await stream.append(makeEventData());
+      await stream.deleteByQuery('nonexistent-query-id');
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+});

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
@@ -148,6 +148,32 @@ describe('PostgresEventStream', () => {
     });
   });
 
+  describe('deleteByQuery', () => {
+    it('removes only rows with the given query_id', async () => {
+      const qA = 'qa-' + Math.random().toString(36).slice(2);
+      const qB = 'qb-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.queryId = qA;
+      const eventB = makeEventData();
+      eventB.data.queryId = qB;
+      await stream.append(eventA);
+      await stream.append({...eventA});
+      await stream.append(eventB);
+
+      await stream.deleteByQuery(qA);
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0].data.data.queryId).toBe(qB);
+    });
+
+    it('is a no-op when no rows match', async () => {
+      await stream.append(makeEventData());
+      await stream.deleteByQuery('nonexistent-query-id');
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+
   describe('getCurrentSequence', () => {
     it('returns 0 when stream is empty', async () => {
       expect(await stream.getCurrentSequence()).toBe(0);

--- a/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/event-stream-factory.ts
@@ -1,8 +1,8 @@
 import type {AppConfig} from '@ark-broker/config/index.js';
 import type {Db} from '@ark-broker/db/db.js';
 import type {Logger} from '@ark-broker/logging/logger.js';
-import type {EventData, EventStream} from '../event-broker.js';
-import {InMemoryStream} from './in-memory-stream.js';
+import type {EventStream} from '../event-broker.js';
+import {InMemoryEventStream} from './in-memory-event-stream.js';
 import {PostgresEventStream} from './postgres-event-stream.js';
 
 export function createEventStream(
@@ -17,7 +17,7 @@ export function createEventStream(
       config.backends.eventVisibilityTtlSeconds
     );
   }
-  return new InMemoryStream<EventData>(
+  return new InMemoryEventStream(
     logger.child({broker: 'memory-events'}),
     'Event',
     config.persistence.eventFilePath,

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
@@ -1,0 +1,16 @@
+import type {Logger} from '@ark-broker/logging/logger.js';
+import type {EventData, EventStream} from '../event-broker.js';
+import {InMemoryStream} from './in-memory-stream.js';
+
+export class InMemoryEventStream
+  extends InMemoryStream<EventData>
+  implements EventStream
+{
+  constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
+    super(logger, name, path, maxItems);
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    await this.delete((item) => item.data.data.queryId === queryId);
+  }
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
@@ -1,16 +1,12 @@
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {EventData, EventStream} from '../event-broker.js';
-import {InMemoryStream} from './in-memory-stream.js';
+import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
 
 export class InMemoryEventStream
-  extends InMemoryStream<EventData>
+  extends InMemoryQueryDeletableStream<EventData>
   implements EventStream
 {
   constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
-    super(logger, name, path, maxItems);
-  }
-
-  async deleteByQuery(queryId: string): Promise<void> {
-    await this.delete((item) => item.data.data.queryId === queryId);
+    super(logger, name, (data) => data.data.queryId, path, maxItems);
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -1,17 +1,13 @@
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {MessageData} from '../memory-broker.js';
-import {InMemoryStream} from './in-memory-stream.js';
+import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
 import type {MessageStream} from './message-stream.js';
 
 export class InMemoryMessageStream
-  extends InMemoryStream<MessageData>
+  extends InMemoryQueryDeletableStream<MessageData>
   implements MessageStream
 {
   constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
-    super(logger, name, path, maxItems);
-  }
-
-  async deleteByQuery(queryId: string): Promise<void> {
-    await this.delete((item) => item.data.queryId === queryId);
+    super(logger, name, (data) => data.queryId, path, maxItems);
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-query-deletable-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-query-deletable-stream.ts
@@ -1,0 +1,20 @@
+import type {Logger} from '@ark-broker/logging/logger.js';
+import {InMemoryStream} from './in-memory-stream.js';
+
+export abstract class InMemoryQueryDeletableStream<
+  T,
+> extends InMemoryStream<T> {
+  constructor(
+    logger: Logger,
+    name: string,
+    private readonly queryIdOf: (data: T) => string,
+    path?: string,
+    maxItems?: number
+  ) {
+    super(logger, name, path, maxItems);
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    await this.delete((item) => this.queryIdOf(item.data) === queryId);
+  }
+}

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
@@ -1,7 +1,7 @@
 import type postgres from 'postgres';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {Db} from '@ark-broker/db/db.js';
-import type {EventData} from '../event-broker.js';
+import type {EventData, EventStream} from '../event-broker.js';
 import {BrokerItem} from './broker-item.js';
 import type {Predicate} from './stream.js';
 import {PostgresStreamBase} from './postgres-stream-base.js';
@@ -23,7 +23,10 @@ function rowToBrokerItem(row: EventRow): BrokerItem<EventData> {
   };
 }
 
-export class PostgresEventStream extends PostgresStreamBase<EventData> {
+export class PostgresEventStream
+  extends PostgresStreamBase<EventData>
+  implements EventStream
+{
   constructor(
     private readonly logger: Logger,
     private readonly db: Db,
@@ -73,6 +76,11 @@ export class PostgresEventStream extends PostgresStreamBase<EventData> {
     const toDelete = items.filter(predicate).map((item) => item.sequenceNumber);
     if (toDelete.length === 0) return;
     await this.db`DELETE FROM events WHERE sequence_number = ANY(${toDelete})`;
+  }
+
+  async deleteByQuery(queryId: string): Promise<void> {
+    this.logger.info({queryId}, 'deleting events by query');
+    await this.db`DELETE FROM events WHERE query_id = ${queryId}`;
   }
 
   async getCurrentSequence(): Promise<number> {

--- a/services/ark-broker/ark-broker/src/http/routes/errors.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/errors.ts
@@ -42,3 +42,13 @@ export function sendInternalError(res: Response, reqId: unknown): void {
     },
   });
 }
+
+export function sendMissingQueryIdError(res: Response, reqId: unknown): void {
+  res.status(400).json({
+    error: {
+      code: 'BAD_REQUEST',
+      message: 'Query ID is required',
+      requestId: reqId === undefined ? undefined : String(reqId),
+    },
+  });
+}

--- a/services/ark-broker/ark-broker/src/http/routes/events/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/events/index.ts
@@ -4,6 +4,7 @@ import {SessionsBroker} from '@ark-broker/brokers/sessions-broker.js';
 import {
   sendValidationError,
   sendInternalError,
+  sendMissingQueryIdError,
 } from '@ark-broker/http/routes/errors.js';
 import {
   getEventsQuerySchema,
@@ -116,13 +117,7 @@ export function createEventsRouter(
     const {query_id: queryId} = req.params;
 
     if (!queryId) {
-      res.status(400).json({
-        error: {
-          code: 'BAD_REQUEST',
-          message: 'Query ID is required',
-          requestId: req.id === undefined ? undefined : String(req.id),
-        },
-      });
+      sendMissingQueryIdError(res, req.id);
       return;
     }
 

--- a/services/ark-broker/ark-broker/src/http/routes/events/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/events/index.ts
@@ -112,5 +112,32 @@ export function createEventsRouter(
     }
   });
 
+  router.delete<{query_id: string}>('/:query_id', async (req, res) => {
+    const {query_id: queryId} = req.params;
+
+    if (!queryId) {
+      res.status(400).json({
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'Query ID is required',
+          requestId: req.id === undefined ? undefined : String(req.id),
+        },
+      });
+      return;
+    }
+
+    try {
+      req.log.info({queryId}, 'deleting events for query');
+      await events.deleteByQuery(queryId);
+      res.json({
+        status: 'success',
+        message: `Query ${queryId} events deleted`,
+      });
+    } catch (error) {
+      req.log.error({err: error}, 'failed to delete query events');
+      sendInternalError(res, req.id);
+    }
+  });
+
   return router;
 }

--- a/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
@@ -5,6 +5,7 @@ import {SessionsBroker} from '@ark-broker/brokers/sessions-broker.js';
 import {
   sendValidationError,
   sendInternalError,
+  sendMissingQueryIdError,
 } from '@ark-broker/http/routes/errors.js';
 import {
   postMessagesBodySchema,
@@ -318,13 +319,7 @@ export function createMemoryRouter(
       }
 
       if (!queryId) {
-        res.status(400).json({
-          error: {
-            code: 'BAD_REQUEST',
-            message: 'Query ID is required',
-            requestId: req.id === undefined ? undefined : String(req.id),
-          },
-        });
+        sendMissingQueryIdError(res, req.id);
         return;
       }
 
@@ -365,13 +360,7 @@ export function createMemoryRouter(
       const {queryId} = req.params;
 
       if (!queryId) {
-        res.status(400).json({
-          error: {
-            code: 'BAD_REQUEST',
-            message: 'Query ID is required',
-            requestId: req.id === undefined ? undefined : String(req.id),
-          },
-        });
+        sendMissingQueryIdError(res, req.id);
         return;
       }
 

--- a/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
@@ -94,6 +94,20 @@ describeIntegration('postgres event backend — HTTP integration', () => {
     expect(res.body.items.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('DELETE /events/:queryId removes only that query rows', async () => {
+    await request(app).post('/events').send(baseEvent).expect(201);
+    await request(app)
+      .post('/events')
+      .send({...baseEvent, data: {...baseEvent.data, queryId: 'q-other'}})
+      .expect(201);
+
+    await request(app).delete('/events/q-pg-events-1').expect(200);
+
+    const res = await request(app).get('/events').expect(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].data.queryId).toBe('q-other');
+  });
+
   it('expired events are not returned (body ttl_seconds override)', async () => {
     const ttlEvent = {
       ...baseEvent,

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -127,9 +127,9 @@ spec:
           value: ($namespace)
         content: |
           QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
-          BROKER_NS=$(kubectl get deployment --all-namespaces \
-            -o jsonpath='{range .items[?(@.metadata.name=="ark-broker")]}{.metadata.namespace}{end}' 2>/dev/null)
-          BROKER_NS=${BROKER_NS:-default}
+          BROKER_DATA=$(kubectl get configmap ark-config-broker -n "$NAMESPACE" -o json | jq -r '.data.serviceRef')
+          BROKER_NS=$(echo "$BROKER_DATA" | grep '^namespace:' | sed 's/^namespace:[[:space:]]*//' | tr -d '"' | tr -d ' ')
+          BROKER_NS=${BROKER_NS:-$NAMESPACE}
           COUNT=$(kubectl exec -n "$BROKER_NS" deployment/ark-broker -- \
             node -e "const h=require('http');h.get('http://localhost:8080/events/${QUERY_UID}',r=>{let d='';r.on('data',c=>{d+=c});r.on('end',()=>{const b=JSON.parse(d);process.stdout.write(String(b.items?b.items.length:0));process.exit(b.items&&b.items.length>=1?0:1)})}).on('error',e=>{process.stderr.write(e.message);process.exit(1)})")
           echo "HTTP events count: ${COUNT}"

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -34,6 +34,8 @@ spec:
     - apply:
         file: manifests/a00-rbac.yaml
     - apply:
+        file: manifests/a00-broker-config.yaml
+    - apply:
         file: manifests/a00-memory.yaml
     - wait:
         apiVersion: ark.mckinsey.com/v1alpha1

--- a/tests/event-broker-postgres/manifests/a00-broker-config.yaml
+++ b/tests/event-broker-postgres/manifests/a00-broker-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ark-config-broker
+  namespace: ($namespace)
+data:
+  enabled: "true"
+  serviceRef: |
+    name: ark-broker
+    namespace: default
+    port: "http"

--- a/tests/query-broker-event-delete-cleanup/README.md
+++ b/tests/query-broker-event-delete-cleanup/README.md
@@ -1,0 +1,15 @@
+# query-broker-event-delete-cleanup
+
+Deleting a Query removes its operation events from the broker's Postgres backend.
+
+## What it tests
+- The controller finalizer calls `DELETE /events/:queryId` on the broker when a Query is deleted
+- Events are looked up by the Query's UID (the convention operation events use), not its name
+- After deletion, no rows remain in the `events` table for that query's UID
+
+## Running
+```bash
+chainsaw test
+```
+
+Successful completion validates that broker events are cascade-deleted alongside the Query, closing the same orphan-row gap that `query-broker-delete-cleanup` closes for messages.

--- a/tests/query-broker-event-delete-cleanup/chainsaw-test.yaml
+++ b/tests/query-broker-event-delete-cleanup/chainsaw-test.yaml
@@ -1,0 +1,138 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: query-broker-event-delete-cleanup
+  labels:
+    postgresql: "true"
+spec:
+  description: Deleting a Query removes its operation events from the broker's Postgres backend via DELETE /events/:queryId
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query
+    try:
+    - apply:
+        file: manifests/a00-rbac.yaml
+    - apply:
+        file: manifests/a00-memory.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Memory
+        name: default
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.lastResolvedAddress}'
+    - apply:
+        file: manifests/a01-agent.yaml
+    - apply:
+        file: manifests/a02-query.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: event-delete-cleanup-query
+        timeout: 4m
+        for:
+          jsonPath:
+            path: '{.status.response.content}'
+    - assert:
+        timeout: 1s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: event-delete-cleanup-query
+          status:
+            phase: done
+            (response != null): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: event-delete-cleanup-query
+
+  - name: delete-query-and-verify-events-removed
+    try:
+    - script:
+        timeout: 30s
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: |
+          QUERY_UID=$(kubectl get query event-delete-cleanup-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
+          if [ -z "$QUERY_UID" ]; then
+            echo "ERROR: could not resolve Query UID" >&2
+            exit 1
+          fi
+          COUNT=0
+          for i in $(seq 1 10); do
+            COUNT=$(bash ../shared/psql-query.sh \
+              "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}';" \
+              | tr -d ' \n')
+            [ "${COUNT}" -ge 1 ] && break
+            sleep 1
+          done
+          echo "events in Postgres before delete: ${COUNT}"
+          [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event before delete, got ${COUNT}"; exit 1; }
+          printf '%s' "$QUERY_UID"
+        outputs:
+        - name: queryUid
+          value: ($stdout)
+    - delete:
+        ref:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          name: event-delete-cleanup-query
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: event-delete-cleanup-query
+        timeout: 2m
+        for:
+          deletion: {}
+    - script:
+        timeout: 30s
+        env:
+        - name: QUERY_UID
+          value: ($queryUid)
+        content: |
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}';" \
+            | tr -d ' \n')
+          echo "events in Postgres after delete: ${COUNT}"
+          [ "${COUNT}" = "0" ] || { echo "expected 0 events in broker, got ${COUNT}"; exit 1; }
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: event-delete-cleanup-query
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/query-broker-event-delete-cleanup/chainsaw-test.yaml
+++ b/tests/query-broker-event-delete-cleanup/chainsaw-test.yaml
@@ -34,6 +34,8 @@ spec:
     - apply:
         file: manifests/a00-rbac.yaml
     - apply:
+        file: manifests/a00-broker-config.yaml
+    - apply:
         file: manifests/a00-memory.yaml
     - wait:
         apiVersion: ark.mckinsey.com/v1alpha1

--- a/tests/query-broker-event-delete-cleanup/manifests/a00-broker-config.yaml
+++ b/tests/query-broker-event-delete-cleanup/manifests/a00-broker-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ark-config-broker
+  namespace: ($namespace)
+data:
+  enabled: "true"
+  serviceRef: |
+    name: ark-broker
+    namespace: default
+    port: "http"

--- a/tests/query-broker-event-delete-cleanup/manifests/a00-memory.yaml
+++ b/tests/query-broker-event-delete-cleanup/manifests/a00-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Memory
+metadata:
+  name: default
+spec:
+  address:
+    valueFrom:
+      serviceRef:
+        name: ark-broker
+        namespace: default
+        port: http

--- a/tests/query-broker-event-delete-cleanup/manifests/a00-rbac.yaml
+++ b/tests/query-broker-event-delete-cleanup/manifests/a00-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: query-broker-event-delete-cleanup-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: query-broker-event-delete-cleanup-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ($namespace)
+roleRef:
+  kind: Role
+  name: query-broker-event-delete-cleanup-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/query-broker-event-delete-cleanup/manifests/a01-agent.yaml
+++ b/tests/query-broker-event-delete-cleanup/manifests/a01-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: event-delete-cleanup-agent
+spec:
+  prompt: You are a helpful assistant.
+  modelRef:
+    name: test-model-mock

--- a/tests/query-broker-event-delete-cleanup/manifests/a02-query.yaml
+++ b/tests/query-broker-event-delete-cleanup/manifests/a02-query.yaml
@@ -1,0 +1,10 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: event-delete-cleanup-query
+spec:
+  input: What is 2+2?
+  target:
+    type: agent
+    name: event-delete-cleanup-agent
+  ttl: "1h0m0s"

--- a/tests/query-broker-event-delete-cleanup/mock-llm-values.yaml
+++ b/tests/query-broker-event-delete-cleanup/mock-llm-values.yaml
@@ -1,0 +1,24 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [{"id": "gpt-4.1-mini", "object": "model", "owned_by": "openai"}]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+        }

--- a/tests/query-event-recorder/chainsaw-test.yaml
+++ b/tests/query-event-recorder/chainsaw-test.yaml
@@ -64,10 +64,11 @@ spec:
           value: ($namespace)
         content: |
           QUERY_UID=$(kubectl get query event-recorder-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
-          BROKER_NS=$(kubectl get configmaps --all-namespaces -o json | jq -r '.items[] | select(.metadata.name == "ark-config-broker") | .metadata.namespace' | head -1)
-          BROKER_DATA=$(kubectl get configmap ark-config-broker -n "$BROKER_NS" -o json | jq -r '.data.serviceRef')
+          BROKER_DATA=$(kubectl get configmap ark-config-broker -n "$NAMESPACE" -o json | jq -r '.data.serviceRef')
           BROKER_SVC=$(echo "$BROKER_DATA" | grep '^name:' | sed 's/^name:[[:space:]]*//' | tr -d '"' | tr -d ' ')
           BROKER_PORT=$(echo "$BROKER_DATA" | grep '^port:' | sed 's/^port:[[:space:]]*//' | tr -d '"' | tr -d ' ')
+          BROKER_NS=$(echo "$BROKER_DATA" | grep '^namespace:' | sed 's/^namespace:[[:space:]]*//' | tr -d '"' | tr -d ' ')
+          if [ -z "$BROKER_NS" ]; then BROKER_NS="$NAMESPACE"; fi
           if [ -z "$BROKER_PORT" ] || [ "$BROKER_PORT" = "http" ]; then BROKER_PORT=80; fi
           BROKER_URL="http://${BROKER_SVC}.${BROKER_NS}.svc.cluster.local:${BROKER_PORT}"
 

--- a/tests/query-event-recorder/manifests/a00-broker-config.yaml
+++ b/tests/query-event-recorder/manifests/a00-broker-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ark-config-broker
+  namespace: ($namespace)
+data:
+  enabled: "true"
+  serviceRef: |
+    name: ark-broker
+    namespace: default
+    port: "http"


### PR DESCRIPTION
## Summary

Today, deleting a Query cleans up the messages it wrote to its Memory backend (#2557), but the operation events emitted during its execution (`QueryExecutionStart`, `LLMCallComplete`, etc.) are left behind in the broker's `events` table. Once Phase 3 moved events to Postgres (#2737), those became permanent orphan rows with no cleanup path until their TTL eventually expires — this PR closes that gap the same way #2557 closed it for messages.

The reason this couldn't simply reuse the existing message-cleanup path is that events aren't part of the Memory contract. They're written directly to a broker endpoint the controller discovers via the `ark-config-broker` ConfigMap (see `internal/eventing/broker`), which can be a completely different address than the Query's `Memory` resource. So this PR adds a second, independent cleanup call from the same Query finalizer: `deleteBrokerEvents` runs alongside the existing `deleteBrokerMessages`, resolving the broker endpoint the same way the event emitter does, and issuing a new `DELETE /events/:queryId` against it. One detail worth flagging up front: events are keyed by the Query's **UID**, not its name, unlike messages — that's the existing convention operation events already use (`operation_tracker.go`), so the cleanup call has to match it.

Both cleanups are independent and best-effort: either one failing doesn't block the other, and the finalizer keeps retrying with the same grace-period/retry policy already in place for messages. If a namespace has no broker configured at all, cleanup is skipped rather than treated as an error.

## Review guide

The core logic is small; most of the diff is mechanically mirroring the existing message-cleanup pattern to the events side. A good order to read it in:

1. **Broker side, TypeScript** (`services/ark-broker/ark-broker/src/brokers/`): `event-broker.ts` gets a `deleteByQuery` that mirrors `MemoryBroker.deleteByQuery`. `stream/postgres-event-stream.ts:81` and the new `stream/in-memory-event-stream.ts:13` implement it for each backend — the Postgres one is a straight indexed `DELETE FROM events WHERE query_id = $1`, no migration needed since `events_query_idx` already exists from Phase 3. `http/routes/events/index.ts:115` adds the `DELETE /:query_id` route next to the existing purge-all `DELETE /`.
2. **Controller side, Go** (`ark/internal/controller/query_controller.go`): `deleteBrokerEvents` at line 1033 is the new function, `resolveBrokerEventsEndpoint` at 1021 is the seam that lets tests inject a fake endpoint resolver instead of depending on real cluster DNS. `finalize` at line 940 now runs both cleanups via `errors.Join`.
3. **The fix commit** (`internal/telemetry/routing/broker_discovery.go:83`): this is worth a closer look. My first pass at `ResolveBrokerEndpoint` did an exact-namespace ConfigMap lookup, but the already-shipped event *emitter* (`BrokerEventEmitter.getEndpointForNamespace`) falls back to any enabled broker when a namespace has no ConfigMap of its own — which is the actual topology in every deployment I've seen (one `ark-config-broker` in `default`, queries running in arbitrary namespaces). Without matching that fallback, cleanup would silently no-op everywhere except the broker's own namespace. I only found this by running the new chainsaw test on a real cluster — the unit tests alone didn't catch it since they don't model the emitter's discovery behavior. It's fixed by reusing `DiscoverBrokerEndpoints` with the same exact-match-else-first selection.
4. **The chainsaw test** (`tests/query-broker-event-delete-cleanup/`): runs a query, confirms events for its UID exist in Postgres, deletes the Query, and confirms they're gone. It's built from the same pieces as `query-broker-delete-cleanup` (messages) and `event-broker-postgres` (events), so it should look familiar.
5. **Docs**: mostly additive, except `reference/resources/query.mdx`'s "Deletion and cleanup" section, which previously stated outright that cleanup was messages-only — that line is now false and had to be corrected rather than just extended.

## Testing

Go and broker unit/integration tests are green (`make test`/`make lint` in both `ark/` and `services/ark-broker/`). Beyond that, I built all four images from source and ran the whole thing end-to-end on a dedicated Kind cluster with both `backends.message=postgres` and `backends.event=postgres`: the new test passed twice back-to-back (to rule out the async-write race that's bitten this area before), and I re-ran `event-broker-postgres` and both `query-broker-delete-cleanup` variants to confirm no regressions.

Relates to #2153. Addresses the events cleanup follow-up called out in #2728 (that issue also tracks the Postgres-sessions phase and purge-all hardening, which are out of scope here).