### PR TITLE
feat: offer marketplace kubernetes-mcp-server as optional CLI install

### DIFF
--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -235,6 +235,19 @@ const defaultArkServices: ServiceCollection = {
     k8sServicePort: 8639,
     k8sDeploymentName: 'noah-mcp',
   },
+
+  'kubernetes-mcp-server': {
+    name: 'kubernetes-mcp-server',
+    helmReleaseName: 'kubernetes-mcp-server',
+    description:
+      'Read-only kubernetes-mcp-server registered with Ark for grounding agents on cluster resources',
+    enabled: false, // Optional - opt in via config override
+    category: 'service',
+    namespace: 'default',
+    chartPath: `${getMarketplaceRegistry()}/kubernetes-mcp-server`,
+    installArgs: ['--create-namespace'],
+    k8sDeploymentName: 'kubernetes-mcp-server',
+  },
 };
 
 function applyConfigOverrides(defaults: ServiceCollection): ServiceCollection {


### PR DESCRIPTION
## Summary
- Register `kubernetes-mcp-server` as a known Ark service in the CLI (`tools/ark-cli/src/arkServices.ts`), pointing at the marketplace chart registry via `getMarketplaceRegistry()` — the same pattern used for `noah` and `file-gateway`.
- Disabled by default (`enabled: false`), so operators opt in via config override, matching `localhost-gateway`.

The chart itself is published from the marketplace: mckinsey/agents-at-scale-marketplace#327. This replaces the in-tree deployment proposed in #2758, which is being closed in favor of shipping from the marketplace.