### PR TITLE
fix(dashboard): stop workflow runs page from flooding the backend with requests

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
@@ -207,14 +207,20 @@ describe('SessionsSection', () => {
     refresh: vi.fn(),
   };
 
-  const mockSearchParams = new URLSearchParams();
+  let currentSearch = '';
   const allWorkflows = [mockWorkflow, mockFailedWorkflow, mockRunningWorkflow];
 
   beforeEach(() => {
     vi.clearAllMocks();
+    currentSearch = '';
+    mockRouter.replace.mockImplementation((url: string) => {
+      currentSearch = url.split('?')[1] ?? '';
+    });
     vi.mocked(useRouter).mockReturnValue(mockRouter as any);
-    vi.mocked(useSearchParams).mockReturnValue(mockSearchParams as any);
-    
+    vi.mocked(useSearchParams).mockImplementation(
+      () => new URLSearchParams(currentSearch) as any,
+    );
+
     vi.mocked(mapArgoWorkflowsToSessions).mockImplementation((workflows) =>
       workflows.map((w: any) => ({
         id: w.metadata.name,

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
@@ -835,6 +835,18 @@ describe('SessionsSection', () => {
         expect(lastCall[0]).not.toContain('workflowName');
       });
     });
+
+    it('should not replace URL when it already matches current filters', async () => {
+      currentSearch = 'workflowName=test';
+
+      render(<SessionsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+      });
+
+      expect(mockRouter.replace).not.toHaveBeenCalled();
+    });
   });
 
   describe('Session Detail View', () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/workflows-hooks.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/workflows-hooks.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { workflowsService } from '@/lib/services/workflows';
+import { useWorkflow } from '@/lib/services/workflows-hooks';
+import type { ArgoWorkflow } from '@/lib/types/argo-workflow';
+
+vi.mock('@/lib/services/workflows', () => ({
+  workflowsService: {
+    get: vi.fn(),
+    list: vi.fn(),
+  },
+}));
+
+const terminalWorkflow: ArgoWorkflow = {
+  apiVersion: 'argoproj.io/v1alpha1',
+  kind: 'Workflow',
+  metadata: {
+    name: 'wf-1',
+    namespace: 'default',
+    creationTimestamp: '2024-01-15T10:00:00Z',
+    uid: 'wf-1-uid',
+  },
+  spec: {},
+  status: {
+    phase: 'Succeeded',
+  },
+};
+
+describe('useWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the workflow using the default namespace and refresh interval', async () => {
+    vi.mocked(workflowsService.get).mockResolvedValue(terminalWorkflow);
+
+    const { result } = renderHook(() => useWorkflow('wf-1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(workflowsService.get).toHaveBeenCalledWith('wf-1', 'default');
+    expect(result.current.workflow).toEqual(terminalWorkflow);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('resets state and skips fetching when no name is provided', () => {
+    const { result } = renderHook(() => useWorkflow(''));
+
+    expect(result.current.workflow).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(workflowsService.get).not.toHaveBeenCalled();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/components/sections/sessions-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sections/sessions-section.tsx
@@ -1031,6 +1031,9 @@ export function SessionsSection() {
     }
 
     const queryString = params.toString();
+    if (queryString === searchParams.toString()) {
+      return;
+    }
     const newUrl = queryString ? `?${queryString}` : window.location.pathname;
     router.replace(newUrl, { scroll: false });
   }, [

--- a/services/ark-dashboard/ark-dashboard/lib/services/workflows-hooks.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/workflows-hooks.ts
@@ -35,7 +35,7 @@ export function useWorkflows(
 export function useWorkflow(
   name: string,
   namespace: string = 'default',
-  refreshInterval: number = 2000,
+  refreshInterval: number = 5000,
 ) {
   const [workflow, setWorkflow] = useState<ArgoWorkflow | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- Fix a render loop on the workflow runs page: the URL-sync effect called `router.replace` on every render, and since `searchParams` is one of its dependencies, each replace produced a new `searchParams` reference that re-fired the effect. This flooded the backend with continuous RSC navigation requests.
- Guard the effect so `router.replace` runs only when the freshly computed query string differs from the current one, breaking the loop.
- Raise the `useWorkflow` detail poll interval from 2s to 5s
- Update the `SessionsSection` test's `useSearchParams`/`router.replace` mocks to reflect URL state so the "clear filters" case exercises the new guard.