### PR TITLE
fix(executor): emit bare agent name in AgentExecution operation data

### DIFF
--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -65,7 +65,7 @@ func (a *Agent) Execute(ctx context.Context, userInput Message, history []Messag
 	})
 
 	operationData := map[string]string{
-		"agent": a.FullName(),
+		"agent": a.Name,
 	}
 	ctx = a.eventingRecorder.Start(ctx, "AgentExecution", fmt.Sprintf("Executing agent %s", a.FullName()), operationData)
 

--- a/ark/executors/completions/approval_test.go
+++ b/ark/executors/completions/approval_test.go
@@ -16,6 +16,7 @@ import (
 
 // recordingAgentRecorder captures operation lifecycle calls for assertions.
 type recordingAgentRecorder struct {
+	starts    map[string]map[string]string
 	completes []string
 	fails     []string
 }
@@ -24,7 +25,11 @@ func (r *recordingAgentRecorder) InitializeQueryContext(ctx context.Context, _ *
 	return ctx
 }
 
-func (r *recordingAgentRecorder) Start(ctx context.Context, _, _ string, _ map[string]string) context.Context {
+func (r *recordingAgentRecorder) Start(ctx context.Context, operation, _ string, data map[string]string) context.Context {
+	if r.starts == nil {
+		r.starts = map[string]map[string]string{}
+	}
+	r.starts[operation] = data
 	return ctx
 }
 
@@ -434,4 +439,33 @@ func TestAgentExecute_ApprovalDoesNotEmitErrorEvent(t *testing.T) {
 	require.ErrorAs(t, err, &approvalErr, "Execute should propagate ApprovalRequiredError")
 	assert.Contains(t, rec.completes, "AgentExecution", "approval pause should emit a completion event")
 	assert.NotContains(t, rec.fails, "AgentExecution", "approval pause must not emit an error event")
+}
+
+// Must match the controller's emission (query_controller.go: target.Name).
+// Divergence lets the broker record two participant strings per agent under
+// event-order race, which the dashboard reads as a workflow conversation.
+func TestAgentExecute_EmitsBareAgentNameInOperationData(t *testing.T) {
+	provider := &mockChatProvider{
+		response: &openai.ChatCompletion{
+			ID:    "cmpl-1",
+			Model: "test-model",
+			Choices: []openai.ChatCompletionChoice{
+				{
+					Message:      openai.ChatCompletionMessage{Role: "assistant", Content: "hi"},
+					FinishReason: "stop",
+				},
+			},
+		},
+	}
+
+	rec := &recordingAgentRecorder{}
+	agent := newTestAgent("my-agent", provider)
+	agent.eventingRecorder = rec
+
+	_, err := agent.Execute(context.Background(), NewUserMessage("hello"), nil, nil, nil, ExecuteOptions{})
+	require.NoError(t, err)
+
+	data, ok := rec.starts["AgentExecution"]
+	require.True(t, ok, "AgentExecution Start event should have been recorded")
+	assert.Equal(t, "my-agent", data["agent"], "expected bare Name, not FullName")
 }

--- a/ark/internal/controller/query_operationdata_test.go
+++ b/ark/internal/controller/query_operationdata_test.go
@@ -1,0 +1,35 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+// Must stay in sync with the completions executor's AgentExecution event
+// (executors/completions/agent.go: operationData["agent"] = a.Name). Divergent
+// forms let the broker record two participant strings per agent under
+// event-order race, which the dashboard reads as a workflow conversation.
+func TestBuildOperationData_EmitsBareTargetName(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetType string
+		wantKey    string
+	}{
+		{"agent target", "agent", "agent"},
+		{"team target", "team", "team"},
+		{"tool target", "tool", "tool"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &arkv1alpha1.QueryTarget{Type: tt.targetType, Name: "my-target"}
+			data := buildOperationData(target, "")
+			assert.Equal(t, "my-target", data[tt.wantKey], "expected bare Name")
+			assert.Equal(t, tt.targetType, data["targetType"])
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Executor's AgentExecution event was emitting the namespaced form (`a.FullName()`) while the controller emits bare (`target.Name`) for the same query. Under event-order race the broker recorded two agent strings for a single-agent conversation → `participants.length > 1` → dashboard classified as a workflow and unmounted the composer. Root cause of the recurring `test_multi_message_conversation` flake.
- Bare is correct: broker is namespace-scoped by design, Query/TeamMember schemas have no Namespace field, executor agent lookups always use `query.Namespace`, so bare names are unambiguous within any broker's scope.
- Pin both sides independently: new unit test on `buildOperationData` in the controller, and a new test on `Agent.Execute` in the executor (extends the existing `recordingAgentRecorder` to capture Start data).

Diagnostics that identified this: #2915 (draft, will close after verifying this fix).