### PR TITLE
chore: openspec-flow setup

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -1,0 +1,40 @@
+# Maintained by openspec-flow. Edit the `uses:` ref to upgrade.
+# Docs: https://github.com/dwmkerr/openspec-flow
+name: openspec-flow
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled, closed]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+# Reusable workflows can only declare permissions UP TO what the caller
+# grants. Without this block the reusable workflow's `contents: write`
+# request is rejected with: "is requesting 'contents: write, issues:
+# write, pull-requests: write', but is only allowed 'contents: read…'".
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  # Required by the OIDC token broker path: the reusable workflow
+  # requests a GitHub-signed OIDC token and exchanges it for an App
+  # installation token at openspec-flow.example.com/api/token. Without
+  # this permission the broker exchange falls through to the legacy
+  # App secret path (or GITHUB_TOKEN, which cannot push workflow
+  # files).
+  id-token: write
+jobs:
+  # Identity: by default openspec-flow runs as github-actions[bot] (via
+  # GITHUB_TOKEN) — fine to try it out, but it cannot push changes under
+  # .github/workflows/. For openspec-flow[bot] identity, install the App
+  # (https://github.com/apps/openspec-flow) and set the
+  # OPENSPEC_FLOW_BROKER_URL variable, or add a `with:` block setting
+  # oidc-broker-url. See the docs for details.
+  flow:
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@v0.1.5
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}
+      OPENSPEC_FLOW_PRIVATE_KEY: ${{ secrets.OPENSPEC_FLOW_PRIVATE_KEY || '' }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- openspec-flow badge-start -->
+[![openspec-flow](https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/openspec-flow.yml/badge.svg)](https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/openspec-flow.yml)
+<!-- openspec-flow badge-end -->
+
 <div align="center">
   <h1 align="center"><code>⚒️ ark</code></h1>
   <h4 align="center">Agentic Runtime for Kubernetes</h4>
@@ -77,3 +81,16 @@ To troubleshoot an installation, run `ark status`.
 ## Credits
 
 The initial design and implementation of Ark was led by [Roman Galeev](https://github.com/Roman-Galeev), [Dave Kerr](https://github.com/dwmkerr), and [Chris Madden](https://github.com/cm94242).
+
+<!-- openspec-flow install-start -->
+## openspec-flow
+
+This repo uses [openspec-flow](https://github.com/dwmkerr/openspec-flow) to drive spec-driven development from GitHub issues.
+
+1. Open an issue describing the feature, fix, or task.
+2. Add the `openspec:go` label.
+3. openspec-flow opens a **spec PR** (`openspec:spec`). Review, comment, iterate (add `openspec:go` to the PR to re-run). Merge when happy.
+4. openspec-flow opens an **impl PR** (`openspec:impl`). Review, iterate, merge. The originating issue closes automatically.
+
+Required Actions secret: `ANTHROPIC_API_KEY`.
+<!-- openspec-flow install-end -->


### PR DESCRIPTION
## Summary
- Trial [openspec-flow](https://github.com/dwmkerr/openspec-flow): label an issue `openspec:go` → spec PR → merge → impl PR
- Adds the workflow shim (`.github/workflows/openspec-flow.yml`, pinned @v0.1.5) + a README block
- Runs as **github-actions[bot]** for now (no App identity); labels `openspec:go`/`openspec:spec`/`openspec:impl` created on the repo

Draft for review before enabling on main.