### PR TITLE
fix(ark-api): resolve false "Cluster unavailable" on webhook-authorizer clusters

### DIFF
--- a/services/ark-api/ark-api/src/ark_api/core/permissions.py
+++ b/services/ark-api/ark-api/src/ark_api/core/permissions.py
@@ -13,6 +13,13 @@ logger = logging.getLogger(__name__)
 ARK_API_GROUP = "ark.mckinsey.com"
 WILDCARD = "*"
 
+# Resources the dashboard access gate requires the user to be able to list.
+# Kept in sync with ESSENTIAL_RESOURCES in ark-dashboard's lib/permissions.ts.
+# Used only for the access-review fallback below, so the fallback returns
+# exactly what the gate needs to render the app or "Access denied".
+ESSENTIAL_RESOURCES = ("agents", "models", "queries", "teams", "tools")
+ESSENTIAL_VERB = "list"
+
 # Returned to the client when permissions cannot be determined. The underlying
 # cause (exception text, evaluation errors) is logged server-side rather than
 # echoed back, so internal details are not exposed to callers.
@@ -63,22 +70,51 @@ async def get_ark_permissions(
                     spec=client.V1SelfSubjectRulesReviewSpec(namespace=namespace)
                 )
             )
+            status = review.status
+            if status is not None and not (
+                status.incomplete or status.evaluation_error
+            ):
+                return PermissionsResponse(
+                    status="ok",
+                    rules=build_ark_rules(status.resource_rules),
+                )
+
+            # The authorizer could not enumerate a complete rule set. This is
+            # expected on clusters whose authorization chain includes a webhook
+            # authorizer (e.g. EKS), which answers concrete access decisions but
+            # not rule enumeration. Fall back to explicit access reviews, which
+            # every authorizer can answer, instead of reporting the whole
+            # authorization service as unavailable.
+            logger.info(
+                "SelfSubjectRulesReview incomplete (%s); falling back to access reviews",
+                None if status is None else status.evaluation_error,
+            )
+            rules = await _access_review_rules(authz, namespace)
+            return PermissionsResponse(status="ok", rules=rules)
     except Exception as e:
-        logger.warning("SelfSubjectRulesReview failed: %s", e)
+        logger.warning("Permission evaluation failed: %s", e)
         return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
 
-    status = review.status
-    if status is None:
-        logger.warning("SelfSubjectRulesReview returned no status")
-        return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
 
-    if status.incomplete or status.evaluation_error:
-        logger.warning(
-            "SelfSubjectRulesReview incomplete: %s", status.evaluation_error
+async def _access_review_rules(authz, namespace: str) -> dict[str, list[str]]:
+    rules: dict[str, list[str]] = {}
+    for resource in ESSENTIAL_RESOURCES:
+        if await _can_i(authz, namespace, resource, ESSENTIAL_VERB):
+            rules[resource] = [ESSENTIAL_VERB]
+    return rules
+
+
+async def _can_i(authz, namespace: str, resource: str, verb: str) -> bool:
+    review = await authz.create_self_subject_access_review(
+        client.V1SelfSubjectAccessReview(
+            spec=client.V1SelfSubjectAccessReviewSpec(
+                resource_attributes=client.V1ResourceAttributes(
+                    namespace=namespace,
+                    group=ARK_API_GROUP,
+                    resource=resource,
+                    verb=verb,
+                )
+            )
         )
-        return PermissionsResponse(status="unavailable", reason=UNAVAILABLE_REASON)
-
-    return PermissionsResponse(
-        status="ok",
-        rules=build_ark_rules(status.resource_rules),
     )
+    return bool(review.status and review.status.allowed)

--- a/services/ark-api/ark-api/tests/services/test_permissions.py
+++ b/services/ark-api/ark-api/tests/services/test_permissions.py
@@ -52,13 +52,32 @@ class TestBuildArkRules(unittest.TestCase):
         self.assertEqual(build_ark_rules(None), {})
 
 
-def _mock_helper(review=None, raises=None):
+def _access_review(allowed_resources=(), raises=None):
+    """Build a create_self_subject_access_review mock.
+
+    Returns allowed=True for resources in ``allowed_resources``, based on the
+    resource read back from the submitted V1SelfSubjectAccessReview spec.
+    """
+    if raises is not None:
+        return AsyncMock(side_effect=raises)
+
+    def _call(body):
+        resource = body.spec.resource_attributes.resource
+        review = Mock()
+        review.status.allowed = resource in allowed_resources
+        return review
+
+    return AsyncMock(side_effect=_call)
+
+
+def _mock_helper(review=None, raises=None, access=None):
     """Patch get_impersonating_api_client to yield an AuthorizationV1Api mock."""
     api = AsyncMock()
     if raises is not None:
         api.create_self_subject_rules_review = AsyncMock(side_effect=raises)
     else:
         api.create_self_subject_rules_review = AsyncMock(return_value=review)
+    api.create_self_subject_access_review = access or _access_review()
     cm = AsyncMock()
     cm.__aenter__.return_value = Mock()
     cm.__aexit__.return_value = False
@@ -100,12 +119,60 @@ class TestGetArkPermissions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.status, "ok")
         self.assertEqual(result.rules, {"agents": ["get", "list"]})
 
-    async def test_incomplete_returns_generic_reason(self):
+    async def test_incomplete_falls_back_to_access_reviews(self):
+        # An incomplete rules review (e.g. EKS webhook authorizer cannot resolve
+        # user rules) falls back to concrete access reviews rather than reporting
+        # the authorization service as unavailable.
         review = Mock()
         review.status.incomplete = True
-        review.status.evaluation_error = "webhook authorizer unavailable"
+        review.status.evaluation_error = (
+            "webhook authorizer does not support user rule resolution"
+        )
         review.status.resource_rules = []
-        api, cm = _mock_helper(review=review)
+        api, cm = _mock_helper(
+            review=review,
+            access=_access_review(allowed_resources={"agents", "models"}),
+        )
+        with patch(
+            "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
+        ), patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.rules, {"agents": ["list"], "models": ["list"]})
+
+    async def test_incomplete_access_reviews_all_denied(self):
+        # Access reviews complete but grant nothing: this is a genuine "no access"
+        # result (dashboard shows Access denied), not "unavailable".
+        review = Mock()
+        review.status.incomplete = True
+        review.status.evaluation_error = "no rule resolution"
+        review.status.resource_rules = []
+        api, cm = _mock_helper(review=review, access=_access_review(allowed_resources=set()))
+        with patch(
+            "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
+        ), patch(
+            "ark_api.core.permissions.client.AuthorizationV1Api", return_value=api
+        ):
+            result = await get_ark_permissions(
+                ImpersonationConfig(username="u", groups=["g"]), "default"
+            )
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.rules, {})
+
+    async def test_incomplete_access_reviews_fail_unavailable(self):
+        # If the fallback access reviews themselves cannot be completed, that is a
+        # genuine authorization failure and must stay unavailable.
+        review = Mock()
+        review.status.incomplete = True
+        review.status.evaluation_error = "no rule resolution"
+        review.status.resource_rules = []
+        api, cm = _mock_helper(
+            review=review, access=_access_review(raises=RuntimeError("boom"))
+        )
         with patch(
             "ark_api.api.v1.client_utils.get_impersonating_api_client", return_value=cm
         ), patch(
@@ -115,9 +182,8 @@ class TestGetArkPermissions(unittest.IsolatedAsyncioTestCase):
                 ImpersonationConfig(username="u", groups=["g"]), "default"
             )
         self.assertEqual(result.status, "unavailable")
-        # Internal evaluation_error must not leak to the client.
         self.assertEqual(result.reason, UNAVAILABLE_REASON)
-        self.assertNotIn("webhook", result.reason or "")
+        self.assertNotIn("boom", result.reason or "")
 
     async def test_review_raises_returns_generic_reason(self):
         api, cm = _mock_helper(raises=RuntimeError("boom"))

--- a/services/ark-api/chart/templates/rbac.yaml
+++ b/services/ark-api/chart/templates/rbac.yaml
@@ -93,6 +93,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 rules:
+  # Read namespace metadata to detect the ark.mckinsey.com/demo label
+  # (read-only mode) in GET /v1/context. Namespaces are cluster-scoped, so this
+  # must be granted here rather than in the namespaced Role.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
   # Cluster-scoped Ark resources (singleton ArkConfig for global defaults)
   - apiGroups: ["ark.mckinsey.com"]
     resources: ["arkconfigs"]


### PR DESCRIPTION
## Summary

After a successful SSO login, the dashboard could show **Cluster unavailable** ("The cluster authorization service may be unreachable") even though the user had valid access. This happened on clusters whose authorization chain includes a webhook authorizer — most notably Amazon EKS.

## Why it happened

The `/v1/context` permission preflight (`core/permissions.py`) ran a `SelfSubjectRulesReview` and treated **any** incomplete result as a total authorization-service failure (`permissions.status = "unavailable"`).

That assumption only holds for native RBAC. A webhook authorizer answers concrete, request-by-request access decisions but is not required to *enumerate* a user's complete rule set. Kubernetes represents this by returning the review with `incomplete: true` and an evaluation error such as `webhook authorizer does not support user rule resolution`, **together with** the RBAC rules it could resolve. The preflight discarded all of that and reported an outage; the dashboard mapped `unavailable` to the cluster-failure page and blocked the app.

## How it is fixed

Rather than special-casing a provider-specific error string (which would fix EKS only), the preflight now falls back to a mechanism every authorizer supports:

- **Complete rules review** → unchanged. Rules are read from the review exactly as before, so native RBAC-only clusters keep their existing behaviour bit-for-bit.
- **Incomplete review** (any provider, no string matching) → issue explicit `SelfSubjectAccessReview` checks for the resources the dashboard gate actually requires, using the same impersonated identity, and build the permission map from the concrete answers.
- **`unavailable`** is now reserved for the case where the authorization requests themselves cannot be completed (e.g. the API is genuinely unreachable).

`SelfSubjectAccessReview` is core Kubernetes and is answered by RBAC, webhook, node and any other authorizer, so the result is accurate on every previously-supported cluster as well as on EKS. No new RBAC is required for the fallback — the service account already holds `selfsubjectaccessreviews: create`.

The fallback checks `list` on the five resources the gate depends on (`agents, models, queries, teams, tools`, kept in sync with the dashboard's `ESSENTIAL_RESOURCES`). This is bounded to five calls and only runs when the rules review is incomplete.

### Secondary fix: namespace metadata RBAC

While investigating, the service account was found to lack `get` on `namespaces`. `GET /v1/context` reads namespace metadata to detect the `ark.mckinsey.com/demo` label that drives read-only mode; without the permission the read returned 403, so label-based read-only detection silently fell back to the env var and a missing namespace returned 403 instead of the 404 the redirect flow expects. Namespaces are cluster-scoped, so the grant is added to the ClusterRole.

## Behaviour change worth noting

Previously an incomplete review was *always* `unavailable`. It is now resolved via concrete access reviews, so a user who genuinely lacks access sees an accurate **Access denied** instead of a misleading cluster-failure page. `unavailable` now means only "authorization could not be evaluated at all".

## Review guide

- `services/ark-api/ark-api/src/ark_api/core/permissions.py` — the primary/complete path is untouched; the new branch is the `incomplete` fallback (`_access_review_rules` / `_can_i`).
- `services/ark-api/ark-api/tests/services/test_permissions.py` — covers complete review, incomplete→granted, incomplete→denied, incomplete→access-review failure, and rules-review failure.
- `services/ark-api/chart/templates/rbac.yaml` — `get namespaces` added to the ClusterRole (`namespaces` is cluster-scoped, so it cannot live in the namespaced Role).

## Security

The `/v1/context` result is a UI gate only. All backend operations continue to run under the authenticated user's impersonated identity and are enforced by Kubernetes. The fix does not disable impersonation, open authentication, or return wildcard permissions.