### PR TITLE
fix(executor): surface silent memory fallback when conversationId is set

### DIFF
--- a/ark/api/v1alpha1/query_types.go
+++ b/ark/api/v1alpha1/query_types.go
@@ -16,6 +16,9 @@ type QueryConditionType string
 const (
 	// QueryCompleted indicates that the query has finished (regardless of outcome)
 	QueryCompleted QueryConditionType = "Completed"
+	// QueryMemoryUnavailable indicates that the query carried a conversationId
+	// but no Memory backend was reachable, so conversation history was dropped.
+	QueryMemoryUnavailable QueryConditionType = "MemoryUnavailable"
 )
 
 const (

--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -79,6 +79,9 @@ type executionState struct {
 	querySpan      telemetry.Span
 	targetSpan     telemetry.Span
 	isResumption   bool
+	// memoryUnavailable is true when the query carried a conversationId but no
+	// Memory backend was reachable, so history was silently dropped.
+	memoryUnavailable bool
 }
 
 func (s *executionState) finalizeStream(ctx context.Context, responseMessages []Message, tokenUsage arkv1alpha1.TokenUsage) {
@@ -296,6 +299,9 @@ func (h *Handler) setupExecution(ctx context.Context, query *arkv1alpha1.Query, 
 		conversationId = httpMemory.GetConversationID()
 	}
 
+	_, isNoop := memory.(*NoopMemory)
+	memoryUnavailable := isNoop && conversationId != ""
+
 	memoryMessages, err := memory.GetMessages(ctx)
 	if err != nil {
 		log.Error(err, "failed to load memory messages, continuing without history")
@@ -324,6 +330,8 @@ func (h *Handler) setupExecution(ctx context.Context, query *arkv1alpha1.Query, 
 		eventStream:    eventStream,
 		querySpan:      querySpan,
 		targetSpan:     targetSpan,
+
+		memoryUnavailable: memoryUnavailable,
 	}
 
 	return ctx, state, nil
@@ -546,6 +554,9 @@ func buildResponseMeta(state *executionState, execResult *ExecutionResult, respo
 	}
 	if state.conversationId != "" {
 		responseMeta["conversationId"] = state.conversationId
+	}
+	if state.memoryUnavailable {
+		responseMeta["memoryUnavailable"] = true
 	}
 	if execResult != nil && execResult.A2AResponse != nil {
 		a2aMeta := map[string]string{}

--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -103,7 +103,13 @@ func NewMemoryForQuery(ctx context.Context, k8sClient client.Client, memoryRef *
 		// Try to load "default" memory from the same namespace
 		_, err := getMemoryResource(ctx, k8sClient, "default", namespace)
 		if err != nil {
-			// If default memory doesn't exist, use noop memory
+			// If default memory doesn't exist, use noop memory. When the query
+			// carries a conversationId the caller expected continuity, so warn
+			// at default verbosity instead of hiding it behind V(2).
+			if conversationId != "" {
+				logf.FromContext(ctx).Info("conversationId set but no Memory backend reachable in namespace; conversation history disabled for this query",
+					"conversationId", conversationId, "queryName", queryName, "namespace", namespace)
+			}
 			return NewNoopMemory(), nil
 		}
 		memoryName, memoryNamespace = "default", namespace //nolint:goconst // "default" here is memory name, not model

--- a/ark/executors/completions/memory_http_test.go
+++ b/ark/executors/completions/memory_http_test.go
@@ -770,6 +770,24 @@ func TestNewMemoryForQueryTtl(t *testing.T) {
 	})
 }
 
+func TestNewMemoryForQueryNoopFallback(t *testing.T) {
+	fakeClient := setupMemoryTestClient(nil)
+
+	t.Run("falls back to noop memory when no default memory exists", func(t *testing.T) {
+		mem, err := NewMemoryForQuery(context.Background(), fakeClient, nil, "tenant-no-memory", "conv-1", "q-1", nil, &noOpMemoryRecorder{})
+		require.NoError(t, err)
+		_, ok := mem.(*NoopMemory)
+		require.True(t, ok)
+	})
+
+	t.Run("falls back to noop memory without a conversationId", func(t *testing.T) {
+		mem, err := NewMemoryForQuery(context.Background(), fakeClient, nil, "tenant-no-memory", "", "q-2", nil, &noOpMemoryRecorder{})
+		require.NoError(t, err)
+		_, ok := mem.(*NoopMemory)
+		require.True(t, ok)
+	})
+}
+
 func TestHTTPMemoryDeleteQuery(t *testing.T) {
 	t.Run("sends DELETE to /queries/:queryId/messages", func(t *testing.T) {
 		var capturedMethod, capturedPath string

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -664,11 +664,12 @@ func extractA2AResponseText(result *protocol.MessageResult) (string, error) {
 }
 
 type engineResponseMeta struct {
-	TokenUsage     *arkv1alpha1.TokenUsage
-	ConversationId string
-	MessagesRaw    string
-	A2AContextID   string
-	A2ATaskID      string
+	TokenUsage        *arkv1alpha1.TokenUsage
+	ConversationId    string
+	MessagesRaw       string
+	A2AContextID      string
+	A2ATaskID         string
+	MemoryUnavailable bool
 }
 
 func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMeta {
@@ -705,6 +706,10 @@ func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMet
 
 	if convId, ok := arkMap["conversationId"].(string); ok {
 		responseMeta.ConversationId = convId
+	}
+
+	if memoryUnavailable, ok := arkMap["memoryUnavailable"].(bool); ok {
+		responseMeta.MemoryUnavailable = memoryUnavailable
 	}
 
 	if messagesRaw, ok := arkMap["messages"]; ok {
@@ -865,6 +870,25 @@ func queryCompletedAt(obj *arkv1alpha1.Query) *time.Time {
 func (r *QueryReconciler) setConditionCompleted(query *arkv1alpha1.Query, status metav1.ConditionStatus, reason, message string) {
 	meta.SetStatusCondition(&query.Status.Conditions, metav1.Condition{
 		Type:               string(arkv1alpha1.QueryCompleted),
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: query.Generation,
+	})
+}
+
+func (r *QueryReconciler) setConditionMemoryUnavailable(query *arkv1alpha1.Query, unavailable bool) {
+	status := metav1.ConditionFalse
+	reason := "MemoryReachable"
+	message := "Conversation history was available for this query"
+	if unavailable {
+		status = metav1.ConditionTrue
+		reason = "NoMemoryBackend"
+		message = "conversationId was set but no Memory backend was reachable; conversation history was disabled for this query"
+	}
+	meta.SetStatusCondition(&query.Status.Conditions, metav1.Condition{
+		Type:               string(arkv1alpha1.QueryMemoryUnavailable),
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
@@ -1389,6 +1413,8 @@ func (r *QueryReconciler) handleQueryDispatch(
 	} else if engineMeta.A2AContextID != "" {
 		obj.Status.ConversationId = engineMeta.A2AContextID
 	}
+
+	r.setConditionMemoryUnavailable(obj, engineMeta.MemoryUnavailable)
 
 	queryStatus := r.determineQueryStatus(response)
 	duration := &metav1.Duration{Duration: time.Since(startTime)}

--- a/ark/internal/controller/query_controller_dispatch_test.go
+++ b/ark/internal/controller/query_controller_dispatch_test.go
@@ -338,6 +338,22 @@ func TestExtractEngineResponseMeta(t *testing.T) {
 		require.NotNil(t, meta.TokenUsage)
 		assert.Equal(t, int64(30), meta.TokenUsage.TotalTokens)
 		assert.NotEmpty(t, meta.MessagesRaw)
+		assert.False(t, meta.MemoryUnavailable)
+	})
+
+	t.Run("extracts memoryUnavailable flag", func(t *testing.T) {
+		msg := &protocol.Message{
+			Role:  protocol.MessageRoleAgent,
+			Parts: []protocol.Part{protocol.NewTextPart("response")},
+			Metadata: map[string]any{
+				arka2a.QueryExtensionMetadataKey: map[string]any{
+					"conversationId":    "conv-1",
+					"memoryUnavailable": true,
+				},
+			},
+		}
+		meta := extractEngineResponseMeta(&protocol.MessageResult{Result: msg})
+		assert.True(t, meta.MemoryUnavailable)
 	})
 
 	t.Run("extracts native A2A contextId and taskId from message", func(t *testing.T) {
@@ -385,6 +401,38 @@ func TestExtractEngineResponseMeta(t *testing.T) {
 		result := &protocol.MessageResult{Result: task}
 		meta := extractEngineResponseMeta(result)
 		assert.Empty(t, meta.ConversationId)
+	})
+}
+
+func TestSetConditionMemoryUnavailable(t *testing.T) {
+	r := &QueryReconciler{}
+	condType := string(arkv1alpha1.QueryMemoryUnavailable)
+
+	t.Run("sets True with NoMemoryBackend reason when unavailable", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryUnavailable(query, true)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+		assert.Equal(t, "NoMemoryBackend", cond.Reason)
+	})
+
+	t.Run("sets False when memory reachable", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryUnavailable(query, false)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, "MemoryReachable", cond.Reason)
+	})
+
+	t.Run("clears a prior True to False on re-run", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryUnavailable(query, true)
+		r.setConditionMemoryUnavailable(query, false)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	})
 }
 


### PR DESCRIPTION
When a Query carries a conversationId (or A2A ContextID) but no Memory backend is reachable, the executor silently fell back to NoopMemory and invoked the LLM with no prior history, with no signal to the user.

- Emit a default-level warning in NewMemoryForQuery when falling back to NoopMemory while a conversationId was requested (was V(2), invisible).
- Detect the noop fallback in the handler and propagate a memoryUnavailable flag over the existing A2A response metadata channel.
- Parse the flag in the controller and set a MemoryUnavailable Query status condition (NoMemoryBackend when unavailable, cleared to False otherwise).

Refs #2642

## Root cause

`ark/executors/completions/memory.go:102-108` — `NewMemoryForQuery` falls back
to `NoopMemory` when no `default` Memory exists, with no signal:

```go
if memoryRef == nil {
    _, err := getMemoryResource(ctx, k8sClient, "default", namespace)
    if err != nil {
        return NewNoopMemory(), nil   // silent fallback
    }
    ...
}
```

`NoopMemory.GetMessages` (`memory_noop.go:20-22`) returns an empty slice and
logs only at `V(2)` — invisible at default verbosity. The empty history flows
into `state.memoryMessages` (`handler.go:269`) and on to the LLM. No Query
condition is set, no default-level log is emitted.

### Architectural constraint

The executor does **not** write Query status — the controller is the sole
writer. Any status/condition surfacing must travel back over the existing A2A
response-metadata channel, which already carries `tokenUsage` and
`conversationId`:

- Executor builds `responseMeta` in `buildResponseMeta` (`handler.go:507`).
- Controller parses it in `extractEngineResponseMeta` → `engineResponseMeta`
  (`query_controller.go:625-679`).
- Controller applies it to `obj.Status` and already calls `SetStatusCondition`
  for the `Completed` condition (`query_controller.go:1284-1291`, `:822`).

The "memory unavailable" signal follows the same wire as `tokenUsage`.

## Status

Backend implementation complete on branch
`fix/conversationid-silent-memory-fallback`. All tasks below done; unit tests
green; `gofumpt`/`go vet` clean on changed files. See "Discovered during
implementation" for two pre-existing (unrelated) lint failures left as-is.

## Tasks

### 1. Default-level warning log — DONE
- [x] In `NewMemoryForQuery`, when falling back to `NoopMemory` **and**
      `conversationId != ""`, emit a default-level warning instead of hiding it
      behind `V(2)`. Implemented in `memory.go` (the fallback branch has the
      `conversationId` in scope, so the log lives there rather than in
      `NoopMemory`).
- [x] `NoopMemory`'s existing `V(2)` debug logs unchanged (no behavior change
      for the no-conversation case).
- Files: `ark/executors/completions/memory.go`

### 2. `MemoryUnavailable` condition on Query status — DONE
- [x] Detect the fallback in the handler by type-asserting `*NoopMemory`
      (mirrors the existing `*HTTPMemory` assertion); recorded on
      `executionState.memoryUnavailable` (true only when `conversationId != ""`).
- [x] `buildResponseMeta` emits `memoryUnavailable: true` on the A2A response
      metadata when the flag is set.
- [x] Added `MemoryUnavailable bool` to `engineResponseMeta`; parsed in
      `extractEngineResponseMeta`.
- [x] Added `QueryMemoryUnavailable QueryConditionType = "MemoryUnavailable"`
      in `ark/api/v1alpha1/query_types.go`. No CRD schema migration — conditions
      are generic `[]metav1.Condition`.
- [x] New `setConditionMemoryUnavailable` helper (mirrors
      `setConditionCompleted`) called in the dispatch completion. Sets
      `status: True, reason: NoMemoryBackend` when unavailable, and explicitly
      `status: False, reason: MemoryReachable` otherwise so a re-run clears a
      stale `True`.
- Files: `ark/executors/completions/handler.go`,
  `ark/internal/controller/query_controller.go`,
  `ark/api/v1alpha1/query_types.go`

### 3. Tests — DONE
- [x] `TestNewMemoryForQueryNoopFallback` in `memory_http_test.go`: noop
      fallback returned with and without a `conversationId`.
- [x] Extended `TestExtractEngineResponseMeta` with a `memoryUnavailable`
      extraction subtest, and added `TestSetConditionMemoryUnavailable`
      (True/False/clear-on-rerun) in `query_controller_dispatch_test.go`.

### 4. Gates before push
- [x] `gofumpt -l` and `go vet` clean on all changed files.
- [x] `go test ./executors/completions/...` green (full package).
- [x] New controller unit tests green
      (`go test ./internal/controller/... -run
      'TestExtractEngineResponseMeta|TestSetConditionMemoryUnavailable'`).
- [x] `make test` full run: works out of the box. The target depends on
      `setup-envtest`, which downloads the envtest binaries into
      `ark/bin/k8s/<version>` (one-time, needs network) and exports an
      **absolute** `KUBEBUILDER_ASSETS`. Provisioned here via `make
      setup-envtest`; the controller Ginkgo suite (`TestControllers`, 77 specs)
      passes with these changes (`go test -count=1 ./internal/controller/...` →
      `ok 10.054s`).

## Discovered during implementation

- **Two pre-existing `goconst` lint failures on `main`** (surface only on a
  full local `make lint`; a stale golangci-lint cache initially hid them):
  - `executors/completions/model_test.go:94` — `"default"` literal where
    `defaultNamespace` const exists.
  - `internal/controller/memory_controller_test.go:90` — `"default"` literal
    where `testNamespace` const exists.

  Neither is touched by this change, and this change adds **zero** new lint
  findings. Left as-is to keep the diff narrow (CI's only-new-issues gate will
  not block on them). Candidate for a separate `chore(lint)` cleanup branch.
- **Warning log placement.** The default-level warning lives in
  `NewMemoryForQuery` (not `NoopMemory`) because that is where both the fallback
  decision and the `conversationId` are in scope; `NoopMemory` itself has no
  knowledge of whether a `conversationId` was requested.

## Follow-up considerations (out of scope here)

- **Dashboard banner.** Once the `MemoryUnavailable` condition
  exists, the chat UI should hide multi-turn affordances or show a "history
  disabled for this namespace" banner. Frontend work in
  `services/ark-dashboard`; depends on this PR landing first. Track separately.
- **Admission rejection.** Optionally reject a Query at admission
  (ValidatingAdmissionPolicy) when `conversationId` is set and no Memory is
  reachable. Strict; needs a cross-namespace reachability check and an opt-in
  Helm value. Largest lift — track as its own issue.
- **Memory readiness accuracy.** `Memory/default` can report `ready` while the
  backing broker pod is `Pending`. Readiness should reflect backend
  reachability, not just object existence. Separate, smaller issue that
  compounds this one.
- **Docs gap (#2599).** `ark-broker` is absent from the tenant install docs, so
  installs that follow the docs literally hit this. Pair the docs fix with this
  change.

## Related

- #2642 — this issue
- #2599 — `ark-broker` not in tenant docs + ark-api 503 path
- #2583 — error/empty state conflation in dashboard

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 