### PR TITLE
chore(ark-dashboard): regenerate generated API types after openai 2.45.0

### DIFF
--- a/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts
@@ -2949,6 +2949,7 @@ export interface components {
          */
         ChatCompletionContentPartImageParam: {
             image_url: components["schemas"]["ImageURL"];
+            prompt_cache_breakpoint?: components["schemas"]["PromptCacheBreakpoint"];
             /**
              * Type
              * @constant
@@ -2961,6 +2962,7 @@ export interface components {
          */
         ChatCompletionContentPartInputAudioParam: {
             input_audio: components["schemas"]["InputAudio"];
+            prompt_cache_breakpoint?: components["schemas"]["PromptCacheBreakpoint"];
             /**
              * Type
              * @constant
@@ -2982,6 +2984,7 @@ export interface components {
          * @description Learn about [text inputs](https://platform.openai.com/docs/guides/text-generation).
          */
         ChatCompletionContentPartTextParam: {
+            prompt_cache_breakpoint?: components["schemas"]["PromptCacheBreakpoint"];
             /** Text */
             text: string;
             /**
@@ -3248,6 +3251,7 @@ export interface components {
          */
         File: {
             file: components["schemas"]["FileFile"];
+            prompt_cache_breakpoint?: components["schemas"]["FilePromptCacheBreakpoint"];
             /**
              * Type
              * @constant
@@ -3271,6 +3275,19 @@ export interface components {
             filename: string;
             /** Mimetype */
             mimeType?: string | null;
+        };
+        /**
+         * FilePromptCacheBreakpoint
+         * @description Marks the exact end of a reusable prompt prefix.
+         *
+         *     The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block.
+         */
+        FilePromptCacheBreakpoint: {
+            /**
+             * Mode
+             * @constant
+             */
+            mode: "explicit";
         };
         /**
          * Function
@@ -3957,6 +3974,19 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "unavailable";
+        };
+        /**
+         * PromptCacheBreakpoint
+         * @description Marks the exact end of a reusable prompt prefix.
+         *
+         *     The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block.
+         */
+        PromptCacheBreakpoint: {
+            /**
+             * Mode
+             * @constant
+             */
+            mode: "explicit";
         };
         /**
          * QueryConfigMapKeyRef


### PR DESCRIPTION
## Summary

`build-and-test-services` has been red on `main` at the **"Check generated types are unchanged"** step, independently of any feature work. This regenerates the dashboard's committed `lib/api/generated/types.ts` from ark-api's OpenAPI and fails if the result differs from what is checked in.

The difference comes from a floating dependency. That build step re-resolves the Python environment with `rm -f uv.lock && uv sync`, so it deliberately ignores the lockfile and pulls the latest releases — currently `openai==2.45.0` (the lockfile still pins `2.44.0`). ark-api embeds OpenAI chat-parameter types in its API surface (e.g. `ChatCompletionMessageParam` in `ark_api/models/queries.py`), and `openai` 2.45.0 adds a `prompt_cache_breakpoint` field plus a `PromptCacheBreakpoint` / `FilePromptCacheBreakpoint` schema to those types. So the regenerated OpenAPI — and therefore the regenerated TypeScript — now carries schema the committed `types.ts` never had, and the guard trips.

Because the drift is produced only when the environment resolves the newer `openai`, it does not reproduce locally against the pinned lockfile, which is why it slipped in: whoever's change first floated onto 2.45.0 in CI didn't refresh the committed types.

## Fix

Regenerate `services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts` against the same inputs CI resolves — a freshly built ark-sdk and `openai==2.45.0` — and commit it. The diff is purely additive (the new `prompt_cache_breakpoint` fields and the two breakpoint schemas); no existing type changed. The OpenAPI JSON is a build artifact (`out/openapi.json`) and is not committed, so only `types.ts` changes here.

## How to review

- `services/ark-dashboard/ark-dashboard/lib/api/generated/types.ts` — generated file; the additions are the `PromptCacheBreakpoint` / `FilePromptCacheBreakpoint` schemas and optional `prompt_cache_breakpoint` fields on the OpenAI content-part / file params.

## Note on the underlying fragility

This will recur: any future `openai` (or other floated dependency) release that touches those embedded schemas will re-break the guard on `main`, since the check re-resolves to latest while the committed types are a point-in-time snapshot. A durable fix is out of scope here but worth considering — either pin `openai` and regenerate deliberately, or have the guard regenerate against the locked (not floated) environment so the committed file and the check share the same inputs.