### PR TITLE
test(ui): stop hiding modal-close failures, log create-tool click outcome

### DIFF
--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -104,12 +104,15 @@ class BasePage:
         self.page.locator("[data-slot='dialog-overlay'], [role='dialog'], [data-slot='dialog-content']").first.wait_for(state="visible", timeout=timeout)
     
     def wait_for_modal_close(self, timeout: int = 10000) -> None:
+        # No Escape fallback: a modal that doesn't close on its own means the
+        # submit click didn't reach its handler, which is a real failure.
         try:
             self.page.locator("[data-slot='dialog-overlay'], [role='dialog']").first.wait_for(state="hidden", timeout=timeout)
-        except:
-            logger.info("Modal did not close")
-            self.page.keyboard.press("Escape")
-            self.wait_for_element_hidden("[data-slot='dialog-overlay'], [role='dialog']")
+        except Exception:
+            logger.error("Modal did not close within %dms (submit click likely didn't reach its handler)", timeout)
+            page_name = urlsplit(self.page.url).path.replace("/", "_")
+            self._capture_failure_debug(f"modal_did_not_close{page_name}")
+            raise
     
     def reload(self) -> None:
         self.page.reload()

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -2,7 +2,7 @@ import logging
 import random
 import pytest
 from datetime import datetime
-from playwright.sync_api import Page
+from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError
 from .base_page import BasePage
 from .dashboard_page import DashboardPage
 
@@ -146,8 +146,19 @@ class ToolsPage(BasePage):
             save_button = self.page.locator("[role='dialog'] button[type='submit'], [data-slot='dialog-content'] button[type='submit']").first
         
         save_button.scroll_into_view_if_needed()
-        save_button.click(force=True)
-        
+
+        # A missing POST after a "successful" click is the stale-DOM re-render
+        # race signature (click event lands on a detached node).
+        try:
+            with self.page.expect_response(
+                lambda r: r.request.method == "POST" and "/api/v1/tools" in r.url,
+                timeout=5000,
+            ) as post_info:
+                save_button.click(force=True)
+            logger.info("Create POST -> %d", post_info.value.status)
+        except PlaywrightTimeoutError:
+            logger.error("Create click did not fire POST /api/v1/tools (stale-DOM race)")
+
         popup_visible = self._check_toast_popup()
         logger.info(f"Toast visible: {popup_visible}")
         


### PR DESCRIPTION
## Summary
- \`wait_for_modal_close\` in \`base_page.py\` pressed Escape when the modal didn't close on its own, silently recovering from what's almost always a stale-DOM re-render race. Remove the fallback so the failure propagates.
- In \`ToolsPage.create_http_tool_with_verification\`, watch for the \`POST /api/v1/tools\` that a successful submit must fire. If it doesn't fire within 5s, log an error identifying the stale-DOM race as the likely cause.

## Why
Diagnostic capture on #2915 caught \`test_create_agent_with_tools\` failing with an empty backend + no dialog in DOM + no console errors. Tracing that back, the dialog wasn't gone because the form submitted — it was gone because \`wait_for_modal_close\` pressed Escape on its own timeout. Removing that fallback (and pinning down "did the POST fire") should turn every future occurrence into a clean signal instead of the confusing state we were debugging from before.

**Draft:** accidentally opened the PR early 😅  but if this issue still applies after the new UI then it's worth fixing. Leaving this open for now, but do not review, it's not worth it.