### PR TITLE
fix: patch protobufjs and axios CVEs (JFrog Xray findings)

### DIFF
--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ark-broker",
-  "version": "0.1.66",
+  "version": "0.1.67-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ark-broker",
-      "version": "0.1.66",
+      "version": "0.1.67-rc",
       "dependencies": {
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
@@ -16,7 +16,7 @@
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
         "postgres": "^3.4.9",
-        "protobufjs": "^8.6.1",
+        "protobufjs": "^8.6.6",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^14.0.0",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1234,7 +1234,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -1265,9 +1264,9 @@
       }
     },
     "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1278,7 +1277,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -2225,13 +2223,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -4437,9 +4428,9 @@
       }
     },
     "node_modules/dockerode/node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -4450,7 +4441,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -8151,9 +8141,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
-      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -36,7 +36,7 @@
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "postgres": "^3.4.9",
-    "protobufjs": "^8.6.1",
+    "protobufjs": "^8.6.6",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^14.0.0",
@@ -91,6 +91,9 @@
     "esbuild": "^0.28.1",
     "ws": "^8.21.0",
     "form-data": "^4.0.6",
-    "undici": "^7.28.0"
+    "undici": "^7.28.0",
+    "dockerode": {
+      "protobufjs": "^7.6.5"
+    }
   }
 }

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.66",
+  "version": "0.1.67-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.66",
+      "version": "0.1.67-rc",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "axios": "^1.16.0",
+        "axios": "^1.18.0",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "debug": "^4.4.1",
@@ -2459,13 +2459,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4251,6 +4252,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/human-signals": {

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "axios": "^1.16.0",
+    "axios": "^1.18.0",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "debug": "^4.4.1",


### PR DESCRIPTION
## Summary
- Fixes two JFrog Xray findings flagged against `main`'s clean baseline (surfaced while PR #2896, an unrelated broker perf refactor, was pulling `main` in for a fresh scan). Both are pre-existing vulnerable dependency versions on `main`, not introduced by that PR, and both are cut fully separately from it here.

## CVE-2026-59877 — protobufjs DoS (High, CVSS 7.5)

protobufjs before 7.6.5 / 8.6.6 parses option names by advancing through schema tokens until it hits `=` without checking for end of input. A crafted `.proto` schema that opens an option declaration and never closes it makes `parse`, `Root.load`, or `Root.loadSync` loop indefinitely.

This is reachable in `services/ark-broker`: it's a direct production dependency (`protobufjs": "^8.6.1"`) used for OTLP protobuf ingestion on `POST /v1/traces`, not dead weight. Bumped to `^8.6.6` (resolves to `8.7.1`); confirmed via the official changelog that 8.6.2 through 8.7.1 are all non-breaking patch/minor releases.

A second, separate instance of the same vulnerable line (`protobufjs@7.6.3`) was pulled in transitively via `testcontainers` → `dockerode` → `@grpc/grpc-js` / `@grpc/proto-loader`. This path is test-only (never shipped in the production image), but Xray flags it regardless. `testcontainers` and its Postgres/Redis plugins were already at their latest release, so bumping them didn't move the resolved `protobufjs` version — the existing lockfile just hadn't picked up the already-in-range patched version. Rather than a blanket `protobufjs` override (which would force the 8.x line onto `@grpc/proto-loader`, itself built against the 7.x API, and risk breaking the gRPC path testcontainers relies on), scoped the override to only the `dockerode` subtree:

```json
"overrides": {
  "dockerode": {
    "protobufjs": "^7.6.5"
  }
}
```

`npm ls protobufjs` now shows every instance in the tree at a patched version (`8.7.1` top-level, `7.6.5` under `dockerode`).

Closes #2924

## GHSA-gcfj-64vw-6mp9 — axios inherited-proxy bypass (High, CVSS 8.3)

axios hardens merged request config into a null-prototype object to block `Object.prototype` pollution from affecting request behavior, but this hardening runs before request interceptors. A common interceptor pattern (`{...config}`) recreates config as a regular object, silently dropping that protection. If `Object.prototype.proxy` has already been polluted elsewhere in the process, the Node HTTP adapter reads the inherited value and routes the request through an attacker-controlled proxy, exposing headers (including `Authorization`), method, URL, and body for plaintext HTTP requests.

`tools/ark-cli` depends directly on `axios@^1.16.0` (vulnerable range: `>=1.15.2`). Its only use is a plain `axios.get` call in `marketplaceFetcher.ts` against a well-formed `https://` URL with no custom interceptors, so this build isn't hitting the specific interceptor-clone trigger today — but it's still the vulnerable code path shipping in a published CLI, and a future interceptor addition would silently reintroduce the exposure. Bumped to `^1.18.0` (resolves to `1.18.1`, the patched release). No breaking API changes between 1.16.0 and 1.18.1 per the axios changelog — the only behavioral changes are in URL/redirect hardening (rejecting malformed URLs missing `//`, stripping sensitive headers on cross-origin redirects), which don't affect our single well-formed HTTPS fetch.

No tracking issue exists for this one — the CI's auto-issue-creation script only fires when it can extract a CVE ID from the scan JSON, and GHSA-gcfj-64vw-6mp9 has no CVE assigned yet, only a GHSA ID.

Advisory: https://github.com/axios/axios/security/advisories/GHSA-gcfj-64vw-6mp9

## Verification

- `services/ark-broker`: `make lint` (eslint + tsc --noEmit + prettier --check) and `make test` (23 suites / 310 tests, including the Postgres and Redis testcontainer-backed integration suites that exercise the patched `dockerode`/`@grpc` chain) both pass clean.
- `tools/ark-cli`: `npm test` passes (58 files / 649 tests). No `make lint` target exists for this package; `npm run lint:check` shows the same 27 pre-existing warnings/errors with and without this change (confirmed via `git stash`), so nothing regressed.
- `npm ls protobufjs` (ark-broker) and `npm ls axios` (ark-cli) confirm no unpatched instance remains in either tree; `npm audit` no longer flags either CVE in either package (remaining findings — `@babel/core`, `body-parser` — are unrelated and out of scope for this PR).