### PR TITLE
fix: address CVEs from issue #2838 (js-yaml 4.3.0, Go 1.26.5)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -238,7 +238,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -1125,7 +1125,7 @@ jobs:
       - name: Setup Go for coverage tools
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           # Coverage tooling only; no project build, so module caching has no value here.
           cache: false
 
@@ -1367,7 +1367,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.5'
           # goreleaser builds tools/fark; cache against its go.sum.
           cache-dependency-path: tools/fark/go.sum
 

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -99,7 +99,7 @@ jobs:
         if: steps.check-coverage.outputs.found == 'false'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: ark/go.sum
 

--- a/ark/Dockerfile
+++ b/ark/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26.5-bookworm AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG ENABLE_COVERAGE=false

--- a/ark/go.mod
+++ b/ark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "y",
-  "version": "0.1.65",
+  "version": "0.1.66-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "y",
-      "version": "0.1.65",
+      "version": "0.1.66-rc",
       "license": "ISC",
       "dependencies": {
         "@napi-rs/simple-git": "^0.1.19",
@@ -24,7 +24,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.5",
         "http-server": "^14.1.1",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.0",
         "jsdom": "^29.1.1",
         "linkinator": "^7.6.1",
         "pagefind": "^1.5.2",
@@ -1371,9 +1371,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1389,9 +1386,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1409,9 +1403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,9 +1418,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5289,9 +5277,9 @@
       "peer": true
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.5",
     "http-server": "^14.1.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "jsdom": "^29.1.1",
     "linkinator": "^7.6.1",
     "pagefind": "^1.5.2",

--- a/images/ark-tools/Dockerfile
+++ b/images/ark-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS fark-builder
+FROM golang:1.26.5-alpine AS fark-builder
 
 WORKDIR /build
 

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ark-broker",
-  "version": "0.1.65",
+  "version": "0.1.66-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ark-broker",
-      "version": "0.1.65",
+      "version": "0.1.66-rc",
       "dependencies": {
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6681,9 +6681,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -74,6 +74,10 @@
     "node": ">=22.0.0"
   },
   "overrides": {
+    "js-yaml": "^4.3.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.0"
+    },
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",
     "qs": "^6.15.2",

--- a/services/ark-dashboard/ark-dashboard/package-lock.json
+++ b/services/ark-dashboard/ark-dashboard/package-lock.json
@@ -38,7 +38,7 @@
         "file-saver": "^2.0.5",
         "git-url-parse": "^16.1.0",
         "jotai": "^2.15.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
         "mermaid": "^11.15.0",
@@ -2594,19 +2594,6 @@
       "engines": {
         "node": ">=18.17.0",
         "npm": ">=9.5.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -8470,9 +8457,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/services/ark-dashboard/ark-dashboard/package.json
+++ b/services/ark-dashboard/ark-dashboard/package.json
@@ -45,7 +45,7 @@
     "file-saver": "^2.0.5",
     "git-url-parse": "^16.1.0",
     "jotai": "^2.15.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",
     "mermaid": "^11.15.0",
@@ -101,6 +101,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
+    "js-yaml": "^4.3.0",
     "tar": "^7.5.11",
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",

--- a/services/ark-landing-page/package-lock.json
+++ b/services/ark-landing-page/package-lock.json
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5125,9 +5125,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/services/ark-landing-page/package.json
+++ b/services/ark-landing-page/package.json
@@ -33,6 +33,10 @@
     "typescript": "5.7.3"
   },
   "overrides": {
+    "js-yaml": "^4.3.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.0"
+    },
     "brace-expansion": ">=5.0.7",
     "jsonpath-plus": "^10.3.0",
     "tough-cookie": "^4.1.3",

--- a/templates/mcp-server/Dockerfile
+++ b/templates/mcp-server/Dockerfile
@@ -63,7 +63,7 @@ ENTRYPOINT [ "/bin/bash", "-c", "mcp-proxy --debug --port 8080 --host 0.0.0.0 --
 {{- end }}
 
 {{- else if eq .Values.technology "go" }}
-FROM golang:1.26.4-alpine AS go-builder
+FROM golang:1.26.5-alpine AS go-builder
 {{- if .Values.packageSource }}
 {{- if eq .Values.packageSource "go-install" }}
 RUN go install {{ .Values.packageName }}@latest

--- a/tools/fark/Dockerfile
+++ b/tools/fark/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tools/fark/go.mod
+++ b/tools/fark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark/tools/fark
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
Closes #2838. Supersedes #2839.

## Summary

- **CVE-2026-59869 (js-yaml)** — direct bump to `^4.3.0` in `docs` and `services/ark-dashboard`; adds npm `overrides` in `services/ark-landing-page` and `services/ark-broker/ark-broker` (both had transitive-only vulnerable copies).
- **CVE-2026-39822 (Go)** — fixed in Go **1.26.5** (July 8, 2026 patch release), not 1.27 as #2839 claimed. Bumped `go 1.26.4` → `1.26.5` in `ark/go.mod` and `tools/fark/go.mod`, plus every `Dockerfile` and CI `setup-go` pin.

## js-yaml override strategy

Four lockfiles had vulnerable js-yaml versions. Direct declarations in two, transitive-only in the other two:

| Location | Direct | Transitive | Fix |
|---|---|---|---|
| `docs` | 4.2.0 | — | direct bump |
| `services/ark-dashboard/ark-dashboard` | 4.1.1 + nested via `@redocly/openapi-core` | — | direct bump + `overrides.js-yaml: ^4.3.0` |
| `services/ark-landing-page` | — | 4.1.1 (via `@kubernetes/client-node`), 3.14.2 (via `@istanbuljs/load-nyc-config`) | two overrides (see below) |
| `services/ark-broker/ark-broker` | — | 4.1.1 (via `@apidevtools/json-schema-ref-parser`), 3.14.2 (via `@istanbuljs/load-nyc-config`) | two overrides |

The two-override pattern is deliberate: `@istanbuljs/load-nyc-config` requires js-yaml `^3.13.1` and uses `safeLoad`, which was removed in js-yaml 4.x. So the 4.x consumers get collapsed to `^4.3.0`, and the istanbul chain is pinned to `^3.15.0` (the fixed 3.x release):

```json
"overrides": {
  "js-yaml": "^4.3.0",
  "@istanbuljs/load-nyc-config": {
    "js-yaml": "^3.15.0"
  }
}
```

## Go patch bump scope

- `ark/go.mod`, `tools/fark/go.mod`: `go 1.26.4` → `1.26.5`
- Dockerfiles: `ark/`, `tools/fark/`, `images/ark-tools/`, `templates/mcp-server/`
- CI: `.github/workflows/cicd.yaml` (4 occurrences), `.github/workflows/sonar_scan.yaml` — these were still on `1.26.2` and relied on the GOTOOLCHAIN=auto machinery to download 1.26.4 for the actual build; now aligned to 1.26.5.

## Why this supersedes #2839

- #2839 targeted only two package.json files (missed the transitive 3.14.2 flagged by Xray and the two other packages).
- #2839 deferred CVE-2026-39822 on the incorrect assumption that Go 1.27 was required.
- The automated tool that authored #2839 also corrupted the four package.json/lock files it did touch (23,055 line deletions replaced with garbled base64), so that branch cannot be fast-forwarded to a clean state.

## Local verification

- `go build ./...` passes in `ark/` and `tools/fark/` (toolchain auto-downloads 1.26.5)
- `make test` in `ark/` — all specs green
- `npm run build` in `services/ark-dashboard/ark-dashboard`
- All four lockfiles resolve to `js-yaml@4.3.0` at top level, with `@istanbuljs/js-yaml@3.15.0` for the istanbul chain (verified via lockfile inspection)
- `make lint` in `ark/` reports two pre-existing `goconst` warnings in files identical to `origin/main` — not caused by this branch