### PR TITLE
docs: add audit trail guide for user attribution

### DIFF
--- a/docs/content/developer-guide/authentication.mdx
+++ b/docs/content/developer-guide/authentication.mdx
@@ -448,6 +448,8 @@ normally use the ark-api service account. This bypasses any RBAC rules configure
 User impersonation forwards the SSO user's identity to Kubernetes via
 `Impersonate-User` and `Impersonate-Group` headers, so K8s RBAC applies to the actual user.
 
+This is also what makes user attribution appear in the Kubernetes audit log. See [Audit Trail](/operations-guide/audit-trail).
+
 ### When impersonation applies
 
 | Auth Mode | Impersonation | Reason |

--- a/docs/content/operations-guide/_meta.js
+++ b/docs/content/operations-guide/_meta.js
@@ -16,6 +16,7 @@ export default {
   'build-pipelines': 'Build Pipelines',
 
   '---security': { type: 'separator', title: 'Security and assurance' },
+  'audit-trail': 'Audit Trail',
   'data-flow-and-encryption': 'Data Flow and Encryption',
   'model-url-security': 'Model URL Security',
   'penetration-testing-reports': 'Penetration Testing Reports',

--- a/docs/content/operations-guide/audit-trail.mdx
+++ b/docs/content/operations-guide/audit-trail.mdx
@@ -1,0 +1,78 @@
+import { Callout } from 'nextra/components'
+
+# Audit Trail
+
+This page shows how to answer "which user created, edited, or deleted this resource?" for Agents, Teams, Models, Queries, and Argo Workflows.
+
+<Callout type="info">
+Ark ships no audit store or audit UI. User attribution comes from the Kubernetes API server audit log, which is standard cluster infrastructure you enable and own. Ark's job is to carry the real user identity through to the API server so the log records a person, not a service account.
+</Callout>
+
+## What you need
+
+Three things must be in place. Miss any one and the audit log shows the ark-api service account instead of a user.
+
+1. **SSO on the dashboard and ark-api.** Set `AUTH_MODE=sso` (or `hybrid`) so requests carry a real user identity. See [Authentication](/developer-guide/authentication).
+2. **Impersonation enabled on ark-api.** Set `impersonation.enabled=true`. ark-api forwards the SSO identity to Kubernetes via `Impersonate-User` and `Impersonate-Group` headers, so RBAC and the audit log see the actual user. See [User Impersonation](/developer-guide/authentication#user-impersonation).
+3. **Kubernetes API server audit logging.** A standard k8s feature, owned by the platform team.
+
+Kubernetes never stores a "created by" field on objects, so the API server audit log is the only place attribution lives.
+
+## Enable the audit log
+
+On self-managed clusters, set `--audit-policy-file` and `--audit-log-path` on the API server. Managed clusters expose it as control-plane logging:
+
+| Platform | How |
+|----------|-----|
+| EKS | Enable the "Audit" control-plane log, sent to CloudWatch |
+| GKE | Admin Activity audit logs, on by default, sent to Cloud Logging |
+| AKS | Diagnostic setting `kube-audit` or `kube-audit-admin`, sent to Log Analytics |
+
+Here is a minimal policy that captures writes to Ark and Argo resources:
+
+```yaml
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages: ["RequestReceived"]
+rules:
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: "ark.mckinsey.com"
+      - group: "argoproj.io"
+        resources: ["workflows", "workflowtemplates", "cronworkflows"]
+  - level: None
+```
+
+## What an event looks like
+
+A create through ark-api produces an audit event like this:
+
+```json
+{
+  "verb": "create",
+  "user":            { "username": "system:serviceaccount:ark:ark-api" },
+  "impersonatedUser": { "username": "nab@example.com", "groups": ["ark-editors"] },
+  "objectRef": { "apiGroup": "argoproj.io", "resource": "workflows", "name": "my-workflow-abc12" },
+  "annotations": { "authorization.k8s.io/decision": "allow" }
+}
+```
+
+The `impersonatedUser` field is the person. Denied attempts are captured too, with `decision: "forbid"` and status `403`.
+
+<Callout type="warning">
+Keep `impersonation.fallback=false` in production. When `true`, a request denied by the user's own RBAC is silently retried as the ark-api service account, so the audit log shows the service account for exactly the actions you most want attributed.
+</Callout>
+
+## Limits
+
+- **Defaults give no attribution.** Out of the box `AUTH_MODE=open` and `impersonation.enabled=false`, so everything is created as the ark-api service account.
+- **Attribution stops at the Workflow.** Query resources created inside Argo workflow steps run as the `argo-workflow` service account, not the launching user. You can see who created the Workflow, then correlate child resources by workflow name or owner references.
+- **Viewing the trail** means querying your cluster's log backend (CloudWatch, Cloud Logging, or Log Analytics), not the Ark dashboard.
+
+## More reading
+
+- [Authentication](/developer-guide/authentication) - SSO, auth modes, and API keys.
+- [User Impersonation](/developer-guide/authentication#user-impersonation) - how the SSO identity reaches Kubernetes.
+- [Tenant and Namespace Management](/operations-guide/tenant-namespace-management) - RBAC and namespace isolation.
+- [Kubernetes Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/) - the upstream audit-log reference.


### PR DESCRIPTION
## Summary
- New operations-guide page `audit-trail.mdx` explaining how to see which user created, edited, or deleted Ark and Argo resources.
- Chain: SSO (`AUTH_MODE=sso`) + ark-api impersonation (`impersonation.enabled=true`) + Kubernetes API server audit logging. The `impersonatedUser` field in the audit log is the person.
- Covers the minimal audit policy, managed-cloud enablement (EKS/GKE/AKS), an example event, the `fallback=false` production caveat, and the Argo child-resource attribution limit.
- Links the new page from the authentication impersonation section.

Verified end-to-end on a local kind cluster with real ark-api, SSO, impersonation, and a real Argo Workflows controller: create/edit/delete of Queries and Workflows attribute to the real user; denied attempts are logged; `fallback=true` drops attribution to the service account; child Queries spawned by Argo steps attribute to the `argo-workflow` service account.