### PR TITLE
fix: honor tenant prefix (base path) across dashboard streaming, SSO sign-in/callback, and A2A agent cards

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2a_gateway.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2a_gateway.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from fastapi import APIRouter, Request
 
 from .a2agw.manager import DynamicManager
-from .a2agw.registry import external_base_from_headers, get_registry
+from .a2agw.registry import external_forwarded_base_from_headers, get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ async def list_agents(request: Request):
     # forwarding gateway is path-routing this deployment; otherwise fall back to
     # the root-relative path (single-tenant / root hosting).
     headers = {key.lower(): value for key, value in request.headers.items()}
-    base = external_base_from_headers(headers)
+    forwarded_base = external_forwarded_base_from_headers(headers)
     agents = await get_registry().list_agents()
     return [
         {
@@ -38,7 +38,7 @@ async def list_agents(request: Request):
             "description": agent.description,
             "capabilities": [skill.name for skill in agent.skills],
             "host": "localhost",
-            "agent-card": f"{base}/a2a/agent/{agent.name}/.well-known/agent.json",
+            "agent-card": f"{forwarded_base}/a2a/agent/{agent.name}/.well-known/agent.json",
             "created_at": datetime.utcnow().isoformat(),
             "metadata": {"type": "analytical", "version": agent.version},
         }

--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2a_gateway.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2a_gateway.py
@@ -2,10 +2,10 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from .a2agw.manager import DynamicManager
-from .a2agw.registry import get_registry
+from .a2agw.registry import external_base_from_headers, get_registry
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +24,13 @@ def get_a2a_manager() -> DynamicManager:
 
 
 @router.get("/agents", response_model=list[dict])
-async def list_agents():
+async def list_agents(request: Request):
     """List all available agents for A2A communication."""
+    # Prefix the agent-card link with the request's external base URL when a
+    # forwarding gateway is path-routing this deployment; otherwise fall back to
+    # the root-relative path (single-tenant / root hosting).
+    headers = {key.lower(): value for key, value in request.headers.items()}
+    base = external_base_from_headers(headers)
     agents = await get_registry().list_agents()
     return [
         {
@@ -33,7 +38,7 @@ async def list_agents():
             "description": agent.description,
             "capabilities": [skill.name for skill in agent.skills],
             "host": "localhost",
-            "agent-card": f"/a2a/agent/{agent.name}/.well-known/agent.json",
+            "agent-card": f"{base}/a2a/agent/{agent.name}/.well-known/agent.json",
             "created_at": datetime.utcnow().isoformat(),
             "metadata": {"type": "analytical", "version": agent.version},
         }

--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/manager.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/manager.py
@@ -14,7 +14,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from .execution import ARKAgentExecutor
 from .registry import (
     apply_forwarded_url,
-    external_base_from_headers,
+    external_forwarded_base_from_headers,
     forwarded_base_ctx,
     get_registry,
 )
@@ -82,9 +82,9 @@ class ProxyApp:
                 key.decode("latin-1").lower(): value.decode("latin-1")
                 for key, value in scope.get("headers", [])
             }
-            base = external_base_from_headers(headers)
-            if base:
-                token = forwarded_base_ctx.set(base)
+            forwarded_base = external_forwarded_base_from_headers(headers)
+            if forwarded_base:
+                token = forwarded_base_ctx.set(forwarded_base)
 
         # Forward to current app - this is safe because we hold a reference
         # Even if set_app() is called during this await, we continue using

--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/manager.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/manager.py
@@ -12,7 +12,12 @@ from starlette.applications import Starlette
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .execution import ARKAgentExecutor
-from .registry import get_registry
+from .registry import (
+    apply_forwarded_url,
+    external_base_from_headers,
+    forwarded_base_ctx,
+    get_registry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,10 +72,28 @@ class ProxyApp:
             })
             return
         
+        # Publish the request's external base URL (derived from X-Forwarded-*
+        # headers) so the agent-card modifier can advertise a tenant-prefixed
+        # URL. Pure ASGI forwarding keeps us in the same task, so a contextvar
+        # set here is visible to the downstream agent-card handler.
+        token = None
+        if scope.get("type") == "http":
+            headers = {
+                key.decode("latin-1").lower(): value.decode("latin-1")
+                for key, value in scope.get("headers", [])
+            }
+            base = external_base_from_headers(headers)
+            if base:
+                token = forwarded_base_ctx.set(base)
+
         # Forward to current app - this is safe because we hold a reference
         # Even if set_app() is called during this await, we continue using
         # the app instance we already have
-        await app(scope, receive, send)
+        try:
+            await app(scope, receive, send)
+        finally:
+            if token is not None:
+                forwarded_base_ctx.reset(token)
     
     def set_app(self, app: ASGIApp):
         """Atomically replace the target app.
@@ -186,7 +209,8 @@ class DynamicManager:
 
             server = A2AStarletteApplication(
                 agent_card=agent_card,
-                http_handler=request_handler
+                http_handler=request_handler,
+                card_modifier=apply_forwarded_url,
             )
 
             new_app.mount(f"/{name}/", server.build())

--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/registry.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/registry.py
@@ -1,3 +1,4 @@
+import contextvars
 import functools
 import logging
 import os
@@ -20,9 +21,44 @@ def _get_agent_card_url_components():
     logger.info(f"Agent cards will advertise URL: {scheme}://{host}:{port}{path}")
     return scheme, host, port, path
 
+def _agent_suffix(agent_name):
+    return f"/a2a/agent/{agent_name}/"
+
 def get_external(agent_name):
     scheme, host, port, path = _get_agent_card_url_components()
-    return f"{scheme}://{host}:{port}{path}/a2a/agent/{agent_name}/"
+    return f"{scheme}://{host}:{port}{path}{_agent_suffix(agent_name)}"
+
+# External base URL (scheme://host{prefix}) derived from the incoming request's
+# X-Forwarded-* headers and published by the A2A ProxyApp. Empty when the
+# request carries no forwarding prefix, in which case the static
+# ARK_A2A_AGENT_CARD_* env values are used instead.
+forwarded_base_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "a2a_forwarded_base", default=""
+)
+
+def external_base_from_headers(headers):
+    """Build scheme://host{prefix} from standard forwarding headers.
+
+    Returns "" unless X-Forwarded-Prefix is present, mirroring the OpenAPI
+    server-URL logic: the prefix is the signal that an external gateway is
+    path-routing this deployment, and without it the static env values apply.
+    """
+    prefix = headers.get("x-forwarded-prefix", "")
+    if not prefix:
+        return ""
+    proto = headers.get("x-forwarded-proto", "http")
+    host = headers.get("x-forwarded-host") or headers.get("host", "localhost")
+    return f"{proto}://{host}{prefix}"
+
+def apply_forwarded_url(card: AgentCard) -> AgentCard:
+    """Card modifier: advertise a URL built from the request's forwarding prefix
+    when present, so path-based multi-tenant deployments serve a card whose URL
+    carries the tenant prefix. Returns a copy; never mutates the shared card
+    cached by the manager."""
+    base = forwarded_base_ctx.get()
+    if not base:
+        return card
+    return card.model_copy(update={"url": f"{base}{_agent_suffix(card.name)}"})
 
 def ark_to_agent_card(ark_agent) -> AgentCard:
     metadata = ark_agent.metadata

--- a/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/registry.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/a2agw/registry.py
@@ -36,12 +36,16 @@ forwarded_base_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
     "a2a_forwarded_base", default=""
 )
 
-def external_base_from_headers(headers):
-    """Build scheme://host{prefix} from standard forwarding headers.
+def external_forwarded_base_from_headers(headers):
+    """Base URL (scheme://host{prefix}) for the FORWARDED-PREFIX case only.
 
-    Returns "" unless X-Forwarded-Prefix is present, mirroring the OpenAPI
-    server-URL logic: the prefix is the signal that an external gateway is
-    path-routing this deployment, and without it the static env values apply.
+    This is not a general "what is my base URL" helper: it returns a non-empty
+    value only when the request carries X-Forwarded-Prefix, which is the signal
+    that an external gateway is path-routing this deployment (mirrors the OpenAPI
+    server-URL logic). It returns "" in every other case — meaning "no external
+    prefix, fall back to the static ARK_A2A_AGENT_CARD_* env / a relative link" —
+    which callers compose directly (see list_agents), so "" is deliberate rather
+    than None.
     """
     prefix = headers.get("x-forwarded-prefix", "")
     if not prefix:
@@ -53,12 +57,20 @@ def external_base_from_headers(headers):
 def apply_forwarded_url(card: AgentCard) -> AgentCard:
     """Card modifier: advertise a URL built from the request's forwarding prefix
     when present, so path-based multi-tenant deployments serve a card whose URL
-    carries the tenant prefix. Returns a copy; never mutates the shared card
-    cached by the manager."""
-    base = forwarded_base_ctx.get()
-    if not base:
+    carries the tenant prefix.
+
+    Returns a copy, never mutating the input. The DynamicManager is a single
+    shared instance whose cached AgentCard objects are reused for every request;
+    the prefix, by contrast, is request-scoped (from X-Forwarded-Prefix), so
+    concurrent requests for the same agent can carry different prefixes. Mutating
+    the shared card in place would race across those requests.
+    """
+    forwarded_base = forwarded_base_ctx.get()
+    if not forwarded_base:
         return card
-    return card.model_copy(update={"url": f"{base}{_agent_suffix(card.name)}"})
+    return card.model_copy(
+        update={"url": f"{forwarded_base}{_agent_suffix(card.name)}"}
+    )
 
 def ark_to_agent_card(ark_agent) -> AgentCard:
     metadata = ark_agent.metadata

--- a/services/ark-api/ark-api/tests/api/test_a2a_agent_card_url.py
+++ b/services/ark-api/ark-api/tests/api/test_a2a_agent_card_url.py
@@ -1,0 +1,133 @@
+"""Tests for A2A agent-card URL derivation from forwarding headers."""
+import os
+import unittest
+from unittest.mock import patch
+
+os.environ["AUTH_MODE"] = "open"
+
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from starlette.testclient import TestClient
+
+from ark_api.api.v1.a2agw import manager as manager_module
+from ark_api.api.v1.a2agw.manager import DynamicManager
+from ark_api.api.v1.a2agw.registry import (
+    apply_forwarded_url,
+    external_base_from_headers,
+    forwarded_base_ctx,
+)
+
+
+def _make_card(name="weather", url="http://localhost:8000/a2a/agent/weather/"):
+    return AgentCard(
+        name=name,
+        description="A test agent",
+        capabilities=AgentCapabilities(
+            streaming=True, push_notifications=False, state_transition_history=False
+        ),
+        skills=[
+            AgentSkill(
+                id=f"{name}-default-skill",
+                name="General",
+                description="General agent capabilities",
+                tags=["general"],
+            )
+        ],
+        url=url,
+        version="1.0.0",
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+    )
+
+
+class TestExternalBaseFromHeaders(unittest.TestCase):
+    """external_base_from_headers only activates on X-Forwarded-Prefix."""
+
+    def test_empty_without_prefix(self):
+        self.assertEqual(external_base_from_headers({}), "")
+        self.assertEqual(external_base_from_headers({"host": "example.com"}), "")
+
+    def test_builds_from_forwarded_headers(self):
+        headers = {
+            "x-forwarded-prefix": "/tenant-a",
+            "x-forwarded-host": "example.com",
+            "x-forwarded-proto": "https",
+        }
+        self.assertEqual(
+            external_base_from_headers(headers), "https://example.com/tenant-a"
+        )
+
+    def test_falls_back_to_host_header_and_http(self):
+        headers = {"x-forwarded-prefix": "/t", "host": "svc:8080"}
+        self.assertEqual(external_base_from_headers(headers), "http://svc:8080/t")
+
+
+class TestApplyForwardedUrl(unittest.TestCase):
+    """apply_forwarded_url rewrites the card URL only when a base is published."""
+
+    def test_no_context_returns_card_unchanged(self):
+        card = _make_card()
+        self.assertIs(apply_forwarded_url(card), card)
+
+    def test_rewrites_url_from_context_without_mutating_original(self):
+        card = _make_card()
+        token = forwarded_base_ctx.set("https://example.com/tenant-a")
+        try:
+            result = apply_forwarded_url(card)
+        finally:
+            forwarded_base_ctx.reset(token)
+
+        self.assertEqual(
+            result.url, "https://example.com/tenant-a/a2a/agent/weather/"
+        )
+        # The shared card cached by the manager must not be mutated.
+        self.assertEqual(card.url, "http://localhost:8000/a2a/agent/weather/")
+
+
+def _mount_gateway_with_agent(card):
+    """Build the real A2A ASGI stack (ProxyApp + mounted A2AStarletteApplication
+    with the card_modifier) serving a single agent, mounted where main.py mounts
+    it. Exercises the whole request -> contextvar -> card_modifier path."""
+    manager = DynamicManager()
+    manager.agents = {card.name: card}
+    manager._update_routes()
+    return Starlette(routes=[Mount("/a2a/agent", app=manager.app)])
+
+
+class TestAgentCardServing(unittest.TestCase):
+    """End-to-end (in-process) serving of .well-known/agent.json through the
+    ProxyApp, asserting the advertised URL honours X-Forwarded-Prefix."""
+
+    def setUp(self):
+        # ARKAgentExecutor reads the pod namespace at construction; pin it so the
+        # test does not depend on a cluster.
+        patcher = patch.object(manager_module, "get_namespace", return_value="default")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_well_known_card_uses_forwarded_prefix(self):
+        client = TestClient(_mount_gateway_with_agent(_make_card()))
+        response = client.get(
+            "/a2a/agent/weather/.well-known/agent.json",
+            headers={
+                "X-Forwarded-Prefix": "/tenant-a",
+                "X-Forwarded-Host": "example.com",
+                "X-Forwarded-Proto": "https",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["url"],
+            "https://example.com/tenant-a/a2a/agent/weather/",
+        )
+
+    def test_well_known_card_without_prefix_keeps_static_base(self):
+        client = TestClient(_mount_gateway_with_agent(_make_card()))
+        response = client.get("/a2a/agent/weather/.well-known/agent.json")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("/tenant-a/", response.json()["url"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/ark-api/ark-api/tests/api/test_a2a_agent_card_url.py
+++ b/services/ark-api/ark-api/tests/api/test_a2a_agent_card_url.py
@@ -14,12 +14,12 @@ from ark_api.api.v1.a2agw import manager as manager_module
 from ark_api.api.v1.a2agw.manager import DynamicManager
 from ark_api.api.v1.a2agw.registry import (
     apply_forwarded_url,
-    external_base_from_headers,
+    external_forwarded_base_from_headers,
     forwarded_base_ctx,
 )
 
 
-def _make_card(name="weather", url="http://localhost:8000/a2a/agent/weather/"):
+def _make_test_card(name="weather", url="http://localhost:8000/a2a/agent/weather/"):
     return AgentCard(
         name=name,
         description="A test agent",
@@ -42,11 +42,11 @@ def _make_card(name="weather", url="http://localhost:8000/a2a/agent/weather/"):
 
 
 class TestExternalBaseFromHeaders(unittest.TestCase):
-    """external_base_from_headers only activates on X-Forwarded-Prefix."""
+    """external_forwarded_base_from_headers only activates on X-Forwarded-Prefix."""
 
     def test_empty_without_prefix(self):
-        self.assertEqual(external_base_from_headers({}), "")
-        self.assertEqual(external_base_from_headers({"host": "example.com"}), "")
+        self.assertEqual(external_forwarded_base_from_headers({}), "")
+        self.assertEqual(external_forwarded_base_from_headers({"host": "example.com"}), "")
 
     def test_builds_from_forwarded_headers(self):
         headers = {
@@ -55,23 +55,23 @@ class TestExternalBaseFromHeaders(unittest.TestCase):
             "x-forwarded-proto": "https",
         }
         self.assertEqual(
-            external_base_from_headers(headers), "https://example.com/tenant-a"
+            external_forwarded_base_from_headers(headers), "https://example.com/tenant-a"
         )
 
     def test_falls_back_to_host_header_and_http(self):
         headers = {"x-forwarded-prefix": "/t", "host": "svc:8080"}
-        self.assertEqual(external_base_from_headers(headers), "http://svc:8080/t")
+        self.assertEqual(external_forwarded_base_from_headers(headers), "http://svc:8080/t")
 
 
 class TestApplyForwardedUrl(unittest.TestCase):
     """apply_forwarded_url rewrites the card URL only when a base is published."""
 
     def test_no_context_returns_card_unchanged(self):
-        card = _make_card()
+        card = _make_test_card()
         self.assertIs(apply_forwarded_url(card), card)
 
     def test_rewrites_url_from_context_without_mutating_original(self):
-        card = _make_card()
+        card = _make_test_card()
         token = forwarded_base_ctx.set("https://example.com/tenant-a")
         try:
             result = apply_forwarded_url(card)
@@ -107,7 +107,7 @@ class TestAgentCardServing(unittest.TestCase):
         self.addCleanup(patcher.stop)
 
     def test_well_known_card_uses_forwarded_prefix(self):
-        client = TestClient(_mount_gateway_with_agent(_make_card()))
+        client = TestClient(_mount_gateway_with_agent(_make_test_card()))
         response = client.get(
             "/a2a/agent/weather/.well-known/agent.json",
             headers={
@@ -123,7 +123,7 @@ class TestAgentCardServing(unittest.TestCase):
         )
 
     def test_well_known_card_without_prefix_keeps_static_base(self):
-        client = TestClient(_mount_gateway_with_agent(_make_card()))
+        client = TestClient(_mount_gateway_with_agent(_make_test_card()))
         response = client.get("/a2a/agent/weather/.well-known/agent.json")
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("/tenant-a/", response.json()["url"])

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/auth-basepath.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/auth-basepath.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { prefixPathname } from '@/lib/auth/base-path';
+
+// Regression for the OIDC callback under a tenant prefix: Next.js strips the
+// basePath before the auth route handler runs, but Auth.js's basePath (derived
+// from AUTH_URL) still carries the prefix, so the stripped
+// /api/auth/callback/<id> fails Auth.js's action parser (UnknownAction -> 400).
+// prefixPathname realigns the inbound pathname before Auth.js parses it.
+describe('prefixPathname', () => {
+  it('re-inserts the prefix Next stripped from the callback path', () => {
+    expect(
+      prefixPathname('/api/auth/callback/keycloak', '/nstenant'),
+    ).toBe('/nstenant/api/auth/callback/keycloak');
+  });
+
+  it('is a no-op when the prefix is already present', () => {
+    expect(
+      prefixPathname('/nstenant/api/auth/callback/keycloak', '/nstenant'),
+    ).toBe('/nstenant/api/auth/callback/keycloak');
+  });
+
+  it('is a no-op when the pathname equals the base path exactly', () => {
+    expect(prefixPathname('/nstenant', '/nstenant')).toBe('/nstenant');
+  });
+
+  it('does not prefix a path that merely shares the prefix string', () => {
+    // /nstenant-other must not be treated as being under /nstenant
+    expect(prefixPathname('/nstenant-other/x', '/nstenant')).toBe(
+      '/nstenant/nstenant-other/x',
+    );
+  });
+
+  it('is a no-op at the root (empty base path)', () => {
+    expect(prefixPathname('/api/auth/callback/keycloak', '')).toBe(
+      '/api/auth/callback/keycloak',
+    );
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat.test.ts
@@ -17,6 +17,12 @@ vi.mock('@/lib/api/client', () => ({
   },
 }));
 
+// Mock apiUrl with a non-empty base path so we can assert the chunk stream
+// honours the tenant prefix (regression: raw fetch used to drop it).
+vi.mock('@/lib/api/config', () => ({
+  apiUrl: vi.fn((path: string) => `/tenant-a${path}`),
+}));
+
 // Mock crypto.randomUUID
 Object.defineProperty(global, 'crypto', {
   value: {
@@ -654,6 +660,42 @@ describe('chatService', () => {
 
       await expect(generator.next()).rejects.toThrow(
         'No response body available for streaming',
+      );
+    });
+
+    it('prefixes the chunk stream URL with the tenant base path', async () => {
+      const messages = [{ role: 'user' as const, content: 'Hello' }];
+      const mockQueryResponse = {
+        name: 'chat-query-mock-uuid',
+        input: messages,
+        target: { type: 'agent', name: 'test-agent' },
+        status: { phase: 'pending' },
+      } as unknown as QueryDetailResponse;
+
+      vi.mocked(apiClient.post).mockResolvedValueOnce(mockQueryResponse);
+
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi.fn().mockResolvedValueOnce({ done: true }),
+            releaseLock: vi.fn(),
+          }),
+        },
+      });
+      global.fetch = fetchMock;
+
+      const generator = chatService.streamChatResponse(
+        messages,
+        'agent',
+        'test-agent',
+        'session-123',
+      );
+      await generator.next();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/tenant-a\/api\/v1\/broker\/chunks\?/),
+        expect.anything(),
       );
     });
   });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
@@ -59,6 +59,7 @@ describe('middleware (auth gate)', () => {
   afterEach(() => {
     delete process.env.BASE_URL;
     delete process.env.AUTH_HUB_URL;
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
   });
 
   describe('unauthenticated requests redirect to the local sign-in (no AUTH_HUB_URL)', () => {
@@ -184,6 +185,45 @@ describe('middleware (auth gate)', () => {
 
       expect(NextResponse.redirect).not.toHaveBeenCalled();
       expect(NextResponse.next).toHaveBeenCalled();
+    });
+  });
+
+  describe('base-path prefix is normalised before matching the allow-list', () => {
+    // Regression: Next.js delivers the pathname WITH the tenant prefix to
+    // middleware (e.g. /nstenant/api/auth/signin), so the auth routes must still be
+    // recognised as public or the sign-in page redirects to itself forever.
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_BASE_PATH = '/nstenant';
+    });
+
+    it.each([
+      '/nstenant/api/auth/signin',
+      '/nstenant/api/auth/session',
+      '/nstenant/signout',
+      '/nstenant/_next/static/chunk.js',
+      '/nstenant/favicon.ico',
+    ])('passes through prefixed public path %s', async pathname => {
+      const request = createMockRequest(pathname);
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).not.toHaveBeenCalled();
+      expect(NextResponse.next).toHaveBeenCalled();
+    });
+
+    it('still redirects a prefixed protected page with the prefix intact', async () => {
+      process.env.BASE_URL = 'https://example.com/nstenant';
+      const request = createMockRequest('/nstenant/dashboard');
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        'https://example.com/nstenant/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com%2Fnstenant%2Fdashboard',
+      );
     });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/middleware.test.ts
@@ -95,6 +95,23 @@ describe('middleware (auth gate)', () => {
         ).toString(),
       );
     });
+
+    // Regression: a subpath-hosted tenant must keep its prefix in the sign-in
+    // redirect. `new URL(SIGNIN_PATH, BASE_URL)` dropped it because SIGNIN_PATH
+    // is root-absolute; concatenation onto BASE_URL preserves it.
+    it('preserves the tenant base-path prefix in the local sign-in redirect', async () => {
+      process.env.BASE_URL = 'https://example.com/tenant-a';
+      const request = createMockRequest('/tenant-a/dashboard');
+      request.auth = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (middleware as any)(request);
+
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        'https://example.com/tenant-a/api/auth/signin?callbackUrl=https%3A%2F%2Fexample.com%2Ftenant-a%2Fdashboard',
+      );
+      expect(NextResponse.next).not.toHaveBeenCalled();
+    });
   });
 
   describe('hub model: unauthenticated requests redirect to AUTH_HUB_URL', () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/services/chat.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/services/chat.test.ts
@@ -21,6 +21,12 @@ vi.mock('@/lib/utils/uuid', () => ({
   generateUUID: vi.fn(() => 'test-uuid-123'),
 }));
 
+// Non-empty base path so the chunk stream assertions double as a guard that
+// the tenant prefix is preserved (regression: raw fetch dropped it).
+vi.mock('@/lib/api/config', () => ({
+  apiUrl: vi.fn((path: string) => `/tenant-a${path}`),
+}));
+
 describe('chatService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -681,7 +687,7 @@ describe('chatService', () => {
 
       expect(chunks).toEqual([{ content: 'Hello' }, { content: 'World' }]);
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/v1/broker/chunks?watch=true&query-id=test-query-1',
+        '/tenant-a/api/v1/broker/chunks?watch=true&query-id=test-query-1',
         expect.objectContaining({ signal: undefined }),
       );
     });
@@ -865,7 +871,7 @@ describe('chatService', () => {
       }
 
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/v1/broker/chunks?watch=true&query-id=test-query-abort',
+        '/tenant-a/api/v1/broker/chunks?watch=true&query-id=test-query-abort',
         expect.objectContaining({ signal: controller.signal }),
       );
     });

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/broker/page.tsx
@@ -137,7 +137,9 @@ export function useSSEStream(endpoint: string | null, memory: string) {
 
       setIsLoading(true);
       try {
-        let url = `/api${endpoint}?memory=${encodeURIComponent(memory)}&limit=1000`;
+        let url = apiUrl(
+          `/api${endpoint}?memory=${encodeURIComponent(memory)}&limit=1000`,
+        );
         if (cursor !== undefined && cursor !== null) {
           url += `&cursor=${cursor}`;
         }
@@ -206,7 +208,7 @@ export function useSSEStream(endpoint: string | null, memory: string) {
   const purge = useCallback(async () => {
     try {
       const res = await fetch(
-        `/api${endpoint}?memory=${encodeURIComponent(memory)}`,
+        apiUrl(`/api${endpoint}?memory=${encodeURIComponent(memory)}`),
         {
           method: 'DELETE',
         },

--- a/services/ark-dashboard/ark-dashboard/auth.ts
+++ b/services/ark-dashboard/ark-dashboard/auth.ts
@@ -1,9 +1,9 @@
 import NextAuth from 'next-auth';
 import type { DefaultSession, Session } from 'next-auth';
-import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { authConfig } from './lib/auth/auth-config';
+import { prefixPathname } from './lib/auth/base-path';
 
 declare module 'next-auth' {
   interface Session {
@@ -66,6 +66,28 @@ function openauth(
   return getDummySession();
 }
 
+// Realign the inbound auth-route pathname with Auth.js's basePath under a tenant
+// prefix (see prefixPathname). Next.js strips the prefix before this handler
+// runs, so /api/auth/callback/<provider> would otherwise fail Auth.js's action
+// parser; the redirect_uri Auth.js emits already carries the prefix, so only the
+// inbound side needs fixing. Mirrors next-auth's own reqWithEnvURL, which
+// rebuilds the request with a new URL and the original request as init.
+function withBasePath(
+  handler: (req: NextRequest) => Promise<Response>,
+): (req: NextRequest) => Promise<Response> {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+  if (!basePath) return handler;
+  return (req: NextRequest) => {
+    const url = new URL(req.url);
+    const realigned = prefixPathname(url.pathname, basePath);
+    if (realigned !== url.pathname) {
+      url.pathname = realigned;
+      req = new NextRequest(url, req);
+    }
+    return handler(req);
+  };
+}
+
 function getAuth() {
   if (!process.env.AUTH_MODE || process.env.AUTH_MODE === 'open') {
     return {
@@ -81,8 +103,8 @@ function getAuth() {
   return {
     auth: nextAuth.auth,
     signIn: nextAuth.signIn,
-    GET: nextAuth.handlers.GET,
-    POST: nextAuth.handlers.POST,
+    GET: withBasePath(nextAuth.handlers.GET),
+    POST: withBasePath(nextAuth.handlers.POST),
   };
 }
 

--- a/services/ark-dashboard/ark-dashboard/components/chat/embedded-chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/embedded-chat-panel.tsx
@@ -21,6 +21,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { apiUrl } from '@/lib/api/config';
 import {
   getAttributeStringValue,
   getSessionDisplayNameFromEntries,
@@ -103,7 +104,9 @@ function useSSEStream(endpoint: string, memory: string, agentName: string) {
       }
 
       setError(null);
-      let url = `/api${endpoint}?memory=${encodeURIComponent(memory)}&watch=true`;
+      let url = apiUrl(
+        `/api${endpoint}?memory=${encodeURIComponent(memory)}&watch=true`,
+      );
       if (cursor !== undefined && cursor !== null) {
         url += `&cursor=${cursor}`;
       }
@@ -157,7 +160,9 @@ function useSSEStream(endpoint: string, memory: string, agentName: string) {
 
       setIsLoading(true);
       try {
-        let url = `/api${endpoint}?memory=${encodeURIComponent(memory)}&limit=${PAGE_SIZE}`;
+        let url = apiUrl(
+          `/api${endpoint}?memory=${encodeURIComponent(memory)}&limit=${PAGE_SIZE}`,
+        );
         if (cursor !== undefined && cursor !== null) {
           url += `&cursor=${cursor}`;
         }

--- a/services/ark-dashboard/ark-dashboard/components/dialogs/agents-api-dialog.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/dialogs/agents-api-dialog.tsx
@@ -62,8 +62,11 @@ export function AgentsAPIDialog({
   const [isInternalEndpoint, setIsInternalEndpoint] = useState(false);
 
   const apiPath = '/api/v1/queries/';
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
   const externalBaseUrl =
-    typeof window !== 'undefined' ? window.location.origin : '';
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${basePath}`
+      : '';
   const internalBaseUrl = 'http://ark-api.<namespace>.svc.cluster.local';
   const fullEndpoint = isInternalEndpoint
     ? `${internalBaseUrl}${apiPath}`

--- a/services/ark-dashboard/ark-dashboard/lib/auth/base-path.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/auth/base-path.ts
@@ -1,0 +1,16 @@
+// Re-insert the deployment base path into a pathname when it is missing.
+//
+// Next.js strips the configured basePath before a request reaches the auth
+// route handler, but Auth.js derives its own basePath from AUTH_URL (e.g.
+// /tenant-a/api/auth) and matches the incoming pathname against it. Under a
+// tenant prefix the stripped /api/auth/callback/<provider> then fails Auth.js's
+// action parser (UnknownAction -> 400). Realigning the inbound pathname fixes
+// the callback while leaving the redirect_uri (built by Auth.js from AUTH_URL,
+// already prefixed) untouched. No-op at the root or when the prefix is present.
+export function prefixPathname(pathname: string, basePath: string): string {
+  if (!basePath) return pathname;
+  if (pathname === basePath || pathname.startsWith(`${basePath}/`)) {
+    return pathname;
+  }
+  return `${basePath}${pathname}`;
+}

--- a/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
@@ -1,6 +1,7 @@
 import { trackEvent } from '@/lib/analytics/singleton';
 import { hashPromptSync } from '@/lib/analytics/utils';
 import { apiClient } from '@/lib/api/client';
+import { apiUrl } from '@/lib/api/config';
 import type { components } from '@/lib/api/generated/types';
 import { ARK_ANNOTATIONS } from '@/lib/constants/annotations';
 import { generateUUID } from '@/lib/utils/uuid';
@@ -423,7 +424,7 @@ export const chatService = {
       unknown
     > {
       const response = await fetch(
-        `/api/v1/broker/chunks?watch=true&query-id=${queryName}`,
+        apiUrl(`/api/v1/broker/chunks?watch=true&query-id=${queryName}`),
         {
           signal: abortSignal,
         },

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -49,13 +49,16 @@ export default auth(async (req: NextRequestWithAuth) => {
     // basePath the local signin path resolves wrong (a leading-slash path drops
     // the prefix), and the hub issues a Path=/ session cookie shared by every
     // tenant on the host — so one login at the hub covers them all.
+    //
+    // Both branches concatenate onto the (hub or tenant) base URL rather than
+    // using `new URL(SIGNIN_PATH, base)`: SIGNIN_PATH is root-absolute, so
+    // `new URL` would discard the base's path segment and drop the tenant
+    // prefix (e.g. https://host/tenant-a -> https://host/api/auth/signin).
     const hubUrl = stripTrailingSlashes(process.env.AUTH_HUB_URL);
+    const baseUrl = stripTrailingSlashes(process.env.BASE_URL) ?? '';
     const target = hubUrl
       ? `${hubUrl}${SIGNIN_PATH}?callbackUrl=${callbackUrl}`
-      : new URL(
-          `${SIGNIN_PATH}?callbackUrl=${callbackUrl}`,
-          process.env.BASE_URL,
-        ).toString();
+      : `${baseUrl}${SIGNIN_PATH}?callbackUrl=${callbackUrl}`;
     return NextResponse.redirect(target);
   }
   return NextResponse.next();

--- a/services/ark-dashboard/ark-dashboard/middleware.ts
+++ b/services/ark-dashboard/ark-dashboard/middleware.ts
@@ -32,8 +32,24 @@ function stripTrailingSlashes(value?: string): string | undefined {
   return value.slice(0, end);
 }
 
+// Under a tenant prefix, Next.js does not reliably strip the configured
+// basePath from req.nextUrl.pathname in middleware, so the request arrives as
+// e.g. /tenant-a/api/auth/signin. The public/sign-in allow-list below is
+// expressed with root-absolute paths, so we must normalise the pathname first
+// or /tenant-a/api/auth/signin fails startsWith('/api/auth') and !== SIGNIN_PATH,
+// and the gate redirects the sign-in route to itself forever. No-op when Next
+// already stripped the prefix, or when NEXT_PUBLIC_BASE_PATH is unset (root
+// hosting). Same env var the api-url helper uses; substituted at container start.
+function stripBasePath(pathname: string, basePath: string): string {
+  if (!basePath) return pathname;
+  if (pathname === basePath) return '/';
+  if (pathname.startsWith(`${basePath}/`)) return pathname.slice(basePath.length);
+  return pathname;
+}
+
 export default auth(async (req: NextRequestWithAuth) => {
-  const { pathname } = req.nextUrl;
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+  const pathname = stripBasePath(req.nextUrl.pathname, basePath);
 
   if (
     pathname === '/favicon.ico' ||


### PR DESCRIPTION
## Summary

Ark supports hosting a dashboard (and its ark-api) under a URL path prefix so several tenants can share one host, e.g. `https://mydomain.com/tenant-a/`. The routing is configured correctly at the ingress and through Next.js `basePath`, yet a number of places built or matched URLs that ignored that prefix, so requests were routed to the host root instead of the tenant and either hit the wrong tenant or failed outright. Confirmed on both `v0.1.65-rc` and `v0.1.66-rc`.

Three end-user symptoms, all the same root cause: (1) running an agent never streamed a response — the browser called `https://<host>/api/v1/broker/chunks?...` and failed with "failed to connect to stream", while prepending the tenant segment worked; (2) SSO sign-in bounced in an infinite redirect loop under a tenant prefix; (3) the OIDC callback returned HTTP 400 with `UnknownAction: Cannot parse action at /api/auth/callback/<provider>`, so login with Keycloak never completed.

## Why it happened

Next.js `basePath` transparently prefixes navigation (`<Link>`, the router), static assets, and the app's own route handlers, so most of the dashboard is already correct. What it does **not** touch is a URL string handed to a raw `fetch()` or `new EventSource()` — those go out exactly as written. The dashboard centralises this in the `apiUrl()` helper (and the shared `apiClient`), which prepend `NEXT_PUBLIC_BASE_PATH`; every REST call already flows through it. The streaming paths, however, used raw `fetch`/`EventSource` against root-relative `/api/...` strings and never went through `apiUrl()`, so under a tenant prefix they addressed the host root. The agent chat chunk stream was the one that broke end-user functionality; the broker debug views and the copyable API snippet had the same latent defect.

The SSO path had three related problems, all stemming from how Next.js treats the prefix differently in different places:

1. The middleware that redirects unauthenticated users built its sign-in target with `new URL(SIGNIN_PATH, BASE_URL)`. Since `SIGNIN_PATH` is root-absolute (`/api/auth/signin`), `new URL` discards the base URL's path, collapsing `https://host/tenant-a` to `https://host/api/auth/signin`.

2. The sign-in loop: in **middleware**, Next.js delivers the *prefixed* pathname (e.g. `/tenant-a/api/auth/signin`), but the gate's allow-list (`PUBLIC_PREFIXES`, `SIGNIN_PATH`) is root-absolute. So the sign-in route fails both `startsWith('/api/auth')` and the `SIGNIN_PATH` check, is treated as a protected page, and is redirected to itself forever.

3. The OIDC callback is the mirror image. For **route handlers** Next.js *strips* the basePath before the handler runs, so Auth.js sees `/api/auth/callback/<provider>`. But Auth.js (next-auth v5) derives its own basePath from `AUTH_URL` (`/tenant-a/api/auth`) and matches the incoming pathname against it, so the stripped path fails its action parser (`UnknownAction` → HTTP 400). The `redirect_uri` Auth.js sends to the IdP is built from `AUTH_URL` and already carries the prefix (so login starts and returns) — only the inbound callback is misaligned. This only bites in `AUTH_MODE=sso`: the multi-tenant chart example uses `AUTH_MODE=open`, where NextAuth is never initialised, so the combination was never exercised.

Finally, the same principle was violated server-side in ark-api's A2A gateway. Agent cards advertise the URL other agents must call, but that URL was assembled solely from the static `ARK_A2A_AGENT_CARD_*` environment variables, so a single ark-api fronting path-based tenants could not advertise a per-tenant URL and dropped the prefix — agent-to-agent calls landed on the wrong tenant. ark-api's own OpenAPI handler already honours the standard `X-Forwarded-Prefix` header for exactly this reason; the A2A layer simply hadn't been taught to do the same.

## How it is fixed

On the dashboard the streaming reads and the copyable API snippet now go through the same `apiUrl()`/`NEXT_PUBLIC_BASE_PATH` machinery as the rest of the data layer, so they inherit the tenant prefix like everything else.

The SSO fixes mirror the two Next.js behaviours above. In middleware the prefix is present, so we (a) concatenate the sign-in redirect onto `BASE_URL` instead of using `new URL`, and (b) strip `NEXT_PUBLIC_BASE_PATH` from the incoming pathname before matching the allow-list, breaking the loop. In the OIDC callback route handler the prefix has been stripped, so we do the opposite: wrap the NextAuth GET/POST handlers to re-insert the prefix into the request pathname before Auth.js parses it, leaving `config.basePath` (and therefore the `redirect_uri`) untouched — the request rebuild mirrors next-auth's own `reqWithEnvURL`. The two directions are deliberate (strip where Next left the prefix, re-add where Next removed it), and every one of these is a no-op at the root, so single-tenant and root deployments are unaffected.

In ark-api the agent card URL is now derived from the request when a forwarding gateway is path-routing the deployment. Because the cards are precomputed in a background sync loop with no request context, the fix cannot read the request inside the card builder; instead the A2A `ProxyApp` — which every A2A request passes through — reads `X-Forwarded-Proto/Host/Prefix` and publishes the external base URL into a `contextvar`. Since the proxy forwards over pure ASGI in the same task, that value is visible to the SDK's card handler, where a `card_modifier` rewrites the advertised URL per request (returning a copy, never mutating the shared cached card). The `/a2a/agents` listing builds its link the same way. When no forwarding prefix is present the previous env-based behaviour is unchanged.

While here I audited the rest of the SSO flow against the same principle. The federated sign-out redirect, the login hub's redirect callback, the hub branch of the middleware, and the sign-in route all already preserve the prefix (the first is covered by an existing test). The remaining prefix concerns in SSO are deployment configuration — `AUTH_URL`/`BASE_URL`, the IdP-registered `redirect_uri` and `post_logout_redirect_uri`, and the hub's per-namespace `dashboard-url` annotation must all include the tenant prefix — and are already documented in the multi-tenant chart example.

## How to review

- `services/ark-dashboard/ark-dashboard/lib/services/chat.ts` — the agent chat chunk stream, the call behind the reported "failed to connect to stream".
- `services/ark-dashboard/ark-dashboard/components/chat/embedded-chat-panel.tsx` and `app/(dashboard)/broker/page.tsx` — the broker debug streams/pagination/purge, same pattern.
- `services/ark-dashboard/ark-dashboard/components/dialogs/agents-api-dialog.tsx` — the copyable external endpoint now includes the base path.
- `services/ark-dashboard/ark-dashboard/middleware.ts` — the sign-in redirect concatenates onto `BASE_URL`, and `stripBasePath()` normalises the prefixed pathname before the allow-list check (the sign-in loop fix). Adjacent comments explain both.
- `services/ark-dashboard/ark-dashboard/auth.ts` + `lib/auth/base-path.ts` — `withBasePath` wraps the NextAuth handlers to re-insert the prefix for the OIDC callback; the path logic is the pure `prefixPathname` helper.
- `services/ark-api/ark-api/src/ark_api/api/v1/a2agw/registry.py` — `external_forwarded_base_from_headers` and the `apply_forwarded_url` card modifier (the core logic); `manager.py` publishes the base from the ProxyApp and wires the modifier; `a2a_gateway.py` prefixes the listing link.

## Tests

Dashboard unit tests cover: the chunk stream and the sign-in redirect carry the prefix (the streaming tests mock `apiUrl` with a non-empty base so a regression to a raw `fetch` fails the build); the auth gate passes prefixed public paths through while still redirecting prefixed protected pages with the prefix intact; and `prefixPathname` re-inserts the prefix for the callback path (with no-op cases for the root, an already-prefixed path, and a look-alike sibling path). The ark-api logic is covered at the unit level (`external_forwarded_base_from_headers`, the `apply_forwarded_url` modifier including its no-mutation guarantee) and by an in-process integration test that drives the real ASGI stack — the `ProxyApp` publishing the forwarded base into the contextvar, the SDK serving `.well-known/agent.json` through the `card_modifier` — asserting the served card URL carries the tenant prefix only when `X-Forwarded-Prefix` is present.

The A2A integration test runs in-process with Starlette's test client rather than as a Chainsaw e2e because ark-api is not deployed in the standard Chainsaw environment (that suite installs the controller, apiserver and broker only), so a cluster-level probe would have nothing to reach; the in-process test exercises the same request → contextvar → card-handler path deterministically.