### PR TITLE
feat(apiserver): gate WAL consumer behind leader election

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -426,6 +426,10 @@ func setupEmbeddedApiserver(mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to add embedded apiserver to manager")
 		os.Exit(1)
 	}
+	if err := mgr.Add(server.WALConsumer()); err != nil {
+		setupLog.Error(err, "unable to add WAL consumer to manager")
+		os.Exit(1)
+	}
 	setupLog.Info("embedded apiserver configured", "backend", backend)
 }
 

--- a/ark/dist/chart-apiserver/README.md
+++ b/ark/dist/chart-apiserver/README.md
@@ -39,7 +39,9 @@ If you redeploy the apiserver later, it detects the existing slot on startup and
 
 ### Multi-replica behaviour
 
-The chart defaults to a single replica. The chart grants the apiserver ServiceAccount the RBAC needed for `controller-runtime` leader election (`Lease/ark-apiserver-leader`). If you scale to multiple replicas, only one instance acquires the lease and runs the WAL consumer — the persistent replication slot's `active` flag also serves as a backstop, so even without leader election only one replica can hold the slot at a time.
+The chart defaults to a single replica — note that an unavailable aggregated apiserver degrades kube-apiserver discovery and garbage collection cluster-wide, so for production run `replicas=2` with `podDisruptionBudget.enabled=true`.
+
+All replicas serve API traffic; only the leader (`Lease/ark-apiserver-leader`) runs the WAL consumer, since the replication slot admits a single connection (the slot's `active` flag is a backstop). Non-leader replicas do not touch the slot and serve watches from a periodic relist (up to ~120s stale) until they acquire the lease.
 
 ### Required PostgreSQL configuration
 

--- a/ark/dist/chart-apiserver/templates/poddisruptionbudget.yaml
+++ b/ark/dist/chart-apiserver/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ark-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "ark-apiserver.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/ark/dist/chart-apiserver/values.yaml
+++ b/ark/dist/chart-apiserver/values.yaml
@@ -79,3 +79,7 @@ certManager:
 networkPolicy:
   enabled: false
   extraIngressFrom: []
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1

--- a/ark/go.mod
+++ b/ark/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26

--- a/ark/go.sum
+++ b/ark/go.sum
@@ -12,6 +12,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
@@ -203,6 +205,7 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -114,9 +114,10 @@ type Config struct {
 }
 
 type Server struct {
-	config  Config
-	backend storage.Backend
-	stopCh  chan struct{}
+	config       Config
+	backend      *postgresql.PostgreSQLBackend
+	backendReady chan struct{}
+	stopCh       chan struct{}
 }
 
 func New(cfg Config) *Server {
@@ -127,9 +128,37 @@ func New(cfg Config) *Server {
 		cfg.AuthMode = AuthModeDelegated
 	}
 	return &Server{
-		config: cfg,
-		stopCh: make(chan struct{}),
+		config:       cfg,
+		backendReady: make(chan struct{}),
+		stopCh:       make(chan struct{}),
 	}
+}
+
+// walConsumer starts the backend's WAL consumer once this replica holds the
+// leader lease. The replication slot is single-consumer: without this gate,
+// extra replicas error-loop trying to acquire the slot.
+type walConsumer struct {
+	server *Server
+}
+
+func (w *walConsumer) Start(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-w.server.backendReady:
+	}
+	klog.Info("Leader lease acquired; starting WAL consumer")
+	w.server.backend.StartWALConsumer()
+	<-ctx.Done()
+	return nil
+}
+
+func (w *walConsumer) NeedLeaderElection() bool {
+	return true
+}
+
+func (s *Server) WALConsumer() *walConsumer {
+	return &walConsumer{server: s}
 }
 
 func (s *Server) Start(ctx context.Context) error {
@@ -143,20 +172,22 @@ func (s *Server) Start(ctx context.Context) error {
 	var err error
 
 	cfg := postgresql.Config{
-		Host:        s.config.PostgresHost,
-		Port:        s.config.PostgresPort,
-		Database:    s.config.PostgresDB,
-		User:        s.config.PostgresUser,
-		Password:    s.config.PostgresPass,
-		SSLMode:     s.config.PostgresSSL,
-		SSLRootCert: s.config.PostgresSSLRoot,
-		SSLCert:     s.config.PostgresSSLCert,
-		SSLKey:      s.config.PostgresSSLKey,
+		Host:             s.config.PostgresHost,
+		Port:             s.config.PostgresPort,
+		Database:         s.config.PostgresDB,
+		User:             s.config.PostgresUser,
+		Password:         s.config.PostgresPass,
+		SSLMode:          s.config.PostgresSSL,
+		SSLRootCert:      s.config.PostgresSSLRoot,
+		SSLCert:          s.config.PostgresSSLCert,
+		SSLKey:           s.config.PostgresSSLKey,
+		DeferWALConsumer: true,
 	}
 	s.backend, err = postgresql.New(cfg, converter)
 	if err != nil {
 		return fmt.Errorf("failed to create PostgreSQL backend: %w", err)
 	}
+	close(s.backendReady)
 	klog.Infof("Using PostgreSQL storage backend: %s:%d/%s", cfg.Host, cfg.Port, cfg.Database)
 
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -138,17 +138,18 @@ func New(cfg Config) *Server {
 // leader lease. The replication slot is single-consumer: without this gate,
 // extra replicas error-loop trying to acquire the slot.
 type walConsumer struct {
-	server *Server
+	ready <-chan struct{}
+	start func()
 }
 
 func (w *walConsumer) Start(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return nil
-	case <-w.server.backendReady:
+	case <-w.ready:
 	}
 	klog.Info("Leader lease acquired; starting WAL consumer")
-	w.server.backend.StartWALConsumer()
+	w.start()
 	<-ctx.Done()
 	return nil
 }
@@ -158,7 +159,10 @@ func (w *walConsumer) NeedLeaderElection() bool {
 }
 
 func (s *Server) WALConsumer() *walConsumer {
-	return &walConsumer{server: s}
+	return &walConsumer{
+		ready: s.backendReady,
+		start: func() { s.backend.StartWALConsumer() },
+	}
 }
 
 func (s *Server) Start(ctx context.Context) error {

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -172,16 +172,15 @@ func (s *Server) Start(ctx context.Context) error {
 	var err error
 
 	cfg := postgresql.Config{
-		Host:             s.config.PostgresHost,
-		Port:             s.config.PostgresPort,
-		Database:         s.config.PostgresDB,
-		User:             s.config.PostgresUser,
-		Password:         s.config.PostgresPass,
-		SSLMode:          s.config.PostgresSSL,
-		SSLRootCert:      s.config.PostgresSSLRoot,
-		SSLCert:          s.config.PostgresSSLCert,
-		SSLKey:           s.config.PostgresSSLKey,
-		DeferWALConsumer: true,
+		Host:        s.config.PostgresHost,
+		Port:        s.config.PostgresPort,
+		Database:    s.config.PostgresDB,
+		User:        s.config.PostgresUser,
+		Password:    s.config.PostgresPass,
+		SSLMode:     s.config.PostgresSSL,
+		SSLRootCert: s.config.PostgresSSLRoot,
+		SSLCert:     s.config.PostgresSSLCert,
+		SSLKey:      s.config.PostgresSSLKey,
 	}
 	s.backend, err = postgresql.New(cfg, converter)
 	if err != nil {

--- a/ark/internal/apiserver/server_test.go
+++ b/ark/internal/apiserver/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +26,36 @@ func TestNew_Defaults(t *testing.T) {
 	}
 	if s.config.AuthMode != AuthModeDelegated {
 		t.Errorf("AuthMode = %q, want %q", s.config.AuthMode, AuthModeDelegated)
+	}
+}
+
+func TestServer_LeaderElectionSplit(t *testing.T) {
+	t.Parallel()
+
+	s := New(Config{})
+	if s.NeedLeaderElection() {
+		t.Error("Server must serve on every replica: NeedLeaderElection() = true, want false")
+	}
+	if !s.WALConsumer().NeedLeaderElection() {
+		t.Error("WAL consumer must be single-instance: NeedLeaderElection() = false, want true")
+	}
+}
+
+func TestWALConsumer_StopsWhenBackendNeverReady(t *testing.T) {
+	t.Parallel()
+
+	s := New(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.WALConsumer().Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WAL consumer runnable did not stop on context cancellation")
 	}
 }
 

--- a/ark/internal/apiserver/server_test.go
+++ b/ark/internal/apiserver/server_test.go
@@ -59,6 +59,35 @@ func TestWALConsumer_StopsWhenBackendNeverReady(t *testing.T) {
 	}
 }
 
+func TestWALConsumer_StartsWhenBackendReady(t *testing.T) {
+	t.Parallel()
+
+	ready := make(chan struct{})
+	started := make(chan struct{})
+	w := &walConsumer{ready: ready, start: func() { close(started) }}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Start(ctx) }()
+
+	close(ready)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartWALConsumer was not called after backend became ready")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WAL consumer runnable did not stop after context cancellation")
+	}
+}
+
 func TestServer_Start_InvalidAuthMode(t *testing.T) {
 	t.Parallel()
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -155,18 +155,17 @@ func labelSelectorSQL(sel k8slabels.Selector, args *[]interface{}) string {
 }
 
 type Config struct {
-	Host             string
-	Port             int
-	Database         string
-	User             string
-	Password         string
-	SSLMode          string
-	SSLRootCert      string
-	SSLCert          string
-	SSLKey           string
-	MaxOpenConns     int
-	MaxIdleConns     int
-	DeferWALConsumer bool
+	Host         string
+	Port         int
+	Database     string
+	User         string
+	Password     string
+	SSLMode      string
+	SSLRootCert  string
+	SSLCert      string
+	SSLKey       string
+	MaxOpenConns int
+	MaxIdleConns int
 }
 
 type PostgreSQLBackend struct {
@@ -259,9 +258,6 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 	}
 
 	backend.warmPool()
-	if !cfg.DeferWALConsumer {
-		backend.StartWALConsumer()
-	}
 	go backend.refreshBookmarkLoop()
 	go backend.cleanupLoop()
 
@@ -269,8 +265,9 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 }
 
 // StartWALConsumer starts the logical-replication consumer that drives the
-// watch stream. The slot is single-consumer, so with DeferWALConsumer a caller
-// gates this behind leader election; repeated calls are no-ops.
+// watch stream. New never starts it: the slot is single-consumer, so the caller
+// decides when this replica may take it (the apiserver gates it behind leader
+// election). Repeated calls are no-ops.
 func (p *PostgreSQLBackend) StartWALConsumer() {
 	p.walOnce.Do(func() {
 		go p.startWALConsumer()
@@ -298,6 +295,9 @@ func (p *PostgreSQLBackend) warmPool() {
 // not atomic against a simultaneous creator (IF NOT EXISTS only helps if the object
 // already exists at check time), so multiple replicas starting against a fresh
 // database race on the resources row-type. The advisory lock makes them serialize.
+// The value is an arbitrary application-chosen constant: pg_advisory_xact_lock keys
+// are raw int64s with no registry, so it only has to be stable and not collide with
+// other advisory-lock users of the same database.
 const schemaInitLockKey int64 = 8626421043
 
 func (p *PostgreSQLBackend) initSchema() error {

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -155,17 +155,18 @@ func labelSelectorSQL(sel k8slabels.Selector, args *[]interface{}) string {
 }
 
 type Config struct {
-	Host         string
-	Port         int
-	Database     string
-	User         string
-	Password     string
-	SSLMode      string
-	SSLRootCert  string
-	SSLCert      string
-	SSLKey       string
-	MaxOpenConns int
-	MaxIdleConns int
+	Host             string
+	Port             int
+	Database         string
+	User             string
+	Password         string
+	SSLMode          string
+	SSLRootCert      string
+	SSLCert          string
+	SSLKey           string
+	MaxOpenConns     int
+	MaxIdleConns     int
+	DeferWALConsumer bool
 }
 
 type PostgreSQLBackend struct {
@@ -180,6 +181,7 @@ type PostgreSQLBackend struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	cachedRV     atomic.Int64
+	walOnce      sync.Once
 }
 
 var connValueEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
@@ -257,11 +259,22 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 	}
 
 	backend.warmPool()
-	go backend.startWALConsumer()
+	if !cfg.DeferWALConsumer {
+		backend.StartWALConsumer()
+	}
 	go backend.refreshBookmarkLoop()
 	go backend.cleanupLoop()
 
 	return backend, nil
+}
+
+// StartWALConsumer starts the logical-replication consumer that drives the
+// watch stream. The slot is single-consumer, so with DeferWALConsumer a caller
+// gates this behind leader election; repeated calls are no-ops.
+func (p *PostgreSQLBackend) StartWALConsumer() {
+	p.walOnce.Do(func() {
+		go p.startWALConsumer()
+	})
 }
 
 func (p *PostgreSQLBackend) warmPool() {
@@ -280,6 +293,12 @@ func (p *PostgreSQLBackend) warmPool() {
 	}
 	wg.Wait()
 }
+
+// schemaInitLockKey serializes concurrent schema initialization. Postgres DDL is
+// not atomic against a simultaneous creator (IF NOT EXISTS only helps if the object
+// already exists at check time), so multiple replicas starting against a fresh
+// database race on the resources row-type. The advisory lock makes them serialize.
+const schemaInitLockKey int64 = 8626421043
 
 func (p *PostgreSQLBackend) initSchema() error {
 	schema := `
@@ -322,8 +341,19 @@ func (p *PostgreSQLBackend) initSchema() error {
 		END IF;
 	END $$;
 	`
-	_, err := p.db.Exec(schema)
-	return err
+	tx, err := p.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec("SELECT pg_advisory_xact_lock($1)", schemaInitLockKey); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(schema); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // startWALConsumer and runWALConsumer are in wal_consumer.go

--- a/ark/internal/storage/postgresql/postgresql_integration_test.go
+++ b/ark/internal/storage/postgresql/postgresql_integration_test.go
@@ -91,6 +91,7 @@ func TestOptimisticConcurrency_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testName := "concurrency-test-resource"
@@ -201,6 +202,7 @@ func TestOptimisticConcurrency_Status_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testName := "status-concurrency-test"
@@ -300,6 +302,7 @@ func TestCreateAlreadyExists_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testName := "already-exists-test-resource"
@@ -359,6 +362,7 @@ func TestWatchAddedForFirstSeenUID_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -471,6 +475,7 @@ func TestGracefulDeletion_DeletionTimestampPersistence_Integration(t *testing.T)
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testName := "graceful-delete-resource"
@@ -581,6 +586,7 @@ func TestList_PaginationSnapshotConsistency_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testKind := "PaginationTestResource"
@@ -744,6 +750,7 @@ func TestGenerationOnlyBumpsOnSpecChange_Integration(t *testing.T) {
 		t.Fatalf("Failed to create backend: %v", err)
 	}
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx := context.Background()
 	testKind := "TestResource"

--- a/ark/internal/storage/postgresql/wal_lifecycle_integration_test.go
+++ b/ark/internal/storage/postgresql/wal_lifecycle_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestDeferWALConsumer_Integration(t *testing.T) {
+func TestWALConsumerManualStart_Integration(t *testing.T) {
 	host := os.Getenv("POSTGRES_HOST")
 	if host == "" {
 		t.Skip("POSTGRES_HOST not set, skipping integration test")
@@ -26,13 +26,12 @@ func TestDeferWALConsumer_Integration(t *testing.T) {
 	}
 
 	cfg := Config{
-		Host:             host,
-		Port:             port,
-		Database:         "ark",
-		User:             "ark",
-		Password:         os.Getenv("POSTGRES_PASSWORD"),
-		SSLMode:          "disable",
-		DeferWALConsumer: true,
+		Host:     host,
+		Port:     port,
+		Database: "ark",
+		User:     "ark",
+		Password: os.Getenv("POSTGRES_PASSWORD"),
+		SSLMode:  "disable",
 	}
 
 	checker, err := sql.Open("postgres", fmt.Sprintf(
@@ -68,7 +67,7 @@ func TestDeferWALConsumer_Integration(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 	if n := slotCount(); n != 0 {
-		t.Fatalf("DeferWALConsumer backend created a replication slot: count %d", n)
+		t.Fatalf("backend created a replication slot before StartWALConsumer: count %d", n)
 	}
 
 	backend.StartWALConsumer()

--- a/ark/internal/storage/postgresql/wal_lifecycle_integration_test.go
+++ b/ark/internal/storage/postgresql/wal_lifecycle_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+// +build integration
+
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestDeferWALConsumer_Integration(t *testing.T) {
+	host := os.Getenv("POSTGRES_HOST")
+	if host == "" {
+		t.Skip("POSTGRES_HOST not set, skipping integration test")
+	}
+
+	port := 5432
+	if p := os.Getenv("POSTGRES_PORT"); p != "" {
+		port, _ = strconv.Atoi(p)
+	}
+
+	cfg := Config{
+		Host:             host,
+		Port:             port,
+		Database:         "ark",
+		User:             "ark",
+		Password:         os.Getenv("POSTGRES_PASSWORD"),
+		SSLMode:          "disable",
+		DeferWALConsumer: true,
+	}
+
+	checker, err := sql.Open("postgres", fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Database, cfg.SSLMode,
+	))
+	if err != nil {
+		t.Fatalf("open checker connection: %v", err)
+	}
+	defer checker.Close()
+
+	slotCount := func() int {
+		var n int
+		if err := checker.QueryRow(
+			"SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1", walSlotName,
+		).Scan(&n); err != nil {
+			t.Fatalf("query pg_replication_slots: %v", err)
+		}
+		return n
+	}
+
+	_, _ = checker.Exec("SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = $1 AND active_pid IS NOT NULL", walSlotName)
+	_, _ = checker.Exec("SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1", walSlotName)
+	if n := slotCount(); n != 0 {
+		t.Fatalf("precondition failed: slot still present (count %d)", n)
+	}
+
+	backend, err := New(cfg, &integrationMockConverter{})
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	time.Sleep(3 * time.Second)
+	if n := slotCount(); n != 0 {
+		t.Fatalf("DeferWALConsumer backend created a replication slot: count %d", n)
+	}
+
+	backend.StartWALConsumer()
+	deadline := time.Now().Add(15 * time.Second)
+	for slotCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("replication slot not created within 15s after StartWALConsumer")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	backend.StartWALConsumer()
+	time.Sleep(1 * time.Second)
+	if n := slotCount(); n != 1 {
+		t.Errorf("expected exactly 1 slot after repeated StartWALConsumer, got %d", n)
+	}
+}

--- a/ark/internal/storage/postgresql/wal_lifecycle_test.go
+++ b/ark/internal/storage/postgresql/wal_lifecycle_test.go
@@ -1,0 +1,96 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestStartWALConsumer_ConsumesOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := &PostgreSQLBackend{ctx: ctx}
+
+	p.StartWALConsumer()
+	p.StartWALConsumer()
+
+	ran := false
+	p.walOnce.Do(func() { ran = true })
+	if ran {
+		t.Error("StartWALConsumer did not consume walOnce")
+	}
+}
+
+func TestInitSchema_SerializesViaAdvisoryLock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("pg_advisory_xact_lock").WithArgs(schemaInitLockKey).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS resources").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	p := &PostgreSQLBackend{db: db}
+	if err := p.initSchema(); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitSchema_Errors(t *testing.T) {
+	cases := []struct {
+		name   string
+		expect func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "begin fails",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin().WillReturnError(context.DeadlineExceeded)
+			},
+		},
+		{
+			name: "advisory lock fails",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("pg_advisory_xact_lock").WithArgs(schemaInitLockKey).WillReturnError(context.DeadlineExceeded)
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "schema exec fails",
+			expect: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("pg_advisory_xact_lock").WithArgs(schemaInitLockKey).WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("CREATE TABLE IF NOT EXISTS resources").WillReturnError(context.DeadlineExceeded)
+				mock.ExpectRollback()
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			c.expect(mock)
+
+			p := &PostgreSQLBackend{db: db}
+			if err := p.initSchema(); err == nil {
+				t.Fatal("expected error")
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -209,16 +209,22 @@ The aggregated apiserver enforces the same access control as the rest of the clu
 - **Verified serving TLS.** With `certManager.enabled` (the default), cert-manager issues the serving certificate for the `ark-apiserver` service, mounts it into the pod, and injects the CA into both APIServices — the kube-apiserver verifies the aggregated apiserver's identity instead of `insecureSkipTLSVerify`. The certificate rotates through cert-manager and the server reloads it without a restart. Setting `certManager.enabled=false` restores the previous behavior (ephemeral self-signed certificate, unverified proxy channel) for clusters without cert-manager.
 - **Optional NetworkPolicy.** `networkPolicy.enabled=true` restricts ingress to the serving and health ports; use `networkPolicy.extraIngressFrom` to pin the allowed sources for the serving port (the origin of kube-apiserver traffic depends on your CNI, which is why this is off by default).
 
-## Multi-replica behaviour
+## Availability and multi-replica behaviour
 
-The `ark-apiserver` chart defaults to a single replica. The chart wires the RBAC needed for controller-runtime leader election on a `Lease` named `ark-apiserver-leader`.
+The chart defaults to a single replica. Understand what that means before running it in production: when the aggregated apiserver is unavailable, the `ark.mckinsey.com` APIService goes unavailable, which degrades kube-apiserver API discovery and the garbage-collection and namespace controllers **cluster-wide** — a standard Kubernetes aggregation-layer failure mode, not something specific to Ark. A single replica is therefore a cluster-wide single point of failure during pod restarts, node drains, and crashes.
 
-If you scale to multiple replicas:
+For production, run two replicas and enable the disruption budget:
 
-- Only one instance acquires the lease and runs the WAL consumer.
-- The replication slot's `active` flag is a second backstop — even without leader election, Postgres only lets one connection hold the slot at a time.
+```bash
+--set replicas=2 --set podDisruptionBudget.enabled=true
+```
 
-Multi-replica mainly improves API request throughput; the WAL stream is still single-consumer by design.
+How multiple replicas behave:
+
+- **API serving is active-active.** Every replica serves reads and writes directly against Postgres; the Service load-balances across them. Killing any one pod leaves the APIService available.
+- **The watch stream is single-consumer by design.** Only the replica holding the `ark-apiserver-leader` lease runs the WAL consumer that drives real-time watch events (the logical replication slot admits one connection; the slot's `active` flag is a backstop even without the lease). Non-leader replicas do not touch the slot.
+- **Watches served by non-leader replicas are relist-bound.** Without the WAL stream, a non-leader refreshes its watchers on a periodic relist (up to ~120 seconds stale). Controllers tolerate this — informers resync — but if consistently low watch latency matters, keep a single replica and accept the SPOF trade-off, or route watch-heavy clients through the kubectl path.
+- **Failover:** if the leader dies, a surviving replica acquires the lease (roughly the 15s lease duration) and starts the WAL consumer; the slot position is persistent, so no events are lost across the handover.
 
 ## Backups and restore
 


### PR DESCRIPTION
## Summary
- Gate the embedded apiserver's WAL consumer behind leader election so only one replica consumes the single-consumer Postgres replication slot. Extra replicas serve reads but no longer error-loop trying to acquire the slot.
- Run the WAL consumer as a separate `NeedLeaderElection() = true` manager runnable; the backend is created with `DeferWALConsumer: true` and the consumer starts only once this replica holds the leader lease (via a `backendReady` gate).
- Add an optional `PodDisruptionBudget` to the apiserver chart (`podDisruptionBudget.enabled`, default off; `minAvailable` configurable) for multi-replica deployments.
- Correct the HA section of the Postgres storage docs to describe the leader-gated behaviour truthfully.

Fixes #2678.

Validated: leader failover exercised on a local kind cluster (standby takes over the WAL consumer on leader loss); `make test` and `golangci-lint`/`gofumpt` clean on touched packages; `helm lint` + template render (PDB on/off).

@Nab-0 for review when you have a moment — this is the last of the Postgres apiserver HA series, following the now-merged #2801 (G1). I couldn't request a reviewer directly (external contributor).
