### PR TITLE
fix: unblock Query TTL GC when finalizer is present (#2828)

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -115,12 +115,16 @@ func (r *QueryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// longer than its TTL. TTL is measured from completion, not creation,
 	// so long-running or queued queries are never reaped mid-flight.
 	// TTL may be nil when using aggregated API server (non-CRD storage).
-	if ttlRemaining(&obj) < 0 && isTerminalPhase(obj.Status.Phase) {
+	if ttlRemaining(&obj) < 0 && isTerminalPhase(obj.Status.Phase) && obj.DeletionTimestamp.IsZero() {
 		if err := r.Delete(ctx, &obj); err != nil {
 			log.Error(err, "unable to delete object")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
+		// Refetch so handleFinalizer below sees the DeletionTimestamp
+		// and clears the finalizer in this same reconcile (#2828).
+		if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
 	}
 
 	if result, err := r.handleFinalizer(ctx, &obj); result != nil {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -532,6 +532,10 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 	ctx := context.Background()
 
 	It("deletes a terminal-phase Query whose TTL has elapsed since completion", func() {
+		// Also covers #2828: with the finalizer present, r.Delete only
+		// marks the Query Terminating, so Reconcile must reach
+		// handleFinalizer in the same pass to clear the finalizer.
+		// Without it the Query stays Terminating forever.
 		name := "ttl-elapsed-terminal-query"
 		key := types.NamespacedName{Name: name, Namespace: "default"}
 
@@ -544,6 +548,10 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		}
 		Expect(query.Spec.SetInputString("hello")).To(Succeed())
 		Expect(k8sClient.Create(ctx, query)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		controllerutil.AddFinalizer(query, finalizer)
+		Expect(k8sClient.Update(ctx, query)).To(Succeed())
 
 		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
 		query.Status.Phase = statusDone
@@ -561,7 +569,7 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		err = k8sClient.Get(ctx, key, &arkv1alpha1.Query{})
-		Expect(errors.IsNotFound(err)).To(BeTrue(), "Query should be deleted when terminal phase + TTL elapsed since completion")
+		Expect(errors.IsNotFound(err)).To(BeTrue(), "Query should be fully reaped when terminal phase + TTL elapsed, not stuck Terminating with finalizer")
 	})
 
 	It("does NOT delete a non-terminal Query even when its TTL has elapsed since creation", func() {
@@ -671,57 +679,6 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		Expect(k8sClient.Delete(ctx, &refetched)).To(Succeed())
 	})
 
-	It("finalizes and removes the finalizer on a terminal, TTL-expired Query so it does not get stuck in Terminating", func() {
-		// Regression test for #2828: once the GC guard sets deletionTimestamp
-		// on a terminal-phase, TTL-expired Query, subsequent reconciles must
-		// reach handleFinalizer so the broker cleanup runs and the finalizer
-		// is removed. Previously Reconcile returned early at the TTL guard,
-		// so a Query carrying the query.ark.mckinsey.com finalizer stayed in
-		// Terminating forever.
-		name := "ttl-elapsed-terminal-with-finalizer"
-		key := types.NamespacedName{Name: name, Namespace: "default"}
-
-		query := &arkv1alpha1.Query{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-			Spec: arkv1alpha1.QuerySpec{
-				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
-				TTL:    &metav1.Duration{Duration: time.Nanosecond},
-			},
-		}
-		Expect(query.Spec.SetInputString("hello")).To(Succeed())
-		Expect(k8sClient.Create(ctx, query)).To(Succeed())
-
-		// Add the finalizer so r.Delete only marks the object Terminating
-		// instead of reaping it immediately.
-		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
-		controllerutil.AddFinalizer(query, finalizer)
-		Expect(k8sClient.Update(ctx, query)).To(Succeed())
-
-		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
-		query.Status.Phase = statusDone
-		query.Status.Conditions = []metav1.Condition{{
-			Type:               string(arkv1alpha1.QueryCompleted),
-			Status:             metav1.ConditionTrue,
-			Reason:             "QuerySucceeded",
-			Message:            "Query completed successfully",
-			LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
-		}}
-		Expect(k8sClient.Status().Update(ctx, query)).To(Succeed())
-
-		r := &QueryReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-		}
-
-		// Reconcile must both issue r.Delete AND clear the finalizer so
-		// the API server can reap the object; before the fix, Reconcile
-		// returned right after r.Delete and looped forever on the guard.
-		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
-		Expect(err).NotTo(HaveOccurred())
-
-		err = k8sClient.Get(ctx, key, &arkv1alpha1.Query{})
-		Expect(errors.IsNotFound(err)).To(BeTrue(), "terminal, TTL-expired Query with finalizer must be reaped, not stuck Terminating")
-	})
 })
 
 var _ = Describe("Query Controller Fallback Raw", func() {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -670,6 +670,58 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		Expect(k8sClient.Update(ctx, &refetched)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, &refetched)).To(Succeed())
 	})
+
+	It("finalizes and removes the finalizer on a terminal, TTL-expired Query so it does not get stuck in Terminating", func() {
+		// Regression test for #2828: once the GC guard sets deletionTimestamp
+		// on a terminal-phase, TTL-expired Query, subsequent reconciles must
+		// reach handleFinalizer so the broker cleanup runs and the finalizer
+		// is removed. Previously Reconcile returned early at the TTL guard,
+		// so a Query carrying the query.ark.mckinsey.com finalizer stayed in
+		// Terminating forever.
+		name := "ttl-elapsed-terminal-with-finalizer"
+		key := types.NamespacedName{Name: name, Namespace: "default"}
+
+		query := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				TTL:    &metav1.Duration{Duration: time.Nanosecond},
+			},
+		}
+		Expect(query.Spec.SetInputString("hello")).To(Succeed())
+		Expect(k8sClient.Create(ctx, query)).To(Succeed())
+
+		// Add the finalizer so r.Delete only marks the object Terminating
+		// instead of reaping it immediately.
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		controllerutil.AddFinalizer(query, finalizer)
+		Expect(k8sClient.Update(ctx, query)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, key, query)).To(Succeed())
+		query.Status.Phase = statusDone
+		query.Status.Conditions = []metav1.Condition{{
+			Type:               string(arkv1alpha1.QueryCompleted),
+			Status:             metav1.ConditionTrue,
+			Reason:             "QuerySucceeded",
+			Message:            "Query completed successfully",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+		}}
+		Expect(k8sClient.Status().Update(ctx, query)).To(Succeed())
+
+		r := &QueryReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		// Reconcile must both issue r.Delete AND clear the finalizer so
+		// the API server can reap the object; before the fix, Reconcile
+		// returned right after r.Delete and looped forever on the guard.
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Get(ctx, key, &arkv1alpha1.Query{})
+		Expect(errors.IsNotFound(err)).To(BeTrue(), "terminal, TTL-expired Query with finalizer must be reaped, not stuck Terminating")
+	})
 })
 
 var _ = Describe("Query Controller Fallback Raw", func() {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -678,7 +678,6 @@ var _ = Describe("Query Controller Reconcile TTL GC guard", func() {
 		Expect(k8sClient.Update(ctx, &refetched)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, &refetched)).To(Succeed())
 	})
-
 })
 
 var _ = Describe("Query Controller Fallback Raw", func() {

--- a/ark/internal/controller/query_controller_ttl_test.go
+++ b/ark/internal/controller/query_controller_ttl_test.go
@@ -1,0 +1,106 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+func TestReconcileTTLGuardErrorPaths(t *testing.T) {
+	key := types.NamespacedName{Name: "q", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+
+	buildQuery := func(withFinalizer bool) *arkv1alpha1.Query {
+		q := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "a"},
+				TTL:    &metav1.Duration{Duration: time.Nanosecond},
+			},
+			Status: arkv1alpha1.QueryStatus{
+				Phase: statusDone,
+				Conditions: []metav1.Condition{{
+					Type:               string(arkv1alpha1.QueryCompleted),
+					Status:             metav1.ConditionTrue,
+					Reason:             "QuerySucceeded",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+				}},
+			},
+		}
+		if withFinalizer {
+			q.Finalizers = []string{finalizer}
+		}
+		return q
+	}
+
+	t.Run("returns error when Delete fails", func(t *testing.T) {
+		deleteErr := errors.New("boom-delete")
+		c := fake.NewClientBuilder().WithScheme(newTestScheme()).
+			WithObjects(buildQuery(true)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+					return deleteErr
+				},
+			}).Build()
+		r := &QueryReconciler{Client: c, Scheme: c.Scheme()}
+
+		_, err := r.Reconcile(context.Background(), req)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, deleteErr)
+	})
+
+	t.Run("returns error when refetch after Delete fails", func(t *testing.T) {
+		getErr := errors.New("boom-refetch")
+		var gets int
+		c := fake.NewClientBuilder().WithScheme(newTestScheme()).
+			WithObjects(buildQuery(true)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, k client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					gets++
+					if gets >= 2 {
+						return getErr
+					}
+					return cl.Get(ctx, k, obj, opts...)
+				},
+			}).Build()
+		r := &QueryReconciler{Client: c, Scheme: c.Scheme()}
+
+		_, err := r.Reconcile(context.Background(), req)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, getErr)
+	})
+
+	t.Run("swallows NotFound on refetch after Delete reaps object", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(newTestScheme()).
+			WithObjects(buildQuery(false)).
+			Build()
+		r := &QueryReconciler{Client: c, Scheme: c.Scheme()}
+
+		_, err := r.Reconcile(context.Background(), req)
+
+		require.NoError(t, err)
+		var got arkv1alpha1.Query
+		err = c.Get(context.Background(), key, &got)
+		assert.True(t, apierrors.IsNotFound(err), "object should be gone after guard")
+	})
+}

--- a/tests/query-ttl-gc-deletion/README.md
+++ b/tests/query-ttl-gc-deletion/README.md
@@ -1,0 +1,15 @@
+# query-ttl-gc-deletion
+
+Regression for [#2828](https://github.com/mckinsey/agents-at-scale-ark/issues/2828): a terminal-phase Query whose TTL elapses must be fully reaped, not stuck in `Terminating` with the `ark.mckinsey.com/finalizer` blocking it.
+
+## What it tests
+- A query with `spec.ttl: 10s` completes with `phase: done`
+- The `ark.mckinsey.com/finalizer` is present after completion
+- The Query is fully deleted (finalizer removed, object gone) within 2m of TTL expiry
+
+Before the #2828 fix the controller's TTL guard called `r.Delete` and returned before `handleFinalizer`, so the finalizer was never removed and the object stayed in `Terminating` forever. This test's final `wait for: deletion: {}` step would time out.
+
+## Running
+```bash
+chainsaw test
+```

--- a/tests/query-ttl-gc-deletion/chainsaw-test.yaml
+++ b/tests/query-ttl-gc-deletion/chainsaw-test.yaml
@@ -1,0 +1,115 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: query-ttl-gc-deletion
+spec:
+  description: Regression for #2828 - a terminal Query whose TTL elapses must be fully reaped, not stuck in Terminating with the query finalizer.
+  timeouts:
+    delete: 15s
+    cleanup: 30s
+  steps:
+  - name: setup-mock-llm
+    try:
+    - script:
+        timeout: 180s
+        content: |
+          bash ../shared/install-mock-llm.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: wait-for-model-ready
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Model
+        name: test-model-mock
+        timeout: 90s
+        for:
+          condition:
+            name: ModelAvailable
+            value: 'True'
+
+  - name: run-query-with-short-ttl
+    try:
+    - apply:
+        file: manifests/a00-rbac.yaml
+    - apply:
+        file: manifests/a00-memory.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Memory
+        name: default
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.lastResolvedAddress}'
+    - apply:
+        file: manifests/a01-agent.yaml
+    - apply:
+        file: manifests/a02-query.yaml
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: ttl-gc-deletion-query
+        timeout: 4m
+        for:
+          jsonPath:
+            path: '{.status.response.content}'
+    - assert:
+        timeout: 1s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: ttl-gc-deletion-query
+          status:
+            phase: done
+            (response != null): true
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: ttl-gc-deletion-query
+
+  - name: assert-finalizer-was-added
+    try:
+    - assert:
+        timeout: 5s
+        resource:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          metadata:
+            name: ttl-gc-deletion-query
+            finalizers:
+            - ark.mckinsey.com/finalizer
+    catch:
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: ttl-gc-deletion-query
+
+  - name: wait-for-ttl-triggered-deletion
+    try:
+    - wait:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: ttl-gc-deletion-query
+        timeout: 15s
+        for:
+          deletion: {}
+    catch:
+    - events: {}
+    - describe:
+        apiVersion: ark.mckinsey.com/v1alpha1
+        kind: Query
+        name: ttl-gc-deletion-query
+
+    cleanup:
+    - script:
+        content: |
+          helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=60s || true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)

--- a/tests/query-ttl-gc-deletion/manifests/a00-memory.yaml
+++ b/tests/query-ttl-gc-deletion/manifests/a00-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Memory
+metadata:
+  name: default
+spec:
+  address:
+    valueFrom:
+      serviceRef:
+        name: ark-broker
+        namespace: default
+        port: http

--- a/tests/query-ttl-gc-deletion/manifests/a00-rbac.yaml
+++ b/tests/query-ttl-gc-deletion/manifests/a00-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: query-ttl-gc-deletion-role
+rules:
+- apiGroups: ["ark.mckinsey.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: query-ttl-gc-deletion-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ($namespace)
+roleRef:
+  kind: Role
+  name: query-ttl-gc-deletion-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/query-ttl-gc-deletion/manifests/a01-agent.yaml
+++ b/tests/query-ttl-gc-deletion/manifests/a01-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: ttl-gc-agent
+spec:
+  prompt: You are a helpful assistant.
+  modelRef:
+    name: test-model-mock

--- a/tests/query-ttl-gc-deletion/manifests/a02-query.yaml
+++ b/tests/query-ttl-gc-deletion/manifests/a02-query.yaml
@@ -1,0 +1,10 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: ttl-gc-deletion-query
+spec:
+  input: What is 2+2?
+  target:
+    type: agent
+    name: ttl-gc-agent
+  ttl: "5s"

--- a/tests/query-ttl-gc-deletion/mock-llm-values.yaml
+++ b/tests/query-ttl-gc-deletion/mock-llm-values.yaml
@@ -1,0 +1,24 @@
+config:
+  rules:
+  - path: "/v1/models"
+    method: "GET"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "list",
+          "data": [{"id": "gpt-4.1-mini", "object": "model", "owned_by": "openai"}]
+        }
+
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "id": "mock-{{timestamp}}",
+          "object": "chat.completion",
+          "model": "{{jmes request body.model}}",
+          "choices": [{"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+        }


### PR DESCRIPTION
## Summary
- Fix: after `r.Delete` in the Query TTL GC guard, refetch and fall through to `handleFinalizer` so the finalizer is cleared in the same reconcile instead of the object staying `Terminating` forever
- Add envtest reproducer covering the terminal + TTL-expired + finalizer-present case
- Add chainsaw regression test `tests/query-ttl-gc-deletion/` 

Closes #2828