### PR TITLE
feat: surface cached tokens for Anthropic/Bedrock prompt caching

### DIFF
--- a/ark/api/v1alpha1/query_types.go
+++ b/ark/api/v1alpha1/query_types.go
@@ -134,6 +134,7 @@ type TokenUsage struct {
 	PromptTokens     int64 `json:"promptTokens,omitempty"`
 	CompletionTokens int64 `json:"completionTokens,omitempty"`
 	TotalTokens      int64 `json:"totalTokens,omitempty"`
+	CachedTokens     int64 `json:"cachedTokens,omitempty"`
 }
 
 type QueryStatus struct {

--- a/ark/config/crd/bases/ark.mckinsey.com_queries.yaml
+++ b/ark/config/crd/bases/ark.mckinsey.com_queries.yaml
@@ -516,6 +516,9 @@ spec:
                 type: object
               tokenUsage:
                 properties:
+                  cachedTokens:
+                    format: int64
+                    type: integer
                   completionTokens:
                     format: int64
                     type: integer

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_queries.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_queries.yaml
@@ -522,6 +522,9 @@ spec:
                 type: object
               tokenUsage:
                 properties:
+                  cachedTokens:
+                    format: int64
+                    type: integer
                   completionTokens:
                     format: int64
                     type: integer

--- a/ark/executors/completions/anthropic_format.go
+++ b/ark/executors/completions/anthropic_format.go
@@ -36,16 +36,32 @@ func extractMessageContent(msg Message) (string, string) {
 	return "", ""
 }
 
+type anthropicCacheControl struct {
+	Type string `json:"type"`
+}
+
+type anthropicSystemBlock struct {
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+type anthropicMessageContent struct {
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
 type anthropicMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
 }
 
 type anthropicRequest struct {
 	Messages         []anthropicMessage     `json:"messages"`
 	MaxTokens        int                    `json:"max_tokens"`
 	Temperature      float64                `json:"temperature"`
-	SystemPrompt     string                 `json:"system,omitempty"`
+	SystemPrompt     []anthropicSystemBlock `json:"system,omitempty"`
 	AnthropicVersion string                 `json:"anthropic_version,omitempty"`
 	Tools            []anthropicTool        `json:"tools,omitempty"`
 	ToolChoice       map[string]interface{} `json:"tool_choice,omitempty"`
@@ -53,9 +69,10 @@ type anthropicRequest struct {
 }
 
 type anthropicTool struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	InputSchema map[string]interface{} `json:"input_schema"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	InputSchema  map[string]interface{} `json:"input_schema"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 
 type anthropicResponse struct {
@@ -64,8 +81,10 @@ type anthropicResponse struct {
 	Model      string             `json:"model"`
 	StopReason string             `json:"stop_reason"`
 	Usage      struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 	} `json:"usage"`
 }
 
@@ -77,9 +96,14 @@ type anthropicContent struct {
 	Input map[string]interface{} `json:"input,omitempty"`
 }
 
-func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, string) {
-	var result []anthropicMessage
-	var systemPrompt string
+func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, []anthropicSystemBlock) {
+	type collectedMessage struct {
+		role string
+		text string
+	}
+
+	var collected []collectedMessage
+	var systemBlocks []anthropicSystemBlock
 
 	for _, msg := range messages {
 		content, role := extractMessageContent(msg)
@@ -89,20 +113,44 @@ func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, string)
 
 		switch role {
 		case RoleSystem:
-			systemPrompt = content
+			systemBlocks = []anthropicSystemBlock{
+				{
+					Type:         "text",
+					Text:         content,
+					CacheControl: &anthropicCacheControl{Type: "ephemeral"},
+				},
+			}
 		case RoleUser, RoleAssistant, RoleTool:
 			msgRole := role
 			if role == RoleTool {
 				msgRole = RoleUser
 			}
-			result = append(result, anthropicMessage{
-				Role:    msgRole,
-				Content: content,
-			})
+			collected = append(collected, collectedMessage{role: msgRole, text: content})
 		}
 	}
 
-	return result, systemPrompt
+	cacheIndex := -1
+	if len(collected) >= 2 {
+		cacheIndex = len(collected) - 2
+	}
+
+	result := make([]anthropicMessage, len(collected))
+	for i, m := range collected {
+		if i == cacheIndex {
+			block := []anthropicMessageContent{
+				{
+					Type:         "text",
+					Text:         m.text,
+					CacheControl: &anthropicCacheControl{Type: "ephemeral"},
+				},
+			}
+			result[i] = anthropicMessage{Role: m.role, Content: mustMarshalRaw(block)}
+		} else {
+			result[i] = anthropicMessage{Role: m.role, Content: mustMarshalRaw(m.text)}
+		}
+	}
+
+	return result, systemBlocks
 }
 
 func convertAnthropicResponse(response anthropicResponse) *openai.ChatCompletion {
@@ -143,6 +191,10 @@ func convertAnthropicResponse(response anthropicResponse) *openai.ChatCompletion
 		message.ToolCalls = toolCalls
 	}
 
+	promptTokens := int64(response.Usage.InputTokens +
+		response.Usage.CacheCreationInputTokens +
+		response.Usage.CacheReadInputTokens)
+
 	return &openai.ChatCompletion{
 		ID:     response.ID,
 		Object: "chat.completion",
@@ -155,9 +207,12 @@ func convertAnthropicResponse(response anthropicResponse) *openai.ChatCompletion
 			},
 		},
 		Usage: openai.CompletionUsage{
-			PromptTokens:     int64(response.Usage.InputTokens),
+			PromptTokens:     promptTokens,
 			CompletionTokens: int64(response.Usage.OutputTokens),
-			TotalTokens:      int64(response.Usage.InputTokens + response.Usage.OutputTokens),
+			TotalTokens:      promptTokens + int64(response.Usage.OutputTokens),
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: int64(response.Usage.CacheReadInputTokens),
+			},
 		},
 	}
 }
@@ -183,10 +238,14 @@ func convertToolsToAnthropic(tools []openai.ChatCompletionToolParam) []anthropic
 		}
 	}
 
+	if len(result) > 0 {
+		result[len(result)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+	}
+
 	return result
 }
 
-func buildAnthropicRequest(messages []anthropicMessage, systemPrompt string, tools []anthropicTool, toolChoice ToolChoice, properties map[string]string) anthropicRequest {
+func buildAnthropicRequest(messages []anthropicMessage, systemPrompt []anthropicSystemBlock, tools []anthropicTool, toolChoice ToolChoice, properties map[string]string) anthropicRequest {
 	temperature := getFloatProperty(properties, "temperature", 1.0)
 	maxTokens := getIntProperty(properties, "max_tokens", 4096)
 
@@ -248,4 +307,12 @@ func mustMarshalJSON(v interface{}) string {
 		return "{}"
 	}
 	return string(data)
+}
+
+func mustMarshalRaw(v interface{}) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`""`)
+	}
+	return json.RawMessage(data)
 }

--- a/ark/executors/completions/anthropic_format_test.go
+++ b/ark/executors/completions/anthropic_format_test.go
@@ -10,16 +10,20 @@ import (
 )
 
 func TestConvertMessagesToAnthropic(t *testing.T) {
-	t.Run("extracts system prompt", func(t *testing.T) {
+	t.Run("extracts system prompt as cached block", func(t *testing.T) {
 		messages := []Message{
 			NewSystemMessage("You are helpful"),
 			NewUserMessage("Hello"),
 		}
-		result, systemPrompt := convertMessagesToAnthropic(messages)
-		assert.Equal(t, "You are helpful", systemPrompt)
+		result, systemBlocks := convertMessagesToAnthropic(messages)
+		require.Len(t, systemBlocks, 1)
+		assert.Equal(t, "text", systemBlocks[0].Type)
+		assert.Equal(t, "You are helpful", systemBlocks[0].Text)
+		require.NotNil(t, systemBlocks[0].CacheControl)
+		assert.Equal(t, "ephemeral", systemBlocks[0].CacheControl.Type)
 		require.Len(t, result, 1)
 		assert.Equal(t, "user", result[0].Role)
-		assert.Equal(t, "Hello", result[0].Content)
+		assert.Equal(t, json.RawMessage(`"Hello"`), result[0].Content)
 	})
 
 	t.Run("converts user and assistant messages", func(t *testing.T) {
@@ -28,12 +32,38 @@ func TestConvertMessagesToAnthropic(t *testing.T) {
 			NewAssistantMessage("Hello!"),
 			NewUserMessage("How are you?"),
 		}
-		result, systemPrompt := convertMessagesToAnthropic(messages)
-		assert.Empty(t, systemPrompt)
+		result, systemBlocks := convertMessagesToAnthropic(messages)
+		assert.Empty(t, systemBlocks)
 		require.Len(t, result, 3)
 		assert.Equal(t, "user", result[0].Role)
 		assert.Equal(t, "assistant", result[1].Role)
 		assert.Equal(t, "user", result[2].Role)
+	})
+
+	t.Run("marks penultimate message with cache_control", func(t *testing.T) {
+		messages := []Message{
+			NewUserMessage("Hi"),
+			NewAssistantMessage("Hello!"),
+			NewUserMessage("How are you?"),
+		}
+		result, _ := convertMessagesToAnthropic(messages)
+		require.Len(t, result, 3)
+
+		var blocks []anthropicMessageContent
+		require.NoError(t, json.Unmarshal(result[1].Content, &blocks))
+		require.Len(t, blocks, 1)
+		assert.Equal(t, "Hello!", blocks[0].Text)
+		require.NotNil(t, blocks[0].CacheControl)
+		assert.Equal(t, "ephemeral", blocks[0].CacheControl.Type)
+
+		assert.Equal(t, json.RawMessage(`"How are you?"`), result[2].Content)
+	})
+
+	t.Run("no cache breakpoint with single message", func(t *testing.T) {
+		messages := []Message{NewUserMessage("only one")}
+		result, _ := convertMessagesToAnthropic(messages)
+		require.Len(t, result, 1)
+		assert.Equal(t, json.RawMessage(`"only one"`), result[0].Content)
 	})
 
 	t.Run("skips empty messages", func(t *testing.T) {
@@ -43,7 +73,7 @@ func TestConvertMessagesToAnthropic(t *testing.T) {
 		}
 		result, _ := convertMessagesToAnthropic(messages)
 		require.Len(t, result, 1)
-		assert.Equal(t, "hello", result[0].Content)
+		assert.Equal(t, json.RawMessage(`"hello"`), result[0].Content)
 	})
 }
 
@@ -57,8 +87,10 @@ func TestConvertAnthropicResponse(t *testing.T) {
 				{Type: "text", Text: "Hello!"},
 			},
 			Usage: struct {
-				InputTokens  int `json:"input_tokens"`
-				OutputTokens int `json:"output_tokens"`
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 			}{InputTokens: 10, OutputTokens: 5},
 		}
 
@@ -71,6 +103,26 @@ func TestConvertAnthropicResponse(t *testing.T) {
 		assert.Equal(t, int64(10), result.Usage.PromptTokens)
 		assert.Equal(t, int64(5), result.Usage.CompletionTokens)
 		assert.Equal(t, int64(15), result.Usage.TotalTokens)
+	})
+
+	t.Run("folds cache tokens into prompt and total", func(t *testing.T) {
+		response := anthropicResponse{
+			ID:         "msg_cache",
+			StopReason: "end_turn",
+			Content:    []anthropicContent{{Type: "text", Text: "Hi"}},
+			Usage: struct {
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			}{InputTokens: 10, OutputTokens: 5, CacheCreationInputTokens: 100, CacheReadInputTokens: 200},
+		}
+
+		result := convertAnthropicResponse(response)
+		assert.Equal(t, int64(310), result.Usage.PromptTokens)
+		assert.Equal(t, int64(5), result.Usage.CompletionTokens)
+		assert.Equal(t, int64(315), result.Usage.TotalTokens)
+		assert.Equal(t, int64(200), result.Usage.PromptTokensDetails.CachedTokens)
 	})
 
 	t.Run("converts tool_use response", func(t *testing.T) {
@@ -123,6 +175,23 @@ func TestConvertToolsToAnthropic(t *testing.T) {
 		assert.NotNil(t, result[0].InputSchema)
 	})
 
+	t.Run("marks last tool with cache_control", func(t *testing.T) {
+		tools := []openai.ChatCompletionToolParam{
+			{Type: "function", Function: openai.FunctionDefinitionParam{Name: "first"}},
+			{Type: "function", Function: openai.FunctionDefinitionParam{Name: "last"}},
+		}
+		result := convertToolsToAnthropic(tools)
+		require.Len(t, result, 2)
+		assert.Nil(t, result[0].CacheControl)
+		require.NotNil(t, result[1].CacheControl)
+		assert.Equal(t, "ephemeral", result[1].CacheControl.Type)
+	})
+
+	t.Run("no panic on nil tools", func(t *testing.T) {
+		result := convertToolsToAnthropic(nil)
+		assert.Empty(t, result)
+	})
+
 	t.Run("skips non-function tools", func(t *testing.T) {
 		tools := []openai.ChatCompletionToolParam{
 			{Type: "other"},
@@ -133,14 +202,16 @@ func TestConvertToolsToAnthropic(t *testing.T) {
 }
 
 func TestBuildAnthropicRequest(t *testing.T) {
-	messages := []anthropicMessage{{Role: "user", Content: "Hi"}}
+	messages := []anthropicMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}}
 	tools := []anthropicTool{{Name: "test", Description: "test tool"}}
+	system := []anthropicSystemBlock{{Type: "text", Text: "system"}}
 
 	t.Run("uses defaults", func(t *testing.T) {
-		req := buildAnthropicRequest(messages, "system", tools, ToolChoiceUnset, nil)
+		req := buildAnthropicRequest(messages, system, tools, ToolChoiceUnset, nil)
 		assert.Equal(t, 4096, req.MaxTokens)
 		assert.Equal(t, 1.0, req.Temperature)
-		assert.Equal(t, "system", req.SystemPrompt)
+		require.Len(t, req.SystemPrompt, 1)
+		assert.Equal(t, "system", req.SystemPrompt[0].Text)
 		assert.Len(t, req.Messages, 1)
 		assert.Len(t, req.Tools, 1)
 		assert.Nil(t, req.ToolChoice)
@@ -148,32 +219,32 @@ func TestBuildAnthropicRequest(t *testing.T) {
 
 	t.Run("uses properties", func(t *testing.T) {
 		props := map[string]string{"temperature": "0.5", "max_tokens": "1024"}
-		req := buildAnthropicRequest(messages, "", tools, ToolChoiceUnset, props)
+		req := buildAnthropicRequest(messages, nil, tools, ToolChoiceUnset, props)
 		assert.Equal(t, 1024, req.MaxTokens)
 		assert.Equal(t, 0.5, req.Temperature)
 	})
 
 	t.Run("required tool choice maps to type=any", func(t *testing.T) {
-		req := buildAnthropicRequest(messages, "", tools, ToolChoiceRequired, nil)
+		req := buildAnthropicRequest(messages, nil, tools, ToolChoiceRequired, nil)
 		assert.Equal(t, map[string]interface{}{"type": "any"}, req.ToolChoice)
 	})
 
 	t.Run("auto and none tool choice map through", func(t *testing.T) {
-		auto := buildAnthropicRequest(messages, "", tools, ToolChoiceAuto, nil)
+		auto := buildAnthropicRequest(messages, nil, tools, ToolChoiceAuto, nil)
 		assert.Equal(t, map[string]interface{}{"type": "auto"}, auto.ToolChoice)
-		none := buildAnthropicRequest(messages, "", tools, ToolChoiceNone, nil)
+		none := buildAnthropicRequest(messages, nil, tools, ToolChoiceNone, nil)
 		assert.Equal(t, map[string]interface{}{"type": "none"}, none.ToolChoice)
 	})
 
 	t.Run("tool_choice is omitted from JSON when unset", func(t *testing.T) {
-		req := buildAnthropicRequest(messages, "", tools, ToolChoiceUnset, nil)
+		req := buildAnthropicRequest(messages, nil, tools, ToolChoiceUnset, nil)
 		body, err := json.Marshal(req)
 		require.NoError(t, err)
 		assert.NotContains(t, string(body), "tool_choice")
 	})
 
 	t.Run("tool_choice is serialized when set", func(t *testing.T) {
-		req := buildAnthropicRequest(messages, "", tools, ToolChoiceRequired, nil)
+		req := buildAnthropicRequest(messages, nil, tools, ToolChoiceRequired, nil)
 		body, err := json.Marshal(req)
 		require.NoError(t, err)
 		assert.Contains(t, string(body), `"tool_choice":{"type":"any"}`)

--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -511,6 +511,7 @@ func buildResponseMeta(state *executionState, execResult *ExecutionResult, respo
 			"prompt_tokens":     tokenSummary.PromptTokens,
 			"completion_tokens": tokenSummary.CompletionTokens,
 			"total_tokens":      tokenSummary.TotalTokens,
+			"cached_tokens":     tokenSummary.CachedTokens,
 		}
 	}
 	if state.conversationId != "" {

--- a/ark/executors/completions/model_generic.go
+++ b/ark/executors/completions/model_generic.go
@@ -94,6 +94,7 @@ func (m *Model) ChatCompletion(ctx context.Context, messages []Message, eventStr
 		PromptTokens:     response.Usage.PromptTokens,
 		CompletionTokens: response.Usage.CompletionTokens,
 		TotalTokens:      response.Usage.TotalTokens,
+		CachedTokens:     response.Usage.PromptTokensDetails.CachedTokens,
 	})
 
 	return response, nil

--- a/ark/executors/completions/provider_anthropic.go
+++ b/ark/executors/completions/provider_anthropic.go
@@ -93,6 +93,12 @@ func (ap *AnthropicProvider) ChatCompletion(ctx context.Context, messages []Mess
 		return nil, fmt.Errorf("failed to unmarshal Anthropic response: %w", err)
 	}
 
+	logf.FromContext(ctx).Info("anthropic token usage",
+		"input", response.Usage.InputTokens,
+		"cacheCreation", response.Usage.CacheCreationInputTokens,
+		"cacheRead", response.Usage.CacheReadInputTokens,
+		"output", response.Usage.OutputTokens)
+
 	return convertAnthropicResponse(response), nil
 }
 

--- a/ark/executors/completions/provider_azure.go
+++ b/ark/executors/completions/provider_azure.go
@@ -147,9 +147,10 @@ func (ap *AzureProvider) ChatCompletionStream(ctx context.Context, messages []Me
 		// Accumulate usage if present in chunk
 		if chunk.Usage.TotalTokens > 0 {
 			fullResponse.Usage = openai.CompletionUsage{
-				PromptTokens:     chunk.Usage.PromptTokens,
-				CompletionTokens: chunk.Usage.CompletionTokens,
-				TotalTokens:      chunk.Usage.TotalTokens,
+				PromptTokens:        chunk.Usage.PromptTokens,
+				CompletionTokens:    chunk.Usage.CompletionTokens,
+				TotalTokens:         chunk.Usage.TotalTokens,
+				PromptTokensDetails: chunk.Usage.PromptTokensDetails,
 			}
 		}
 	}

--- a/ark/executors/completions/provider_bedrock.go
+++ b/ark/executors/completions/provider_bedrock.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/smithy-go/auth/bearer"
 	"github.com/openai/openai-go"
 	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type BedrockModel struct {
@@ -123,6 +124,12 @@ func (bm *BedrockModel) ChatCompletion(ctx context.Context, messages []Message, 
 	if err := json.Unmarshal(result.Body, &response); err != nil {
 		return nil, err
 	}
+
+	logf.FromContext(ctx).Info("bedrock token usage",
+		"input", response.Usage.InputTokens,
+		"cacheCreation", response.Usage.CacheCreationInputTokens,
+		"cacheRead", response.Usage.CacheReadInputTokens,
+		"output", response.Usage.OutputTokens)
 
 	return convertAnthropicResponse(response), nil
 }

--- a/ark/executors/completions/provider_openai.go
+++ b/ark/executors/completions/provider_openai.go
@@ -241,9 +241,10 @@ func (op *OpenAIProvider) ChatCompletionStream(ctx context.Context, messages []M
 
 		if chunk.Usage.TotalTokens > 0 {
 			fullResponse.Usage = openai.CompletionUsage{
-				PromptTokens:     chunk.Usage.PromptTokens,
-				CompletionTokens: chunk.Usage.CompletionTokens,
-				TotalTokens:      chunk.Usage.TotalTokens,
+				PromptTokens:        chunk.Usage.PromptTokens,
+				CompletionTokens:    chunk.Usage.CompletionTokens,
+				TotalTokens:         chunk.Usage.TotalTokens,
+				PromptTokensDetails: chunk.Usage.PromptTokensDetails,
 			}
 		}
 	}

--- a/ark/executors/completions/team_selector_mocks_test.go
+++ b/ark/executors/completions/team_selector_mocks_test.go
@@ -234,7 +234,7 @@ func (m *mockEventingRecorder) StartTokenCollection(ctx context.Context) context
 	return ctx
 }
 
-func (m *mockEventingRecorder) AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens int64) {
+func (m *mockEventingRecorder) AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens, cachedTokens int64) {
 }
 
 func (m *mockEventingRecorder) AddTokenUsage(ctx context.Context, usage arkv1alpha1.TokenUsage) {}

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -706,6 +706,9 @@ func extractTokenUsage(arkMap map[string]any, responseMeta *engineResponseMeta) 
 	if v, ok := tokenData["total_tokens"].(float64); ok {
 		usage.TotalTokens = int64(v)
 	}
+	if v, ok := tokenData["cached_tokens"].(float64); ok {
+		usage.CachedTokens = int64(v)
+	}
 	if usage.TotalTokens > 0 {
 		responseMeta.TokenUsage = usage
 	}

--- a/ark/internal/eventing/recorder/tokens/token_collector.go
+++ b/ark/internal/eventing/recorder/tokens/token_collector.go
@@ -22,7 +22,7 @@ func (tc *TokenCollector) StartTokenCollection(ctx context.Context) context.Cont
 	return context.WithValue(ctx, tokenUsageKey, usage)
 }
 
-func (tc *TokenCollector) AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens int64) {
+func (tc *TokenCollector) AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens, cachedTokens int64) {
 	usage, ok := ctx.Value(tokenUsageKey).(*arkv1alpha1.TokenUsage)
 	if !ok || usage == nil {
 		return
@@ -31,14 +31,15 @@ func (tc *TokenCollector) AddTokens(ctx context.Context, promptTokens, completio
 	usage.PromptTokens += promptTokens
 	usage.CompletionTokens += completionTokens
 	usage.TotalTokens += totalTokens
+	usage.CachedTokens += cachedTokens
 }
 
 func (tc *TokenCollector) AddTokenUsage(ctx context.Context, usage arkv1alpha1.TokenUsage) {
-	tc.AddTokens(ctx, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
+	tc.AddTokens(ctx, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens, usage.CachedTokens)
 }
 
 func (tc *TokenCollector) AddCompletionUsage(ctx context.Context, usage openai.CompletionUsage) {
-	tc.AddTokens(ctx, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
+	tc.AddTokens(ctx, usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens, usage.PromptTokensDetails.CachedTokens)
 }
 
 func (tc *TokenCollector) GetTokenSummary(ctx context.Context) arkv1alpha1.TokenUsage {

--- a/ark/internal/eventing/recorder/tokens/token_collector_test.go
+++ b/ark/internal/eventing/recorder/tokens/token_collector_test.go
@@ -27,32 +27,34 @@ func TestTokenCollector_AddTokens(t *testing.T) {
 	tc := NewTokenCollector()
 	ctx := tc.StartTokenCollection(context.Background())
 
-	tc.AddTokens(ctx, 100, 50, 150)
+	tc.AddTokens(ctx, 100, 50, 150, 40)
 
 	usage := tc.GetTokenSummary(ctx)
 	assert.Equal(t, int64(100), usage.PromptTokens)
 	assert.Equal(t, int64(50), usage.CompletionTokens)
 	assert.Equal(t, int64(150), usage.TotalTokens)
+	assert.Equal(t, int64(40), usage.CachedTokens)
 }
 
 func TestTokenCollector_AddTokens_Multiple(t *testing.T) {
 	tc := NewTokenCollector()
 	ctx := tc.StartTokenCollection(context.Background())
 
-	tc.AddTokens(ctx, 100, 50, 150)
-	tc.AddTokens(ctx, 200, 100, 300)
+	tc.AddTokens(ctx, 100, 50, 150, 40)
+	tc.AddTokens(ctx, 200, 100, 300, 80)
 
 	usage := tc.GetTokenSummary(ctx)
 	assert.Equal(t, int64(300), usage.PromptTokens)
 	assert.Equal(t, int64(150), usage.CompletionTokens)
 	assert.Equal(t, int64(450), usage.TotalTokens)
+	assert.Equal(t, int64(120), usage.CachedTokens)
 }
 
 func TestTokenCollector_AddTokens_NoCollection(t *testing.T) {
 	tc := NewTokenCollector()
 	ctx := context.Background()
 
-	tc.AddTokens(ctx, 100, 50, 150)
+	tc.AddTokens(ctx, 100, 50, 150, 40)
 
 	usage := tc.GetTokenSummary(ctx)
 	assert.Equal(t, int64(0), usage.PromptTokens)
@@ -68,6 +70,7 @@ func TestTokenCollector_AddTokenUsage(t *testing.T) {
 		PromptTokens:     100,
 		CompletionTokens: 50,
 		TotalTokens:      150,
+		CachedTokens:     40,
 	}
 	tc.AddTokenUsage(ctx, tokenUsage)
 
@@ -75,6 +78,7 @@ func TestTokenCollector_AddTokenUsage(t *testing.T) {
 	assert.Equal(t, int64(100), usage.PromptTokens)
 	assert.Equal(t, int64(50), usage.CompletionTokens)
 	assert.Equal(t, int64(150), usage.TotalTokens)
+	assert.Equal(t, int64(40), usage.CachedTokens)
 }
 
 func TestTokenCollector_AddCompletionUsage(t *testing.T) {
@@ -85,6 +89,9 @@ func TestTokenCollector_AddCompletionUsage(t *testing.T) {
 		PromptTokens:     100,
 		CompletionTokens: 50,
 		TotalTokens:      150,
+		PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+			CachedTokens: 40,
+		},
 	}
 	tc.AddCompletionUsage(ctx, completionUsage)
 
@@ -92,6 +99,7 @@ func TestTokenCollector_AddCompletionUsage(t *testing.T) {
 	assert.Equal(t, int64(100), usage.PromptTokens)
 	assert.Equal(t, int64(50), usage.CompletionTokens)
 	assert.Equal(t, int64(150), usage.TotalTokens)
+	assert.Equal(t, int64(40), usage.CachedTokens)
 }
 
 func TestTokenCollector_GetTokenSummary_NoCollection(t *testing.T) {

--- a/ark/internal/eventing/recorders.go
+++ b/ark/internal/eventing/recorders.go
@@ -18,7 +18,7 @@ type OperationTracker interface {
 
 type TokenCollector interface {
 	StartTokenCollection(ctx context.Context) context.Context
-	AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens int64)
+	AddTokens(ctx context.Context, promptTokens, completionTokens, totalTokens, cachedTokens int64)
 	AddTokenUsage(ctx context.Context, usage arkv1alpha1.TokenUsage)
 	AddCompletionUsage(ctx context.Context, usage openai.CompletionUsage)
 	GetTokenSummary(ctx context.Context) arkv1alpha1.TokenUsage

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/chat-history.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/atoms/chat-history.test.ts
@@ -41,6 +41,7 @@ describe('Chat History Atoms', () => {
         prompt_tokens: 100,
         completion_tokens: 50,
         total_tokens: 150,
+        cached_tokens: 0,
       };
       const session: ChatSession = {
         messages: [],
@@ -54,8 +55,18 @@ describe('Chat History Atoms', () => {
 
     it('should store a chat session with messageTokenUsage', () => {
       const msgUsage: Record<number, TokenUsage> = {
-        1: { prompt_tokens: 50, completion_tokens: 25, total_tokens: 75 },
-        3: { prompt_tokens: 80, completion_tokens: 40, total_tokens: 120 },
+        1: {
+          prompt_tokens: 50,
+          completion_tokens: 25,
+          total_tokens: 75,
+          cached_tokens: 0,
+        },
+        3: {
+          prompt_tokens: 80,
+          completion_tokens: 40,
+          total_tokens: 120,
+          cached_tokens: 0,
+        },
       };
       const session: ChatSession = {
         messages: [],
@@ -82,7 +93,12 @@ describe('Chat History Atoms', () => {
       const initial: ChatSession = {
         messages: [],
         sessionId: 'session-1',
-        tokenUsage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        tokenUsage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cached_tokens: 10,
+        },
       };
       store.set(chatHistoryAtom, { 'agent-test': initial });
 
@@ -97,6 +113,7 @@ describe('Chat History Atoms', () => {
               prompt_tokens: current.prompt_tokens + 200,
               completion_tokens: current.completion_tokens + 100,
               total_tokens: current.total_tokens + 300,
+              cached_tokens: current.cached_tokens + 20,
             },
           },
         };
@@ -107,6 +124,7 @@ describe('Chat History Atoms', () => {
         prompt_tokens: 300,
         completion_tokens: 150,
         total_tokens: 450,
+        cached_tokens: 30,
       });
     });
 
@@ -126,12 +144,22 @@ describe('Chat History Atoms', () => {
       const session1: ChatSession = {
         messages: [],
         sessionId: 'session-1',
-        tokenUsage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        tokenUsage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+          cached_tokens: 0,
+        },
       };
       const session2: ChatSession = {
         messages: [],
         sessionId: 'session-2',
-        tokenUsage: { prompt_tokens: 200, completion_tokens: 100, total_tokens: 300 },
+        tokenUsage: {
+          prompt_tokens: 200,
+          completion_tokens: 100,
+          total_tokens: 300,
+          cached_tokens: 0,
+        },
       };
       store.set(chatHistoryAtom, { 'agent-a': session1, 'agent-b': session2 });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/chat-message.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/chat-message.test.tsx
@@ -185,6 +185,7 @@ describe('ChatMessage', () => {
             prompt_tokens: 1200,
             completion_tokens: 340,
             total_tokens: 1540,
+            cached_tokens: 0,
           }}
         />,
       );
@@ -192,6 +193,25 @@ describe('ChatMessage', () => {
       expect(screen.getByText(/1,540 tokens/)).toBeInTheDocument();
       expect(screen.getByText(/1,200 in/)).toBeInTheDocument();
       expect(screen.getByText(/340 out/)).toBeInTheDocument();
+    });
+
+    it('should subtract cached tokens from input and show cached count', () => {
+      render(
+        <ChatMessage
+          role="assistant"
+          content="Answer"
+          tokenUsage={{
+            prompt_tokens: 1200,
+            completion_tokens: 340,
+            total_tokens: 1540,
+            cached_tokens: 1150,
+          }}
+        />,
+      );
+
+      expect(screen.getByText(/50 in/)).toBeInTheDocument();
+      expect(screen.getByText(/340 out/)).toBeInTheDocument();
+      expect(screen.getByText(/1,150 cached/)).toBeInTheDocument();
     });
 
     it('should not display token usage when total is zero', () => {
@@ -203,6 +223,7 @@ describe('ChatMessage', () => {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: 0,
+            cached_tokens: 0,
           }}
         />,
       );
@@ -219,6 +240,7 @@ describe('ChatMessage', () => {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: 15,
+            cached_tokens: 0,
           }}
         />,
       );

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
@@ -49,11 +49,13 @@ function createArkFinalChunk(opts: {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
+    cachedTokens?: number;
   };
   openaiUsage?: {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    prompt_tokens_details?: { cached_tokens: number };
   };
   phase?: string;
   raw?: string;
@@ -165,6 +167,7 @@ describe('useChatSession', () => {
               promptTokens: 100,
               completionTokens: 50,
               totalTokens: 150,
+              cachedTokens: 30,
             },
           }),
         ]),
@@ -184,6 +187,7 @@ describe('useChatSession', () => {
           prompt_tokens: 100,
           completion_tokens: 50,
           total_tokens: 150,
+          cached_tokens: 30,
         });
       });
     });
@@ -206,6 +210,7 @@ describe('useChatSession', () => {
               prompt_tokens: 200,
               completion_tokens: 80,
               total_tokens: 280,
+              prompt_tokens_details: { cached_tokens: 60 },
             },
           },
         ]),
@@ -225,6 +230,7 @@ describe('useChatSession', () => {
           prompt_tokens: 200,
           completion_tokens: 80,
           total_tokens: 280,
+          cached_tokens: 60,
         });
       });
     });
@@ -263,6 +269,7 @@ describe('useChatSession', () => {
           prompt_tokens: 100,
           completion_tokens: 50,
           total_tokens: 150,
+          cached_tokens: 0,
         });
       });
     });
@@ -345,6 +352,7 @@ describe('useChatSession', () => {
           prompt_tokens: 100,
           completion_tokens: 50,
           total_tokens: 150,
+          cached_tokens: 0,
         });
       });
 
@@ -357,6 +365,7 @@ describe('useChatSession', () => {
           prompt_tokens: 300,
           completion_tokens: 150,
           total_tokens: 450,
+          cached_tokens: 0,
         });
       });
     });
@@ -393,6 +402,7 @@ describe('useChatSession', () => {
           prompt_tokens: 50,
           completion_tokens: 25,
           total_tokens: 75,
+          cached_tokens: 0,
         });
       });
     });
@@ -436,6 +446,7 @@ describe('useChatSession', () => {
           prompt_tokens: 0,
           completion_tokens: 0,
           total_tokens: 0,
+          cached_tokens: 0,
         });
         expect(result.current.messageTokenUsage).toEqual({});
         expect(result.current.messages).toEqual([]);

--- a/services/ark-dashboard/ark-dashboard/atoms/chat-history.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/chat-history.ts
@@ -9,6 +9,7 @@ export interface TokenUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  cached_tokens: number;
 }
 
 export interface ChatSession {

--- a/services/ark-dashboard/ark-dashboard/components/chat/chat-message.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/chat-message.tsx
@@ -23,6 +23,7 @@ interface ChatMessageProps {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cached_tokens: number;
   };
   approvalRequest?: ToolApprovalRequest;
   namespace?: string;
@@ -306,8 +307,14 @@ export function ChatMessage({
             {!isUser && tokenUsage && tokenUsage.total_tokens > 0 && (
               <div className="text-muted-foreground text-xs opacity-60">
                 {tokenUsage.total_tokens.toLocaleString()} tokens (
-                {tokenUsage.prompt_tokens.toLocaleString()} in,{' '}
-                {tokenUsage.completion_tokens.toLocaleString()} out)
+                {Math.max(
+                  0,
+                  tokenUsage.prompt_tokens - tokenUsage.cached_tokens,
+                ).toLocaleString()}{' '}
+                in, {tokenUsage.completion_tokens.toLocaleString()} out
+                {tokenUsage.cached_tokens > 0 &&
+                  `, ${tokenUsage.cached_tokens.toLocaleString()} cached`}
+                )
               </div>
             )}
           </div>

--- a/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
@@ -191,8 +191,17 @@ export function ChatPanel({
                   <TooltipContent>
                     <div className="space-y-1 text-xs">
                       <div>
-                        Prompt: {tokenUsage.prompt_tokens.toLocaleString()}
+                        Input (new):{' '}
+                        {Math.max(
+                          0,
+                          tokenUsage.prompt_tokens - tokenUsage.cached_tokens,
+                        ).toLocaleString()}
                       </div>
+                      {tokenUsage.cached_tokens > 0 && (
+                        <div>
+                          Cached: {tokenUsage.cached_tokens.toLocaleString()}
+                        </div>
+                      )}
                       <div>
                         Completion:{' '}
                         {tokenUsage.completion_tokens.toLocaleString()}

--- a/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/queries-section.tsx
@@ -126,8 +126,12 @@ export const QueriesSection = forwardRef<
     const usage = query.status.tokenUsage as {
       promptTokens?: number;
       completionTokens?: number;
+      cachedTokens?: number;
     };
-    return `${usage.promptTokens || 0} / ${usage.completionTokens || 0}`;
+    const cached = usage.cachedTokens || 0;
+    const newInput = Math.max(0, (usage.promptTokens || 0) - cached);
+    const base = `${newInput} / ${usage.completionTokens || 0}`;
+    return cached > 0 ? `${base} (${cached} cached)` : base;
   };
 
   const getTargetDisplay = (query: QueryResponse) => {
@@ -306,7 +310,7 @@ export const QueriesSection = forwardRef<
                         </div>
                       </div>
                     </th>
-                    <th className="px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100">Token Usage (Prompt / Completion)</th>
+                    <th className="px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100">Token Usage (Input / Completion)</th>
                     <th className="px-3 py-2 text-center text-sm font-medium text-gray-900 dark:text-gray-100">Status</th>
                     <th className="px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100">Actions</th>
                   </tr>

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
@@ -207,6 +207,7 @@ export function useChatSession({
           prompt_tokens: 0,
           completion_tokens: 0,
           total_tokens: 0,
+          cached_tokens: 0,
         };
         return {
           ...safePrev,
@@ -217,6 +218,7 @@ export function useChatSession({
               completion_tokens:
                 currentUsage.completion_tokens + usage.completion_tokens,
               total_tokens: currentUsage.total_tokens + usage.total_tokens,
+              cached_tokens: currentUsage.cached_tokens + usage.cached_tokens,
             },
           },
         };
@@ -503,12 +505,15 @@ export function useChatSession({
                 prompt_tokens: arkTokenUsage.promptTokens || 0,
                 completion_tokens: arkTokenUsage.completionTokens || 0,
                 total_tokens: arkTokenUsage.totalTokens || 0,
+                cached_tokens: arkTokenUsage.cachedTokens || 0,
               }
             : typedChunk?.usage
               ? {
                   prompt_tokens: typedChunk.usage.prompt_tokens ?? 0,
                   completion_tokens: typedChunk.usage.completion_tokens ?? 0,
                   total_tokens: typedChunk.usage.total_tokens ?? 0,
+                  cached_tokens:
+                    typedChunk.usage.prompt_tokens_details?.cached_tokens ?? 0,
                 }
               : null;
 
@@ -1003,7 +1008,12 @@ export function useChatSession({
       [chatKey]: {
         messages: [],
         sessionId: newSessionId,
-        tokenUsage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        tokenUsage: {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+          cached_tokens: 0,
+        },
         messageTokenUsage: {},
       },
     }));

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
@@ -512,8 +512,7 @@ export function useChatSession({
                   prompt_tokens: typedChunk.usage.prompt_tokens ?? 0,
                   completion_tokens: typedChunk.usage.completion_tokens ?? 0,
                   total_tokens: typedChunk.usage.total_tokens ?? 0,
-                  cached_tokens:
-                    typedChunk.usage.prompt_tokens_details?.cached_tokens ?? 0,
+                  cached_tokens: typedChunk.usage.prompt_tokens_details?.cached_tokens ?? 0,
                 }
               : null;
 

--- a/services/ark-dashboard/ark-dashboard/lib/types/chat-message.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/types/chat-message.ts
@@ -14,6 +14,7 @@ export interface ArkCompletedQueryData {
         promptTokens?: number;
         completionTokens?: number;
         totalTokens?: number;
+        cachedTokens?: number;
       };
     };
   };


### PR DESCRIPTION
# Anthropic/Bedrock prompt caching + cached-token visibility

## Summary
Adds prompt caching for Anthropic/Bedrock models in the completions executor, and
surfaces **cached tokens** end-to-end (executor → CRD → API → dashboard) so users can
see the cache working and the true "new" token cost per turn. `cachedTokens` is a
provider-neutral count normalized from OpenAI's native `cached_tokens` and
Anthropic/Bedrock `cache_read_input_tokens`.

## How it helps
- **Cost & latency:** cached prompt prefixes (system prompt, tools, history) are billed
  at a fraction of normal input cost and skip reprocessing. For a ~6k-token system
  prompt, repeat turns within the cache window drop from ~6k full-price input tokens to
  a few hundred.
- **Visibility:** before this, prompt caching had *no Ark-visible signal*
  — `promptTokens` looked flat whether or not the cache hit. Now `cachedTokens` flows to
  `query.status.tokenUsage` and both dashboard surfaces, so the cache benefit is
  measurable per query.
- **Provider-agnostic:** one `cachedTokens` field; downstream code never branches on
  provider.

## Changes by layer

### CRD / API type
- `ark/api/v1alpha1/query_types.go` — add `CachedTokens int64` to `TokenUsage`.
- `ark/config/crd/bases/ark.mckinsey.com_queries.yaml`,
  `ark/dist/chart/templates/crd/ark.mckinsey.com_queries.yaml` — regenerated CRD
  (`make manifests`; also refreshes the `internal/apiserver/crds` embed).

### Completions executor (Go)
- `anthropic_format.go` — emit `cache_control` cache breakpoints (system, tools, history)
  **and** map `cache_read_input_tokens → openai.CompletionUsage.PromptTokensDetails.CachedTokens`;
  `promptTokens` remains the full total.
- `provider_openai.go`, `provider_azure.go` — preserve `PromptTokensDetails` in the
  streaming usage copy (previously dropped).
- `provider_anthropic.go`, `provider_bedrock.go` — structured log of the token split
  (`input`/`cacheCreation`/`cacheRead`/`output`) as the proof-of-cache signal.
- `model_generic.go` — carry `PromptTokensDetails.CachedTokens` into `arkv1alpha1.TokenUsage`.
- `handler.go` — emit `cached_tokens` in `buildResponseMeta` (A2A meta) and include it in
  the streamed `completedQuery.status.tokenUsage`.

### Aggregation / controller (Go)
- `internal/eventing/recorder/tokens/token_collector.go` + `internal/eventing/recorders.go`
  — `AddTokens` now sums `cachedTokens` (interface signature updated).
- `internal/controller/query_controller.go` — `extractTokenUsage` reads `cached_tokens`
  from A2A meta into CRD status.
- Tests: `anthropic_format_test.go`, `token_collector_test.go`, `team_selector_mocks_test.go`.

### Dashboard (TypeScript)
- `atoms/chat-history.ts`, `lib/types/chat-message.ts`, `components/chat/chat-message.tsx`
  — add `cached_tokens`/`cachedTokens` to the token-usage types/props.
- `lib/hooks/use-chat-session.ts` — ingest `cachedTokens` from the CRD-shaped stream
  payload and `prompt_tokens_details.cached_tokens` from the OpenAI chunk; aggregate
  across the session; zero in init defaults.
- `components/chat/chat-message.tsx`, `components/chat/chat-panel.tsx` — show
  **new input = promptTokens − cachedTokens**, plus a cached count (inline in the bubble;
  in the panel's hover tooltip).
- `components/sections/queries-section.tsx` — `formatTokenUsage` shows
  `newInput / completion (N cached)`; column header → "Token Usage (Input / Completion)".
- Tests: `__tests__/unit/atoms/chat-history.test.ts`,
  `.../components/chat/chat-message.test.tsx`, `.../lib/hooks/use-chat-session.test.ts`.

### SDK / ark-api dependency
- The Python `ark-sdk` model `query_v1alpha1_status_token_usage.py` is **generated from
  the CRD**; the added field regenerates automatically. The wheel is a build artifact
  (gitignored) — no wheel is committed.
- `services/ark-api/ark-api/pyproject.toml`, `services/ark-api/ark-api/uv.lock`,
  `lib/ark-sdk/uv.lock` — dependency/lock churn from the SDK wheel wiring.
  **Reviewer: confirm these are intended and not stray local-build artifacts.**

## Verification
- Go: `go build ./...`, `go vet`, `gofmt` clean; `go test ./executors/completions/...
  ./internal/eventing/...` pass.
- Dashboard: `next build` + `vitest` (55 tests) pass.
- End-to-end on a live cluster: executor logged `cacheCreation:5979` (turn 1) →
  `cacheRead:5979` (turn 2); CRD showed `cachedTokens:5979`; verified through ark-api and
  both UI surfaces.

## Provider behavior (OpenAI / Azure)
`cachedTokens` populates for OpenAI and Azure too, but with meaningful differences from
Anthropic/Bedrock:

- **Automatic, not explicit.** OpenAI/Azure cache prompt prefixes server-side
  automatically — there is no `cache_control` to set. Our code only reads back the
  provider-reported `prompt_tokens_details.cached_tokens`. Caching engages when the prompt
  exceeds the provider's minimum prefix length and a matching prefix was seen recently; it
  cannot be forced.
- **Cleaner "new" semantics.** OpenAI/Azure have no separate cache-creation/write concept:
  `promptTokens` already includes the cached portion and `cachedTokens` is a subset, so
  `new = promptTokens − cachedTokens` is exactly the uncached input with no write surcharge
  folded in (unlike Anthropic — see consideration 3). The first call to a new prefix
  reports `cachedTokens: 0`; repeat calls report the cached read.
- **Model / API-version dependent.** Only newer models emit
  `prompt_tokens_details.cached_tokens` (recent OpenAI GPT / o-series; Azure OpenAI on
  recent api-versions). Older deployments and OpenAI-compatible proxies (vLLM, LiteLLM,
  local gateways) may omit it → `cachedTokens` stays 0 (correct, just no signal).
- **Streaming requires `include_usage`.** Both providers set
  `stream_options.include_usage=true`, so streaming and non-streaming both populate. A
  proxy that ignores `stream_options` yields no streaming usage at all (pre-existing
  behavior, unchanged here).

## Additional considerations / notes for reviewers
1. **SDK regeneration is mandatory in the build.** ark-api deserializes queries through
   the typed `ark-sdk` model and calls `.to_dict()`, which **silently drops unknown
   fields**. If the SDK isn't regenerated from the updated CRD, `cachedTokens` is stripped
   before it reaches the API/dashboard. A clean `make`/CI build handles this automatically
   (SDK wheel depends on `ark/config/crd/bases/ark*.yaml`); **incremental `devspace dev`
   can reuse a stale wheel** and needs a clean rebuild. 
2. **Chat vs queries-page divergence is expected during a stale-wheel window.** The
   chat/broker path relays raw SSE (no SDK), so it shows `cachedTokens` independently; the
   queries page depends on the regenerated SDK. If they disagree, the SDK wheel is stale.
3. **"New" includes `cache_creation`.** Displayed "new/input" = `promptTokens −
   cachedTokens`, where `cachedTokens` is cache **reads** only. Cache *writes* (full price
   + 25% on Anthropic) count as "new" — cost-honest, but the first turn (or any turn after
   the 5-min TTL expires) shows the full system prompt as "new". Could optionally split
   into a separate "cache-write" line later.
4. **Count is comparable, cost is not.** `cachedTokens` is directly comparable across
   providers as a *count*; billing differs (OpenAI ~50% off reads; Anthropic ~90% off
   reads + write surcharge). Any cost math needs per-provider rates.
5. **Caching thresholds.** Anthropic min cacheable prefix is 1024 tokens (2048 Haiku) and
   TTL is 5 min. Small prompts legitimately report `cachedTokens: 0`; that's correct, not
   a bug.
6. **Backward compatible.** `cachedTokens` is `omitempty`/optional throughout; pre-existing
   data renders as 0 (no "cached" shown). Dashboard persists per-message token usage in
   `sessionStorage`, so old chat sessions won't retroactively display cached.
7. **Internal interface change.** `TokenCollector.AddTokens` gained a parameter; all
   implementers (noop/otel/mock + test mocks) are updated. This is an internal Go interface
   — Python `BaseExecutor` executors are unaffected — but note it for anyone with an
   out-of-tree recorder.
8. **Telemetry not extended.** Spans/metrics (`RecordTokenUsage`) still record
   prompt/completion/total only. Adding cache dimensions there is a possible follow-up.
9. **Out of scope (from the original plan):** Bedrock cache-effectiveness tuning; history
   summarization. OpenAI/Azure cache automatically server-side.

Fixes #2606 


## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #eg101 