### PR TITLE
docs: remove broken README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<!-- openspec-flow badge-start -->
-[![openspec-flow](https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/openspec-flow.yml/badge.svg)](https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/openspec-flow.yml)
-<!-- openspec-flow badge-end -->
-
 <div align="center">
   <h1 align="center"><code>⚒️ ark</code></h1>
   <h4 align="center">Agentic Runtime for Kubernetes</h4>
@@ -18,8 +14,6 @@
   </p>
   <p align="center">
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/cicd.yaml/badge.svg" alt="CI/CD"></a>
-    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy.yml/badge.svg" alt="Deploy"></a>
-    <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/deploy_gcp.yml/badge.svg" alt="Deploy GCP"></a>
     <a href="https://codecov.io/gh/mckinsey/agents-at-scale-ark"><img src="https://codecov.io/gh/mckinsey/agents-at-scale-ark/branch/main/graph/badge.svg" alt="Coverage"></a>
     <a href="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml"><img src="https://github.com/mckinsey/agents-at-scale-ark/actions/workflows/sonar_scan.yaml/badge.svg" alt="SonarQube Scan"></a>
     <a href="https://www.npmjs.com/package/@agents-at-scale/ark"><img src="https://img.shields.io/npm/v/@agents-at-scale/ark.svg" alt="npm version"></a>


### PR DESCRIPTION
## Summary
- Remove three broken badge images from the README: openspec-flow, Deploy, and Deploy GCP (their workflow badge URLs 404).