### PR TITLE
ci: make PostgreSQL E2E lanes blocking and revive watch validation assertions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -577,7 +577,6 @@ jobs:
     name: E2E Standard (${{ matrix.storage-backend }})
     needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.storage-backend == 'postgresql' }}
     strategy:
       fail-fast: false
       matrix:
@@ -643,7 +642,6 @@ jobs:
     needs: [setup-container-cache-registry, build-containers]
     runs-on: ubuntu-24.04
     if: ${{ needs.setup-container-cache-registry.outputs.is-fork-pr == 'false' }}
-    continue-on-error: ${{ matrix.storage-backend == 'postgresql' }}
     strategy:
       fail-fast: false
       matrix:

--- a/ark/internal/storage/postgresql/watch_validation_test.go
+++ b/ark/internal/storage/postgresql/watch_validation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +16,15 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"mckinsey.com/ark/internal/storage"
 )
+
+func rvInt(t *testing.T, s string) int64 {
+	t.Helper()
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		t.Fatalf("non-numeric resourceVersion %q: %v", s, err)
+	}
+	return n
+}
 
 func newTestBackend(t *testing.T) *PostgreSQLBackend {
 	t.Helper()
@@ -66,6 +76,7 @@ func createTestResource(t *testing.T, backend *PostgreSQLBackend, kind, ns, name
 func TestWatch_EventDropUnderBurst(t *testing.T) {
 	backend := newTestBackend(t)
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -119,29 +130,34 @@ drained:
 		_ = backend.Create(ctx, kind, ns, name, obj)
 	}
 
-	// Wait for notifications to propagate
+	// Wait for notifications to propagate while the consumer stays stalled
 	time.Sleep(5 * time.Second)
 
-	// Now drain the channel and count events
-	received := 0
-	for {
+	// Drain until every resource has been delivered. Drops into the full buffer
+	// are by design (the watcher is marked behind and recovers via its own
+	// relist, at the latest on the 30s bookmark tick); permanent loss is not.
+	received := make(map[string]bool)
+	events := 0
+	deadline := time.After(60 * time.Second)
+	for len(received) < count {
 		select {
 		case ev := <-w.ResultChan():
-			if ev.Type == watch.Added {
-				received++
+			if ev.Type == watch.Added || ev.Type == watch.Modified {
+				events++
+				if obj, ok := ev.Object.(*integrationTestObject); ok {
+					received[obj.Metadata.Name] = true
+				}
 			}
-		default:
+		case <-deadline:
 			goto done
 		}
 	}
 done:
 
-	t.Logf("Created %d resources, received %d ADDED events (channel buffer=100)", count, received)
+	t.Logf("Created %d resources, received %d events covering %d unique resources (channel buffer=100)", count, events, len(received))
 
-	if received < count {
-		t.Logf("CONFIRMED: %d events were dropped (%d created, %d received)", count-received, count, received)
-	} else {
-		t.Log("No drops detected — consumer kept up or notifications coalesced")
+	if len(received) < count {
+		t.Errorf("%d of %d resources never delivered — slow consumer did not recover", count-len(received), count)
 	}
 
 	backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
@@ -150,6 +166,7 @@ done:
 func TestWatch_VersionSkipping(t *testing.T) {
 	backend := newTestBackend(t)
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -196,19 +213,28 @@ drained:
 		}
 	}
 
-	// Wait for notifications to propagate
-	time.Sleep(5 * time.Second)
+	got, err := backend.Get(ctx, kind, ns, name)
+	if err != nil {
+		t.Fatalf("Get after updates failed: %v", err)
+	}
+	finalRV := got.(*integrationTestObject).Metadata.ResourceVersion
 
-	// Collect all MODIFIED events
+	// Intermediate versions may coalesce (the store holds only the latest row per
+	// resource), but the final state must be delivered.
 	var versions []string
-	for {
+	sawFinal := false
+	deadline := time.After(30 * time.Second)
+	for !sawFinal {
 		select {
 		case ev := <-w.ResultChan():
 			if ev.Type == watch.Modified {
 				obj := ev.Object.(*integrationTestObject)
 				versions = append(versions, obj.Metadata.ResourceVersion)
+				if obj.Metadata.ResourceVersion == finalRV {
+					sawFinal = true
+				}
 			}
-		default:
+		case <-deadline:
 			goto collected
 		}
 	}
@@ -218,12 +244,15 @@ collected:
 	t.Logf("Versions received: %v", versions)
 
 	if len(versions) < updateCount {
-		t.Logf("CONFIRMED: %d versions were skipped (%d updates, %d events)", updateCount-len(versions), updateCount, len(versions))
+		t.Logf("%d intermediate versions coalesced (%d updates, %d events)", updateCount-len(versions), updateCount, len(versions))
+	}
+	if !sawFinal {
+		t.Errorf("final version %s never delivered (%d updates, %d events)", finalRV, updateCount, len(versions))
 	}
 
 	// Check monotonic ordering
 	for i := 1; i < len(versions); i++ {
-		if versions[i] <= versions[i-1] {
+		if rvInt(t, versions[i]) <= rvInt(t, versions[i-1]) {
 			t.Errorf("OUT OF ORDER: version[%d]=%s <= version[%d]=%s", i, versions[i], i-1, versions[i-1])
 		}
 	}
@@ -234,6 +263,7 @@ collected:
 func TestWatch_NotifyLatency(t *testing.T) {
 	backend := newTestBackend(t)
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -314,6 +344,7 @@ drained:
 func TestWatch_ConcurrentWriteOrdering(t *testing.T) {
 	backend := newTestBackend(t)
 	defer backend.Close()
+	backend.StartWALConsumer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -376,25 +407,27 @@ drained:
 	}
 	wg.Wait()
 
-	time.Sleep(5 * time.Second)
-
+	want := int(created.Load())
 	var events []watch.Event
-	for {
+	seen := make(map[string]bool)
+	deadline := time.After(45 * time.Second)
+	for len(seen) < want {
 		select {
 		case ev := <-w.ResultChan():
 			if ev.Type == watch.Added {
 				events = append(events, ev)
+				seen[ev.Object.(*integrationTestObject).Metadata.Name] = true
 			}
-		default:
+		case <-deadline:
 			goto collected
 		}
 	}
 collected:
 
-	t.Logf("Created %d resources from %d concurrent writers, received %d events", created.Load(), writers, len(events))
+	t.Logf("Created %d resources from %d concurrent writers, received %d events", want, writers, len(events))
 
-	if len(events) < int(created.Load()) {
-		t.Logf("CONFIRMED: %d events lost under concurrent writes", int(created.Load())-len(events))
+	if len(seen) < want {
+		t.Errorf("%d of %d resources never delivered under concurrent writes", want-len(seen), want)
 	}
 
 	// Check version ordering
@@ -402,12 +435,12 @@ collected:
 	for i := 1; i < len(events); i++ {
 		prev := events[i-1].Object.(*integrationTestObject).Metadata.ResourceVersion
 		curr := events[i].Object.(*integrationTestObject).Metadata.ResourceVersion
-		if curr <= prev {
+		if rvInt(t, curr) <= rvInt(t, prev) {
 			outOfOrder++
 		}
 	}
 	if outOfOrder > 0 {
-		t.Logf("CONFIRMED: %d out-of-order events detected", outOfOrder)
+		t.Errorf("%d out-of-order events detected", outOfOrder)
 	} else {
 		t.Log("All events arrived in resourceVersion order")
 	}
@@ -418,6 +451,7 @@ collected:
 func TestWatch_CrossReplicaDelivery(t *testing.T) {
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
+	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
 
@@ -471,8 +505,10 @@ drained:
 
 	t.Logf("Created %d resources on replica A, waiting for replica B watcher...", count)
 
+	// Replica B has no WAL consumer; its only signal is the broadcaster's 120s
+	// safety-net relist, so the deadline must exceed one tick.
 	received := 0
-	deadline := time.After(15 * time.Second)
+	deadline := time.After(150 * time.Second)
 	for received < count {
 		select {
 		case ev := <-w.ResultChan():
@@ -487,11 +523,8 @@ timeout:
 
 	t.Logf("Replica B received %d/%d events", received, count)
 
-	if received == 0 {
-		t.Fatal("Replica B received ZERO events — cross-replica delivery is broken")
-	}
-	if received >= count {
-		t.Log("All events delivered cross-replica via pg_notify nudge")
+	if received < count {
+		t.Errorf("Replica B received %d/%d events — cross-replica delivery incomplete", received, count)
 	}
 
 	replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
@@ -500,6 +533,7 @@ timeout:
 func TestWatch_CrossReplicaBurst(t *testing.T) {
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
+	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
 
@@ -556,7 +590,7 @@ drained2:
 	t.Logf("Created %d/%d resources on replica A, waiting for replica B...", actual, count)
 
 	seen := make(map[string]bool)
-	deadline := time.After(45 * time.Second)
+	deadline := time.After(150 * time.Second)
 	for len(seen) < actual {
 		select {
 		case ev := <-w.ResultChan():
@@ -589,6 +623,7 @@ timeout2:
 func TestWatch_CrossReplicaDelete(t *testing.T) {
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
+	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
 
@@ -629,7 +664,7 @@ func TestWatch_CrossReplicaDelete(t *testing.T) {
 	}
 
 	gotDelete := false
-	deadline := time.After(10 * time.Second)
+	deadline := time.After(150 * time.Second)
 	for {
 		select {
 		case ev := <-w.ResultChan():


### PR DESCRIPTION
## Summary
- Remove `continue-on-error` from the `E2E Standard (postgresql)` and `E2E LLM (postgresql)` lanes — the watch/list contract defects that justified the non-blocking gate are fixed (#2760, #2773, #2781, #2721, #2907, #2880)
- Revive `watch_validation_test.go`: since #2880 made the WAL consumer start explicit, the suite observed zero events; it now calls `StartWALConsumer()` (writer-side only in cross-replica tests, mirroring leader gating)
- Promote the log-only defect counters to assertions for what the delivery design guarantees: eventual completeness under a slow consumer (drop + relist recovery is by design; permanent loss is not), final-state delivery under rapid same-resource updates (intermediates legitimately coalesce in a latest-row store), monotonic ordering, and cross-replica delivery
- Fix resourceVersion ordering checks comparing rv as strings, which breaks at digit-width boundaries (`"999" > "1000"`)

## Evidence for flipping the gate
- Last 25 `main` runs (Jul 21–24): `E2E LLM (postgresql)` 25/25, `E2E Standard (postgresql)` 23/25 vs etcd 50/50; both postgresql failures were unrelated to the storage backend (one `setup-e2e` infra failure, one chainsaw namespace race in `agent-partial-tool-invalid`)
- Watch validation integration suite: two consecutive clean passes against PostgreSQL 16 (`wal_level=logical`)
- Full `!llm,!etcd-only` chainsaw suite green on a local kind cluster running the postgresql stack from this branch (apiserver with `verify-full` TLS, controller in postgresql mode, broker on postgres backends)

## Observation for #2680
With the pg_notify trigger removed in #2721, the broadcaster's 120s safety-net relist is the only cross-replica watch signal: a replica not running the WAL consumer delivers events with up to 120s latency (measured: 9.8ms average locally vs consistently ~120s cross-replica). The cross-replica tests assert eventual delivery with deadlines above one tick; prompt cross-replica fan-out remains an open gap under #2680.

Fixes #3012
Related: #2680

cc @Nab-0 @skazinka