### PR TITLE
fix: tag test secrets that gitleaks is flagging

### DIFF
--- a/tools/ark-cli/src/commands/models/providers/bedrock.spec.ts
+++ b/tools/ark-cli/src/commands/models/providers/bedrock.spec.ts
@@ -379,7 +379,7 @@ describe('BedrockConfigCollector', () => {
     it('collects full API-key configuration through interactive prompts', async () => {
       mockInquirer.prompt.mockResolvedValueOnce({region: 'eu-west-1'});
       mockInquirer.prompt.mockResolvedValueOnce({authMethod: 'api-key'});
-      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'bedrock-key-123'});
+      mockInquirer.prompt.mockResolvedValueOnce({apiKey: 'bedrock-key-123'}); // gitleaks:allow
       mockInquirer.prompt.mockResolvedValueOnce({modelArn: ''});
 
       const options = {
@@ -394,7 +394,7 @@ describe('BedrockConfigCollector', () => {
         secretName: '',
         region: 'eu-west-1',
         authMethod: 'api-key',
-        apiKey: 'bedrock-key-123',
+        apiKey: 'bedrock-key-123', // gitleaks:allow
         accessKeyId: undefined,
         secretAccessKey: undefined,
         sessionToken: undefined,


### PR DESCRIPTION
If this works, we can use this against all test secrets. These are the most recent ones so these are the ones Gitleaks is currently flagging.

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 