### PR TITLE
fix: persist follow up user messages

### DIFF
--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -59,6 +59,7 @@ type executionState struct {
 	eventStream    EventStreamInterface
 	querySpan      telemetry.Span
 	targetSpan     telemetry.Span
+	isResumption   bool
 }
 
 func (s *executionState) finalizeStream(ctx context.Context, responseMessages []Message, tokenUsage arkv1alpha1.TokenUsage) {
@@ -120,6 +121,7 @@ func (h *Handler) ProcessMessage(
 	// Check if this is a resumption from HITL approval or rejection
 	//nolint:nestif // TODO: Refactor to reduce nesting complexity
 	if isResumption, a2aTask := h.checkResumption(ctx, query); isResumption {
+		state.isResumption = true
 		decision := "approved"
 		if a2aTask.Status.Phase == arka2a.PhaseFailed {
 			decision = "rejected"
@@ -913,7 +915,7 @@ func resolveResumptionAgent(state *executionState, a2aTask *arkv1alpha1.A2ATask)
 
 // saveInputMessagesToMemory saves input messages to memory before first approval
 func (h *Handler) saveInputMessagesToMemory(ctx context.Context, state *executionState) {
-	if state.memory == nil || len(state.inputMessages) == 0 || len(state.memoryMessages) != 0 {
+	if state.memory == nil || len(state.inputMessages) == 0 {
 		return
 	}
 
@@ -950,9 +952,8 @@ func (h *Handler) saveFinalMessagesToMemory(ctx context.Context, state *executio
 
 	log := logf.FromContext(ctx)
 	var messagesToSave []Message
-	isResumption := len(state.memoryMessages) > 0
 
-	if isResumption {
+	if state.isResumption {
 		messagesToSave = responseMessages
 		log.Info("Saving final messages (resumption)", "messageCount", len(messagesToSave), "queryName", state.query.Name)
 	} else {

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1278,7 +1282,36 @@ func TestSaveFinalMessagesToMemory(t *testing.T) {
 	})
 }
 
-func TestProcessMessageRoutesToResumption(t *testing.T) {
+func TestProcessMessageResumptionSucceeds(t *testing.T) {
+	var mu sync.Mutex
+	var llmRequestBody string
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		llmRequestBody = string(body)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cmpl-1","object":"chat.completion","created":0,"model":"gpt-test","choices":[{"index":0,"message":{"role":"assistant","content":"resumed answer"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	defer llm.Close()
+
+	model := &arkv1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec: arkv1alpha1.ModelSpec{
+			Model:    arkv1alpha1.ValueSource{Value: "gpt-test"},
+			Provider: ProviderOpenAI,
+			Config: arkv1alpha1.ModelConfig{
+				OpenAI: &arkv1alpha1.OpenAIModelConfig{
+					BaseURL: arkv1alpha1.ValueSource{Value: llm.URL},
+					APIKey:  arkv1alpha1.ValueSource{Value: "test"},
+				},
+			},
+		},
+	}
+	agent := &arkv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+		Spec:       arkv1alpha1.AgentSpec{ModelRef: &arkv1alpha1.AgentModelRef{Name: "test-model"}},
+	}
 	query := &arkv1alpha1.Query{
 		ObjectMeta: metav1.ObjectMeta{Name: "resume-query", Namespace: "default"},
 		Spec: arkv1alpha1.QuerySpec{
@@ -1293,15 +1326,16 @@ func TestProcessMessageRoutesToResumption(t *testing.T) {
 	}
 	a2aTask := &arkv1alpha1.A2ATask{
 		ObjectMeta: metav1.ObjectMeta{Name: "a2a-task-resume-123", Namespace: "default"},
+		Spec:       arkv1alpha1.A2ATaskSpec{TaskID: "resume-123", ContextID: "conv-1"},
 		Status: arkv1alpha1.A2ATaskStatus{
 			Phase: arka2a.PhaseCompleted,
 			ProtocolMetadata: map[string]string{
-				"toolCalls": `[{"id":"call-1","type":"function","function":{"name":"t","arguments":"{}"}}]`,
+				"toolCalls": `[{"id":"call-1","type":"function","function":{"name":"noop","arguments":"{}"}}]`,
 			},
 		},
 	}
 
-	h := newTestHandler(query, a2aTask)
+	h := newTestHandler(model, agent, query, a2aTask)
 	msg := protocol.Message{
 		Role:  protocol.MessageRoleUser,
 		Parts: []protocol.Part{protocol.NewTextPart("hello")},
@@ -1313,14 +1347,17 @@ func TestProcessMessageRoutesToResumption(t *testing.T) {
 	}
 	ctx := logf.IntoContext(context.Background(), funcr.New(func(pfx, args string) {}, funcr.Options{}))
 
-	// Verifies routing only: a completed A2ATask sends ProcessMessage down the
-	// resumption branch (setting state.isResumption). handleResumption then fails
-	// on the missing contextId, so ProcessMessage surfaces "resumption failed".
-	// The effect of state.isResumption on what gets persisted is covered by
-	// TestSaveFinalMessagesToMemory / TestSaveInputMessagesToMemory.
-	_, err := h.ProcessMessage(ctx, msg, taskmanager.ProcessOptions{}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resumption failed")
+	result, err := h.ProcessMessage(ctx, msg, taskmanager.ProcessOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Result)
+
+	// Proves the resumption branch ran (not a fresh dispatch): the reconstructed
+	// approved tool call and its result were sent to the model.
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, llmRequestBody, "call-1")
+	assert.Contains(t, llmRequestBody, "tool")
 }
 
 func TestHandleResumption_EarlyExits(t *testing.T) {

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -1126,7 +1126,7 @@ func TestSaveInputMessagesToMemory(t *testing.T) {
 		assert.Zero(t, mem.addCalls, "should not call AddMessages on empty input")
 	})
 
-	t.Run("no-op when memoryMessages already populated", func(t *testing.T) {
+	t.Run("saves input on follow-up turn with existing history", func(t *testing.T) {
 		mem := &stubMemory{}
 		state := &executionState{
 			query:          arkv1alpha1.Query{ObjectMeta: metav1.ObjectMeta{Name: "q"}},
@@ -1135,7 +1135,8 @@ func TestSaveInputMessagesToMemory(t *testing.T) {
 			memoryMessages: []Message{NewUserMessage("previous")},
 		}
 		h.saveInputMessagesToMemory(ctx, state)
-		assert.Zero(t, mem.addCalls, "should skip save when memory already has history")
+		require.Equal(t, 1, mem.addCalls, "should save follow-up input even when memory has history")
+		assert.Len(t, mem.receivedMsg[0], 1)
 	})
 
 	t.Run("saves input messages on first approval", func(t *testing.T) {
@@ -1242,11 +1243,26 @@ func TestSaveFinalMessagesToMemory(t *testing.T) {
 			memory:         mem,
 			inputMessages:  []Message{NewUserMessage("orig")},
 			memoryMessages: []Message{NewUserMessage("from-memory")},
+			isResumption:   true,
 		}
 		response := []Message{NewAssistantMessage("post-approval")}
 		h.saveFinalMessagesToMemory(ctx, state, response)
 		require.Equal(t, 1, mem.addCalls)
 		assert.Len(t, mem.receivedMsg[0], 1)
+	})
+
+	t.Run("follow-up turn saves input and response despite existing history", func(t *testing.T) {
+		mem := &stubMemory{}
+		state := &executionState{
+			query:          arkv1alpha1.Query{ObjectMeta: metav1.ObjectMeta{Name: "q-followup"}},
+			memory:         mem,
+			inputMessages:  []Message{NewUserMessage("second question")},
+			memoryMessages: []Message{NewUserMessage("first"), NewAssistantMessage("first-answer")},
+		}
+		response := []Message{NewAssistantMessage("second answer")}
+		h.saveFinalMessagesToMemory(ctx, state, response)
+		require.Equal(t, 1, mem.addCalls)
+		assert.Len(t, mem.receivedMsg[0], 2, "must persist the new user message alongside the response")
 	})
 
 	t.Run("tolerates AddMessages error", func(t *testing.T) {

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/taskmanager"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	arka2a "mckinsey.com/ark/internal/a2a"
@@ -1275,6 +1276,51 @@ func TestSaveFinalMessagesToMemory(t *testing.T) {
 		h.saveFinalMessagesToMemory(ctx, state, []Message{NewAssistantMessage("done")})
 		assert.Equal(t, 1, mem.addCalls)
 	})
+}
+
+func TestProcessMessageRoutesToResumption(t *testing.T) {
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "resume-query", Namespace: "default"},
+		Spec: arkv1alpha1.QuerySpec{
+			Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "my-agent"},
+			Input:  runtime.RawExtension{Raw: []byte(`"hello"`)},
+		},
+		Status: arkv1alpha1.QueryStatus{
+			Response: &arkv1alpha1.Response{
+				A2A: &arkv1alpha1.A2AMetadata{TaskID: "resume-123"},
+			},
+		},
+	}
+	a2aTask := &arkv1alpha1.A2ATask{
+		ObjectMeta: metav1.ObjectMeta{Name: "a2a-task-resume-123", Namespace: "default"},
+		Status: arkv1alpha1.A2ATaskStatus{
+			Phase: arka2a.PhaseCompleted,
+			ProtocolMetadata: map[string]string{
+				"toolCalls": `[{"id":"call-1","type":"function","function":{"name":"t","arguments":"{}"}}]`,
+			},
+		},
+	}
+
+	h := newTestHandler(query, a2aTask)
+	msg := protocol.Message{
+		Role:  protocol.MessageRoleUser,
+		Parts: []protocol.Part{protocol.NewTextPart("hello")},
+		Metadata: map[string]any{
+			arka2a.QueryExtensionMetadataKey: map[string]any{
+				"name": "resume-query", "namespace": "default",
+			},
+		},
+	}
+	ctx := logf.IntoContext(context.Background(), funcr.New(func(pfx, args string) {}, funcr.Options{}))
+
+	// Verifies routing only: a completed A2ATask sends ProcessMessage down the
+	// resumption branch (setting state.isResumption). handleResumption then fails
+	// on the missing contextId, so ProcessMessage surfaces "resumption failed".
+	// The effect of state.isResumption on what gets persisted is covered by
+	// TestSaveFinalMessagesToMemory / TestSaveInputMessagesToMemory.
+	_, err := h.ProcessMessage(ctx, msg, taskmanager.ProcessOptions{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resumption failed")
 }
 
 func TestHandleResumption_EarlyExits(t *testing.T) {


### PR DESCRIPTION
Multi-turn conversations in the session detail chat panel were missing user messages (and the typing indicator got stuck), because the executor stopped saving follow-up user messages to memory.

A recent HITL PR changed how messages get persisted. It decided "should I save the user's message?" based on whether memory already had prior messages — assuming that meant it was resuming from an approval. But any 2nd, 3rd, … turn in a normal conversation also has prior messages, so those turns were wrongly treated as resumptions and only the agent's reply was saved. The user's message was dropped.

The session detail panel reads messages from the broker, so the missing messages showed up there. The simple chat panel kept its own local copy, so it looked fine.

How the 3 changes fix it

1. Track resumptions explicitly — added an isResumption flag set only when we actually detect an approval resumption, instead of guessing from memory contents.
2. Save based on the real flag — saveFinalMessagesToMemory now uses that flag, so normal turns always save the user message + reply, and only genuine resumptions skip the (already-saved) input.
3. Fix the same bug in the approval path — saveInputMessagesToMemory no longer skips saving just because memory has history, so follow-up turns that need approval keep their user message too.

Result: every user message is persisted, so the session detail panel renders full, consistent history across sends and reloads.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #2797 