### PR TITLE
test(argo): run ark-query success and failure cases in parallel

### DIFF
--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -85,10 +85,7 @@ if [ "${PREFETCH_TEST_IMAGES}" = "true" ]; then
     docker.io/mockserver/mockserver:5.15.0 \
     ghcr.io/orange-opensource/hurl:6.1.1 \
     docker.io/python:3.12-bookworm \
-    ghcr.io/dwmkerr/mock-llm:0.1.28 \
-    quay.io/argoproj/workflow-controller:v3.7.2 \
-    quay.io/argoproj/argoexec:v3.7.2 \
-    quay.io/argoproj/argocli:v3.7.2; do
+    ghcr.io/dwmkerr/mock-llm:0.1.28; do
     sudo k3s crictl pull "$img" > /dev/null 2>&1 &
     IMAGE_PULL_PIDS+=($!)
   done

--- a/.github/actions/setup-e2e/setup-local.sh
+++ b/.github/actions/setup-e2e/setup-local.sh
@@ -85,7 +85,10 @@ if [ "${PREFETCH_TEST_IMAGES}" = "true" ]; then
     docker.io/mockserver/mockserver:5.15.0 \
     ghcr.io/orange-opensource/hurl:6.1.1 \
     docker.io/python:3.12-bookworm \
-    ghcr.io/dwmkerr/mock-llm:0.1.28; do
+    ghcr.io/dwmkerr/mock-llm:0.1.28 \
+    quay.io/argoproj/workflow-controller:v3.7.2 \
+    quay.io/argoproj/argoexec:v3.7.2 \
+    quay.io/argoproj/argocli:v3.7.2; do
     sudo k3s crictl pull "$img" > /dev/null 2>&1 &
     IMAGE_PULL_PIDS+=($!)
   done

--- a/services/argo-workflows/chart/values.yaml
+++ b/services/argo-workflows/chart/values.yaml
@@ -1,6 +1,14 @@
 # Argo Workflows configuration. This is config for the actual Argo workflows
 # chart from Argo itself, which is a dependency of our own chart.
 argo-workflows:
+  # We ship a pinned, immutable Argo release tag, so IfNotPresent is the
+  # correct policy: the digest never changes, and cached (or prefetched)
+  # images start without a per-pod registry round-trip - which matters
+  # because the executor image runs in every workflow pod. Set this to
+  # Always only if you point the images at a mutable tag (e.g. latest).
+  images:
+    pullPolicy: IfNotPresent
+
   # Single namespace mode. Suitable for development and does not require
   # cluster roles.
   singleNamespace: false

--- a/tests/argo-ark-query/chainsaw-test.yaml
+++ b/tests/argo-ark-query/chainsaw-test.yaml
@@ -73,95 +73,7 @@ spec:
             name: ModelAvailable
             value: 'True'
 
-  - name: agent-target-success
-    try:
-    - apply:
-        file: manifests/wf-agent.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-agent
-        timeout: 4m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-agent -o json > /tmp/wf-agent.json
-
-          PHASE=$(jq -r '.status.phase' /tmp/wf-agent.json)
-          echo "workflow phase: $PHASE"
-          [ "$PHASE" = "Succeeded" ] || { echo "expected Succeeded"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-agent.json | head -1)
-          QUERY_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="phase") | .value' /tmp/wf-agent.json | head -1)
-          CONVERSATION_ID=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="conversation-id") | .value' /tmp/wf-agent.json | head -1)
-          QUERY_JSON=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="query-json") | .value' /tmp/wf-agent.json | head -1)
-          SESSION_ID=$(echo "$QUERY_JSON" | jq -r '.spec.sessionId')
-
-          echo "response: $RESPONSE"
-          echo "query phase: $QUERY_PHASE"
-          echo "conversation-id: $CONVERSATION_ID"
-          echo "sessionId: $SESSION_ID"
-
-          [ "$QUERY_PHASE" = "done" ] || { echo "expected query phase done"; exit 1; }
-          echo "$RESPONSE" | grep -q "WEATHER:" || { echo "missing WEATHER: in response"; exit 1; }
-          [ "$SESSION_ID" = "wf-ark-query-agent" ] || { echo "expected sessionId wf-ark-query-agent"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-agent
-
-  - name: team-target-success
-    try:
-    - apply:
-        file: manifests/wf-team.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-team
-        timeout: 4m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-team -o json > /tmp/wf-team.json
-
-          PHASE=$(jq -r '.status.phase' /tmp/wf-team.json)
-          echo "workflow phase: $PHASE"
-          [ "$PHASE" = "Succeeded" ] || { echo "expected Succeeded"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-team.json | head -1)
-          QUERY_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="phase") | .value' /tmp/wf-team.json | head -1)
-
-          echo "response: $RESPONSE"
-          echo "query phase: $QUERY_PHASE"
-
-          [ "$QUERY_PHASE" = "done" ] || { echo "expected query phase done"; exit 1; }
-          echo "$RESPONSE" | grep -q "FINAL:" || { echo "missing final assistant message"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-team
-
-  - name: tool-target-success
+  - name: success-cases
     try:
     - apply:
         file: ../shared/mock-geocoding-api.yaml
@@ -222,312 +134,43 @@ spec:
           metadata:
             name: geocoder
     - apply:
+        file: manifests/wf-agent.yaml
+    - apply:
+        file: manifests/wf-team.yaml
+    - apply:
         file: manifests/wf-tool.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-tool
-        timeout: 4m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-tool -o json > /tmp/wf-tool.json
-
-          PHASE=$(jq -r '.status.phase' /tmp/wf-tool.json)
-          echo "workflow phase: $PHASE"
-          [ "$PHASE" = "Succeeded" ] || { echo "expected Succeeded"; exit 1; }
-
-          RESPONSE=$(jq -r 'first(.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value)' /tmp/wf-tool.json)
-          QUERY_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="phase") | .value' /tmp/wf-tool.json | head -1)
-          TARGET_TYPE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="query-json") | .value | fromjson | .spec.target.type' /tmp/wf-tool.json | head -1)
-
-          echo "response: $RESPONSE"
-          echo "query phase: $QUERY_PHASE"
-          echo "target type: $TARGET_TYPE"
-
-          [ "$QUERY_PHASE" = "done" ] || { echo "expected query phase done"; exit 1; }
-          [ "$TARGET_TYPE" = "tool" ] || { echo "expected target type tool"; exit 1; }
-          echo "$RESPONSE" | grep -q "New York" || { echo "missing tool response content"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-tool
-
-  - name: error-target-node-failed
-    try:
-    - apply:
-        file: manifests/wf-error.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-error
-        timeout: 4m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-error -o json > /tmp/wf-error.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-error.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          QUERY_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="phase") | .value' /tmp/wf-error.json | head -1)
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-error.json | head -1)
-          QUERY_JSON=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="query-json") | .value' /tmp/wf-error.json | head -1)
-
-          echo "query phase output: $QUERY_PHASE"
-          echo "response output: $RESPONSE"
-
-          [ "$QUERY_PHASE" = "error" ] || { echo "expected query phase output error"; exit 1; }
-          [ -n "$QUERY_JSON" ] || { echo "expected query-json output to be readable"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-error
-
-  - name: bad-target-noslash
-    try:
-    - apply:
-        file: manifests/wf-bad-target-noslash.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-noslash
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-bad-target-noslash -o json > /tmp/wf-bad-target-noslash.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-bad-target-noslash.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-bad-target-noslash.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "expected type/name" || { echo "missing target-format error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-noslash
-
-  - name: bad-target-type
-    try:
-    - apply:
-        file: manifests/wf-bad-target-type.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-type
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-bad-target-type -o json > /tmp/wf-bad-target-type.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-bad-target-type.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-bad-target-type.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "invalid target type" || { echo "missing target-type error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-type
-
-  - name: bad-target-empty
-    try:
-    - apply:
-        file: manifests/wf-bad-target-empty.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-empty
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-bad-target-empty -o json > /tmp/wf-bad-target-empty.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-bad-target-empty.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-bad-target-empty.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "name is empty" || { echo "missing empty-name error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-target-empty
-
-  - name: bad-params-nonjson
-    try:
-    - apply:
-        file: manifests/wf-bad-params-nonjson.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-params-nonjson
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-bad-params-nonjson -o json > /tmp/wf-bad-params-nonjson.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-bad-params-nonjson.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-bad-params-nonjson.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "invalid parameters" || { echo "missing parameters error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-params-nonjson
-
-  - name: bad-params-nonlist
-    try:
-    - apply:
-        file: manifests/wf-bad-params-nonlist.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-params-nonlist
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-bad-params-nonlist -o json > /tmp/wf-bad-params-nonlist.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-bad-params-nonlist.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-bad-params-nonlist.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "invalid parameters" || { echo "missing parameters error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-bad-params-nonlist
-
-  - name: apply-fail-missing-target
-    try:
-    - apply:
-        file: manifests/wf-apply-fail.yaml
-    - wait:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-apply-fail
-        timeout: 2m
-        for:
-          condition:
-            name: Completed
-            value: 'True'
-    - script:
-        timeout: 30s
-        content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-apply-fail -o json > /tmp/wf-apply-fail.json
-
-          NODE_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .phase' /tmp/wf-apply-fail.json | head -1)
-          echo "ark-query node phase: $NODE_PHASE"
-          [ "$NODE_PHASE" = "Failed" ] || { echo "expected node Failed"; exit 1; }
-
-          RESPONSE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="response") | .value' /tmp/wf-apply-fail.json | head -1)
-          echo "response output: $RESPONSE"
-          echo "$RESPONSE" | grep -q "failed to create Query" || { echo "missing apply-failure error"; exit 1; }
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-    catch:
-    - events: {}
-    - describe:
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        name: ark-query-apply-fail
-
-  - name: optional-spec-success
-    try:
     - apply:
         file: manifests/wf-optional-spec.yaml
     - wait:
         apiVersion: argoproj.io/v1alpha1
         kind: Workflow
+        name: ark-query-agent
+        timeout: 4m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-team
+        timeout: 4m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-tool
+        timeout: 4m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
         name: ark-query-optional-spec
         timeout: 4m
         for:
@@ -535,34 +178,218 @@ spec:
             name: Completed
             value: 'True'
     - script:
-        timeout: 30s
+        timeout: 60s
         content: |
-          set -e
-          kubectl -n "$NAMESPACE" get workflow ark-query-optional-spec -o json > /tmp/wf-optional-spec.json
+          set -u
+          failed=0
 
-          PHASE=$(jq -r '.status.phase' /tmp/wf-optional-spec.json)
-          echo "workflow phase: $PHASE"
-          [ "$PHASE" = "Succeeded" ] || { echo "expected Succeeded"; exit 1; }
+          fetch() {
+            kubectl -n "$NAMESPACE" get workflow "$1" -o json > "/tmp/$1.json"
+          }
+          jp() {
+            jq -r "first(.status.nodes[] | select(.type==\"Pod\") | .outputs.parameters[]? | select(.name==\"$2\") | .value)" "/tmp/$1.json"
+          }
+          qj() {
+            jq -r "first(.status.nodes[] | select(.type==\"Pod\") | .outputs.parameters[]? | select(.name==\"query-json\") | .value | fromjson | $2)" "/tmp/$1.json"
+          }
+          wf_phase() {
+            jq -r '.status.phase' "/tmp/$1.json"
+          }
 
-          QUERY_PHASE=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="phase") | .value' /tmp/wf-optional-spec.json | head -1)
-          [ "$QUERY_PHASE" = "done" ] || { echo "expected query phase done"; exit 1; }
+          check_success_response() {
+            local wf=$1 needle=$2
+            fetch "$wf"
+            local phase query_phase response
+            phase=$(wf_phase "$wf")
+            query_phase=$(jp "$wf" phase)
+            response=$(jp "$wf" response)
+            echo "[$wf] wf_phase=$phase query_phase=$query_phase"
+            echo "[$wf] response=$response"
+            [ "$phase" = "Succeeded" ] || { echo "  FAIL: expected wf Succeeded"; failed=1; }
+            [ "$query_phase" = "done" ] || { echo "  FAIL: expected query phase done"; failed=1; }
+            echo "$response" | grep -q "$needle" || { echo "  FAIL: response missing \"$needle\""; failed=1; }
+          }
 
-          QUERY_JSON=$(jq -r '.status.nodes[] | select(.type=="Pod") | .outputs.parameters[]? | select(.name=="query-json") | .value' /tmp/wf-optional-spec.json | head -1)
-          echo "query-json output: $QUERY_JSON"
+          check_success_response ark-query-agent WEATHER:
+          check_success_response ark-query-team  FINAL:
+          check_success_response ark-query-tool  "New York"
 
-          NAME=$(echo "$QUERY_JSON" | jq -r '.metadata.name')
-          TTL=$(echo "$QUERY_JSON" | jq -r '.spec.ttl')
-          SESSION_ID=$(echo "$QUERY_JSON" | jq -r '.spec.sessionId')
-          echo "query name: $NAME, ttl: $TTL, sessionId: $SESSION_ID"
-          [ "$NAME" = "ark-query-custom-name" ] || { echo "expected custom query name"; exit 1; }
-          [ "$TTL" = "1m0s" ] || { echo "expected ttl 1m0s"; exit 1; }
-          [ "$SESSION_ID" = "argo-ark-query-session" ] || { echo "expected sessionId argo-ark-query-session"; exit 1; }
+          # agent: default sessionId is wf-<workflow-name> when none supplied.
+          agent_sid=$(qj ark-query-agent '.spec.sessionId')
+          echo "[ark-query-agent] sessionId=$agent_sid"
+          [ "$agent_sid" = "wf-ark-query-agent" ] || { echo "  FAIL: expected sessionId wf-ark-query-agent, got $agent_sid"; failed=1; }
+
+          # tool: verify the query targeted a tool.
+          tool_target_type=$(qj ark-query-tool '.spec.target.type')
+          echo "[ark-query-tool] target_type=$tool_target_type"
+          [ "$tool_target_type" = "tool" ] || { echo "  FAIL: expected target type tool, got $tool_target_type"; failed=1; }
+
+          # optional-spec: verify custom query metadata was applied.
+          fetch ark-query-optional-spec
+          phase=$(wf_phase ark-query-optional-spec)
+          query_phase=$(jp ark-query-optional-spec phase)
+          echo "[ark-query-optional-spec] wf_phase=$phase query_phase=$query_phase"
+          [ "$phase" = "Succeeded" ] || { echo "  FAIL: expected wf Succeeded"; failed=1; }
+          [ "$query_phase" = "done" ] || { echo "  FAIL: expected query phase done"; failed=1; }
+          name=$(qj ark-query-optional-spec '.metadata.name')
+          ttl=$(qj ark-query-optional-spec '.spec.ttl')
+          sid=$(qj ark-query-optional-spec '.spec.sessionId')
+          [ "$name" = "ark-query-custom-name" ]      || { echo "  FAIL: expected custom query name, got $name"; failed=1; }
+          [ "$ttl"  = "1m0s" ]                        || { echo "  FAIL: expected ttl 1m0s, got $ttl"; failed=1; }
+          [ "$sid"  = "argo-ark-query-session" ]      || { echo "  FAIL: expected sessionId argo-ark-query-session, got $sid"; failed=1; }
+
+          exit $failed
         env:
         - name: NAMESPACE
           value: ($namespace)
     catch:
     - events: {}
-    - describe:
+    - script:
+        content: |
+          for wf in ark-query-agent ark-query-team ark-query-tool ark-query-optional-spec; do
+            echo "=== $wf ==="; kubectl -n "$NAMESPACE" describe workflow "$wf" || true
+          done
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: failure-cases
+    try:
+    - apply:
+        file: manifests/wf-error.yaml
+    - apply:
+        file: manifests/wf-bad-target-noslash.yaml
+    - apply:
+        file: manifests/wf-bad-target-type.yaml
+    - apply:
+        file: manifests/wf-bad-target-empty.yaml
+    - apply:
+        file: manifests/wf-bad-params-nonjson.yaml
+    - apply:
+        file: manifests/wf-bad-params-nonlist.yaml
+    - apply:
+        file: manifests/wf-apply-fail.yaml
+    - wait:
         apiVersion: argoproj.io/v1alpha1
         kind: Workflow
-        name: ark-query-optional-spec
+        name: ark-query-error
+        timeout: 4m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-bad-target-noslash
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-bad-target-type
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-bad-target-empty
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-bad-params-nonjson
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-bad-params-nonlist
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - wait:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        name: ark-query-apply-fail
+        timeout: 2m
+        for:
+          condition:
+            name: Completed
+            value: 'True'
+    - script:
+        timeout: 60s
+        content: |
+          set -u
+          failed=0
+
+          fetch() {
+            kubectl -n "$NAMESPACE" get workflow "$1" -o json > "/tmp/$1.json"
+          }
+          jp() {
+            jq -r "first(.status.nodes[] | select(.type==\"Pod\") | .outputs.parameters[]? | select(.name==\"$2\") | .value)" "/tmp/$1.json"
+          }
+          node_phase() {
+            jq -r '.status.nodes[] | select(.type=="Pod") | .phase' "/tmp/$1.json" | head -1
+          }
+
+          # error-target-node-failed: Query itself errors; Argo node fails but outputs are readable.
+          fetch ark-query-error
+          np=$(node_phase ark-query-error)
+          qp=$(jp ark-query-error phase)
+          qj=$(jp ark-query-error query-json)
+          echo "[ark-query-error] node_phase=$np query_phase=$qp"
+          [ "$np" = "Failed" ] || { echo "  FAIL: expected node Failed"; failed=1; }
+          [ "$qp" = "error" ] || { echo "  FAIL: expected query phase error"; failed=1; }
+          [ -n "$qj" ]        || { echo "  FAIL: expected query-json to be readable"; failed=1; }
+
+          # bad-* / apply-fail: ark-query.py exits non-zero; check response mentions the expected error.
+          check_response() {
+            local wf=$1 needle=$2
+            fetch "$wf"
+            local np resp
+            np=$(node_phase "$wf")
+            resp=$(jp "$wf" response)
+            echo "[$wf] node_phase=$np response=$resp"
+            [ "$np" = "Failed" ] || { echo "  FAIL: expected node Failed"; failed=1; }
+            echo "$resp" | grep -q "$needle" || { echo "  FAIL: response missing \"$needle\""; failed=1; }
+          }
+
+          check_response ark-query-bad-target-noslash "expected type/name"
+          check_response ark-query-bad-target-type    "invalid target type"
+          check_response ark-query-bad-target-empty   "name is empty"
+          check_response ark-query-bad-params-nonjson "invalid parameters"
+          check_response ark-query-bad-params-nonlist "invalid parameters"
+          check_response ark-query-apply-fail         "failed to create Query"
+
+          exit $failed
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+    catch:
+    - events: {}
+    - script:
+        content: |
+          for wf in ark-query-error ark-query-bad-target-noslash ark-query-bad-target-type \
+                    ark-query-bad-target-empty ark-query-bad-params-nonjson \
+                    ark-query-bad-params-nonlist ark-query-apply-fail; do
+            echo "=== $wf ==="; kubectl -n "$NAMESPACE" describe workflow "$wf" || true
+          done
+        env:
+        - name: NAMESPACE
+          value: ($namespace)


### PR DESCRIPTION
## Summary
- Consolidate the argo-ark-query chainsaw test's ten per-workflow steps into two (`success-cases`, `failure-cases`), each of which applies all workflows up front, waits for each `Completed` condition, then validates all outputs in a single script that collects failures rather than exiting on the first.
- Each Argo workflow costs ~10s (pod cold start + Query controller reconcile + 1s poll) regardless of how trivial the query is, so running them serially through Chainsaw pins the wall clock at N × 10s. Submitting in parallel lets Argo run the pods concurrently and the sequential `wait` becomes bounded by the slowest single case.
- Local minikube run: 121s vs ~174s previously (~30% off). Failure-cases improvement was smaller than predicted because single-node minikube serializes some pod starts; expect the CI win on fresh k3s to be larger.
- Assertions are unchanged in intent -- node phase and response substring for each workflow. The diff is sort of annoying to review I'm afraid but it's basically just reorganizing the tests so that the expected failures and expected successes run in parallel.