### PR TITLE
fix: populate turn.output on team OTEL spans

### DIFF
--- a/ark/executors/completions/team.go
+++ b/ark/executors/completions/team.go
@@ -111,7 +111,7 @@ func (t *Team) executeSequential(ctx context.Context, userInput Message, history
 		signal, err := t.executeMemberAndAccumulate(turnCtx, member, userInput, &messages, &newMessages, i)
 
 		if len(newMessages) > 0 {
-			t.telemetryRecorder.RecordTurnOutput(turnSpan, newMessages, len(newMessages))
+			t.telemetryRecorder.RecordTurnOutput(turnSpan, ExtractLastAssistantMessageContent(newMessages), len(newMessages))
 		}
 
 		if err != nil {
@@ -165,7 +165,7 @@ func (t *Team) executeSequentialWithLoops(ctx context.Context, userInput Message
 		signal, err := t.executeMemberAndAccumulate(turnCtx, member, userInput, &messages, &newMessages, messageCount)
 
 		if len(newMessages) > 0 {
-			t.telemetryRecorder.RecordTurnOutput(turnSpan, newMessages, len(newMessages))
+			t.telemetryRecorder.RecordTurnOutput(turnSpan, ExtractLastAssistantMessageContent(newMessages), len(newMessages))
 		}
 
 		if err != nil {

--- a/ark/executors/completions/team_graph.go
+++ b/ark/executors/completions/team_graph.go
@@ -46,7 +46,7 @@ func (t *Team) executeGraph(ctx context.Context, userInput Message, history []Me
 		signal, err := t.executeMemberAndAccumulate(turnCtx, member, userInput, &messages, &newMessages, turns)
 
 		if len(newMessages) > 0 {
-			t.telemetryRecorder.RecordTurnOutput(turnSpan, newMessages, len(newMessages))
+			t.telemetryRecorder.RecordTurnOutput(turnSpan, ExtractLastAssistantMessageContent(newMessages), len(newMessages))
 		}
 
 		if err != nil {

--- a/ark/executors/completions/team_selector.go
+++ b/ark/executors/completions/team_selector.go
@@ -352,7 +352,7 @@ func (t *Team) startTurnTelemetry(ctx context.Context, turn int, memberName, mem
 
 func (t *Team) recordTurnOutput(tel turnTelemetry, newMessages []Message) {
 	if len(newMessages) > 0 {
-		t.telemetryRecorder.RecordTurnOutput(tel.span, newMessages, len(newMessages))
+		t.telemetryRecorder.RecordTurnOutput(tel.span, ExtractLastAssistantMessageContent(newMessages), len(newMessages))
 	}
 }
 

--- a/ark/executors/completions/team_selector_mocks_test.go
+++ b/ark/executors/completions/team_selector_mocks_test.go
@@ -158,6 +158,7 @@ type mockTeamRecorder struct {
 	lastMemberName         string
 	lastMemberType         string
 	lastOutputMessageCount int
+	lastOutput             string
 }
 
 func (m *mockTeamRecorder) StartTeamExecution(ctx context.Context, teamName, namespace, strategy string, memberCount, maxTurns int) (context.Context, telemetry.Span) {
@@ -172,9 +173,10 @@ func (m *mockTeamRecorder) StartTurn(ctx context.Context, turn int, memberName, 
 	return ctx, &mockTelemetrySpan{}
 }
 
-func (m *mockTeamRecorder) RecordTurnOutput(span telemetry.Span, messages any, messageCount int) {
+func (m *mockTeamRecorder) RecordTurnOutput(span telemetry.Span, output string, messageCount int) {
 	m.recordOutputCalled = true
 	m.lastOutputMessageCount = messageCount
+	m.lastOutput = output
 }
 
 func (m *mockTeamRecorder) RecordTokenUsage(span telemetry.Span, promptTokens, completionTokens, totalTokens int64) {

--- a/ark/executors/completions/team_selector_test.go
+++ b/ark/executors/completions/team_selector_test.go
@@ -737,12 +737,14 @@ func TestRecordTurnOutput(t *testing.T) {
 		messages         []Message
 		wantRecordCalled bool
 		wantMessageCount int
+		wantOutput       string
 	}{
 		{
 			name:             "records output for non-empty messages",
 			messages:         []Message{NewAssistantMessage("test")},
 			wantRecordCalled: true,
 			wantMessageCount: 1,
+			wantOutput:       "test",
 		},
 		{
 			name:             "skips recording for empty messages",
@@ -750,10 +752,18 @@ func TestRecordTurnOutput(t *testing.T) {
 			wantRecordCalled: false,
 		},
 		{
-			name:             "records multiple messages",
+			name:             "records last assistant content across multiple messages",
 			messages:         []Message{NewUserMessage("q"), NewAssistantMessage("a")},
 			wantRecordCalled: true,
 			wantMessageCount: 2,
+			wantOutput:       "a",
+		},
+		{
+			name:             "extracts assistant content when a system message is last",
+			messages:         []Message{NewAssistantMessage("I AM AGENT A"), NewSystemMessage("done")},
+			wantRecordCalled: true,
+			wantMessageCount: 2,
+			wantOutput:       "I AM AGENT A",
 		},
 	}
 
@@ -773,6 +783,7 @@ func TestRecordTurnOutput(t *testing.T) {
 			assert.Equal(t, tt.wantRecordCalled, mockTelemetry.recordOutputCalled)
 			if tt.wantRecordCalled {
 				assert.Equal(t, tt.wantMessageCount, mockTelemetry.lastOutputMessageCount)
+				assert.Equal(t, tt.wantOutput, mockTelemetry.lastOutput)
 			}
 		})
 	}

--- a/ark/executors/completions/team_test.go
+++ b/ark/executors/completions/team_test.go
@@ -164,3 +164,23 @@ func TestExecuteSequential_ContextCancelled(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+func TestExecuteGraph_RecordsTurnOutput(t *testing.T) {
+	members := []TeamMember{
+		&execMockTeamMember{
+			name: "m1",
+			execFunc: func(_ context.Context, _ Message, _ []Message, _ MemoryInterface, _ EventStreamInterface, _ ExecuteOptions) (*ExecutionResult, error) {
+				return &ExecutionResult{Messages: []Message{NewAssistantMessage("graph response")}}, nil
+			},
+		},
+	}
+	team := newTestTeam(members, "graph", false, nil)
+	rec := &mockTeamRecorder{}
+	team.telemetryRecorder = rec
+
+	result, err := team.Execute(context.Background(), NewUserMessage("hello"), nil, nil, nil, ExecuteOptions{})
+	require.NoError(t, err)
+	assert.Len(t, result.Messages, 1)
+	assert.True(t, rec.recordOutputCalled)
+	assert.Equal(t, "graph response", rec.lastOutput)
+}

--- a/ark/internal/telemetry/mock/mock.go
+++ b/ark/internal/telemetry/mock/mock.go
@@ -356,6 +356,9 @@ func (r *MockTeamRecorder) RecordTurnOutput(span telemetry.Span, output string, 
 	span.SetAttributes(
 		telemetry.Int("turn.output_message_count", messageCount),
 	)
+	if output != "" {
+		span.SetAttributes(telemetry.String("turn.output", output))
+	}
 }
 
 func (r *MockTeamRecorder) RecordTokenUsage(span telemetry.Span, promptTokens, completionTokens, totalTokens int64) {

--- a/ark/internal/telemetry/mock/mock.go
+++ b/ark/internal/telemetry/mock/mock.go
@@ -352,7 +352,7 @@ func (r *MockTeamRecorder) StartTurn(ctx context.Context, turn int, memberName, 
 	)
 }
 
-func (r *MockTeamRecorder) RecordTurnOutput(span telemetry.Span, messages any, messageCount int) {
+func (r *MockTeamRecorder) RecordTurnOutput(span telemetry.Span, output string, messageCount int) {
 	span.SetAttributes(
 		telemetry.Int("turn.output_message_count", messageCount),
 	)

--- a/ark/internal/telemetry/mock/mock_test.go
+++ b/ark/internal/telemetry/mock/mock_test.go
@@ -1,0 +1,34 @@
+/* Copyright 2025. McKinsey & Company */
+
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockTeamRecorder_RecordTurnOutput(t *testing.T) {
+	r := NewTeamRecorder()
+	_, span := r.StartTurn(context.Background(), 0, "agent-a", "agent")
+
+	r.RecordTurnOutput(span, "I AM AGENT A", 2)
+
+	mockSpan, ok := span.(*MockSpan)
+	require.True(t, ok)
+	assert.Equal(t, 2, mockSpan.GetAttribute("turn.output_message_count"))
+	assert.Equal(t, "I AM AGENT A", mockSpan.GetAttribute("turn.output"))
+}
+
+func TestMockTeamRecorder_RecordTurnOutput_EmptyOmitsOutput(t *testing.T) {
+	r := NewTeamRecorder()
+	_, span := r.StartTurn(context.Background(), 0, "agent-a", "agent")
+
+	r.RecordTurnOutput(span, "", 1)
+
+	mockSpan := span.(*MockSpan)
+	assert.Equal(t, 1, mockSpan.GetAttribute("turn.output_message_count"))
+	assert.False(t, mockSpan.HasAttribute("turn.output"))
+}

--- a/ark/internal/telemetry/noop/noop.go
+++ b/ark/internal/telemetry/noop/noop.go
@@ -137,7 +137,7 @@ func (r *noopTeamRecorder) StartTurn(ctx context.Context, turn int, memberName, 
 	return ctx, &noopSpan{}
 }
 
-func (r *noopTeamRecorder) RecordTurnOutput(span telemetry.Span, messages any, messageCount int) {
+func (r *noopTeamRecorder) RecordTurnOutput(span telemetry.Span, output string, messageCount int) {
 } //nolint:revive
 func (r *noopTeamRecorder) RecordTokenUsage(span telemetry.Span, promptTokens, completionTokens, totalTokens int64) {
 }                                                                      //nolint:revive

--- a/ark/internal/telemetry/otel/team_recorder.go
+++ b/ark/internal/telemetry/otel/team_recorder.go
@@ -51,20 +51,11 @@ func (r *teamRecorder) StartTurn(ctx context.Context, turn int, memberName, memb
 	)
 }
 
-func (r *teamRecorder) RecordTurnOutput(span telemetry.Span, messages any, messageCount int) {
-	if messages == nil {
-		return
-	}
-
+func (r *teamRecorder) RecordTurnOutput(span telemetry.Span, output string, messageCount int) {
 	span.SetAttributes(telemetry.Int("turn.output_message_count", messageCount))
 
-	if slice, ok := messages.([]interface{}); ok && len(slice) > 0 {
-		lastMessage := slice[len(slice)-1]
-		if msgMap, ok := lastMessage.(map[string]interface{}); ok {
-			if content, ok := msgMap["content"].(string); ok && content != "" {
-				span.SetAttributes(telemetry.String("turn.output", content))
-			}
-		}
+	if output != "" {
+		span.SetAttributes(telemetry.String("turn.output", output))
 	}
 }
 

--- a/ark/internal/telemetry/otel/team_recorder_test.go
+++ b/ark/internal/telemetry/otel/team_recorder_test.go
@@ -1,0 +1,54 @@
+/* Copyright 2025. McKinsey & Company */
+
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mckinsey.com/ark/internal/telemetry"
+	telemetrymock "mckinsey.com/ark/internal/telemetry/mock"
+)
+
+func TestTeamRecorder(t *testing.T) {
+	tracer := telemetrymock.NewTracer()
+	recorder := NewTeamRecorder(tracer)
+	ctx := context.Background()
+
+	t.Run("StartTurn names span with turn number", func(t *testing.T) {
+		_, span := recorder.StartTurn(ctx, 1, "agent-a", "agent")
+		mockSpan, ok := span.(*telemetrymock.MockSpan)
+		require.True(t, ok)
+		assert.Equal(t, "turn.1", mockSpan.Name)
+		assert.Equal(t, "agent-a", mockSpan.Attributes["turn.member.name"])
+	})
+
+	t.Run("RecordTurnOutput sets turn.output and count", func(t *testing.T) {
+		_, span := recorder.StartTurn(ctx, 0, "agent-a", "agent")
+		recorder.RecordTurnOutput(span, "I AM AGENT A", 2)
+		mockSpan := span.(*telemetrymock.MockSpan)
+		assert.Equal(t, "I AM AGENT A", mockSpan.Attributes["turn.output"])
+		assert.Equal(t, 2, mockSpan.Attributes["turn.output_message_count"])
+	})
+
+	t.Run("RecordTurnOutput records count but omits turn.output when empty", func(t *testing.T) {
+		_, span := recorder.StartTurn(ctx, 0, "agent-a", "agent")
+		recorder.RecordTurnOutput(span, "", 1)
+		mockSpan := span.(*telemetrymock.MockSpan)
+		assert.Equal(t, 1, mockSpan.Attributes["turn.output_message_count"])
+		_, hasOutput := mockSpan.Attributes["turn.output"]
+		assert.False(t, hasOutput)
+	})
+
+	t.Run("RecordTokenUsage sets token attributes", func(t *testing.T) {
+		_, span := recorder.StartTurn(ctx, 0, "agent-a", "agent")
+		recorder.RecordTokenUsage(span, 10, 20, 30)
+		mockSpan := span.(*telemetrymock.MockSpan)
+		assert.Equal(t, int64(10), mockSpan.Attributes[telemetry.AttrTokensPrompt])
+		assert.Equal(t, int64(20), mockSpan.Attributes[telemetry.AttrTokensCompletion])
+		assert.Equal(t, int64(30), mockSpan.Attributes[telemetry.AttrTokensTotal])
+	})
+}

--- a/ark/internal/telemetry/recorders.go
+++ b/ark/internal/telemetry/recorders.go
@@ -118,8 +118,8 @@ type TeamRecorder interface {
 	// StartTurn begins tracing a single turn in team execution.
 	StartTurn(ctx context.Context, turn int, memberName, memberType string) (context.Context, Span)
 
-	// RecordTurnOutput records turn execution output messages.
-	RecordTurnOutput(span Span, messages any, messageCount int)
+	// RecordTurnOutput records turn execution output.
+	RecordTurnOutput(span Span, output string, messageCount int)
 
 	// RecordTokenUsage records token consumption for team execution.
 	RecordTokenUsage(span Span, promptTokens, completionTokens, totalTokens int64)


### PR DESCRIPTION
## Summary
- Fixes #2509: `turn.output` was always empty on team OTEL spans.
- `RecordTurnOutput` type-asserted the turn messages to `[]interface{}`, which never matches the `[]completions.Message` passed by team executors, so `turn.output` was never set.
- Changed the `TeamRecorder.RecordTurnOutput` signature to take the extracted `output string`; content extraction now happens at the call sites via `ExtractLastAssistantMessageContent`.
- Applies to all team strategies (sequential, round-robin, selector, graph).
- Added a regression test on the OTEL team recorder and extended the caller-side test.