### PR TITLE
chore(ark-dashboard): speed up devspace dev npm install (skip audit + persist cache)

### DIFF
--- a/services/ark-dashboard/devspace.yaml
+++ b/services/ark-dashboard/devspace.yaml
@@ -16,9 +16,9 @@ pipelines:
   dev: |-
     create_deployments --all
 
-    # Patch deployment to add PVC for node modules
+    # Patch deployment to add PVCs for node modules and the npm cache
     kubectl patch deployment ark-dashboard -n ${DEVSPACE_NAMESPACE:-default} --type=strategic -p \
-      '{"spec":{"template":{"spec":{"volumes":[{"name":"node-modules","persistentVolumeClaim":{"claimName":"ark-dashboard-node-modules"}}],"containers":[{"name":"ark-dashboard","volumeMounts":[{"name":"node-modules","mountPath":"/app/ark-dashboard/node_modules"}]}]}}}}' || true
+      '{"spec":{"template":{"spec":{"volumes":[{"name":"node-modules","persistentVolumeClaim":{"claimName":"ark-dashboard-node-modules"}},{"name":"npm-cache","persistentVolumeClaim":{"claimName":"ark-dashboard-npm-cache"}}],"containers":[{"name":"ark-dashboard","volumeMounts":[{"name":"node-modules","mountPath":"/app/ark-dashboard/node_modules"},{"name":"npm-cache","mountPath":"/npm-cache"}]}]}}}}' || true
 
     start_dev --all
 
@@ -62,6 +62,8 @@ deployments:
         extraPVCs:
           - name: ark-dashboard-node-modules
             size: 2Gi
+          - name: ark-dashboard-npm-cache
+            size: 2Gi
 
 dev:
   ark-dashboard:
@@ -70,6 +72,8 @@ dev:
     env:
       - name: NODE_ENV
         value: development
+      - name: npm_config_cache
+        value: /npm-cache
     command:
       [
         "sh",

--- a/services/ark-dashboard/devspace.yaml
+++ b/services/ark-dashboard/devspace.yaml
@@ -74,7 +74,7 @@ dev:
       [
         "sh",
         "-c",
-        "cd /app/ark-dashboard && npm install && npm run dev 2>&1",
+        "cd /app/ark-dashboard && npm install --prefer-offline --no-audit --no-fund && npm run dev 2>&1",
       ]
     namespace: default
     # Stream logs instead of terminal


### PR DESCRIPTION
## Summary
Speed up the dashboard's `npm install` inside the devspace dev container. Two complementary changes, both scoped entirely to devspace — production is unaffected.

1. **Skip audit/fund, prefer cache** — add `--prefer-offline --no-audit --no-fund` to the dev container's `npm install`. Install result is identical; only the registry audit round-trip and funding message are dropped.
2. **Persist the npm cache** — add an `ark-dashboard-npm-cache` PVC mounted at `/npm-cache` (via `npm_config_cache`) so the cache survives pod restarts. This makes `--prefer-offline` effective on cold `node_modules` rebuilds.

### Measurement
Verified in an ad-hoc minikube cluster reproducing the devspace dev container (`node:24-alpine` + persistent `node_modules` PVC + npm-cache PVC; fresh pod per `devspace dev`).

| Scenario | Before | After | Change |
|---|---|---|---|
| Warm restart (`node_modules` intact) | ~1010ms | ~590ms | ~41% faster (from `--no-audit --no-fund`) |
| Cold `node_modules` rebuild | ~49–62s | ~7s | **~7–9× faster** (from warm cache PVC) |

The cold-rebuild win is the big one — it hits whenever `node_modules` needs rebuilding (first run after cache warms, lockfile change, or cleared PVC). `--offline` ≈ `--prefer-offline` in testing, confirming zero network fetches with a warm cache.

### Production safety
All changes live under devspace-only keys (`pipelines.dev`, `dev.*`, and `deployments.*.helm.values`). The chart defines no `extraPVCs` by default, so production `helm upgrade --install` (from `build.mk`, which never reads `devspace.yaml`) renders **0 PVCs** and no env/patch changes — verified with `helm template`.