### PR TITLE
fix: bump fast-uri to 3.1.4 (CVE-2026-16221)

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -3793,9 +3793,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -93,7 +93,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.4",
     "ws": "^8.21.0",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6"


### PR DESCRIPTION
## Summary
- Bump `fast-uri` override in `tools/ark-cli` from `^3.1.3` to `^3.1.4` and regenerate the lockfile
- Resolves XRAY-1029269 / CVE-2026-16221 (High): fast-uri <=3.1.3 does not treat a literal backslash as an authority delimiter, disagreeing with Node's WHATWG URL parser and enabling SSRF/allowlist bypass
- Pulled transitively via `@modelcontextprotocol/sdk` -> `ajv` -> `fast-uri`; not a direct dependency
- Unblocks the `jfrog-xray-scan` gate, which currently fails on all open PRs due to this violation on `main`

Closes #2906

🤖 Generated with [Claude Code](https://claude.com/claude-code)