### PR TITLE
fix(dashboard): restore Manage marketplace settings gated by marketplace flag

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-content.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-content.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SettingsContent } from '@/components/settings/settings-content';
+
+vi.mock('@/components/settings/queries-settings', () => ({
+  QueriesSettings: () => <div>queries-settings-stub</div>,
+}));
+vi.mock('@/components/settings/experimental-features-settings', () => ({
+  ExperimentalFeaturesSettings: () => <div>experimental-settings-stub</div>,
+}));
+vi.mock('@/components/settings/execution-engines-settings', () => ({
+  ExecutionEnginesSettings: () => <div>execution-engines-stub</div>,
+}));
+vi.mock('@/components/settings/manage-marketplace-settings', () => ({
+  ManageMarketplaceSettings: () => <div>manage-marketplace-stub</div>,
+}));
+
+describe('SettingsContent', () => {
+  it('routes the manage-marketplace page to ManageMarketplaceSettings', () => {
+    render(<SettingsContent activePage="manage-marketplace" />);
+    expect(
+      screen.getByRole('heading', { name: 'Manage marketplace' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('manage-marketplace-stub')).toBeInTheDocument();
+  });
+
+  it('routes the queries page to QueriesSettings', () => {
+    render(<SettingsContent activePage="queries" />);
+    expect(screen.getByText('queries-settings-stub')).toBeInTheDocument();
+    expect(
+      screen.queryByText('manage-marketplace-stub'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-sidebar.test.tsx
@@ -4,9 +4,10 @@ import { Provider, createStore } from 'jotai';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { storedIsMarketplaceEnabledAtom } from '@/atoms/experimental-features';
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
-import type { SettingPage } from '@/components/settings/settings-types';
 import { SettingsSidebar } from '@/components/settings/settings-sidebar';
+import type { SettingPage } from '@/components/settings/settings-types';
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
@@ -50,13 +51,26 @@ describe('SettingsSidebar', () => {
     expect(screen.getByText('Experimental features')).toBeInTheDocument();
   });
 
+  it('should hide Manage marketplace when the marketplace flag is off', () => {
+    renderWithStore();
+    expect(screen.queryByText('Manage marketplace')).not.toBeInTheDocument();
+  });
+
+  it('should reveal Manage marketplace when the marketplace flag is enabled', () => {
+    store.set(storedIsMarketplaceEnabledAtom, true);
+    renderWithStore();
+    expect(screen.getByText('Manage marketplace')).toBeInTheDocument();
+  });
+
   it('should navigate to settings page preserving namespace when a menu item is clicked', async () => {
     const user = userEvent.setup();
     renderWithStore();
 
     await user.click(screen.getByText('Queries'));
 
-    expect(mockReplace).toHaveBeenCalledWith('/settings/queries?namespace=demo');
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/settings/queries?namespace=demo',
+    );
   });
 
   it('should navigate to entry URL preserving namespace when close button is clicked after soft navigation', async () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-types.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/settings/settings-types.test.ts
@@ -11,11 +11,12 @@ describe('settingsSections', () => {
     const settings = settingsSections.find(s => s.sectionKey === 'settings');
     expect(settings).toBeDefined();
     expect(settings!.sectionLabel).toBe('');
-    expect(settings!.items).toHaveLength(3);
+    expect(settings!.items).toHaveLength(4);
     expect(settings!.items.map(i => i.key)).toEqual([
       'queries',
       'experimental-features',
       'execution-engines',
+      'manage-marketplace',
     ]);
   });
 
@@ -26,6 +27,15 @@ describe('settingsSections', () => {
     );
     expect(executionEngines).toBeDefined();
     expect(executionEngines!.experimental).toBe(true);
+  });
+
+  it('should mark manage-marketplace as experimental', () => {
+    const settings = settingsSections.find(s => s.sectionKey === 'settings');
+    const manageMarketplace = settings!.items.find(
+      i => i.key === 'manage-marketplace',
+    );
+    expect(manageMarketplace).toBeDefined();
+    expect(manageMarketplace!.experimental).toBe(true);
   });
 
   it('should have icons for all items', () => {

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-content.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-content.tsx
@@ -2,11 +2,11 @@
 
 import { Suspense, useMemo } from 'react';
 
-import type { SettingPage } from './settings-types';
-
 import { ExecutionEnginesSettings } from './execution-engines-settings';
 import { ExperimentalFeaturesSettings } from './experimental-features-settings';
+import { ManageMarketplaceSettings } from './manage-marketplace-settings';
 import { QueriesSettings } from './queries-settings';
+import type { SettingPage } from './settings-types';
 
 type SettingsContentProps = {
   activePage: SettingPage;
@@ -31,6 +31,10 @@ export function SettingsContent({ activePage }: SettingsContentProps) {
       'execution-engines': {
         title: 'Execution Engines',
         component: <ExecutionEnginesSettings />,
+      },
+      'manage-marketplace': {
+        title: 'Manage marketplace',
+        component: <ManageMarketplaceSettings />,
       },
     }),
     [],

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-sidebar.tsx
@@ -3,7 +3,10 @@
 import { useAtomValue } from 'jotai';
 import { X } from 'lucide-react';
 
-import { isExperimentalExecutionEngineEnabledAtom } from '@/atoms/experimental-features';
+import {
+  isExperimentalExecutionEngineEnabledAtom,
+  isMarketplaceEnabledAtom,
+} from '@/atoms/experimental-features';
 import { settingsEntryUrlAtom } from '@/atoms/navigation-history';
 import { useNamespacedNavigation } from '@/lib/hooks/use-namespaced-navigation';
 import { cn } from '@/lib/utils';
@@ -20,9 +23,11 @@ export function SettingsSidebar({ activePage }: SettingsSidebarProps) {
   const isExperimentalExecutionEngineEnabled = useAtomValue(
     isExperimentalExecutionEngineEnabledAtom,
   );
+  const isMarketplaceEnabled = useAtomValue(isMarketplaceEnabledAtom);
 
   const isExperimentalEnabled: Record<string, boolean> = {
     'execution-engines': isExperimentalExecutionEngineEnabled,
+    'manage-marketplace': isMarketplaceEnabled,
   };
 
   const visibleSections = settingsSections.map(section => ({

--- a/services/ark-dashboard/ark-dashboard/components/settings/settings-types.ts
+++ b/services/ark-dashboard/ark-dashboard/components/settings/settings-types.ts
@@ -1,9 +1,12 @@
-import { Cog, Search, Zap } from 'lucide-react';
+import { Cog, Search, Store, Zap } from 'lucide-react';
 
 export type SettingPage =
   | 'queries'
   | 'experimental-features'
-  | 'execution-engines';
+  | 'execution-engines'
+  | 'manage-marketplace';
+
+export const MANAGE_MARKETPLACE_KEY = 'manage-marketplace' as const;
 
 export type SettingMenuItem = {
   key: SettingPage;
@@ -37,6 +40,12 @@ export const settingsSections: SettingsSection[] = [
         key: 'execution-engines',
         label: 'Execution Engines',
         icon: Cog,
+        experimental: true,
+      },
+      {
+        key: 'manage-marketplace',
+        label: 'Manage marketplace',
+        icon: Store,
         experimental: true,
       },
     ],


### PR DESCRIPTION
## Summary

Fixes #2961. On `feat/qb-design-migration` (#2151), enabling the **Marketplace** experimental toggle was a no-op: the **Manage marketplace** settings page it gates never appeared, and the feature flag's only consumer had become its own toggle.

The Settings refactor dropped the marketplace wiring. The sidebar filters experimental items with `item => !item.experimental || isExperimentalEnabled[item.key]`, so any experimental item whose key is missing from the map resolves to `undefined` and is silently hidden — no type/lint error. The `manage-marketplace` item, its route, and its gate were all removed, while `ManageMarketplaceSettings` remained orphaned.

## Fix

Re-port the wiring into the refactored Settings (narrow, matching the new `experimental` gating design):

- `components/settings/settings-types.ts` — add `manage-marketplace` to `SettingPage` / `settingsSections` (`experimental: true`, `Store` icon) and re-export `MANAGE_MARKETPLACE_KEY`.
- `components/settings/settings-sidebar.tsx` — add `'manage-marketplace': isMarketplaceEnabled` to the `isExperimentalEnabled` map, reading `isMarketplaceEnabledAtom`.
- `components/settings/settings-content.tsx` — route the page to the existing `ManageMarketplaceSettings` component.

The `[[...page]]` route derives `VALID_SETTINGS_PAGES` from `settingsSections`, so the page becomes reachable automatically, and `SettingsContent`'s `Record<SettingPage, PageConfig>` makes the routing entry type-enforced.

## Behavior

- Marketplace flag **off** (default): Settings menu shows Queries + Experimental features only (unchanged).
- Marketplace flag **on**: **Manage marketplace** appears and opens the add/manage 3rd-party sources page (as on `main`).

## Tests

- `settings-sidebar.test.tsx` — reveals the item when the marketplace flag is enabled; hides it when off (reproduces the regression: the reveal test fails before this change).
- `settings-content.test.tsx` (new) — routes `manage-marketplace` to `ManageMarketplaceSettings`.
- `settings-types.test.ts` — updated for the restored item and its `experimental` flag.

```
npx vitest run __tests__/unit/components/settings/ components/settings/
# Test Files  9 passed (9)   Tests  44 passed (44)
```

`prettier --check` passes on all touched files. (Repo-wide `next lint` / `tsc` have pre-existing, unrelated failures on this branch; no new type errors are introduced by this change.)