### PR TITLE
fix(controller): mark query errored on async execute panic and stop nil telemetry deref in tests

### DIFF
--- a/ark/executors/completions/model_test.go
+++ b/ark/executors/completions/model_test.go
@@ -91,7 +91,7 @@ func setupModelTestClient(objects []client.Object) client.Client {
 }
 
 func TestLoadModelCRD_ConcurrentAccess(t *testing.T) {
-	name, ns := "concurrent-model", "default"
+	name, ns := "concurrent-model", defaultNamespace
 	cacheKey := ns + "/" + name
 	modelCRDCache.Delete(cacheKey)
 	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
@@ -143,7 +143,7 @@ func TestResolveModelHeaders_FromSecret(t *testing.T) {
 		},
 	}
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "api-secret", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "api-secret", Namespace: defaultNamespace},
 		Data:       map[string][]byte{"token": []byte("secret-token")},
 	}
 	fakeClient := setupModelTestClient([]client.Object{secret})
@@ -167,7 +167,7 @@ func TestResolveModelHeaders_FromQueryParameter(t *testing.T) {
 		},
 	}
 	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-query", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-query", Namespace: defaultNamespace},
 		Spec:       arkv1alpha1.QuerySpec{Parameters: []arkv1alpha1.Parameter{{Name: "userId", Value: "user-123"}}},
 	}
 	fakeClient := setupModelTestClient(nil)
@@ -180,8 +180,8 @@ func TestResolveModelHeaders_FromQueryParameter(t *testing.T) {
 }
 
 func TestLoadModelCRD_CacheHit(t *testing.T) {
-	cacheKey := "default/cached-model"
-	cached := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: "default"}}
+	cacheKey := defaultNamespace + "/cached-model"
+	cached := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: defaultNamespace}}
 	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{
 		crd:       cached,
 		expiresAt: time.Now().Add(modelCRDCacheTTL),
@@ -190,13 +190,13 @@ func TestLoadModelCRD_CacheHit(t *testing.T) {
 
 	fakeClient := setupModelTestClient(nil)
 
-	got, err := loadModelCRD(context.Background(), fakeClient, "cached-model", "default")
+	got, err := loadModelCRD(context.Background(), fakeClient, "cached-model", defaultNamespace)
 	require.NoError(t, err)
 	require.Same(t, cached, got)
 }
 
 func TestLoadModelCRD_CacheMiss(t *testing.T) {
-	name, ns := "miss-model", "default"
+	name, ns := "miss-model", defaultNamespace
 	cacheKey := ns + "/" + name
 	modelCRDCache.Delete(cacheKey)
 	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
@@ -214,7 +214,7 @@ func TestLoadModelCRD_CacheMiss(t *testing.T) {
 }
 
 func TestLoadModelCRD_ExpiredEntry(t *testing.T) {
-	name, ns := "expired-model", "default"
+	name, ns := "expired-model", defaultNamespace
 	cacheKey := ns + "/" + name
 
 	stale := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}

--- a/ark/internal/controller/executionengine_controller_test.go
+++ b/ark/internal/controller/executionengine_controller_test.go
@@ -38,14 +38,14 @@ var _ = Describe("ExecutionEngine Controller", func() {
 		secretList := &corev1.SecretList{}
 		_ = k8sClient.List(ctx, secretList)
 		for i := range secretList.Items {
-			if secretList.Items[i].Namespace == "default" {
+			if secretList.Items[i].Namespace == testNamespace {
 				_ = k8sClient.Delete(ctx, &secretList.Items[i])
 			}
 		}
 		configMapList := &corev1.ConfigMapList{}
 		_ = k8sClient.List(ctx, configMapList)
 		for i := range configMapList.Items {
-			if configMapList.Items[i].Namespace == "default" {
+			if configMapList.Items[i].Namespace == testNamespace {
 				_ = k8sClient.Delete(ctx, &configMapList.Items[i])
 			}
 		}
@@ -55,7 +55,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 		It("reaches ready", func() {
 			name := "ee-direct"
 			engine := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{Value: "http://engine:8080"},
 				},
@@ -63,7 +63,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 			Expect(k8sClient.Create(ctx, engine)).To(Succeed())
 
 			r := newReconciler()
-			nn := types.NamespacedName{Name: name, Namespace: "default"}
+			nn := types.NamespacedName{Name: name, Namespace: testNamespace}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
@@ -84,7 +84,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 			secretName := "ee-selfheal-secret"
 
 			engine := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{
 						ValueFrom: &arkv1prealpha1.ValueFromSource{
@@ -99,7 +99,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 			Expect(k8sClient.Create(ctx, engine)).To(Succeed())
 
 			r := newReconciler()
-			nn := types.NamespacedName{Name: name, Namespace: "default"}
+			nn := types.NamespacedName{Name: name, Namespace: testNamespace}
 
 			By("First reconcile initializes phase to running")
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
@@ -118,7 +118,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 
 			By("Creating the Secret so resolution now succeeds")
 			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
 				Data:       map[string][]byte{"addr": []byte("http://healed-engine:8080")},
 			}
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
@@ -136,7 +136,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 		It("stays terminal in the ready phase without reprocessing", func() {
 			name := "ee-ready-terminal"
 			engine := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{Value: "http://ready:8080"},
 				},
@@ -146,7 +146,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 			Expect(k8sClient.Status().Update(ctx, engine)).To(Succeed())
 
 			r := newReconciler()
-			nn := types.NamespacedName{Name: name, Namespace: "default"}
+			nn := types.NamespacedName{Name: name, Namespace: testNamespace}
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
@@ -170,7 +170,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 		It("maps a changed ConfigMap to the ExecutionEngines that reference it", func() {
 			configMapName := "ee-mapped-configmap"
 			referencing := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: "ee-ref-cm", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ee-ref-cm", Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{
 						ValueFrom: &arkv1prealpha1.ValueFromSource{
@@ -185,17 +185,17 @@ var _ = Describe("ExecutionEngine Controller", func() {
 			Expect(k8sClient.Create(ctx, referencing)).To(Succeed())
 
 			r := newReconciler()
-			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: "default"}}
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: testNamespace}}
 			requests := r.mapConfigMapToExecutionEngines(ctx, cm)
 			Expect(requests).To(ConsistOf(reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: "ee-ref-cm", Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: "ee-ref-cm", Namespace: testNamespace},
 			}))
 		})
 
 		It("maps a changed Secret to the ExecutionEngines that reference it", func() {
 			secretName := "ee-mapped-secret"
 			referencing := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: "ee-ref-secret", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ee-ref-secret", Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{
 						ValueFrom: &arkv1prealpha1.ValueFromSource{
@@ -208,7 +208,7 @@ var _ = Describe("ExecutionEngine Controller", func() {
 				},
 			}
 			unrelated := &arkv1prealpha1.ExecutionEngine{
-				ObjectMeta: metav1.ObjectMeta{Name: "ee-direct-map", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ee-direct-map", Namespace: testNamespace},
 				Spec: arkv1prealpha1.ExecutionEngineSpec{
 					Address: arkv1prealpha1.ValueSource{Value: "http://direct:8080"},
 				},
@@ -218,11 +218,11 @@ var _ = Describe("ExecutionEngine Controller", func() {
 
 			r := newReconciler()
 			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
 			}
 			requests := r.mapSecretToExecutionEngines(ctx, secret)
 			Expect(requests).To(ConsistOf(reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: "ee-ref-secret", Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: "ee-ref-secret", Namespace: testNamespace},
 			}))
 		})
 	})

--- a/ark/internal/controller/memory_controller_test.go
+++ b/ark/internal/controller/memory_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Memory Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: testNamespace, // TODO(user):Modify as needed
 		}
 		memory := &arkv1alpha1.Memory{}
 
@@ -38,7 +38,7 @@ var _ = Describe("Memory Controller", func() {
 				resource := &arkv1alpha1.Memory{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: testNamespace,
 					},
 					Spec: arkv1alpha1.MemorySpec{
 						Address: arkv1alpha1.ValueSource{
@@ -89,7 +89,7 @@ var _ = Describe("Memory Controller", func() {
 			secretList := &corev1.SecretList{}
 			_ = k8sClient.List(ctx, secretList)
 			for _, s := range secretList.Items {
-				if s.Namespace == "default" {
+				if s.Namespace == testNamespace {
 					_ = k8sClient.Delete(ctx, &s)
 				}
 			}
@@ -97,7 +97,7 @@ var _ = Describe("Memory Controller", func() {
 			configMapList := &corev1.ConfigMapList{}
 			_ = k8sClient.List(ctx, configMapList)
 			for _, cm := range configMapList.Items {
-				if cm.Namespace == "default" {
+				if cm.Namespace == testNamespace {
 					_ = k8sClient.Delete(ctx, &cm)
 				}
 			}
@@ -108,7 +108,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -139,19 +139,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 		})
 
@@ -162,7 +162,7 @@ var _ = Describe("Memory Controller", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "memory-token-secret",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
 					"token": []byte("secret-bearer-token"),
@@ -174,7 +174,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -206,19 +206,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 		})
 
@@ -229,7 +229,7 @@ var _ = Describe("Memory Controller", func() {
 			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "memory-config",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Data: map[string]string{
 					"api-key": "configmap-api-key-value",
@@ -241,7 +241,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -273,19 +273,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 		})
 
@@ -296,7 +296,7 @@ var _ = Describe("Memory Controller", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mixed-secret",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
 					"token": []byte("secret-token-value"),
@@ -308,7 +308,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -346,19 +346,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 		})
 
@@ -369,7 +369,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -386,19 +386,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 		})
 
@@ -409,7 +409,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -444,19 +444,19 @@ var _ = Describe("Memory Controller", func() {
 
 			By("First reconcile to set running state")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Second reconcile to validate and reach ready state")
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: memoryName, Namespace: testNamespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying memory reached ready state with queryParameterRef in spec")
 			updatedMemory := &arkv1alpha1.Memory{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: "default"}, updatedMemory)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: memoryName, Namespace: testNamespace}, updatedMemory)).To(Succeed())
 			Expect(updatedMemory.Status.Phase).To(Equal(statusReady))
 			Expect(updatedMemory.Spec.Headers).To(HaveLen(2))
 			Expect(updatedMemory.Spec.Headers[0].Value.ValueFrom.QueryParameterRef.Name).To(Equal("userId"))
@@ -479,14 +479,14 @@ var _ = Describe("Memory Controller", func() {
 			secretList := &corev1.SecretList{}
 			_ = k8sClient.List(ctx, secretList)
 			for i := range secretList.Items {
-				if secretList.Items[i].Namespace == "default" {
+				if secretList.Items[i].Namespace == testNamespace {
 					_ = k8sClient.Delete(ctx, &secretList.Items[i])
 				}
 			}
 			configMapList := &corev1.ConfigMapList{}
 			_ = k8sClient.List(ctx, configMapList)
 			for i := range configMapList.Items {
-				if configMapList.Items[i].Namespace == "default" {
+				if configMapList.Items[i].Namespace == testNamespace {
 					_ = k8sClient.Delete(ctx, &configMapList.Items[i])
 				}
 			}
@@ -500,7 +500,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -519,7 +519,7 @@ var _ = Describe("Memory Controller", func() {
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
-			nn := types.NamespacedName{Name: memoryName, Namespace: "default"}
+			nn := types.NamespacedName{Name: memoryName, Namespace: testNamespace}
 
 			By("First reconcile initializes phase to running")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
@@ -540,7 +540,7 @@ var _ = Describe("Memory Controller", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Data: map[string][]byte{
 					"addr": []byte("http://healed-memory-service:8080"),
@@ -566,7 +566,7 @@ var _ = Describe("Memory Controller", func() {
 			memory := &arkv1alpha1.Memory{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memoryName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
@@ -583,7 +583,7 @@ var _ = Describe("Memory Controller", func() {
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
-			nn := types.NamespacedName{Name: memoryName, Namespace: "default"}
+			nn := types.NamespacedName{Name: memoryName, Namespace: testNamespace}
 
 			By("Reconciling an errored resource with a valid address reaches ready")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
@@ -597,7 +597,7 @@ var _ = Describe("Memory Controller", func() {
 		It("stays terminal in the ready phase without reprocessing", func() {
 			memoryName := "memory-ready-terminal"
 			memory := &arkv1alpha1.Memory{
-				ObjectMeta: metav1.ObjectMeta{Name: memoryName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: memoryName, Namespace: testNamespace},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{Value: "http://ready:8080"},
 				},
@@ -607,7 +607,7 @@ var _ = Describe("Memory Controller", func() {
 			Expect(k8sClient.Status().Update(ctx, memory)).To(Succeed())
 
 			controllerReconciler := &MemoryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			nn := types.NamespacedName{Name: memoryName, Namespace: "default"}
+			nn := types.NamespacedName{Name: memoryName, Namespace: testNamespace}
 
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
@@ -624,13 +624,13 @@ var _ = Describe("Memory Controller", func() {
 
 			By("Creating a Secret whose value is empty")
 			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
 				Data:       map[string][]byte{"addr": []byte("")},
 			}
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			memory := &arkv1alpha1.Memory{
-				ObjectMeta: metav1.ObjectMeta{Name: memoryName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: memoryName, Namespace: testNamespace},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
 						ValueFrom: &arkv1alpha1.ValueFromSource{
@@ -645,7 +645,7 @@ var _ = Describe("Memory Controller", func() {
 			Expect(k8sClient.Create(ctx, memory)).To(Succeed())
 
 			controllerReconciler := &MemoryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			nn := types.NamespacedName{Name: memoryName, Namespace: "default"}
+			nn := types.NamespacedName{Name: memoryName, Namespace: testNamespace}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
@@ -668,7 +668,7 @@ var _ = Describe("Memory Controller", func() {
 		It("maps a changed ConfigMap to the Memories that reference it", func() {
 			configMapName := "mapped-configmap"
 			referencing := &arkv1alpha1.Memory{
-				ObjectMeta: metav1.ObjectMeta{Name: "mem-ref-cm", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mem-ref-cm", Namespace: testNamespace},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
 						ValueFrom: &arkv1alpha1.ValueFromSource{
@@ -683,10 +683,10 @@ var _ = Describe("Memory Controller", func() {
 			Expect(k8sClient.Create(ctx, referencing)).To(Succeed())
 
 			controllerReconciler := &MemoryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: "default"}}
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: testNamespace}}
 			requests := controllerReconciler.mapConfigMapToMemories(ctx, cm)
 			Expect(requests).To(ConsistOf(reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: "mem-ref-cm", Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: "mem-ref-cm", Namespace: testNamespace},
 			}))
 		})
 
@@ -694,7 +694,7 @@ var _ = Describe("Memory Controller", func() {
 			secretName := "mapped-secret"
 			By("Creating one Memory referencing the Secret and one that does not")
 			referencing := &arkv1alpha1.Memory{
-				ObjectMeta: metav1.ObjectMeta{Name: "mem-ref-secret", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mem-ref-secret", Namespace: testNamespace},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{
 						ValueFrom: &arkv1alpha1.ValueFromSource{
@@ -707,7 +707,7 @@ var _ = Describe("Memory Controller", func() {
 				},
 			}
 			unrelated := &arkv1alpha1.Memory{
-				ObjectMeta: metav1.ObjectMeta{Name: "mem-direct", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mem-direct", Namespace: testNamespace},
 				Spec: arkv1alpha1.MemorySpec{
 					Address: arkv1alpha1.ValueSource{Value: "http://direct:8080"},
 				},
@@ -721,11 +721,11 @@ var _ = Describe("Memory Controller", func() {
 			}
 
 			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
 			}
 			requests := controllerReconciler.mapSecretToMemories(ctx, secret)
 			Expect(requests).To(ConsistOf(reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: "mem-ref-secret", Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: "mem-ref-secret", Namespace: testNamespace},
 			}))
 		})
 	})

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -422,11 +423,34 @@ func (r *QueryReconciler) executeQueryAsync(opCtx context.Context, obj arkv1alph
 
 func (r *QueryReconciler) finishExecuteQueryAsync(ctx context.Context, namespacedName types.NamespacedName) {
 	if rec := recover(); rec != nil {
-		logf.FromContext(ctx).Error(fmt.Errorf("query execution goroutine panic: %v", rec), "Query execution goroutine panicked")
+		logf.FromContext(ctx).Error(
+			fmt.Errorf("query execution goroutine panic: %v", rec),
+			"Query execution goroutine panicked",
+			"stack", string(debug.Stack()),
+		)
+		r.markQueryErroredAfterPanic(ctx, namespacedName, rec)
 	}
 	r.operations.Delete(namespacedName)
 	if r.sem != nil {
 		r.sem.Release(1)
+	}
+}
+
+// markQueryErroredAfterPanic sets the query status to error so it converges
+// instead of relying on the safety-net requeue to retry the panicking dispatch.
+func (r *QueryReconciler) markQueryErroredAfterPanic(ctx context.Context, namespacedName types.NamespacedName, rec any) {
+	var q arkv1alpha1.Query
+	if err := r.Get(ctx, namespacedName, &q); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to fetch query after panic; leaving to safety-net requeue")
+		return
+	}
+	if q.Status.Response == nil {
+		q.Status.Response = &arkv1alpha1.Response{}
+	}
+	q.Status.Response.Phase = statusError
+	q.Status.Response.Content = fmt.Sprintf("query execution goroutine panicked: %v", rec)
+	if err := r.updateStatus(ctx, &q, statusError); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to mark query errored after panic; leaving to safety-net requeue")
 	}
 }
 

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -21,6 +21,8 @@ import (
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
 	"mckinsey.com/ark/internal/annotations"
+	eventingconfig "mckinsey.com/ark/internal/eventing/config"
+	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
 )
 
 var _ = Describe("Query Controller", func() {
@@ -292,6 +294,8 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			r := &QueryReconciler{
 				Client:               k8sClient,
 				Scheme:               k8sClient.Scheme(),
+				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
+				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 0,
 			}
 			Expect(r.sem).To(BeNil(), "nil semaphore means enforcement is disabled")
@@ -335,6 +339,8 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			r := &QueryReconciler{
 				Client:               k8sClient,
 				Scheme:               k8sClient.Scheme(),
+				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
+				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 1,
 				sem:                  semaphore.NewWeighted(1),
 			}
@@ -371,6 +377,8 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			r := &QueryReconciler{
 				Client:               k8sClient,
 				Scheme:               k8sClient.Scheme(),
+				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
+				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 0,
 			}
 			Expect(r.sem).To(BeNil())
@@ -533,6 +541,10 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 		It("recovers from a panic in the goroutine and still cleans up", func() {
 			r := &QueryReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
+				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 1,
 				sem:                  semaphore.NewWeighted(1),
 			}


### PR DESCRIPTION
## Summary
- Fix `finishExecuteQueryAsync` recover body to log the stack trace and set the Query phase to `error` via a new `markQueryErroredAfterPanic` helper — previously a panic was swallowed and the Query stayed in `running` until the 30s safety-net requeue hit the same panic again.
- Wire the three semaphore-drain tests added in #2956 (and the existing "recovers from a panic" test, which now needs a real Client because the recover body Gets the query) with `telemetryconfig.NewProvider(ctx, nil)` and `eventingconfig.NewProviderWithClient(ctx, nil)`. Both constructors already return fully-noop `*Provider` values when passed a nil client and no OTEL endpoint, so this closes the race where a bare `QueryReconciler` would nil-deref on `r.Telemetry.Tracer()` inside the async goroutine without introducing any new production API surface.
- Separate cleanup commit replaces literal `"default"` with the existing `testNamespace` / `defaultNamespace` constants in three test files to unblock `make lint` (goconst).

Verified with 20 consecutive `TestControllers` runs green; previously flaky at ~10–20%.