### PR TITLE
fix(executor): fetch full conversation history and surface memory read failures

### DIFF
--- a/ark/api/v1alpha1/query_types.go
+++ b/ark/api/v1alpha1/query_types.go
@@ -19,6 +19,9 @@ const (
 	// QueryMemoryUnavailable indicates that the query carried a conversationId
 	// but no Memory backend was reachable, so conversation history was dropped.
 	QueryMemoryUnavailable QueryConditionType = "MemoryUnavailable"
+	// QueryMemoryDegraded indicates that a Memory backend was reachable but
+	// reading the conversation history failed, so the query ran without it.
+	QueryMemoryDegraded QueryConditionType = "MemoryDegraded"
 )
 
 const (

--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -82,6 +82,9 @@ type executionState struct {
 	// memoryUnavailable is true when the query carried a conversationId but no
 	// Memory backend was reachable, so history was silently dropped.
 	memoryUnavailable bool
+	// memoryDegraded is true when a Memory backend was reachable but reading the
+	// conversation history from it failed, so the query ran without prior context.
+	memoryDegraded bool
 }
 
 func (s *executionState) finalizeStream(ctx context.Context, responseMessages []Message, tokenUsage arkv1alpha1.TokenUsage) {
@@ -303,9 +306,12 @@ func (h *Handler) setupExecution(ctx context.Context, query *arkv1alpha1.Query, 
 	memoryUnavailable := isNoop && conversationId != ""
 
 	memoryMessages, err := memory.GetMessages(ctx)
+	memoryDegraded := false
 	if err != nil {
-		log.Error(err, "failed to load memory messages, continuing without history")
+		log.Error(err, "failed to load memory messages, continuing without history",
+			"queryName", query.Name, "namespace", query.Namespace, "conversationId", conversationId)
 		memoryMessages = nil
+		memoryDegraded = true
 	}
 
 	eventStream, err := NewEventStreamForQuery(ctx, h.k8sClient, query.Namespace, sessionId, query.Name)
@@ -332,6 +338,7 @@ func (h *Handler) setupExecution(ctx context.Context, query *arkv1alpha1.Query, 
 		targetSpan:     targetSpan,
 
 		memoryUnavailable: memoryUnavailable,
+		memoryDegraded:    memoryDegraded,
 	}
 
 	return ctx, state, nil
@@ -557,6 +564,9 @@ func buildResponseMeta(state *executionState, execResult *ExecutionResult, respo
 	}
 	if state.memoryUnavailable {
 		responseMeta["memoryUnavailable"] = true
+	}
+	if state.memoryDegraded {
+		responseMeta["memoryDegraded"] = true
 	}
 	if execResult != nil && execResult.A2AResponse != nil {
 		a2aMeta := map[string]string{}

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -470,6 +470,19 @@ func TestBuildResponseMeta(t *testing.T) {
 		_, hasMessages := meta["messages"]
 		assert.True(t, hasMessages)
 	})
+
+	t.Run("flags degraded memory so the controller can surface it", func(t *testing.T) {
+		state := &executionState{conversationId: "conv-1", memoryDegraded: true}
+		meta := buildResponseMeta(state, nil, nil, arkv1alpha1.TokenUsage{})
+		assert.Equal(t, true, meta["memoryDegraded"])
+	})
+
+	t.Run("omits memoryDegraded when history loaded", func(t *testing.T) {
+		state := &executionState{conversationId: "conv-1"}
+		meta := buildResponseMeta(state, nil, nil, arkv1alpha1.TokenUsage{})
+		_, hasDegraded := meta["memoryDegraded"]
+		assert.False(t, hasDegraded)
+	})
 }
 
 func TestResolveSelectorResourceTypes(t *testing.T) {

--- a/ark/executors/completions/memory.go
+++ b/ark/executors/completions/memory.go
@@ -24,6 +24,8 @@ const (
 	MaxRetries            = 3
 	RetryDelay            = 100 * time.Millisecond
 	UserAgent             = "ark-memory-client/1.0"
+	MessagesPageLimit     = 1000
+	MessagesMaxPages      = 1000
 )
 
 // getMemoryTimeout reads ARK_MEMORY_HTTP_TIMEOUT_SECONDS env var or returns default
@@ -72,7 +74,7 @@ type MessagesResponse struct {
 	Items      []MessageRecord `json:"items"`
 	Total      int             `json:"total"`
 	HasMore    bool            `json:"hasMore"`
-	NextCursor *string         `json:"nextCursor,omitempty"`
+	NextCursor *int64          `json:"nextCursor,omitempty"`
 }
 
 func DefaultConfig() Config {

--- a/ark/executors/completions/memory_http.go
+++ b/ark/executors/completions/memory_http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/openai/openai-go"
@@ -232,23 +233,74 @@ func (m *HTTPMemory) AddMessages(ctx context.Context, queryID string, messages [
 	return nil
 }
 
-// GetMessages retrieves messages from the memory backend
+// GetMessages retrieves the full conversation history from the memory backend,
+// following the broker's cursor pagination until no pages remain.
 func (m *HTTPMemory) GetMessages(ctx context.Context) ([]Message, error) {
 	ctx = m.eventingRecorder.Start(ctx, "MemoryGetMessages", "Getting messages from memory", nil)
 
 	// Resolve address dynamically
 	if err := m.resolveAndUpdateAddress(ctx); err != nil {
-		operationData := map[string]string{"result": fmt.Sprintf("Failed to resolve memory address: %v", err)}
-		m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-		return nil, err
+		return nil, m.failGetMessages(ctx, fmt.Sprintf("Failed to resolve memory address: %v", err), err)
 	}
 
-	requestURL := fmt.Sprintf("%s%s?conversation_id=%s", m.baseURL, MessagesEndpoint, url.QueryEscape(m.conversationId))
+	var messages []Message
+	var cursor *int64
+
+	for page := 0; page < MessagesMaxPages; page++ {
+		response, err := m.fetchMessagePage(ctx, cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		pageMessages, err := m.decodeMessagePage(ctx, response.Items, len(messages))
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, pageMessages...)
+
+		if !response.HasMore {
+			operationData := map[string]string{
+				"messages": fmt.Sprintf("%d", len(messages)),
+				"pages":    fmt.Sprintf("%d", page+1),
+				"result":   "Memory get messages completed successfully",
+			}
+			m.eventingRecorder.Complete(ctx, "MemoryGetMessages", operationData["result"], operationData)
+			return messages, nil
+		}
+
+		if response.NextCursor == nil {
+			err := fmt.Errorf("memory backend reported more messages after %d but returned no nextCursor", len(messages))
+			return nil, m.failGetMessages(ctx, err.Error(), err)
+		}
+		if cursor != nil && *response.NextCursor <= *cursor {
+			err := fmt.Errorf("memory backend returned non-advancing nextCursor %d (previous %d)", *response.NextCursor, *cursor)
+			return nil, m.failGetMessages(ctx, err.Error(), err)
+		}
+		cursor = response.NextCursor
+	}
+
+	err := fmt.Errorf("memory backend still reported more messages after %d pages of %d", MessagesMaxPages, MessagesPageLimit)
+	return nil, m.failGetMessages(ctx, err.Error(), err)
+}
+
+func (m *HTTPMemory) failGetMessages(ctx context.Context, result string, err error) error {
+	operationData := map[string]string{"result": result}
+	m.eventingRecorder.Fail(ctx, "MemoryGetMessages", result, err, operationData)
+	return err
+}
+
+func (m *HTTPMemory) fetchMessagePage(ctx context.Context, cursor *int64) (*MessagesResponse, error) {
+	query := url.Values{}
+	query.Set("conversation_id", m.conversationId)
+	query.Set("limit", strconv.Itoa(MessagesPageLimit))
+	if cursor != nil {
+		query.Set("cursor", strconv.FormatInt(*cursor, 10))
+	}
+
+	requestURL := fmt.Sprintf("%s%s?%s", m.baseURL, MessagesEndpoint, query.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
-		operationData := map[string]string{"result": fmt.Sprintf("Failed to create request: %v", err)}
-		m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, m.failGetMessages(ctx, fmt.Sprintf("Failed to create request: %v", err), fmt.Errorf("failed to create request: %w", err))
 	}
 
 	req.Header.Set("Accept", ContentTypeJSON)
@@ -261,42 +313,35 @@ func (m *HTTPMemory) GetMessages(ctx context.Context) ([]Message, error) {
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {
-		operationData := map[string]string{"result": fmt.Sprintf("HTTP request failed: %v", err)}
-		m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-		return nil, fmt.Errorf("HTTP request failed: %w", err)
+		return nil, m.failGetMessages(ctx, fmt.Sprintf("HTTP request failed: %v", err), fmt.Errorf("HTTP request failed: %w", err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		err := fmt.Errorf("HTTP status %d", resp.StatusCode)
-		operationData := map[string]string{"result": err.Error()}
-		m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-		return nil, err
+		return nil, m.failGetMessages(ctx, err.Error(), err)
 	}
 
 	var response MessagesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		operationData := map[string]string{"result": fmt.Sprintf("Failed to decode response: %v", err)}
-		m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+		return nil, m.failGetMessages(ctx, fmt.Sprintf("Failed to decode response: %v", err), fmt.Errorf("failed to decode response: %w", err))
 	}
 
-	messages := make([]Message, 0, len(response.Items))
-	for i, record := range response.Items {
+	return &response, nil
+}
+
+func (m *HTTPMemory) decodeMessagePage(ctx context.Context, records []MessageRecord, offset int) ([]Message, error) {
+	messages := make([]Message, 0, len(records))
+	for i, record := range records {
 		openaiMessage, err := unmarshalMessageRobust(record.Message)
 		if err != nil {
-			operationData := map[string]string{"result": fmt.Sprintf("Failed to unmarshal message at index %d: %v", i, err)}
-			m.eventingRecorder.Fail(ctx, "MemoryGetMessages", operationData["result"], err, operationData)
-			return nil, fmt.Errorf("failed to unmarshal message at index %d: %w", i, err)
+			index := offset + i
+			return nil, m.failGetMessages(ctx,
+				fmt.Sprintf("Failed to unmarshal message at index %d: %v", index, err),
+				fmt.Errorf("failed to unmarshal message at index %d: %w", index, err))
 		}
 		messages = append(messages, Message(openaiMessage))
 	}
-
-	operationData := map[string]string{
-		"messages": fmt.Sprintf("%d", len(messages)),
-		"result":   "Memory get messages completed successfully",
-	}
-	m.eventingRecorder.Complete(ctx, "MemoryGetMessages", operationData["result"], operationData)
 	return messages, nil
 }
 

--- a/ark/executors/completions/memory_http_test.go
+++ b/ark/executors/completions/memory_http_test.go
@@ -3,9 +3,11 @@ package completions
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/openai/openai-go"
@@ -415,6 +417,184 @@ func TestHTTPMemoryGetMessagesWithHeaders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newPagedMessageTestMemory(t *testing.T, serverURL string, httpClient *http.Client) *HTTPMemory {
+	t.Helper()
+
+	resolvedAddress := serverURL
+	mem := &arkv1alpha1.Memory{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-memory", Namespace: "default"},
+		Spec: arkv1alpha1.MemorySpec{
+			Address: arkv1alpha1.ValueSource{Value: serverURL},
+		},
+		Status: arkv1alpha1.MemoryStatus{
+			LastResolvedAddress: &resolvedAddress,
+			Phase:               "ready",
+		},
+	}
+
+	return &HTTPMemory{
+		client:           setupMemoryTestClient([]client.Object{mem}),
+		httpClient:       httpClient,
+		baseURL:          serverURL,
+		conversationId:   "conv-1",
+		name:             "test-memory",
+		namespace:        "default",
+		headers:          map[string]string{},
+		eventingRecorder: &noOpMemoryRecorder{},
+	}
+}
+
+func messageRecordsPage(t *testing.T, from, count int) []MessageRecord {
+	t.Helper()
+
+	records := make([]MessageRecord, 0, count)
+	for i := 0; i < count; i++ {
+		sequence := int64(from + i)
+		records = append(records, MessageRecord{
+			ConversationID: "conv-1",
+			Message:        json.RawMessage(fmt.Sprintf(`{"role": "user", "content": "msg-%d"}`, sequence)),
+			Sequence:       sequence,
+		})
+	}
+	return records
+}
+
+func TestMessagesResponseDecodesNumericNextCursor(t *testing.T) {
+	var response MessagesResponse
+	err := json.Unmarshal([]byte(`{"items":[],"total":4598,"hasMore":true,"nextCursor":4598}`), &response)
+
+	require.NoError(t, err, "broker emits nextCursor as a sequence number, not a string")
+	require.NotNil(t, response.NextCursor)
+	require.Equal(t, int64(4598), *response.NextCursor)
+}
+
+func TestHTTPMemoryGetMessagesFollowsPagination(t *testing.T) {
+	var requestedCursors []string
+	var requestedLimits []string
+	var requestedConversations []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != MessagesEndpoint || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		cursor := r.URL.Query().Get("cursor")
+		requestedCursors = append(requestedCursors, cursor)
+		requestedLimits = append(requestedLimits, r.URL.Query().Get("limit"))
+		requestedConversations = append(requestedConversations, r.URL.Query().Get("conversation_id"))
+
+		response := MessagesResponse{Total: 250}
+		switch cursor {
+		case "":
+			nextCursor := int64(100)
+			response.Items = messageRecordsPage(t, 1, 100)
+			response.HasMore = true
+			response.NextCursor = &nextCursor
+		case "100":
+			nextCursor := int64(200)
+			response.Items = messageRecordsPage(t, 101, 100)
+			response.HasMore = true
+			response.NextCursor = &nextCursor
+		case "200":
+			response.Items = messageRecordsPage(t, 201, 50)
+			response.HasMore = false
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", ContentTypeJSON)
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	httpMemory := newPagedMessageTestMemory(t, server.URL, server.Client())
+
+	messages, err := httpMemory.GetMessages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, messages, 250, "all pages should be accumulated")
+	require.Equal(t, []string{"", "100", "200"}, requestedCursors)
+
+	for _, limit := range requestedLimits {
+		require.Equal(t, strconv.Itoa(MessagesPageLimit), limit)
+	}
+	for _, conversationID := range requestedConversations {
+		require.Equal(t, "conv-1", conversationID)
+	}
+
+	first := openai.ChatCompletionMessageParamUnion(messages[0])
+	require.NotNil(t, first.OfUser)
+	require.Equal(t, "msg-1", first.OfUser.Content.OfString.Value)
+
+	last := openai.ChatCompletionMessageParamUnion(messages[249])
+	require.NotNil(t, last.OfUser)
+	require.Equal(t, "msg-250", last.OfUser.Content.OfString.Value)
+}
+
+func TestHTTPMemoryGetMessagesPaginationErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		secondPage    func() MessagesResponse
+		expectedError string
+	}{
+		{
+			name: "hasMore without a cursor",
+			secondPage: func() MessagesResponse {
+				return MessagesResponse{Items: messageRecordsPage(t, 101, 1), HasMore: true}
+			},
+			expectedError: "returned no nextCursor",
+		},
+		{
+			name: "cursor does not advance",
+			secondPage: func() MessagesResponse {
+				stuck := int64(100)
+				return MessagesResponse{Items: messageRecordsPage(t, 101, 1), HasMore: true, NextCursor: &stuck}
+			},
+			expectedError: "non-advancing nextCursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := tt.secondPage()
+				if r.URL.Query().Get("cursor") == "" {
+					nextCursor := int64(100)
+					response = MessagesResponse{Items: messageRecordsPage(t, 1, 100), HasMore: true, NextCursor: &nextCursor}
+				}
+				w.Header().Set("Content-Type", ContentTypeJSON)
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			httpMemory := newPagedMessageTestMemory(t, server.URL, server.Client())
+
+			messages, err := httpMemory.GetMessages(context.Background())
+			require.Error(t, err, "a broker that cannot be paginated must not look like an empty conversation")
+			require.Contains(t, err.Error(), tt.expectedError)
+			require.Nil(t, messages)
+		})
+	}
+}
+
+func TestHTTPMemoryGetMessagesSinglePageBackend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", ContentTypeJSON)
+		_ = json.NewEncoder(w).Encode(MessagesResponse{
+			Items: messageRecordsPage(t, 1, 3),
+			Total: 3,
+		})
+	}))
+	defer server.Close()
+
+	httpMemory := newPagedMessageTestMemory(t, server.URL, server.Client())
+
+	messages, err := httpMemory.GetMessages(context.Background())
+	require.NoError(t, err, "backends that ignore limit/cursor must keep working")
+	require.Len(t, messages, 3)
 }
 
 func TestHTTPMemoryHeadersLoadedFromStatus(t *testing.T) {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -705,6 +705,7 @@ type engineResponseMeta struct {
 	A2AContextID      string
 	A2ATaskID         string
 	MemoryUnavailable bool
+	MemoryDegraded    bool
 }
 
 func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMeta {
@@ -745,6 +746,10 @@ func extractEngineResponseMeta(result *protocol.MessageResult) engineResponseMet
 
 	if memoryUnavailable, ok := arkMap["memoryUnavailable"].(bool); ok {
 		responseMeta.MemoryUnavailable = memoryUnavailable
+	}
+
+	if memoryDegraded, ok := arkMap["memoryDegraded"].(bool); ok {
+		responseMeta.MemoryDegraded = memoryDegraded
 	}
 
 	if messagesRaw, ok := arkMap["messages"]; ok {
@@ -924,6 +929,25 @@ func (r *QueryReconciler) setConditionMemoryUnavailable(query *arkv1alpha1.Query
 	}
 	meta.SetStatusCondition(&query.Status.Conditions, metav1.Condition{
 		Type:               string(arkv1alpha1.QueryMemoryUnavailable),
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: query.Generation,
+	})
+}
+
+func (r *QueryReconciler) setConditionMemoryDegraded(query *arkv1alpha1.Query, degraded bool) {
+	status := metav1.ConditionFalse
+	reason := "MemoryHealthy"
+	message := "Conversation history was read from memory for this query"
+	if degraded {
+		status = metav1.ConditionTrue
+		reason = "GetMessagesFailed"
+		message = "failed to read conversation history from the memory backend; the query ran without prior context. See the MemoryGetMessagesError event for the underlying error"
+	}
+	meta.SetStatusCondition(&query.Status.Conditions, metav1.Condition{
+		Type:               string(arkv1alpha1.QueryMemoryDegraded),
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
@@ -1452,6 +1476,7 @@ func (r *QueryReconciler) handleQueryDispatch(
 	}
 
 	r.setConditionMemoryUnavailable(obj, engineMeta.MemoryUnavailable)
+	r.setConditionMemoryDegraded(obj, engineMeta.MemoryDegraded)
 
 	queryStatus := r.determineQueryStatus(response)
 	duration := &metav1.Duration{Duration: time.Since(startTime)}

--- a/ark/internal/controller/query_controller_dispatch_test.go
+++ b/ark/internal/controller/query_controller_dispatch_test.go
@@ -356,6 +356,22 @@ func TestExtractEngineResponseMeta(t *testing.T) {
 		assert.True(t, meta.MemoryUnavailable)
 	})
 
+	t.Run("extracts memoryDegraded flag", func(t *testing.T) {
+		msg := &protocol.Message{
+			Role:  protocol.MessageRoleAgent,
+			Parts: []protocol.Part{protocol.NewTextPart("response")},
+			Metadata: map[string]any{
+				arka2a.QueryExtensionMetadataKey: map[string]any{
+					"conversationId": "conv-1",
+					"memoryDegraded": true,
+				},
+			},
+		}
+		meta := extractEngineResponseMeta(&protocol.MessageResult{Result: msg})
+		assert.True(t, meta.MemoryDegraded)
+		assert.False(t, meta.MemoryUnavailable)
+	})
+
 	t.Run("extracts native A2A contextId and taskId from message", func(t *testing.T) {
 		contextID := "native-ctx"
 		taskID := "native-task"
@@ -430,6 +446,39 @@ func TestSetConditionMemoryUnavailable(t *testing.T) {
 		query := &arkv1alpha1.Query{}
 		r.setConditionMemoryUnavailable(query, true)
 		r.setConditionMemoryUnavailable(query, false)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	})
+}
+
+func TestSetConditionMemoryDegraded(t *testing.T) {
+	r := &QueryReconciler{}
+	condType := string(arkv1alpha1.QueryMemoryDegraded)
+
+	t.Run("sets True with GetMessagesFailed reason when degraded", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryDegraded(query, true)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+		assert.Equal(t, "GetMessagesFailed", cond.Reason)
+		assert.NotEmpty(t, cond.Message)
+	})
+
+	t.Run("sets False when history was read", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryDegraded(query, false)
+		cond := findCondition(query.Status.Conditions, condType)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, "MemoryHealthy", cond.Reason)
+	})
+
+	t.Run("clears a prior True to False on re-run", func(t *testing.T) {
+		query := &arkv1alpha1.Query{}
+		r.setConditionMemoryDegraded(query, true)
+		r.setConditionMemoryDegraded(query, false)
 		cond := findCondition(query.Status.Conditions, condType)
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)


### PR DESCRIPTION
## Summary

Fixes #2652 — conversations past the broker's first page of messages silently lost all history, so the LLM was invoked with only `[system, current_user]` from ~turn 51 onward.

- **Type mismatch** — `MessagesResponse.NextCursor` is now `*int64`. The broker emits `nextCursor` as a sequence number, so the old `*string` made every paginated response fail to decode.
- **No pagination** — `HTTPMemory.GetMessages` follows `hasMore`/`nextCursor`, sending `limit` and `cursor` and accumulating all pages. Backends that ignore those params still work (single page, `hasMore` false). A backend that claims `hasMore` but cannot be paginated — no cursor, a non-advancing cursor, or more than 1000 pages — is an error rather than a silently truncated history.
- **Silent swallow** — the fallback behaviour is unchanged (run without history), but it is no longer invisible: the executor sets `memoryDegraded` in its A2A response metadata and the controller writes `status.conditions[type=MemoryDegraded, reason=GetMessagesFailed]`, mirroring the existing `MemoryUnavailable` path from #2642. No new event was needed — `recorder.Fail` in `GetMessages` already emits a `MemoryGetMessagesError` warning carrying the underlying error, and the condition message points at it.

`make lint`, `gofumpt -l .` and `make test` are clean in `ark/`. `make manifests` produces no drift — condition types are not part of the CRD schema.

## Known consequence: long conversations will now hit provider context limits

There is no token-budget trimming anywhere between `GetMessages` and the LLM call — `PrepareModelMessages` sends everything. That was always the intent for conversations under one page; the bug was masking it above that. A 2000-message conversation that used to "work" (while remembering nothing) will now return a real context-length error from the provider.

The issue calls full-fetch the behaviour-preserving fix, so that is what this implements, but trimming or a token budget is a likely follow-up.

## Out of scope: ark-api has the same first-page-only read

`services/ark-api/ark-api/src/ark_api/api/v1/memories.py:208` takes `data.get("items", [])` with no pagination follow-through, so the dashboard's message list also stops at 100 messages per memory. Same failure family as bug 3 here, but a different read path — left alone, as #2652 is scoped to the executor.
