### PR TITLE
perf(broker): push Postgres stream filters and aggregates into SQL

### DIFF
--- a/services/ark-broker/ark-broker/src/brokers/event-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/event-broker.ts
@@ -21,8 +21,20 @@ export interface EventData {
   };
 }
 
+export interface EventFilter {
+  queryId?: string;
+  sessionId?: string;
+  afterSequence?: number;
+}
+
 export interface EventStream extends Stream<EventData> {
   deleteByQuery(queryId: string): Promise<void>;
+  paginateBy(
+    params: PaginationParams,
+    filter?: EventFilter
+  ): Promise<PaginatedList<BrokerItem<EventData>>>;
+  filterBy(filter: EventFilter): Promise<BrokerItem<EventData>[]>;
+  deleteBy(filter: EventFilter): Promise<void>;
 }
 
 export class EventBroker {

--- a/services/ark-broker/ark-broker/src/brokers/event-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/event-broker.ts
@@ -52,11 +52,25 @@ export class EventBroker {
   }
 
   async getByQuery(queryId: string): Promise<BrokerItem<EventData>[]> {
-    return this.stream.filter((item) => item.data.data.queryId === queryId);
+    return this.stream.filterBy({queryId});
   }
 
   async getEventsByQuery(queryId: string): Promise<EventData[]> {
     return (await this.getByQuery(queryId)).map((item) => item.data);
+  }
+
+  async eventsAfter(
+    cursor: number,
+    sessionId?: string
+  ): Promise<BrokerItem<EventData>[]> {
+    return this.stream.filterBy({sessionId, afterSequence: cursor});
+  }
+
+  async queryEventsAfter(
+    queryId: string,
+    cursor: number
+  ): Promise<BrokerItem<EventData>[]> {
+    return this.stream.filterBy({queryId, afterSequence: cursor});
   }
 
   all(): Promise<BrokerItem<EventData>[]> {
@@ -93,27 +107,21 @@ export class EventBroker {
   async paginate(
     params: PaginationParams
   ): Promise<PaginatedList<BrokerItem<EventData>>> {
-    return this.stream.paginate(params);
+    return this.stream.paginateBy(params);
   }
 
   async paginateByQuery(
     queryId: string,
     params: PaginationParams
   ): Promise<PaginatedList<BrokerItem<EventData>>> {
-    return this.stream.paginate(
-      params,
-      (item) => item.data.data.queryId === queryId
-    );
+    return this.stream.paginateBy(params, {queryId});
   }
 
   async paginateBySessionId(
     sessionId: string,
     params: PaginationParams
   ): Promise<PaginatedList<BrokerItem<EventData>>> {
-    return this.stream.paginate(
-      params,
-      (item) => item.data.data.sessionId === sessionId
-    );
+    return this.stream.paginateBy(params, {sessionId});
   }
 
   async getCurrentSequence(): Promise<number> {

--- a/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
@@ -1,5 +1,8 @@
 import {BrokerItem} from './stream/broker-item.js';
-import type {MessageStream} from './stream/message-stream.js';
+import type {
+  ConversationStats,
+  MessageStream,
+} from './stream/message-stream.js';
 import {PaginatedList, PaginationParams} from './pagination.js';
 
 export type Message = unknown;
@@ -59,9 +62,11 @@ export class MemoryBroker {
   }
 
   async getConversationIds(): Promise<string[]> {
-    const all = await this.stream.all();
-    const ids = new Set(all.map((item) => item.data.conversationId));
-    return Array.from(ids);
+    return this.stream.distinctConversationIds();
+  }
+
+  async getConversationStats(): Promise<ConversationStats[]> {
+    return this.stream.conversationStats();
   }
 
   all(): Promise<BrokerItem<MessageData>[]> {

--- a/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
@@ -35,13 +35,10 @@ export class MemoryBroker {
     messages: Message[],
     ttlSeconds?: number
   ): Promise<BrokerItem<MessageData>[]> {
-    const items: BrokerItem<MessageData>[] = [];
-    for (const message of messages) {
-      items.push(
-        await this.addMessage(conversationId, queryId, message, ttlSeconds)
-      );
-    }
-    return items;
+    return this.stream.appendMany(
+      messages.map((message) => ({conversationId, queryId, message})),
+      ttlSeconds
+    );
   }
 
   async getByConversation(

--- a/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/memory-broker.ts
@@ -44,13 +44,18 @@ export class MemoryBroker {
   async getByConversation(
     conversationId: string
   ): Promise<BrokerItem<MessageData>[]> {
-    return this.stream.filter(
-      (item) => item.data.conversationId === conversationId
-    );
+    return this.stream.filterBy({conversationId});
   }
 
   async getByQuery(queryId: string): Promise<BrokerItem<MessageData>[]> {
-    return this.stream.filter((item) => item.data.queryId === queryId);
+    return this.stream.filterBy({queryId});
+  }
+
+  async messagesAfter(
+    cursor: number,
+    conversationId?: string
+  ): Promise<BrokerItem<MessageData>[]> {
+    return this.stream.filterBy({conversationId, afterSequence: cursor});
   }
 
   async getConversationIds(): Promise<string[]> {
@@ -72,17 +77,11 @@ export class MemoryBroker {
   }
 
   async deleteConversation(conversationId: string): Promise<void> {
-    return this.stream.delete(
-      (item) => item.data.conversationId === conversationId
-    );
+    return this.stream.deleteBy({conversationId});
   }
 
   async deleteQuery(conversationId: string, queryId: string): Promise<void> {
-    return this.stream.delete(
-      (item) =>
-        item.data.conversationId === conversationId &&
-        item.data.queryId === queryId
-    );
+    return this.stream.deleteBy({conversationId, queryId});
   }
 
   async deleteByQuery(queryId: string): Promise<void> {
@@ -108,19 +107,7 @@ export class MemoryBroker {
     params: PaginationParams,
     filters?: {conversationId?: string; queryId?: string}
   ): Promise<PaginatedList<BrokerItem<MessageData>>> {
-    const predicate = filters
-      ? (item: BrokerItem<MessageData>): boolean => {
-          if (
-            filters.conversationId &&
-            item.data.conversationId !== filters.conversationId
-          )
-            return false;
-          if (filters.queryId && item.data.queryId !== filters.queryId)
-            return false;
-          return true;
-        }
-      : undefined;
-    return this.stream.paginate(params, predicate);
+    return this.stream.paginateBy(params, filters);
   }
 
   async getCurrentSequence(): Promise<number> {

--- a/services/ark-broker/ark-broker/src/brokers/pagination.ts
+++ b/services/ark-broker/ark-broker/src/brokers/pagination.ts
@@ -21,8 +21,8 @@
 export interface PaginatedList<T> {
   /** The items in this page of results */
   items: T[];
-  /** Total number of items matching the query (across all pages) */
-  total: number;
+  /** Total number of items matching the query (across all pages), when known */
+  total?: number;
   /** Whether more items exist beyond this page */
   hasMore: boolean;
   /** Cursor for fetching the next page, or for starting a watch stream */

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
@@ -34,4 +34,141 @@ describe('InMemoryEventStream', () => {
       expect(await stream.all()).toHaveLength(1);
     });
   });
+
+  describe('filterBy', () => {
+    it('returns only items matching queryId, in sequence order', async () => {
+      const queryId = 'query-a';
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      const a = await stream.append(eventA);
+      const b = await stream.append(eventB);
+      await stream.append(makeEventData());
+
+      const result = await stream.filterBy({queryId});
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        a.sequenceNumber,
+        b.sequenceNumber,
+      ]);
+    });
+
+    it('returns only items matching sessionId', async () => {
+      const sessionId = 'session-a';
+      const event = makeEventData();
+      event.data.sessionId = sessionId;
+      const a = await stream.append(event);
+      await stream.append(makeEventData());
+
+      const result = await stream.filterBy({sessionId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(a.sequenceNumber);
+    });
+
+    it('applies afterSequence as a keyset cursor', async () => {
+      const queryId = 'query-a';
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      const a = await stream.append(eventA);
+      const b = await stream.append(eventB);
+
+      const result = await stream.filterBy({
+        queryId,
+        afterSequence: a.sequenceNumber,
+      });
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        b.sequenceNumber,
+      ]);
+    });
+  });
+
+  describe('paginateBy', () => {
+    it('returns only items matching the filter', async () => {
+      const queryId = 'query-a';
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      await stream.append(eventA);
+      await stream.append(eventB);
+      await stream.append(makeEventData());
+
+      const result = await stream.paginateBy({limit: 10}, {queryId});
+
+      expect(result.items).toHaveLength(2);
+      expect(
+        result.items.every((item) => item.data.data.queryId === queryId)
+      ).toBe(true);
+    });
+
+    it('applies the keyset cursor across pages', async () => {
+      const queryId = 'query-a';
+      const appended = [];
+      for (let i = 0; i < 3; i++) {
+        const event = makeEventData();
+        event.data.queryId = queryId;
+        appended.push(await stream.append(event));
+      }
+
+      const page1 = await stream.paginateBy({limit: 2}, {queryId});
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextCursor).toBe(appended[1]!.sequenceNumber);
+
+      const page2 = await stream.paginateBy(
+        {limit: 2, cursor: page1.nextCursor},
+        {queryId}
+      );
+      expect(page2.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[2]!.sequenceNumber,
+      ]);
+      expect(page2.hasMore).toBe(false);
+    });
+  });
+
+  describe('deleteBy', () => {
+    it('removes only rows matching queryId, leaving others intact', async () => {
+      const queryA = 'query-a';
+      const queryB = 'query-b';
+      const eventA = makeEventData();
+      eventA.data.queryId = queryA;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryB;
+      await stream.append(eventA);
+      const survivor = await stream.append(eventB);
+
+      await stream.deleteBy({queryId: queryA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes only rows matching sessionId, leaving others intact', async () => {
+      const sessionA = 'session-a';
+      const sessionB = 'session-b';
+      const eventA = makeEventData();
+      eventA.data.sessionId = sessionA;
+      const eventB = makeEventData();
+      eventB.data.sessionId = sessionB;
+      await stream.append(eventA);
+      const survivor = await stream.append(eventB);
+
+      await stream.deleteBy({sessionId: sessionA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('rejects an empty filter without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
 });

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-event-stream.test.ts
@@ -170,5 +170,17 @@ describe('InMemoryEventStream', () => {
       await expect(stream.deleteBy({})).rejects.toThrow();
       expect(await stream.all()).toHaveLength(1);
     });
+
+    it('rejects an empty-string queryId without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({queryId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+
+    it('rejects an empty-string sessionId without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({sessionId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
   });
 });

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
@@ -169,4 +169,57 @@ describe('InMemoryMessageStream', () => {
       expect(await stream.all()).toHaveLength(1);
     });
   });
+
+  describe('distinctConversationIds', () => {
+    it('returns empty array when stream is empty', async () => {
+      expect(await stream.distinctConversationIds()).toEqual([]);
+    });
+
+    it('returns each conversation id once', async () => {
+      await stream.append(makeMessageData({conversationId: 'conv-a'}));
+      await stream.append(makeMessageData({conversationId: 'conv-a'}));
+      await stream.append(makeMessageData({conversationId: 'conv-b'}));
+
+      const ids = await stream.distinctConversationIds();
+
+      expect(ids.sort()).toEqual(['conv-a', 'conv-b']);
+    });
+  });
+
+  describe('conversationStats', () => {
+    it('returns empty array when stream is empty', async () => {
+      expect(await stream.conversationStats()).toEqual([]);
+    });
+
+    it('counts messages and distinct queries per conversation', async () => {
+      await stream.append(
+        makeMessageData({conversationId: 'conv-a', queryId: 'query-a1'})
+      );
+      await stream.append(
+        makeMessageData({conversationId: 'conv-a', queryId: 'query-a1'})
+      );
+      await stream.append(
+        makeMessageData({conversationId: 'conv-a', queryId: 'query-a2'})
+      );
+      await stream.append(
+        makeMessageData({conversationId: 'conv-b', queryId: 'query-b1'})
+      );
+
+      const stats = await stream.conversationStats();
+      const byConversation = new Map(
+        stats.map((stat) => [stat.conversationId, stat])
+      );
+
+      expect(byConversation.get('conv-a')).toEqual({
+        conversationId: 'conv-a',
+        messageCount: 3,
+        queryCount: 2,
+      });
+      expect(byConversation.get('conv-b')).toEqual({
+        conversationId: 'conv-b',
+        messageCount: 1,
+        queryCount: 1,
+      });
+    });
+  });
 });

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
@@ -170,6 +170,36 @@ describe('InMemoryMessageStream', () => {
     });
   });
 
+  describe('appendMany', () => {
+    it('returns [] without appending anything for an empty array', async () => {
+      const items = await stream.appendMany([]);
+      expect(items).toEqual([]);
+      expect(await stream.all()).toHaveLength(0);
+    });
+
+    it('appends all messages in order and returns matching items', async () => {
+      const dataList = [
+        makeMessageData(),
+        makeMessageData(),
+        makeMessageData(),
+      ];
+
+      const items = await stream.appendMany(dataList);
+
+      expect(items.map((item) => item.sequenceNumber)).toEqual([1, 2, 3]);
+      expect(items.map((item) => item.data)).toEqual(dataList);
+    });
+
+    it('emits one item event per message', async () => {
+      const received: number[] = [];
+      stream.subscribe((item) => received.push(item.sequenceNumber));
+
+      await stream.appendMany([makeMessageData(), makeMessageData()]);
+
+      expect(received).toEqual([1, 2]);
+    });
+  });
+
   describe('distinctConversationIds', () => {
     it('returns empty array when stream is empty', async () => {
       expect(await stream.distinctConversationIds()).toEqual([]);

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
@@ -168,6 +168,18 @@ describe('InMemoryMessageStream', () => {
       await expect(stream.deleteBy({})).rejects.toThrow();
       expect(await stream.all()).toHaveLength(1);
     });
+
+    it('rejects an empty-string conversationId without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({conversationId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+
+    it('rejects an empty-string queryId without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({queryId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
   });
 
   describe('appendMany', () => {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/in-memory-message-stream.test.ts
@@ -1,0 +1,172 @@
+import {createLogger} from '@ark-broker/logging/logger.js';
+import {InMemoryMessageStream} from '../in-memory-message-stream.js';
+import {makeMessageData} from './testHelpers/message-data-factory.js';
+
+const silentLogger = createLogger({level: 'silent', pretty: false});
+
+describe('InMemoryMessageStream', () => {
+  let stream: InMemoryMessageStream;
+
+  beforeEach(() => {
+    stream = new InMemoryMessageStream(silentLogger, 'test-messages');
+  });
+
+  describe('filterBy', () => {
+    it('returns only items matching conversationId, in sequence order', async () => {
+      const conversationId = 'conv-a';
+      const a = await stream.append(makeMessageData({conversationId}));
+      const b = await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.filterBy({conversationId});
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        a.sequenceNumber,
+        b.sequenceNumber,
+      ]);
+    });
+
+    it('returns only items matching queryId', async () => {
+      const queryId = 'query-a';
+      const a = await stream.append(makeMessageData({queryId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.filterBy({queryId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(a.sequenceNumber);
+    });
+
+    it('combines conversationId and queryId as AND', async () => {
+      const conversationId = 'conv-a';
+      const queryId = 'query-a';
+      const match = await stream.append(
+        makeMessageData({conversationId, queryId})
+      );
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData({queryId}));
+
+      const result = await stream.filterBy({conversationId, queryId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(match.sequenceNumber);
+    });
+
+    it('applies afterSequence as a keyset cursor', async () => {
+      const conversationId = 'conv-a';
+      const a = await stream.append(makeMessageData({conversationId}));
+      const b = await stream.append(makeMessageData({conversationId}));
+      const c = await stream.append(makeMessageData({conversationId}));
+
+      const result = await stream.filterBy({
+        conversationId,
+        afterSequence: a.sequenceNumber,
+      });
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        b.sequenceNumber,
+        c.sequenceNumber,
+      ]);
+    });
+  });
+
+  describe('paginateBy', () => {
+    it('returns only items matching the filter', async () => {
+      const conversationId = 'conv-a';
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.paginateBy({limit: 10}, {conversationId});
+
+      expect(result.items).toHaveLength(2);
+      expect(
+        result.items.every(
+          (item) => item.data.conversationId === conversationId
+        )
+      ).toBe(true);
+    });
+
+    it('paginates a filtered subset across multiple keyset pages', async () => {
+      const conversationId = 'conv-a';
+      const appended = [];
+      for (let i = 0; i < 5; i++) {
+        appended.push(await stream.append(makeMessageData({conversationId})));
+      }
+      await stream.append(makeMessageData());
+
+      const page1 = await stream.paginateBy({limit: 2}, {conversationId});
+      expect(page1.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[0]!.sequenceNumber,
+        appended[1]!.sequenceNumber,
+      ]);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextCursor).toBe(appended[1]!.sequenceNumber);
+
+      const page2 = await stream.paginateBy(
+        {limit: 2, cursor: page1.nextCursor},
+        {conversationId}
+      );
+      expect(page2.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[2]!.sequenceNumber,
+        appended[3]!.sequenceNumber,
+      ]);
+      expect(page2.hasMore).toBe(true);
+
+      const page3 = await stream.paginateBy(
+        {limit: 2, cursor: page2.nextCursor},
+        {conversationId}
+      );
+      expect(page3.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[4]!.sequenceNumber,
+      ]);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextCursor).toBeUndefined();
+    });
+
+    it('works without a filter, mirroring paginate', async () => {
+      for (let i = 0; i < 3; i++) {
+        await stream.append(makeMessageData());
+      }
+      const result = await stream.paginateBy({limit: 10});
+      expect(result.items).toHaveLength(3);
+    });
+  });
+
+  describe('deleteBy', () => {
+    it('removes only rows matching conversationId, leaving others intact', async () => {
+      const convA = 'conv-a';
+      const convB = 'conv-b';
+      await stream.append(makeMessageData({conversationId: convA}));
+      await stream.append(makeMessageData({conversationId: convA}));
+      const survivor = await stream.append(
+        makeMessageData({conversationId: convB})
+      );
+
+      await stream.deleteBy({conversationId: convA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes only rows matching queryId, leaving others intact', async () => {
+      const queryA = 'query-a';
+      const queryB = 'query-b';
+      await stream.append(makeMessageData({queryId: queryA}));
+      const survivor = await stream.append(makeMessageData({queryId: queryB}));
+
+      await stream.deleteBy({queryId: queryA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('rejects an empty filter without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+});

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
@@ -148,6 +148,216 @@ describe('PostgresEventStream', () => {
     });
   });
 
+  describe('filterBy', () => {
+    it('returns only items matching queryId, in sequence order', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      const a = await stream.append(eventA);
+      const b = await stream.append(eventB);
+      await stream.append(makeEventData());
+
+      const result = await stream.filterBy({queryId});
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        a.sequenceNumber,
+        b.sequenceNumber,
+      ]);
+    });
+
+    it('returns only items matching sessionId', async () => {
+      const sessionId = 's-' + Math.random().toString(36).slice(2);
+      const event = makeEventData();
+      event.data.sessionId = sessionId;
+      const a = await stream.append(event);
+      await stream.append(makeEventData());
+
+      const result = await stream.filterBy({sessionId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(a.sequenceNumber);
+    });
+
+    it('combines queryId and sessionId as AND', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const sessionId = 's-' + Math.random().toString(36).slice(2);
+      const matching = makeEventData();
+      matching.data.queryId = queryId;
+      matching.data.sessionId = sessionId;
+      const match = await stream.append(matching);
+
+      const onlyQuery = makeEventData();
+      onlyQuery.data.queryId = queryId;
+      await stream.append(onlyQuery);
+
+      const onlySession = makeEventData();
+      onlySession.data.sessionId = sessionId;
+      await stream.append(onlySession);
+
+      const result = await stream.filterBy({queryId, sessionId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(match.sequenceNumber);
+    });
+
+    it('returns empty array when nothing matches', async () => {
+      await stream.append(makeEventData());
+      const result = await stream.filterBy({queryId: 'nonexistent-query-id'});
+      expect(result).toHaveLength(0);
+    });
+
+    it('applies afterSequence as a keyset cursor', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      const eventC = makeEventData();
+      eventC.data.queryId = queryId;
+      const a = await stream.append(eventA);
+      const b = await stream.append(eventB);
+      const c = await stream.append(eventC);
+
+      const result = await stream.filterBy({
+        queryId,
+        afterSequence: a.sequenceNumber,
+      });
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        b.sequenceNumber,
+        c.sequenceNumber,
+      ]);
+    });
+  });
+
+  describe('paginateBy', () => {
+    it('returns only items matching the filter', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.queryId = queryId;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryId;
+      await stream.append(eventA);
+      await stream.append(eventB);
+      await stream.append(makeEventData());
+
+      const result = await stream.paginateBy({limit: 10}, {queryId});
+
+      expect(result.items).toHaveLength(2);
+      expect(
+        result.items.every((item) => item.data.data.queryId === queryId)
+      ).toBe(true);
+    });
+
+    it('paginates a filtered subset across multiple keyset pages', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const appended = [];
+      for (let i = 0; i < 5; i++) {
+        const event = makeEventData();
+        event.data.queryId = queryId;
+        appended.push(await stream.append(event));
+      }
+      await stream.append(makeEventData());
+
+      const page1 = await stream.paginateBy({limit: 2}, {queryId});
+      expect(page1.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[0]!.sequenceNumber,
+        appended[1]!.sequenceNumber,
+      ]);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextCursor).toBe(appended[1]!.sequenceNumber);
+
+      const page2 = await stream.paginateBy(
+        {limit: 2, cursor: page1.nextCursor},
+        {queryId}
+      );
+      expect(page2.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[2]!.sequenceNumber,
+        appended[3]!.sequenceNumber,
+      ]);
+      expect(page2.hasMore).toBe(true);
+
+      const page3 = await stream.paginateBy(
+        {limit: 2, cursor: page2.nextCursor},
+        {queryId}
+      );
+      expect(page3.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[4]!.sequenceNumber,
+      ]);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextCursor).toBeUndefined();
+    });
+
+    it('works without a filter, mirroring paginate', async () => {
+      for (let i = 0; i < 3; i++) {
+        await stream.append(makeEventData());
+      }
+      const result = await stream.paginateBy({limit: 10});
+      expect(result.items).toHaveLength(3);
+    });
+  });
+
+  describe('deleteBy', () => {
+    it('removes only rows matching queryId, leaving others intact', async () => {
+      const queryA = 'q-a-' + Math.random().toString(36).slice(2);
+      const queryB = 'q-b-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.queryId = queryA;
+      const eventB = makeEventData();
+      eventB.data.queryId = queryB;
+      await stream.append(eventA);
+      await stream.append({...eventA});
+      const survivor = await stream.append(eventB);
+
+      await stream.deleteBy({queryId: queryA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes only rows matching sessionId, leaving others intact', async () => {
+      const sessionA = 's-a-' + Math.random().toString(36).slice(2);
+      const sessionB = 's-b-' + Math.random().toString(36).slice(2);
+      const eventA = makeEventData();
+      eventA.data.sessionId = sessionA;
+      const eventB = makeEventData();
+      eventB.data.sessionId = sessionB;
+      await stream.append(eventA);
+      const survivor = await stream.append(eventB);
+
+      await stream.deleteBy({sessionId: sessionA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes rows regardless of expiry (ignores TTL)', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const event = makeEventData();
+      event.data.queryId = queryId;
+      const item = await stream.append(event, 1);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      await stream.deleteBy({queryId});
+
+      const pgDb = db();
+      const rows = await pgDb`
+        SELECT sequence_number FROM events WHERE sequence_number = ${item.sequenceNumber}
+      `;
+      expect(rows).toHaveLength(0);
+    });
+
+    it('rejects an empty filter without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+
   describe('deleteByQuery', () => {
     it('removes only rows with the given query_id', async () => {
       const qA = 'qa-' + Math.random().toString(36).slice(2);

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-event-stream.test.ts
@@ -356,6 +356,18 @@ describe('PostgresEventStream', () => {
       await expect(stream.deleteBy({})).rejects.toThrow();
       expect(await stream.all()).toHaveLength(1);
     });
+
+    it('rejects an empty-string queryId without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({queryId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+
+    it('rejects an empty-string sessionId without deleting anything', async () => {
+      await stream.append(makeEventData());
+      await expect(stream.deleteBy({sessionId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
   });
 
   describe('deleteByQuery', () => {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -1,3 +1,4 @@
+import postgres from 'postgres';
 import {createLogger} from '@ark-broker/logging/logger.js';
 import {usePgContainer} from '../../../db/__tests__/testHelpers/pg-testcontainer.js';
 import {PostgresMessageStream} from '../postgres-message-stream.js';
@@ -8,7 +9,7 @@ jest.setTimeout(120_000);
 const silentLogger = createLogger({level: 'silent', pretty: false});
 
 describe('PostgresMessageStream', () => {
-  const {db} = usePgContainer();
+  const {db, connectionUrl} = usePgContainer();
   let stream: PostgresMessageStream;
 
   beforeAll(() => {
@@ -40,6 +41,95 @@ describe('PostgresMessageStream', () => {
       stream.subscribe((item) => received.push(item.sequenceNumber));
       await stream.append(makeMessageData());
       expect(received).toHaveLength(1);
+    });
+  });
+
+  describe('appendMany', () => {
+    it('returns [] and issues no query for an empty array', async () => {
+      const queries: string[] = [];
+      const debugDb = postgres(connectionUrl(), {
+        debug: (_id: number, query: string): void => {
+          queries.push(query);
+        },
+      });
+      const debugStream = new PostgresMessageStream(
+        silentLogger,
+        debugDb,
+        3600
+      );
+
+      const items = await debugStream.appendMany([]);
+
+      expect(items).toEqual([]);
+      expect(queries).toHaveLength(0);
+      await debugDb.end();
+    });
+
+    it('inserts every message in a single round-trip', async () => {
+      const queries: string[] = [];
+      const debugDb = postgres(connectionUrl(), {
+        debug: (_id: number, query: string): void => {
+          queries.push(query);
+        },
+      });
+      // postgres.js runs a one-off type-oid bootstrap query the first time a
+      // fresh connection is used; warm it up so it doesn't skew the count.
+      await debugDb`SELECT 1`;
+      queries.length = 0;
+      const debugStream = new PostgresMessageStream(
+        silentLogger,
+        debugDb,
+        3600
+      );
+
+      await debugStream.appendMany([
+        makeMessageData(),
+        makeMessageData(),
+        makeMessageData(),
+      ]);
+
+      expect(queries).toHaveLength(1);
+      expect(queries[0]).toMatch(/insert into messages/i);
+      await debugDb.end();
+    });
+
+    it('returns items in sequence/input order and emits one item event per row', async () => {
+      const dataList = [
+        makeMessageData(),
+        makeMessageData(),
+        makeMessageData(),
+      ];
+      const received: number[] = [];
+      stream.subscribe((item) => received.push(item.sequenceNumber));
+
+      const items = await stream.appendMany(dataList);
+
+      expect(items.map((item) => item.sequenceNumber)).toEqual([1, 2, 3]);
+      expect(items.map((item) => item.data)).toEqual(dataList);
+      expect(received).toEqual([1, 2, 3]);
+    });
+
+    it('uses ttlSeconds for every row in the batch', async () => {
+      const customTtl = 60;
+      const before = Date.now();
+      const items = await stream.appendMany(
+        [makeMessageData(), makeMessageData()],
+        customTtl
+      );
+      const after = Date.now();
+
+      const pgDb = db();
+      const rows = await pgDb<{expires_at: Date}[]>`
+        SELECT expires_at FROM messages
+        WHERE sequence_number = ANY(${items.map((item) => item.sequenceNumber)})
+      `;
+      for (const row of rows) {
+        const expiresAt = row.expires_at.getTime();
+        expect(expiresAt).toBeGreaterThanOrEqual(
+          before + customTtl * 1000 - 2000
+        );
+        expect(expiresAt).toBeLessThanOrEqual(after + customTtl * 1000 + 2000);
+      }
     });
   });
 

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -139,6 +139,188 @@ describe('PostgresMessageStream', () => {
     });
   });
 
+  describe('filterBy', () => {
+    it('returns only items matching conversationId, in sequence order', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      const a = await stream.append(makeMessageData({conversationId}));
+      const b = await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.filterBy({conversationId});
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        a.sequenceNumber,
+        b.sequenceNumber,
+      ]);
+    });
+
+    it('returns only items matching queryId', async () => {
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const a = await stream.append(makeMessageData({queryId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.filterBy({queryId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(a.sequenceNumber);
+    });
+
+    it('combines conversationId and queryId as AND', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      const queryId = 'q-' + Math.random().toString(36).slice(2);
+      const match = await stream.append(
+        makeMessageData({conversationId, queryId})
+      );
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData({queryId}));
+
+      const result = await stream.filterBy({conversationId, queryId});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sequenceNumber).toBe(match.sequenceNumber);
+    });
+
+    it('returns empty array when nothing matches', async () => {
+      await stream.append(makeMessageData());
+      const result = await stream.filterBy({
+        conversationId: 'nonexistent-conversation-id',
+      });
+      expect(result).toHaveLength(0);
+    });
+
+    it('applies afterSequence as a keyset cursor', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      const a = await stream.append(makeMessageData({conversationId}));
+      const b = await stream.append(makeMessageData({conversationId}));
+      const c = await stream.append(makeMessageData({conversationId}));
+
+      const result = await stream.filterBy({
+        conversationId,
+        afterSequence: a.sequenceNumber,
+      });
+
+      expect(result.map((item) => item.sequenceNumber)).toEqual([
+        b.sequenceNumber,
+        c.sequenceNumber,
+      ]);
+    });
+  });
+
+  describe('paginateBy', () => {
+    it('returns only items matching the filter', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData({conversationId}));
+      await stream.append(makeMessageData());
+
+      const result = await stream.paginateBy({limit: 10}, {conversationId});
+
+      expect(result.items).toHaveLength(2);
+      expect(
+        result.items.every(
+          (item) => item.data.conversationId === conversationId
+        )
+      ).toBe(true);
+    });
+
+    it('paginates a filtered subset across multiple keyset pages', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      const appended = [];
+      for (let i = 0; i < 5; i++) {
+        appended.push(await stream.append(makeMessageData({conversationId})));
+      }
+      await stream.append(makeMessageData());
+
+      const page1 = await stream.paginateBy({limit: 2}, {conversationId});
+      expect(page1.items).toHaveLength(2);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[0]!.sequenceNumber,
+        appended[1]!.sequenceNumber,
+      ]);
+      expect(page1.nextCursor).toBe(appended[1]!.sequenceNumber);
+
+      const page2 = await stream.paginateBy(
+        {limit: 2, cursor: page1.nextCursor},
+        {conversationId}
+      );
+      expect(page2.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[2]!.sequenceNumber,
+        appended[3]!.sequenceNumber,
+      ]);
+      expect(page2.hasMore).toBe(true);
+
+      const page3 = await stream.paginateBy(
+        {limit: 2, cursor: page2.nextCursor},
+        {conversationId}
+      );
+      expect(page3.items.map((item) => item.sequenceNumber)).toEqual([
+        appended[4]!.sequenceNumber,
+      ]);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextCursor).toBeUndefined();
+    });
+
+    it('works without a filter, mirroring paginate', async () => {
+      for (let i = 0; i < 3; i++) {
+        await stream.append(makeMessageData());
+      }
+      const result = await stream.paginateBy({limit: 10});
+      expect(result.items).toHaveLength(3);
+    });
+  });
+
+  describe('deleteBy', () => {
+    it('removes only rows matching conversationId, leaving others intact', async () => {
+      const convA = 'conv-a-' + Math.random().toString(36).slice(2);
+      const convB = 'conv-b-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({conversationId: convA}));
+      await stream.append(makeMessageData({conversationId: convA}));
+      const survivor = await stream.append(
+        makeMessageData({conversationId: convB})
+      );
+
+      await stream.deleteBy({conversationId: convA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes only rows matching queryId, leaving others intact', async () => {
+      const queryA = 'q-a-' + Math.random().toString(36).slice(2);
+      const queryB = 'q-b-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({queryId: queryA}));
+      const survivor = await stream.append(makeMessageData({queryId: queryB}));
+
+      await stream.deleteBy({queryId: queryA});
+
+      const all = await stream.all();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
+    });
+
+    it('removes rows regardless of expiry (ignores TTL)', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      const item = await stream.append(makeMessageData({conversationId}), 1);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      await stream.deleteBy({conversationId});
+
+      const pgDb = db();
+      const rows = await pgDb`
+        SELECT sequence_number FROM messages WHERE sequence_number = ${item.sequenceNumber}
+      `;
+      expect(rows).toHaveLength(0);
+    });
+
+    it('rejects an empty filter without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+  });
+
   describe('deleteByQuery', () => {
     it('removes only rows with the given query_id', async () => {
       const qA = 'qa-' + Math.random().toString(36).slice(2);

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -131,6 +131,15 @@ describe('PostgresMessageStream', () => {
         expect(expiresAt).toBeLessThanOrEqual(after + customTtl * 1000 + 2000);
       }
     });
+
+    it('inserts a large batch without exceeding the call stack', async () => {
+      const dataList = Array.from({length: 5000}, () => makeMessageData());
+
+      const items = await stream.appendMany(dataList);
+
+      expect(items).toHaveLength(5000);
+      expect(await stream.getCurrentSequence()).toBe(5000);
+    });
   });
 
   describe('all', () => {
@@ -407,6 +416,18 @@ describe('PostgresMessageStream', () => {
     it('rejects an empty filter without deleting anything', async () => {
       await stream.append(makeMessageData());
       await expect(stream.deleteBy({})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+
+    it('rejects an empty-string conversationId without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({conversationId: ''})).rejects.toThrow();
+      expect(await stream.all()).toHaveLength(1);
+    });
+
+    it('rejects an empty-string queryId without deleting anything', async () => {
+      await stream.append(makeMessageData());
+      await expect(stream.deleteBy({queryId: ''})).rejects.toThrow();
       expect(await stream.all()).toHaveLength(1);
     });
   });

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -343,6 +343,75 @@ describe('PostgresMessageStream', () => {
     });
   });
 
+  describe('distinctConversationIds', () => {
+    it('returns empty array when stream is empty', async () => {
+      expect(await stream.distinctConversationIds()).toEqual([]);
+    });
+
+    it('returns each conversation id once', async () => {
+      const convA = 'conv-a-' + Math.random().toString(36).slice(2);
+      const convB = 'conv-b-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({conversationId: convA}));
+      await stream.append(makeMessageData({conversationId: convA}));
+      await stream.append(makeMessageData({conversationId: convB}));
+
+      const ids = await stream.distinctConversationIds();
+
+      expect(ids.sort()).toEqual([convA, convB].sort());
+    });
+  });
+
+  describe('conversationStats', () => {
+    it('returns empty array when stream is empty', async () => {
+      expect(await stream.conversationStats()).toEqual([]);
+    });
+
+    it('counts messages and distinct queries per conversation', async () => {
+      const convA = 'conv-a-' + Math.random().toString(36).slice(2);
+      const convB = 'conv-b-' + Math.random().toString(36).slice(2);
+      const queryA1 = 'q-a1-' + Math.random().toString(36).slice(2);
+      const queryA2 = 'q-a2-' + Math.random().toString(36).slice(2);
+      const queryB1 = 'q-b1-' + Math.random().toString(36).slice(2);
+
+      await stream.append(
+        makeMessageData({conversationId: convA, queryId: queryA1})
+      );
+      await stream.append(
+        makeMessageData({conversationId: convA, queryId: queryA1})
+      );
+      await stream.append(
+        makeMessageData({conversationId: convA, queryId: queryA2})
+      );
+      await stream.append(
+        makeMessageData({conversationId: convB, queryId: queryB1})
+      );
+
+      const stats = await stream.conversationStats();
+      const byConversation = new Map(
+        stats.map((stat) => [stat.conversationId, stat])
+      );
+
+      expect(byConversation.get(convA)).toEqual({
+        conversationId: convA,
+        messageCount: 3,
+        queryCount: 2,
+      });
+      expect(byConversation.get(convB)).toEqual({
+        conversationId: convB,
+        messageCount: 1,
+        queryCount: 1,
+      });
+    });
+
+    it('excludes expired messages', async () => {
+      const conversationId = 'conv-' + Math.random().toString(36).slice(2);
+      await stream.append(makeMessageData({conversationId}), 1);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      expect(await stream.conversationStats()).toEqual([]);
+    });
+  });
+
   describe('getCurrentSequence', () => {
     it('returns 0 when stream is empty', async () => {
       expect(await stream.getCurrentSequence()).toBe(0);

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
@@ -1,6 +1,9 @@
 import type {Logger} from '@ark-broker/logging/logger.js';
-import type {EventData, EventStream} from '../event-broker.js';
+import type {EventData, EventFilter, EventStream} from '../event-broker.js';
+import type {PaginatedList, PaginationParams} from '../pagination.js';
+import type {BrokerItem} from './broker-item.js';
 import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
+import type {Predicate} from './stream.js';
 
 export class InMemoryEventStream
   extends InMemoryQueryDeletableStream<EventData>
@@ -8,5 +11,41 @@ export class InMemoryEventStream
 {
   constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
     super(logger, name, (data) => data.data.queryId, path, maxItems);
+  }
+
+  private predicateFor(filter: EventFilter): Predicate<EventData> {
+    return (item) =>
+      (filter.queryId === undefined ||
+        item.data.data.queryId === filter.queryId) &&
+      (filter.sessionId === undefined ||
+        item.data.data.sessionId === filter.sessionId);
+  }
+
+  async paginateBy(
+    params: PaginationParams,
+    filter?: EventFilter
+  ): Promise<PaginatedList<BrokerItem<EventData>>> {
+    return this.paginate(
+      params,
+      filter ? this.predicateFor(filter) : undefined
+    );
+  }
+
+  async filterBy(filter: EventFilter): Promise<BrokerItem<EventData>[]> {
+    const items = await this.filter(this.predicateFor(filter));
+    const afterSequence = filter.afterSequence;
+    return afterSequence === undefined
+      ? items
+      : items.filter((item) => item.sequenceNumber > afterSequence);
+  }
+
+  async deleteBy(filter: EventFilter): Promise<void> {
+    const hasScopingField = Object.entries(
+      filter as Record<string, unknown>
+    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
+    if (!hasScopingField) {
+      throw new Error('deleteBy requires at least one filter field');
+    }
+    return this.delete(this.predicateFor(filter));
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-event-stream.ts
@@ -3,7 +3,7 @@ import type {EventData, EventFilter, EventStream} from '../event-broker.js';
 import type {PaginatedList, PaginationParams} from '../pagination.js';
 import type {BrokerItem} from './broker-item.js';
 import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
-import type {Predicate} from './stream.js';
+import {hasScopingField, type Predicate} from './stream.js';
 
 export class InMemoryEventStream
   extends InMemoryQueryDeletableStream<EventData>
@@ -40,10 +40,7 @@ export class InMemoryEventStream
   }
 
   async deleteBy(filter: EventFilter): Promise<void> {
-    const hasScopingField = Object.entries(
-      filter as Record<string, unknown>
-    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
-    if (!hasScopingField) {
+    if (!hasScopingField(filter as Record<string, unknown>)) {
       throw new Error('deleteBy requires at least one filter field');
     }
     return this.delete(this.predicateFor(filter));

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -3,7 +3,11 @@ import type {MessageData} from '../memory-broker.js';
 import type {PaginatedList, PaginationParams} from '../pagination.js';
 import type {BrokerItem} from './broker-item.js';
 import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
-import type {MessageFilter, MessageStream} from './message-stream.js';
+import type {
+  ConversationStats,
+  MessageFilter,
+  MessageStream,
+} from './message-stream.js';
 import type {Predicate} from './stream.js';
 
 export class InMemoryMessageStream
@@ -47,5 +51,36 @@ export class InMemoryMessageStream
       throw new Error('deleteBy requires at least one filter field');
     }
     return this.delete(this.predicateFor(filter));
+  }
+
+  async distinctConversationIds(): Promise<string[]> {
+    const items = await this.all();
+    return Array.from(new Set(items.map((item) => item.data.conversationId)));
+  }
+
+  async conversationStats(): Promise<ConversationStats[]> {
+    const items = await this.all();
+    const statsByConversation = new Map<
+      string,
+      {messageCount: number; queryIds: Set<string>}
+    >();
+
+    for (const item of items) {
+      const entry = statsByConversation.get(item.data.conversationId) ?? {
+        messageCount: 0,
+        queryIds: new Set<string>(),
+      };
+      entry.messageCount += 1;
+      entry.queryIds.add(item.data.queryId);
+      statsByConversation.set(item.data.conversationId, entry);
+    }
+
+    return Array.from(statsByConversation.entries()).map(
+      ([conversationId, entry]) => ({
+        conversationId,
+        messageCount: entry.messageCount,
+        queryCount: entry.queryIds.size,
+      })
+    );
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -1,7 +1,10 @@
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {MessageData} from '../memory-broker.js';
+import type {PaginatedList, PaginationParams} from '../pagination.js';
+import type {BrokerItem} from './broker-item.js';
 import {InMemoryQueryDeletableStream} from './in-memory-query-deletable-stream.js';
-import type {MessageStream} from './message-stream.js';
+import type {MessageFilter, MessageStream} from './message-stream.js';
+import type {Predicate} from './stream.js';
 
 export class InMemoryMessageStream
   extends InMemoryQueryDeletableStream<MessageData>
@@ -9,5 +12,40 @@ export class InMemoryMessageStream
 {
   constructor(logger: Logger, name: string, path?: string, maxItems?: number) {
     super(logger, name, (data) => data.queryId, path, maxItems);
+  }
+
+  private predicateFor(filter: MessageFilter): Predicate<MessageData> {
+    return (item) =>
+      (filter.conversationId === undefined ||
+        item.data.conversationId === filter.conversationId) &&
+      (filter.queryId === undefined || item.data.queryId === filter.queryId);
+  }
+
+  async paginateBy(
+    params: PaginationParams,
+    filter?: MessageFilter
+  ): Promise<PaginatedList<BrokerItem<MessageData>>> {
+    return this.paginate(
+      params,
+      filter ? this.predicateFor(filter) : undefined
+    );
+  }
+
+  async filterBy(filter: MessageFilter): Promise<BrokerItem<MessageData>[]> {
+    const items = await this.filter(this.predicateFor(filter));
+    const afterSequence = filter.afterSequence;
+    return afterSequence === undefined
+      ? items
+      : items.filter((item) => item.sequenceNumber > afterSequence);
+  }
+
+  async deleteBy(filter: MessageFilter): Promise<void> {
+    const hasScopingField = Object.entries(
+      filter as Record<string, unknown>
+    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
+    if (!hasScopingField) {
+      throw new Error('deleteBy requires at least one filter field');
+    }
+    return this.delete(this.predicateFor(filter));
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -8,7 +8,7 @@ import type {
   MessageFilter,
   MessageStream,
 } from './message-stream.js';
-import type {Predicate} from './stream.js';
+import {hasScopingField, type Predicate} from './stream.js';
 
 export class InMemoryMessageStream
   extends InMemoryQueryDeletableStream<MessageData>
@@ -44,10 +44,7 @@ export class InMemoryMessageStream
   }
 
   async deleteBy(filter: MessageFilter): Promise<void> {
-    const hasScopingField = Object.entries(
-      filter as Record<string, unknown>
-    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
-    if (!hasScopingField) {
+    if (!hasScopingField(filter as Record<string, unknown>)) {
       throw new Error('deleteBy requires at least one filter field');
     }
     return this.delete(this.predicateFor(filter));

--- a/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/in-memory-message-stream.ts
@@ -53,6 +53,17 @@ export class InMemoryMessageStream
     return this.delete(this.predicateFor(filter));
   }
 
+  async appendMany(
+    dataList: MessageData[],
+    ttlSeconds?: number
+  ): Promise<BrokerItem<MessageData>[]> {
+    const items: BrokerItem<MessageData>[] = [];
+    for (const data of dataList) {
+      items.push(await this.append(data, ttlSeconds));
+    }
+    return items;
+  }
+
   async distinctConversationIds(): Promise<string[]> {
     const items = await this.all();
     return Array.from(new Set(items.map((item) => item.data.conversationId)));

--- a/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
@@ -25,4 +25,8 @@ export interface MessageStream extends Stream<MessageData> {
   deleteBy(filter: MessageFilter): Promise<void>;
   distinctConversationIds(): Promise<string[]>;
   conversationStats(): Promise<ConversationStats[]>;
+  appendMany(
+    dataList: MessageData[],
+    ttlSeconds?: number
+  ): Promise<BrokerItem<MessageData>[]>;
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
@@ -9,6 +9,12 @@ export interface MessageFilter {
   afterSequence?: number;
 }
 
+export interface ConversationStats {
+  conversationId: string;
+  messageCount: number;
+  queryCount: number;
+}
+
 export interface MessageStream extends Stream<MessageData> {
   deleteByQuery(queryId: string): Promise<void>;
   paginateBy(
@@ -17,4 +23,6 @@ export interface MessageStream extends Stream<MessageData> {
   ): Promise<PaginatedList<BrokerItem<MessageData>>>;
   filterBy(filter: MessageFilter): Promise<BrokerItem<MessageData>[]>;
   deleteBy(filter: MessageFilter): Promise<void>;
+  distinctConversationIds(): Promise<string[]>;
+  conversationStats(): Promise<ConversationStats[]>;
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/message-stream.ts
@@ -1,6 +1,20 @@
 import type {MessageData} from '../memory-broker.js';
+import type {PaginatedList, PaginationParams} from '../pagination.js';
+import type {BrokerItem} from './broker-item.js';
 import type {Stream} from './stream.js';
+
+export interface MessageFilter {
+  conversationId?: string;
+  queryId?: string;
+  afterSequence?: number;
+}
 
 export interface MessageStream extends Stream<MessageData> {
   deleteByQuery(queryId: string): Promise<void>;
+  paginateBy(
+    params: PaginationParams,
+    filter?: MessageFilter
+  ): Promise<PaginatedList<BrokerItem<MessageData>>>;
+  filterBy(filter: MessageFilter): Promise<BrokerItem<MessageData>[]>;
+  deleteBy(filter: MessageFilter): Promise<void>;
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
@@ -27,12 +27,22 @@ export class PostgresEventStream
   extends PostgresStreamBase<EventData>
   implements EventStream
 {
-  constructor(
-    private readonly logger: Logger,
-    private readonly db: Db,
-    private readonly ttlSeconds: number
-  ) {
-    super();
+  protected readonly tableName = 'events';
+  protected readonly selectColumns = [
+    'sequence_number',
+    'query_id',
+    'session_id',
+    'reason',
+    'event',
+    'created_at',
+  ];
+
+  constructor(logger: Logger, db: Db, ttlSeconds: number) {
+    super(logger, db, ttlSeconds);
+  }
+
+  protected rowToItem(row: postgres.Row): BrokerItem<EventData> {
+    return rowToBrokerItem(row as unknown as EventRow);
   }
 
   async append(
@@ -54,16 +64,6 @@ export class PostgresEventStream
     const item = rowToBrokerItem(rows[0]!);
     this.emitter.emit('item', item);
     return item;
-  }
-
-  async all(): Promise<BrokerItem<EventData>[]> {
-    const rows = await this.db<EventRow[]>`
-      SELECT sequence_number, query_id, session_id, reason, event, created_at
-      FROM events
-      WHERE expires_at > now()
-      ORDER BY sequence_number ASC
-    `;
-    return rows.map(rowToBrokerItem);
   }
 
   async delete(predicate?: Predicate<EventData>): Promise<void> {

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-event-stream.ts
@@ -1,7 +1,7 @@
 import type postgres from 'postgres';
 import type {Logger} from '@ark-broker/logging/logger.js';
 import type {Db} from '@ark-broker/db/db.js';
-import type {EventData, EventStream} from '../event-broker.js';
+import type {EventData, EventFilter, EventStream} from '../event-broker.js';
 import {BrokerItem} from './broker-item.js';
 import type {Predicate} from './stream.js';
 import {PostgresStreamBase} from './postgres-stream-base.js';
@@ -24,7 +24,7 @@ function rowToBrokerItem(row: EventRow): BrokerItem<EventData> {
 }
 
 export class PostgresEventStream
-  extends PostgresStreamBase<EventData>
+  extends PostgresStreamBase<EventData, EventFilter>
   implements EventStream
 {
   protected readonly tableName = 'events';
@@ -43,6 +43,13 @@ export class PostgresEventStream
 
   protected rowToItem(row: postgres.Row): BrokerItem<EventData> {
     return rowToBrokerItem(row as unknown as EventRow);
+  }
+
+  protected whereFor(filter: EventFilter): postgres.Fragment {
+    return this.db`
+      ${filter.queryId ? this.db`AND query_id = ${filter.queryId}` : this.db``}
+      ${filter.sessionId ? this.db`AND session_id = ${filter.sessionId}` : this.db``}
+    `;
   }
 
   async append(

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -69,7 +69,7 @@ export class PostgresMessageStream
       VALUES (
         ${data.conversationId},
         ${data.queryId},
-        ${this.db.json(data.message as unknown as postgres.JSONValue)},
+        ${this.db.json(data.message as postgres.JSONValue)},
         now() + make_interval(secs => ${effectiveTtl})
       )
       RETURNING sequence_number, conversation_id, query_id, message, created_at
@@ -90,13 +90,16 @@ export class PostgresMessageStream
         this.db`(
           ${data.conversationId},
           ${data.queryId},
-          ${this.db.json(data.message as unknown as postgres.JSONValue)},
+          ${this.db.json(data.message as postgres.JSONValue)},
           now() + make_interval(secs => ${effectiveTtl})
         )`
     );
+    const values = valueRows
+      .slice(1)
+      .reduce((acc, row) => this.db`${acc}, ${row}`, valueRows[0]);
     const rows = await this.db<MessageRow[]>`
       INSERT INTO messages (conversation_id, query_id, message, expires_at)
-      VALUES ${valueRows.reduce((acc, row) => this.db`${acc}, ${row}`)}
+      VALUES ${values}
       RETURNING sequence_number, conversation_id, query_id, message, created_at
     `;
     const items = rows

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -85,24 +85,18 @@ export class PostgresMessageStream
   ): Promise<BrokerItem<MessageData>[]> {
     if (dataList.length === 0) return [];
     const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
-    const valueRows = dataList.map(
-      (data): postgres.Fragment =>
-        this.db`(
-          ${data.conversationId},
-          ${data.queryId},
-          ${this.db.json(data.message as postgres.JSONValue)},
-          now() + make_interval(secs => ${effectiveTtl})
-        )`
-    );
-    const values = valueRows
-      .slice(1)
-      .reduce((acc, row) => this.db`${acc}, ${row}`, valueRows[0]);
-    const rows = await this.db<MessageRow[]>`
+    const valueRows = dataList.map((data) => [
+      data.conversationId,
+      data.queryId,
+      JSON.stringify(data.message),
+    ]);
+    const inserted = await this.db<MessageRow[]>`
       INSERT INTO messages (conversation_id, query_id, message, expires_at)
-      VALUES ${values}
+      SELECT v.conversation_id, v.query_id, v.message::jsonb, now() + make_interval(secs => ${effectiveTtl})
+      FROM (VALUES ${this.db(valueRows)}) AS v(conversation_id, query_id, message)
       RETURNING sequence_number, conversation_id, query_id, message, created_at
     `;
-    const items = rows
+    const items = inserted
       .map(rowToBrokerItem)
       .sort((a, b) => a.sequenceNumber - b.sequenceNumber);
     for (const item of items) {

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -79,6 +79,35 @@ export class PostgresMessageStream
     return item;
   }
 
+  async appendMany(
+    dataList: MessageData[],
+    ttlSeconds?: number
+  ): Promise<BrokerItem<MessageData>[]> {
+    if (dataList.length === 0) return [];
+    const effectiveTtl = ttlSeconds ?? this.ttlSeconds;
+    const valueRows = dataList.map(
+      (data): postgres.Fragment =>
+        this.db`(
+          ${data.conversationId},
+          ${data.queryId},
+          ${this.db.json(data.message as unknown as postgres.JSONValue)},
+          now() + make_interval(secs => ${effectiveTtl})
+        )`
+    );
+    const rows = await this.db<MessageRow[]>`
+      INSERT INTO messages (conversation_id, query_id, message, expires_at)
+      VALUES ${valueRows.reduce((acc, row) => this.db`${acc}, ${row}`)}
+      RETURNING sequence_number, conversation_id, query_id, message, created_at
+    `;
+    const items = rows
+      .map(rowToBrokerItem)
+      .sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+    for (const item of items) {
+      this.emitter.emit('item', item);
+    }
+    return items;
+  }
+
   async delete(predicate?: Predicate<MessageData>): Promise<void> {
     if (!predicate) {
       this.logger.info('deleting all messages');

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -4,7 +4,11 @@ import type {Db} from '@ark-broker/db/db.js';
 import type {MessageData} from '../memory-broker.js';
 import {BrokerItem} from './broker-item.js';
 import type {Predicate} from './stream.js';
-import type {MessageFilter, MessageStream} from './message-stream.js';
+import type {
+  ConversationStats,
+  MessageFilter,
+  MessageStream,
+} from './message-stream.js';
 import {PostgresStreamBase} from './postgres-stream-base.js';
 
 type MessageRow = {
@@ -98,5 +102,31 @@ export class PostgresMessageStream
       SELECT MAX(sequence_number) as seq FROM messages WHERE expires_at > now()
     `;
     return seq === null ? 0 : Number(seq);
+  }
+
+  async distinctConversationIds(): Promise<string[]> {
+    const rows = await this.db<{conversation_id: string}[]>`
+      SELECT DISTINCT conversation_id FROM messages WHERE expires_at > now()
+    `;
+    return rows.map((row) => row.conversation_id);
+  }
+
+  async conversationStats(): Promise<ConversationStats[]> {
+    const rows = await this.db<
+      {conversation_id: string; message_count: number; query_count: number}[]
+    >`
+      SELECT
+        conversation_id,
+        count(*)::int AS message_count,
+        count(DISTINCT query_id)::int AS query_count
+      FROM messages
+      WHERE expires_at > now()
+      GROUP BY conversation_id
+    `;
+    return rows.map((row) => ({
+      conversationId: row.conversation_id,
+      messageCount: row.message_count,
+      queryCount: row.query_count,
+    }));
   }
 }

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -4,7 +4,7 @@ import type {Db} from '@ark-broker/db/db.js';
 import type {MessageData} from '../memory-broker.js';
 import {BrokerItem} from './broker-item.js';
 import type {Predicate} from './stream.js';
-import type {MessageStream} from './message-stream.js';
+import type {MessageFilter, MessageStream} from './message-stream.js';
 import {PostgresStreamBase} from './postgres-stream-base.js';
 
 type MessageRow = {
@@ -28,7 +28,7 @@ function rowToBrokerItem(row: MessageRow): BrokerItem<MessageData> {
 }
 
 export class PostgresMessageStream
-  extends PostgresStreamBase<MessageData>
+  extends PostgresStreamBase<MessageData, MessageFilter>
   implements MessageStream
 {
   protected readonly tableName = 'messages';
@@ -46,6 +46,13 @@ export class PostgresMessageStream
 
   protected rowToItem(row: postgres.Row): BrokerItem<MessageData> {
     return rowToBrokerItem(row as unknown as MessageRow);
+  }
+
+  protected whereFor(filter: MessageFilter): postgres.Fragment {
+    return this.db`
+      ${filter.conversationId ? this.db`AND conversation_id = ${filter.conversationId}` : this.db``}
+      ${filter.queryId ? this.db`AND query_id = ${filter.queryId}` : this.db``}
+    `;
   }
 
   async append(

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-message-stream.ts
@@ -31,12 +31,21 @@ export class PostgresMessageStream
   extends PostgresStreamBase<MessageData>
   implements MessageStream
 {
-  constructor(
-    private readonly logger: Logger,
-    private readonly db: Db,
-    private readonly ttlSeconds: number
-  ) {
-    super();
+  protected readonly tableName = 'messages';
+  protected readonly selectColumns = [
+    'sequence_number',
+    'conversation_id',
+    'query_id',
+    'message',
+    'created_at',
+  ];
+
+  constructor(logger: Logger, db: Db, ttlSeconds: number) {
+    super(logger, db, ttlSeconds);
+  }
+
+  protected rowToItem(row: postgres.Row): BrokerItem<MessageData> {
+    return rowToBrokerItem(row as unknown as MessageRow);
   }
 
   async append(
@@ -57,16 +66,6 @@ export class PostgresMessageStream
     const item = rowToBrokerItem(rows[0]!);
     this.emitter.emit('item', item);
     return item;
-  }
-
-  async all(): Promise<BrokerItem<MessageData>[]> {
-    const rows = await this.db<MessageRow[]>`
-      SELECT sequence_number, conversation_id, query_id, message, created_at
-      FROM messages
-      WHERE expires_at > now()
-      ORDER BY sequence_number ASC
-    `;
-    return rows.map(rowToBrokerItem);
   }
 
   async delete(predicate?: Predicate<MessageData>): Promise<void> {

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
@@ -8,7 +8,7 @@ import {
   type PaginatedList,
   type PaginationParams,
 } from '../pagination.js';
-import type {Predicate, Stream} from './stream.js';
+import {hasScopingField, type Predicate, type Stream} from './stream.js';
 
 export abstract class PostgresStreamBase<
   T,
@@ -115,10 +115,7 @@ export abstract class PostgresStreamBase<
   }
 
   async deleteBy(filter: F): Promise<void> {
-    const hasScopingField = Object.entries(
-      filter as Record<string, unknown>
-    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
-    if (!hasScopingField) {
+    if (!hasScopingField(filter as Record<string, unknown>)) {
       throw new Error('deleteBy requires at least one filter field');
     }
     this.logger.info({filter}, 'deleting by filter');

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
@@ -10,7 +10,10 @@ import {
 } from '../pagination.js';
 import type {Predicate, Stream} from './stream.js';
 
-export abstract class PostgresStreamBase<T> implements Stream<T> {
+export abstract class PostgresStreamBase<
+  T,
+  F extends {afterSequence?: number},
+> implements Stream<T> {
   protected readonly emitter = new EventEmitter();
 
   protected constructor(
@@ -22,6 +25,7 @@ export abstract class PostgresStreamBase<T> implements Stream<T> {
   protected abstract readonly tableName: string;
   protected abstract readonly selectColumns: string[];
   protected abstract rowToItem(row: postgres.Row): BrokerItem<T>;
+  protected abstract whereFor(filter: F): postgres.Fragment;
 
   abstract append(data: T, ttlSeconds?: number): Promise<BrokerItem<T>>;
   abstract delete(predicate?: Predicate<T>): Promise<void>;
@@ -66,6 +70,65 @@ export abstract class PostgresStreamBase<T> implements Stream<T> {
       hasMore,
       nextCursor: hasMore && lastItem ? lastItem.sequenceNumber : undefined,
     };
+  }
+
+  async filterBy(filter: F): Promise<BrokerItem<T>[]> {
+    const afterSequence = filter.afterSequence;
+    const rows = await this.db`
+      SELECT ${this.db(this.selectColumns)}
+      FROM ${this.db(this.tableName)}
+      WHERE expires_at > now()
+      ${this.whereFor(filter)}
+      ${afterSequence === undefined ? this.db`` : this.db`AND sequence_number > ${afterSequence}`}
+      ORDER BY sequence_number ASC
+    `;
+    return rows.map((row) => this.rowToItem(row));
+  }
+
+  async paginateBy(
+    params: PaginationParams,
+    filter?: F
+  ): Promise<PaginatedList<BrokerItem<T>>> {
+    const limit = params.limit ?? DEFAULT_LIMIT;
+    const cursor = params.cursor;
+
+    const rows = await this.db`
+      SELECT ${this.db(this.selectColumns)}
+      FROM ${this.db(this.tableName)}
+      WHERE expires_at > now()
+      ${filter ? this.whereFor(filter) : this.db``}
+      ${cursor === undefined ? this.db`` : this.db`AND sequence_number > ${cursor}`}
+      ORDER BY sequence_number ASC
+      LIMIT ${limit + 1}
+    `;
+
+    const hasMore = rows.length > limit;
+    const items = rows.slice(0, limit).map((row) => this.rowToItem(row));
+    const lastItem = items.at(-1);
+
+    return {
+      items,
+      // total is intentionally left unpopulated here (no COUNT(*)); pagination.ts
+      // makes PaginatedList.total optional in the next commit.
+      total: undefined as unknown as number,
+      hasMore,
+      nextCursor: hasMore && lastItem ? lastItem.sequenceNumber : undefined,
+    };
+  }
+
+  async deleteBy(filter: F): Promise<void> {
+    const hasScopingField = Object.entries(
+      filter as Record<string, unknown>
+    ).some(([key, value]) => key !== 'afterSequence' && value !== undefined);
+    if (!hasScopingField) {
+      throw new Error('deleteBy requires at least one filter field');
+    }
+    this.logger.info({filter}, 'deleting by filter');
+    await this.db`
+      DELETE FROM ${this.db(this.tableName)}
+      WHERE true
+      ${this.whereFor(filter)}
+    `;
   }
 
   async save(): Promise<void> {

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
@@ -1,4 +1,7 @@
 import {EventEmitter} from 'node:events';
+import type postgres from 'postgres';
+import type {Logger} from '@ark-broker/logging/logger.js';
+import type {Db} from '@ark-broker/db/db.js';
 import {BrokerItem} from './broker-item.js';
 import {
   DEFAULT_LIMIT,
@@ -10,10 +13,29 @@ import type {Predicate, Stream} from './stream.js';
 export abstract class PostgresStreamBase<T> implements Stream<T> {
   protected readonly emitter = new EventEmitter();
 
+  protected constructor(
+    protected readonly logger: Logger,
+    protected readonly db: Db,
+    protected readonly ttlSeconds: number
+  ) {}
+
+  protected abstract readonly tableName: string;
+  protected abstract readonly selectColumns: string[];
+  protected abstract rowToItem(row: postgres.Row): BrokerItem<T>;
+
   abstract append(data: T, ttlSeconds?: number): Promise<BrokerItem<T>>;
-  abstract all(): Promise<BrokerItem<T>[]>;
   abstract delete(predicate?: Predicate<T>): Promise<void>;
   abstract getCurrentSequence(): Promise<number>;
+
+  async all(): Promise<BrokerItem<T>[]> {
+    const rows = await this.db`
+      SELECT ${this.db(this.selectColumns)}
+      FROM ${this.db(this.tableName)}
+      WHERE expires_at > now()
+      ORDER BY sequence_number ASC
+    `;
+    return rows.map((row) => this.rowToItem(row));
+  }
 
   async filter(predicate: Predicate<T>): Promise<BrokerItem<T>[]> {
     return (await this.all()).filter(predicate);

--- a/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/postgres-stream-base.ts
@@ -108,9 +108,7 @@ export abstract class PostgresStreamBase<
 
     return {
       items,
-      // total is intentionally left unpopulated here (no COUNT(*)); pagination.ts
-      // makes PaginatedList.total optional in the next commit.
-      total: undefined as unknown as number,
+      // total is intentionally left unpopulated here: no COUNT(*).
       hasMore,
       nextCursor: hasMore && lastItem ? lastItem.sequenceNumber : undefined,
     };

--- a/services/ark-broker/ark-broker/src/brokers/stream/stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/stream.ts
@@ -8,7 +8,7 @@ export type Predicate<T> = (item: BrokerItem<T>) => boolean;
 
 export function hasScopingField(filter: Record<string, unknown>): boolean {
   return Object.entries(filter).some(
-    ([key, value]) => key !== 'afterSequence' && value !== undefined
+    ([key, value]) => key !== 'afterSequence' && Boolean(value)
   );
 }
 

--- a/services/ark-broker/ark-broker/src/brokers/stream/stream.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/stream.ts
@@ -6,6 +6,12 @@ import type {
 
 export type Predicate<T> = (item: BrokerItem<T>) => boolean;
 
+export function hasScopingField(filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).some(
+    ([key, value]) => key !== 'afterSequence' && value !== undefined
+  );
+}
+
 export interface Stream<T> {
   append(data: T, ttlSeconds?: number): Promise<BrokerItem<T>>;
   all(): Promise<BrokerItem<T>[]>;

--- a/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.down.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS messages_conversation_query_idx;
+DROP INDEX CONCURRENTLY IF EXISTS messages_conversation_query_idx;

--- a/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.down.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS messages_conversation_query_idx;

--- a/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.up.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX messages_conversation_query_idx ON messages (conversation_id, query_id);

--- a/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.up.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000003_messages_conversation_query_idx.up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX messages_conversation_query_idx ON messages (conversation_id, query_id);
+CREATE INDEX CONCURRENTLY messages_conversation_query_idx ON messages (conversation_id, query_id);

--- a/services/ark-broker/ark-broker/src/http/routes/events/handlers.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/events/handlers.ts
@@ -24,14 +24,7 @@ export function handleStreamingAllEvents(
     cursor === undefined
       ? undefined
       : async (): Promise<EventData[]> => {
-          let items = (await events.all()).filter(
-            (item) => item.sequenceNumber > cursor
-          );
-          if (sessionId) {
-            items = items.filter(
-              (item) => item.data.data.sessionId === sessionId
-            );
-          }
+          const items = await events.eventsAfter(cursor, sessionId);
           return items.map((item) => item.data);
         };
 
@@ -97,9 +90,8 @@ export function handleStreamingQueryEvents(
           if (fromBeginning) {
             return events.getEventsByQuery(queryId);
           }
-          return (await events.getByQuery(queryId))
-            .filter((item) => item.sequenceNumber > cursor!)
-            .map((item) => item.data);
+          const items = await events.queryEventsAfter(queryId, cursor!);
+          return items.map((item) => item.data);
         }
       : undefined;
 

--- a/services/ark-broker/ark-broker/src/http/routes/memory/handlers.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/memory/handlers.ts
@@ -32,14 +32,7 @@ export function handleStreamingMessages(
     cursor === undefined
       ? undefined
       : async (): Promise<MessageItem[]> => {
-          let items = (await memory.all()).filter(
-            (item) => item.sequenceNumber > cursor
-          );
-          if (conversationId) {
-            items = items.filter(
-              (item) => item.data.conversationId === conversationId
-            );
-          }
+          const items = await memory.messagesAfter(cursor, conversationId);
           return items.map((item) => ({
             timestamp: item.timestamp.toISOString(),
             conversation_id: item.data.conversationId,

--- a/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/memory/index.ts
@@ -134,29 +134,25 @@ export function createMemoryRouter(
 
   router.get('/memory-status', async (req, res) => {
     try {
-      const conversationIds = await memory.getConversationIds();
-      const allItems = await memory.all();
+      const stats = await memory.getConversationStats();
 
-      const conversationStats: Record<
+      const conversations: Record<
         string,
         {message_count: number; query_count: number}
       > = {};
-      for (const conversationId of conversationIds) {
-        const convItems = allItems.filter(
-          (i) => i.data.conversationId === conversationId
-        );
-        const queryIds = new Set(convItems.map((i) => i.data.queryId));
-
-        conversationStats[conversationId] = {
-          message_count: convItems.length,
-          query_count: queryIds.size,
+      let totalMessages = 0;
+      for (const stat of stats) {
+        conversations[stat.conversationId] = {
+          message_count: stat.messageCount,
+          query_count: stat.queryCount,
         };
+        totalMessages += stat.messageCount;
       }
 
       res.json({
-        total_conversations: conversationIds.length,
-        total_messages: allItems.length,
-        conversations: conversationStats,
+        total_conversations: stats.length,
+        total_messages: totalMessages,
+        conversations,
       });
     } catch (error) {
       req.log.error({err: error}, 'failed to get memory status');

--- a/services/ark-broker/ark-broker/test/memory-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/memory-broker.test.ts
@@ -97,6 +97,35 @@ describe('MemoryBroker', () => {
     });
   });
 
+  describe('getConversationStats', () => {
+    test('should return message and query counts per conversation', async () => {
+      await broker.addMessage('conv1', 'query1', 'message1');
+      await broker.addMessage('conv1', 'query1', 'message2');
+      await broker.addMessage('conv1', 'query2', 'message3');
+      await broker.addMessage('conv2', 'query3', 'message4');
+
+      const stats = await broker.getConversationStats();
+      const byConversation = new Map(
+        stats.map((stat) => [stat.conversationId, stat])
+      );
+
+      expect(byConversation.get('conv1')).toEqual({
+        conversationId: 'conv1',
+        messageCount: 3,
+        queryCount: 2,
+      });
+      expect(byConversation.get('conv2')).toEqual({
+        conversationId: 'conv2',
+        messageCount: 1,
+        queryCount: 1,
+      });
+    });
+
+    test('should return empty array when there are no messages', async () => {
+      expect(await broker.getConversationStats()).toEqual([]);
+    });
+  });
+
   describe('all', () => {
     test('should return all messages', async () => {
       await broker.addMessage('conv1', 'query1', 'message1');

--- a/services/ark-broker/ark-broker/test/memory-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/memory-broker.test.ts
@@ -48,6 +48,18 @@ describe('MemoryBroker', () => {
       expect(items[1].sequenceNumber).toBe(2);
       expect(items[2].sequenceNumber).toBe(3);
     });
+
+    test('should return items in the same order as the input messages', async () => {
+      const messages = ['first', 'second', 'third', 'fourth'];
+      const items = await broker.addMessages('conv1', 'query1', messages);
+
+      expect(items.map((item) => item.data.message)).toEqual(messages);
+    });
+
+    test('should return [] for an empty messages array', async () => {
+      const items = await broker.addMessages('conv1', 'query1', []);
+      expect(items).toEqual([]);
+    });
   });
 
   describe('getByConversation', () => {

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -1,9 +1,12 @@
-import type {Express} from 'express';
+import {EventEmitter} from 'node:events';
+import type {Express, Request, Response} from 'express';
 import request from 'supertest';
 import {loadConfig} from '../src/config/index.js';
 import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
 import {createDb} from '../src/db/db.js';
+import {MemoryBroker} from '../src/brokers/memory-broker.js';
+import {handleStreamingMessages} from '../src/http/routes/memory/handlers.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
 import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
@@ -16,9 +19,40 @@ const logger = createLogger({level: 'silent', pretty: false});
 const describeIntegration =
   process.env.SKIP_INTEGRATION === 'true' ? describe.skip : describe;
 
+/**
+ * Drives an SSE handler with an in-process fake req/res (an EventEmitter and
+ * a write-capturing stub) instead of a real socket, so the reconnect replay
+ * path can be asserted without the surrounding HTTP transport.
+ */
+async function captureReplay(
+  run: (req: Request, res: Response) => void
+): Promise<Record<string, unknown>[]> {
+  const writes: string[] = [];
+  const reqEmitter = new EventEmitter();
+  const fakeReq = Object.assign(reqEmitter, {
+    log: logger,
+  }) as unknown as Request;
+  const fakeRes = {
+    setHeader: (): void => {},
+    write: (chunk: string): boolean => {
+      writes.push(chunk);
+      return true;
+    },
+  } as unknown as Response;
+
+  run(fakeReq, fakeRes);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  reqEmitter.emit('close');
+
+  return writes
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice(6, -2)));
+}
+
 describeIntegration('postgres backend — HTTP integration', () => {
   const {db, connectionUrl} = usePgContainer();
   let app: Express;
+  let memory: MemoryBroker;
 
   beforeAll(() => {
     const config = loadConfig({
@@ -26,6 +60,7 @@ describeIntegration('postgres backend — HTTP integration', () => {
       DATABASE_URL: connectionUrl(),
     });
     const stream = createMessageStream(config, logger, db());
+    memory = new MemoryBroker(stream);
     ({app} = buildApp({
       config,
       logger,
@@ -93,6 +128,93 @@ describeIntegration('postgres backend — HTTP integration', () => {
 
   it('GET /readyz returns 200 when the database is reachable', async () => {
     await request(app).get('/readyz').expect(200);
+  });
+
+  it('GET /messages?conversation_id= returns only that conversation when multiple conversations exist', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'conv-scope-a',
+        query_id: 'q-scope-a',
+        messages: ['a1', 'a2'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'conv-scope-b',
+        query_id: 'q-scope-b',
+        messages: ['b1'],
+      })
+      .expect(200);
+
+    const res = await request(app)
+      .get('/messages?conversation_id=conv-scope-a')
+      .expect(200);
+
+    expect(res.body.items).toHaveLength(2);
+    for (const item of res.body.items as {conversation_id: string}[]) {
+      expect(item.conversation_id).toBe('conv-scope-a');
+    }
+  });
+
+  it('watch-mode reconnect with a cursor replays only items after the cursor, scoped to conversation_id', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'conv-replay',
+        query_id: 'q-replay',
+        messages: ['first', 'second'],
+      })
+      .expect(200); // sequence 1, 2
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'conv-other',
+        query_id: 'q-other',
+        messages: ['other'],
+      })
+      .expect(200); // sequence 3, higher than the cursor but a different conversation
+
+    const events = await captureReplay((req, res) =>
+      handleStreamingMessages(req, res, memory, 'conv-replay', 1)
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      conversation_id: 'conv-replay',
+      message: 'second',
+    });
+  });
+
+  it('a scoped read on conversation_id uses messages_conversation_idx, not a sequential scan', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post('/messages')
+        .send({
+          conversation_id: 'conv-explain',
+          query_id: `q-explain-${i}`,
+          messages: ['m'],
+        })
+        .expect(200);
+    }
+
+    const plan = await db().begin(async (sql) => {
+      await sql`SET LOCAL enable_seqscan = off`;
+      const rows = await sql.unsafe(`
+        EXPLAIN ANALYZE
+        SELECT sequence_number, conversation_id, query_id, message, created_at
+        FROM messages
+        WHERE expires_at > now() AND conversation_id = 'conv-explain'
+        ORDER BY sequence_number ASC
+        LIMIT 101
+      `);
+      return (rows as unknown as {'QUERY PLAN': string}[])
+        .map((row) => row['QUERY PLAN'])
+        .join('\n');
+    });
+
+    expect(plan).toContain('messages_conversation_idx');
   });
 
   it('DELETE /queries/:queryId/messages removes only that query rows', async () => {

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -187,7 +187,7 @@ describeIntegration('postgres backend — HTTP integration', () => {
     });
   });
 
-  it('a scoped read on conversation_id uses messages_conversation_idx, not a sequential scan', async () => {
+  it('a scoped read on conversation_id uses a conversation_id-leading index, not a sequential scan', async () => {
     for (let i = 0; i < 5; i++) {
       await request(app)
         .post('/messages')
@@ -214,7 +214,66 @@ describeIntegration('postgres backend — HTTP integration', () => {
         .join('\n');
     });
 
-    expect(plan).toContain('messages_conversation_idx');
+    // messages_conversation_query_idx (added for conversationStats) also
+    // starts with conversation_id, so the planner may pick either index
+    // over a sequential scan.
+    expect(plan).toMatch(/messages_conversation_(idx|query_idx)/);
+  });
+
+  it('the conversationStats aggregate uses messages_conversation_query_idx once the planner has fresh stats', async () => {
+    // A handful of rows isn't representative: the planner needs a
+    // realistically sized table (and fresh stats, mirroring what autovacuum
+    // provides in production) before it prefers this index over a full
+    // expires_at scan + explicit sort.
+    const pgDb = db();
+    const conversationCount = 40;
+    const messagesPerConversation = 150;
+    const rows: {
+      conversation_id: string;
+      query_id: string;
+      message: string;
+      expires_at: Date;
+    }[] = [];
+    const expiresAt = new Date(Date.now() + 3600 * 1000);
+    for (let c = 0; c < conversationCount; c++) {
+      for (let m = 0; m < messagesPerConversation; m++) {
+        rows.push({
+          conversation_id: `conv-stats-explain-${c}`,
+          query_id: `q-stats-explain-${c}-${m % 10}`,
+          message: JSON.stringify({role: 'user', content: `m${m}`}),
+          expires_at: expiresAt,
+        });
+      }
+    }
+    const batchSize = 1000;
+    for (let i = 0; i < rows.length; i += batchSize) {
+      await pgDb`
+        INSERT INTO messages ${pgDb(
+          rows.slice(i, i + batchSize),
+          'conversation_id',
+          'query_id',
+          'message',
+          'expires_at'
+        )}
+      `;
+    }
+    await pgDb.unsafe('ANALYZE messages');
+
+    const rowsExplain = await pgDb.unsafe(`
+      EXPLAIN ANALYZE
+      SELECT
+        conversation_id,
+        count(*)::int AS message_count,
+        count(DISTINCT query_id)::int AS query_count
+      FROM messages
+      WHERE expires_at > now()
+      GROUP BY conversation_id
+    `);
+    const plan = (rowsExplain as unknown as {'QUERY PLAN': string}[])
+      .map((row) => row['QUERY PLAN'])
+      .join('\n');
+
+    expect(plan).toContain('messages_conversation_query_idx');
   });
 
   it('DELETE /queries/:queryId/messages removes only that query rows', async () => {

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -88,6 +88,24 @@ describeIntegration('postgres backend — HTTP integration', () => {
     expect(res.body.items[0].message).toEqual(message);
   });
 
+  it('POST /messages with multiple messages stores and returns them in the same order', async () => {
+    const messages = ['first', 'second', 'third', 'fourth', 'fifth'];
+
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'conv-batch', query_id: 'q-batch', messages})
+      .expect(200);
+
+    const res = await request(app)
+      .get('/messages?conversation_id=conv-batch')
+      .expect(200);
+
+    expect(res.body.items).toHaveLength(messages.length);
+    expect(
+      res.body.items.map((item: {message: string}) => item.message)
+    ).toEqual(messages);
+  });
+
   it('messages survive a stream instance restart against the same database', async () => {
     await request(app)
       .post('/messages')

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -242,6 +242,46 @@ describeIntegration('postgres backend — HTTP integration', () => {
     expect(res.body.items[0].query_id).toBe('keep-q');
   });
 
+  it('GET /memory-status aggregates per-conversation counts via a single query', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'status-conv-1',
+        query_id: 'status-q1',
+        messages: ['one', 'two'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'status-conv-1',
+        query_id: 'status-q2',
+        messages: ['three'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'status-conv-2',
+        query_id: 'status-q3',
+        messages: ['four'],
+      })
+      .expect(200);
+
+    const res = await request(app).get('/memory-status').expect(200);
+
+    expect(res.body.total_conversations).toBe(2);
+    expect(res.body.total_messages).toBe(4);
+    expect(res.body.conversations['status-conv-1']).toEqual({
+      message_count: 3,
+      query_count: 2,
+    });
+    expect(res.body.conversations['status-conv-2']).toEqual({
+      message_count: 1,
+      query_count: 1,
+    });
+  });
+
   it('expired messages are not returned by GET /messages', async () => {
     await request(app)
       .post('/messages')

--- a/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-events.integration.test.ts
@@ -1,8 +1,14 @@
-import type {Express} from 'express';
+import {EventEmitter} from 'node:events';
+import type {Express, Request, Response} from 'express';
 import request from 'supertest';
 import {loadConfig} from '../src/config/index.js';
 import {createLogger} from '../src/logging/logger.js';
 import {buildApp} from '../src/server.js';
+import {EventBroker} from '../src/brokers/event-broker.js';
+import {
+  handleStreamingAllEvents,
+  handleStreamingQueryEvents,
+} from '../src/http/routes/events/handlers.js';
 import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
 import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
 import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
@@ -14,6 +20,36 @@ const logger = createLogger({level: 'silent', pretty: false});
 
 const describeIntegration =
   process.env.SKIP_INTEGRATION === 'true' ? describe.skip : describe;
+
+/**
+ * Drives an SSE handler with an in-process fake req/res (an EventEmitter and
+ * a write-capturing stub) instead of a real socket, so the reconnect replay
+ * path can be asserted without the surrounding HTTP transport.
+ */
+async function captureReplay(
+  run: (req: Request, res: Response) => void
+): Promise<Record<string, unknown>[]> {
+  const writes: string[] = [];
+  const reqEmitter = new EventEmitter();
+  const fakeReq = Object.assign(reqEmitter, {
+    log: logger,
+  }) as unknown as Request;
+  const fakeRes = {
+    setHeader: (): void => {},
+    write: (chunk: string): boolean => {
+      writes.push(chunk);
+      return true;
+    },
+  } as unknown as Response;
+
+  run(fakeReq, fakeRes);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  reqEmitter.emit('close');
+
+  return writes
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice(6, -2)));
+}
 
 const baseEvent = {
   timestamp: new Date().toISOString(),
@@ -31,19 +67,22 @@ const baseEvent = {
 describeIntegration('postgres event backend — HTTP integration', () => {
   const {db, connectionUrl} = usePgContainer();
   let app: Express;
+  let events: EventBroker;
 
   beforeAll(() => {
     const config = loadConfig({
       EVENT_BACKEND: 'postgres',
       DATABASE_URL: connectionUrl(),
     });
+    const stream = createEventStream(config, logger, db());
+    events = new EventBroker(stream);
     ({app} = buildApp({
       config,
       logger,
       version: 'test',
       messageStream: createMessageStream(config, logger),
       chunkStream: createChunkStream(config, logger),
-      eventStream: createEventStream(config, logger, db()),
+      eventStream: stream,
       db: db(),
     }));
   });
@@ -70,6 +109,93 @@ describeIntegration('postgres event backend — HTTP integration', () => {
     for (const item of res.body.items as {data: {queryId: string}}[]) {
       expect(item.data.queryId).toBe('q-pg-events-1');
     }
+  });
+
+  it('GET /events?session_id= returns only events for that session when multiple sessions exist', async () => {
+    await request(app)
+      .post('/events')
+      .send({
+        ...baseEvent,
+        data: {
+          ...baseEvent.data,
+          queryId: 'q-sess-a',
+          sessionId: 'sess-scope-a',
+        },
+      })
+      .expect(201);
+    await request(app)
+      .post('/events')
+      .send({
+        ...baseEvent,
+        data: {
+          ...baseEvent.data,
+          queryId: 'q-sess-b',
+          sessionId: 'sess-scope-b',
+        },
+      })
+      .expect(201);
+
+    const res = await request(app)
+      .get('/events?session_id=sess-scope-a')
+      .expect(200);
+
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].data.sessionId).toBe('sess-scope-a');
+  });
+
+  it('watch-mode reconnect with a cursor replays only items after the cursor, scoped to session_id', async () => {
+    await request(app)
+      .post('/events')
+      .send({
+        ...baseEvent,
+        data: {...baseEvent.data, queryId: 'q-r1', sessionId: 'sess-replay'},
+      })
+      .expect(201); // sequence 1
+    await request(app)
+      .post('/events')
+      .send({
+        ...baseEvent,
+        data: {...baseEvent.data, queryId: 'q-r2', sessionId: 'sess-replay'},
+      })
+      .expect(201); // sequence 2
+    await request(app)
+      .post('/events')
+      .send({
+        ...baseEvent,
+        data: {...baseEvent.data, queryId: 'q-r3', sessionId: 'sess-other'},
+      })
+      .expect(201); // sequence 3, higher than the cursor but a different session
+
+    const replayed = await captureReplay((req, res) =>
+      handleStreamingAllEvents(req, res, events, 'sess-replay', 1)
+    );
+
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]).toMatchObject({
+      data: {queryId: 'q-r2', sessionId: 'sess-replay'},
+    });
+  });
+
+  it('watch-mode reconnect on a query stream (not from-beginning) replays only that query events after the cursor', async () => {
+    await request(app)
+      .post('/events')
+      .send({...baseEvent, data: {...baseEvent.data, queryId: 'q-qr'}})
+      .expect(201); // sequence 1
+    await request(app)
+      .post('/events')
+      .send({...baseEvent, data: {...baseEvent.data, queryId: 'q-qr'}})
+      .expect(201); // sequence 2
+    await request(app)
+      .post('/events')
+      .send({...baseEvent, data: {...baseEvent.data, queryId: 'q-other-qr'}})
+      .expect(201); // sequence 3, higher than the cursor but a different query
+
+    const replayed = await captureReplay((req, res) =>
+      handleStreamingQueryEvents(req, res, events, 'q-qr', false, 1)
+    );
+
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]).toMatchObject({data: {queryId: 'q-qr'}});
   });
 
   it('events survive a stream instance restart against the same database', async () => {

--- a/services/ark-broker/ark-broker/test/server.test.ts
+++ b/services/ark-broker/ark-broker/test/server.test.ts
@@ -212,6 +212,57 @@ describe('ARK Broker API', () => {
     });
   });
 
+  describe('GET /memory-status', () => {
+    test('returns aggregated per-conversation message and query counts', async () => {
+      await request(app)
+        .post('/messages')
+        .send({
+          conversation_id: 'status-conv-1',
+          query_id: 'status-q1',
+          messages: [{role: 'user', content: 'one'}],
+        });
+
+      await request(app)
+        .post('/messages')
+        .send({
+          conversation_id: 'status-conv-1',
+          query_id: 'status-q2',
+          messages: [{role: 'user', content: 'two'}],
+        });
+
+      await request(app)
+        .post('/messages')
+        .send({
+          conversation_id: 'status-conv-2',
+          query_id: 'status-q3',
+          messages: [{role: 'user', content: 'three'}],
+        });
+
+      const response = await request(app).get('/memory-status');
+
+      expect(response.status).toBe(200);
+      expect(response.body.total_conversations).toBe(2);
+      expect(response.body.total_messages).toBe(3);
+      expect(response.body.conversations['status-conv-1']).toEqual({
+        message_count: 2,
+        query_count: 2,
+      });
+      expect(response.body.conversations['status-conv-2']).toEqual({
+        message_count: 1,
+        query_count: 1,
+      });
+    });
+
+    test('returns zero totals when memory is empty', async () => {
+      const response = await request(app).get('/memory-status');
+
+      expect(response.status).toBe(200);
+      expect(response.body.total_conversations).toBe(0);
+      expect(response.body.total_messages).toBe(0);
+      expect(response.body.conversations).toEqual({});
+    });
+  });
+
   describe('Multiple Messages Endpoints', () => {
     test('should add and retrieve multiple messages at once', async () => {
       const messages = [


### PR DESCRIPTION
## Context

Sub-issue of #2153. Closes #2736.

Both Postgres-backed streams in ark-broker — `PostgresMessageStream` (Phase 1) and `PostgresEventStream` (Phase 3, mirroring the same pattern) — implemented every filtered/paginated read on top of a single unbounded `all()` call (`SELECT ... WHERE expires_at > now()`), then filtered and paginated in JS:

```ts
async paginate(params, predicate) {
  const all = await this.all();               // whole non-expired table
  const filtered = predicate ? all.filter(predicate) : all;  // JS filter
  return filtered.slice(offset, offset + limit);             // JS slice
}
```

No `conversation_id`/`query_id`/`session_id` predicate ever reached SQL, so the existing composite indexes (`messages_conversation_idx`, `messages_query_idx`, `events_query_idx`, `events_session_idx`) were dead weight, and every scoped read — most importantly `GET /messages?conversation_id=X`, read before every agent/LLM turn — scaled with the size of the *whole* table, not the conversation being read. This is not a regression: Phase 1 shipped focused on durability first, Phase 3 mirrored the same `Stream<T>` pattern for consistency. The Redis-backed chunk stream (Phase 2) already does this correctly (`XRANGE` on a per-query key), so the right pattern already existed in the codebase — it just hadn't been applied to the Postgres streams yet.

The issue write-up initially scoped this to reads only. While implementing it, the same root cause (`all()` + JS instead of SQL) turned out to also apply to scoped deletes, two aggregate endpoints, and a batch-write path — all fixed here, since they share one code path and splitting them into separate PRs would have meant re-touching the same files repeatedly for no benefit. Full rationale below; the issue has been updated to reflect the final scope.

## Fix

Replaced the opaque `Predicate<T>` used by the Postgres read paths with structured filter descriptors (`MessageFilter { conversationId?, queryId?, afterSequence? }`, `EventFilter { queryId?, sessionId?, afterSequence? }`) that translate directly to a SQL `WHERE` clause. The SQL skeleton (filter → `WHERE`, keyset pagination, `all()`) lives once in `PostgresStreamBase<T, F>`; each concrete stream only supplies its table name, column list, row mapper, and its own `whereFor(filter)`. The old predicate-based `filter()`/`paginate()`/`delete(predicate)` methods stay on the `Stream<T>` interface for the in-memory backend and for interface compatibility, but nothing on a hot path calls them anymore.

- **Reads**: `paginateBy`/`filterBy` push `conversation_id`/`query_id`/`session_id` into SQL, with `sequence_number` keyset pagination (`LIMIT n+1` to compute `hasMore`, no offset scan, no JS `.slice()`). This covers `GET /messages?conversation_id=`, `GET /events/:queryId`, `GET /events?session_id=`, and the SSE watch-mode cursor replay on reconnect for both messages and events (previously a per-connection `.all()` + JS filter).
- **Scoped deletes**: `deleteConversation`/`deleteQuery` used to scan the whole table via `all()`, filter in JS, then `DELETE ... WHERE sequence_number = ANY(...)`. Added `deleteBy(filter)` — a direct `DELETE ... WHERE <predicate>` — guarded to throw on an empty filter so it can never silently degrade into a delete-all. `deleteBy` intentionally does **not** filter on `expires_at`: an explicit scoped delete (e.g. "remove this conversation") should win over TTL, not silently skip already-expired rows the way the old `all()`-sourced predicate delete did.
- **Aggregates**: `getConversationIds()` (backing `GET /conversations`) now issues `SELECT DISTINCT conversation_id` instead of `all()` + building a JS `Set`. `GET /memory-status` used to call `all()` *twice* (once via `getConversationIds()`, once directly) and then nested-loop over every message per conversation in JS — replaced with a single `GROUP BY conversation_id` query (`count(*)`, `count(DISTINCT query_id)`).
- **`total` becomes optional**: rather than adding a `SELECT count(*)` per paginated request just to keep an exact `total`, I checked who actually reads it — ark-api recomputes its own `len()` for its response envelope, the dashboard only ever reads `hasMore`/`nextCursor` from these endpoints. `PaginatedList.total` is now `total?: number`, left `undefined` on the Postgres path. The in-memory backend still computes it for free (no cost there), so nothing regresses for that backend.
- **Batch writes**: same root cause on the write side — `MemoryBroker.addMessages` looped a single-row `INSERT ... RETURNING` once per message. The SDK posts an entire conversation's message history in one `POST /messages` call, so this was N sequential round-trips where one would do. Replaced with a single multi-row `INSERT ... VALUES (...), (...), ... RETURNING ...`; `item` events still fire once per row (in `sequence_number` order) so SSE subscribers see every message individually.
- **New index, evidence-gated**: `conversationStats` (the `GROUP BY` behind `/memory-status`) does `count(DISTINCT query_id)`, which the existing `(conversation_id, sequence_number)` index doesn't help with. Rather than adding an index on intuition, I measured it with `EXPLAIN ANALYZE` against a realistically seeded table before deciding: at 6,000 rows / 40 conversations, adding `messages (conversation_id, query_id)` took the query from a Bitmap Heap Scan + explicit Sort (2.8ms) to a single ordered Index Scan (0.86ms, ~3.2x). Re-checked at 30,000 rows / 60 conversations: 13.6ms → 4.1ms, same ~3.3x, confirming the win holds as the table grows (relevant since there's no TTL reaper yet — see below).

## Out of scope

- Postgres-backed `subscribe()` stays in-process (`EventEmitter`), so SSE live-push doesn't propagate cross-replica for Postgres-backed messages/events — unlike the cross-replica `XREAD` fan-out already built for Redis Streams chunks in Phase 2. Different concern (live-push consistency, not read performance).
- **No TTL reaper exists.** `expires_at` is only ever checked at read time (`WHERE expires_at > now()`); nothing physically deletes a row once it expires, so both tables grow unbounded over the TTL window regardless of this fix, and the `expires_at` indexes are dead weight without a reaper to use them. This is a real gap but a distinct piece of work (background job lifecycle, new config), so it's being tracked as its own follow-up rather than folded in here.

## Review guide

The six commits build on each other; reading them in order tracks the reasoning better than the flat diff:

1. **`775454e7`** — pure refactor, no behavior change: hoists `logger`/`db`/`ttlSeconds` and the duplicated `all()` into `PostgresStreamBase` (`postgres-stream-base.ts:19` ctor, `:25-27` abstract `tableName`/`selectColumns`/`rowToItem`, `:34` `all()`). `PostgresMessageStream`/`PostgresEventStream` shrink to `super(...)` + their table config.
2. **`b4e2c57d`** — the actual SQL pushdown: `whereFor` abstract hook (`postgres-stream-base.ts:28`) plus `filterBy`/`paginateBy`/`deleteBy` (`:75`, `:88`, `:117`); concrete `whereFor` implementations in `postgres-message-stream.ts:55` (`conversationId`/`queryId`) and `postgres-event-stream.ts:48` (`queryId`/`sessionId`). In-memory parity added to `in-memory-message-stream.ts`/`in-memory-event-stream.ts`. Nothing calls these new methods yet — added in isolation with their own test coverage first.
3. **`c62fdb9c`** — wires it up: `memory-broker.ts` (`getByConversation:47`, `getByQuery:51`, `messagesAfter:54`, `paginate→paginateBy:112`, `deleteConversation:82`, `deleteQuery:86`) and `event-broker.ts` (`getByQuery:55`, `eventsAfter:62`, `queryEventsAfter:69`, `paginate:110`, `paginateByQuery:117`, `paginateBySessionId:124`) now call the structured methods instead of building closures. SSE replay in `http/routes/memory/handlers.ts:35` and `http/routes/events/handlers.ts:27,93` switches from `.all()` to the new `*After` helpers. `pagination.ts:25` makes `total` optional.
4. **`776db925`** — `distinctConversationIds`/`conversationStats` (`postgres-message-stream.ts:136,143`), wired through `memory-broker.ts:62,65`; `GET /memory-status` and `GET /conversations` in `http/routes/memory/index.ts:135,163` rewritten to use them.
5. **`ff2bee9e`** — the evidence-gated migration: `db/migrations/000003_messages_conversation_query_idx.{up,down}.sql`.
6. **`293a2781`** — `appendMany` (`postgres-message-stream.ts:82`), wired through `memory-broker.ts:38`.

## Verification

- Full unit + integration suite (real Postgres via testcontainers, both streams, both backends): `cd services/ark-broker && make lint && make test` — 24 suites / 383 tests, clean lint (ESLint + tsc + Prettier).
- End-to-end on a local Kind cluster running the real images (controller, completions, broker, migrate) against a real SSL-enabled Postgres instance, `EVENT_BACKEND=postgres`: 9/9 chainsaw tests pass — `aggregation-smoke`, `query-broker-ttl`, `event-broker-postgres`, `query-broker-delete-cleanup`, `query-broker-delete-cleanup-default`, `query-broker-event-delete-cleanup`, `query-ttl-propagation`, `query-ttl-gc-deletion`, `queries-ttl-timeout`. These exercise exactly the paths touched here — scoped message/event pagination, scoped deletes on query deletion, TTL propagation to Postgres rows — end to end, not just at the unit level.
