### PR TITLE
fix(ci): probe apiserver reachability before k3s bootstrap RBAC check

### DIFF
--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -151,6 +151,33 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    # The install script returns as soon as `systemctl start k3s` returns,
+    # which is well before the apiserver has bound :6443 on a cold runner
+    # (60-90s is typical with --docker). Wait for reachability before probing
+    # anything auth-related, so a slow apiserver start doesn't look like an
+    # RBAC race in the failure diagnostics.
+    - name: Wait for k3s apiserver reachable
+      run: |
+        echo "::group::Wait for k3s apiserver reachable"
+        for attempt in $(seq 1 60); do
+          if kubectl get --raw /livez >/dev/null 2>&1; then
+            echo "k3s apiserver reachable (attempt $attempt/60)"
+            break
+          fi
+          echo "Waiting for k3s apiserver (attempt $attempt/60)..."
+          sleep 3
+          if [ "$attempt" -eq 60 ]; then
+            echo "Timed out waiting for k3s apiserver"
+            echo "--- systemctl status k3s ---"
+            sudo systemctl status k3s --no-pager || true
+            echo "--- journalctl -u k3s (last 5 min) ---"
+            sudo journalctl -u k3s --no-pager --since "5 minutes ago" --lines=200 || true
+            exit 1
+          fi
+        done
+        echo "::endgroup::"
+      shell: bash
+
     # Wait for k3s to finish creating the bootstrap RBAC the cloud-controller
     # manager needs before we apply anything on top of it. If we don't, the
     # cloud-controller can race against its own rolebinding, hit a 403 reading


### PR DESCRIPTION
## Summary
- Split k3s post-install wait into two probes so failures point at the right cause
- New step polls \`kubectl get --raw /livez\` (60 × 3s = 3 min budget) before the existing RBAC-race probe runs
- On timeout, dump \`systemctl status k3s\` and the last 5 min of \`journalctl -u k3s\` so we can see why the apiserver didn't come up

## Why
The k3s install script returns as soon as \`systemctl start k3s\` returns — well before the apiserver binds \`127.0.0.1:6443\`. On a cold GHA runner with the docker driver this can take 60–90s. The existing "Wait for k3s bootstrap RBAC" step has a 48s budget (24 × 2s) and its probe (\`kubectl auth can-i\`) can't distinguish \`connection refused\` from a genuine RBAC race, so every apiserver-slow-to-start failure looked like an RBAC issue in the logs.

Recent example: [run 30012708640](https://github.com/mckinsey/agents-at-scale-ark/actions/runs/30012708640/job/89225831501?pr=2966) — 24 attempts, all \`connection refused\`.