### PR TITLE
test(ui): drop force=True on Create-tool click, unmask modal-close failure

### DIFF
--- a/tests/pytest/ui-tests/pages/base_page.py
+++ b/tests/pytest/ui-tests/pages/base_page.py
@@ -104,12 +104,15 @@ class BasePage:
         self.page.locator("[data-slot='dialog-overlay'], [role='dialog'], [data-slot='dialog-content']").first.wait_for(state="visible", timeout=timeout)
     
     def wait_for_modal_close(self, timeout: int = 10000) -> None:
+        # No Escape fallback: a modal that doesn't close on its own means the
+        # submit click didn't reach its handler, which is a real failure.
         try:
             self.page.locator("[data-slot='dialog-overlay'], [role='dialog']").first.wait_for(state="hidden", timeout=timeout)
-        except:
-            logger.info("Modal did not close")
-            self.page.keyboard.press("Escape")
-            self.wait_for_element_hidden("[data-slot='dialog-overlay'], [role='dialog']")
+        except Exception:
+            logger.exception("Modal did not close within %dms (submit click likely didn't reach its handler)", timeout)
+            page_name = urlsplit(self.page.url).path.replace("/", "_")
+            self._capture_failure_debug(f"modal_did_not_close{page_name}")
+            raise
     
     def reload(self) -> None:
         self.page.reload()

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -2,7 +2,7 @@ import logging
 import random
 import pytest
 from datetime import datetime
-from playwright.sync_api import Page
+from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError
 from .base_page import BasePage
 from .dashboard_page import DashboardPage
 
@@ -146,8 +146,18 @@ class ToolsPage(BasePage):
             save_button = self.page.locator("[role='dialog'] button[type='submit'], [data-slot='dialog-content'] button[type='submit']").first
         
         save_button.scroll_into_view_if_needed()
-        save_button.click(force=True)
-        
+
+        # A missing POST after a "successful" click is the stale-DOM re-render
+        # race signature (click event lands on a detached node).
+        try:
+            with self.page.expect_response(
+                lambda r: r.request.method == "POST" and "/api/v1/tools" in r.url,
+                timeout=5000,
+            ):
+                save_button.click()
+        except PlaywrightTimeoutError:
+            logger.error("Create click did not fire POST /api/v1/tools (stale-DOM race)")
+
         popup_visible = self._check_toast_popup()
         logger.info(f"Toast visible: {popup_visible}")
         


### PR DESCRIPTION
## Summary
- Drop \`force=True\` on the Create-tool click in \`tools_page.py\`. \`force=True\` skipped Playwright's actionability check — including the stability check that waits for the element to be at the same position for two consecutive animation frames. Under CPU pressure the button was still being re-rendered when the click fired, so the click landed on a detached DOM node and never reached React's submit handler.
- Wrap the click in \`page.expect_response(POST /api/v1/tools)\` so a missing POST is logged as a clear error at the source, rather than surfacing later as an unexplained toast timeout.
- Drop the Escape fallback in \`wait_for_modal_close\` (\`base_page.py\`). It was silently masking the same class of failure — a submit click that didn't reach its handler. Let the timeout propagate with a debug capture at the failure site.

## Why
On PR #2915's diagnostic branch we caught this repeatedly: no POST fired, no toast, modal open. Locally reproducible 5/5 with \`force=True\`; passes 5/5 with plain \`click()\`. Root cause: React 18 was re-rendering the button mid-click (form-state subscription), and \`force=True\` was letting Playwright fire the click anyway on the pre-render DOM node.

\`force=True\` on this specific call originated in #1141, which replaced an earlier \`element.evaluate("click()")\` from #562/#627 — both were masking the same actionability failure without addressing it.

Supersedes #2938 (which contained just the modal-close half).