### PR TITLE
fix: lowercase fork registry namespace for container cache tags

### DIFF
--- a/.github/actions/setup-container-cache-registry/action.yml
+++ b/.github/actions/setup-container-cache-registry/action.yml
@@ -51,7 +51,8 @@ runs:
           # The fork owner's GITHUB_TOKEN has write access to their own namespace
           # Example: ttl.sh/forked-owner/forked-repo-name
 
-          REGISTRY="ttl.sh/${{ github.event.pull_request.head.repo.full_name }}"
+          # Docker/OCI repository paths must be lowercase, but fork owner logins can be mixed-case.
+          REGISTRY="ttl.sh/$(echo "${{ github.event.pull_request.head.repo.full_name }}" | tr '[:upper:]' '[:lower:]')"
           IS_FORK_PR="true"
           echo "External PR detected - using fork's registry: $REGISTRY"
         elif [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then


### PR DESCRIPTION
Container builds on fork PRs failed with ERROR: failed to build: invalid tag "ttl.sh/<Owner>/agents-at-scale-ark/<service>:<sha>": repository name must be lowercase, because the CI cache-registry action built the fork's ttl.sh namespace directly from github.event.pull_request.head.repo.full_name, and GitHub logins can contain uppercase letters while Docker/OCI repository paths must be lowercase.
This fixes it by lowercasing that value with tr '[:upper:]' '[:lower:]' when constructing the registry string. Only the fork path was affected — the org (ghcr.io/mckinsey/…) and dependabot paths are already lowercase — so this is a no-op for internal PRs and pushes.