### PR TITLE
fix: bump ws to 8.21.1 (CVE-2026-62389)

### DIFF
--- a/services/ark-dashboard/ark-dashboard/package-lock.json
+++ b/services/ark-dashboard/ark-dashboard/package-lock.json
@@ -13230,9 +13230,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/services/ark-landing-page/package-lock.json
+++ b/services/ark-landing-page/package-lock.json
@@ -7297,9 +7297,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7245,9 +7245,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- Bumps transitive `ws` from 8.21.0 → 8.21.1 in `services/ark-dashboard`, `services/ark-landing-page`, and `tools/ark-cli` lockfiles to close CVE-2026-62389 (memory-exhaustion DoS in the ws WebSocket receiver via unfinished fragmented frames; CVSS 3.1 7.5, CWE-770).
- All three occurrences are transitive (`@kubernetes/client-node`, `isomorphic-ws`, `jsdom`, `ink`, `openai` peer dep); ws is used as a client or in dev/test tooling, not as a server-facing WebSocket endpoint — realistic risk is low, but the existing semver ranges already permit 8.21.1, so `npm update ws` resolves the pin cleanly.

Ref: https://cve.threatint.eu/CVE/CVE-2026-62389