### PR TITLE
perf(apiserver): index the resource-version range queries on the PostgreSQL watch path

### DIFF
--- a/ark/internal/storage/postgresql/broadcaster.go
+++ b/ark/internal/storage/postgresql/broadcaster.go
@@ -130,6 +130,12 @@ func (b *kindBroadcaster) run() {
 	}
 }
 
+const broadcasterRelistQuery = `
+		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deleted_at, deletion_timestamp
+		FROM resources
+		WHERE kind = $1 AND resource_version > $2
+		ORDER BY resource_version ASC`
+
 // relist runs ONE query for the kind and fans the rows out to all subscribers.
 // Mirrors the old postgresWatcher.relist lookback/dedup semantics, but without the
 // namespace/label SQL filters (those become in-memory predicates at fan-out) and
@@ -146,16 +152,10 @@ func (b *kindBroadcaster) relist() {
 		from = 0
 	}
 
-	query := `
-		SELECT resource_version, generation, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references, created_at, deleted_at, deletion_timestamp
-		FROM resources
-		WHERE kind = $1 AND resource_version > $2
-		ORDER BY resource_version ASC`
-
 	broadcasterRelistTotal.WithLabelValues(b.kind).Inc()
 	ctx, cancel := context.WithTimeout(b.backend.ctx, relistQueryTimeout)
 	defer cancel()
-	rows, err := b.backend.db.QueryContext(ctx, query, b.kind, from)
+	rows, err := b.backend.db.QueryContext(ctx, broadcasterRelistQuery, b.kind, from)
 	if err != nil {
 		b.onRelistFailure(err)
 		return

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -345,6 +345,8 @@ func (p *PostgreSQLBackend) initSchema() error {
 	CREATE INDEX IF NOT EXISTS idx_resources_labels ON resources USING GIN(labels);
 	CREATE INDEX IF NOT EXISTS idx_resources_lookup ON resources(kind, namespace, name, resource_version);
 	CREATE INDEX IF NOT EXISTS idx_resources_deleted ON resources(deleted_at) WHERE deleted_at IS NOT NULL;
+	CREATE INDEX IF NOT EXISTS idx_resources_kind_rv ON resources(kind, resource_version);
+	CREATE INDEX IF NOT EXISTS idx_resources_rv ON resources(resource_version);
 
 	DROP TRIGGER IF EXISTS resource_change_trigger ON resources;
 	DROP FUNCTION IF EXISTS notify_resource_change();

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -1038,9 +1038,11 @@ func (p *PostgreSQLBackend) nudgeAllWatchers() {
 	}
 }
 
+const maxResourceVersionQuery = `SELECT MAX(resource_version) FROM resources`
+
 func (p *PostgreSQLBackend) getMaxResourceVersion() (int64, error) {
 	var rv sql.NullInt64
-	err := p.db.QueryRowContext(p.ctx, `SELECT MAX(resource_version) FROM resources`).Scan(&rv)
+	err := p.db.QueryRowContext(p.ctx, maxResourceVersionQuery).Scan(&rv)
 	if err != nil {
 		return 0, err
 	}

--- a/ark/internal/storage/postgresql/relist_index_integration_test.go
+++ b/ark/internal/storage/postgresql/relist_index_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+// +build integration
+
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+const (
+	relistIndexProbeKind  = "RelistIndexProbe"
+	relistIndexProbeKinds = 5
+	relistIndexProbeRows  = 30000
+	relistIndexLookback   = 500
+)
+
+func relistIndexBackend(t *testing.T) *PostgreSQLBackend {
+	t.Helper()
+
+	backend, err := New(testConfig(t), &integrationMockConverter{})
+	if err != nil {
+		t.Fatalf("create backend: %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	return backend
+}
+
+func TestSchemaCreatesRelistIndexes_Integration(t *testing.T) {
+	backend := relistIndexBackend(t)
+
+	for _, tc := range []struct {
+		index   string
+		columns string
+	}{
+		{"idx_resources_kind_rv", "(kind, resource_version)"},
+		{"idx_resources_rv", "(resource_version)"},
+	} {
+		var def string
+		err := backend.db.QueryRowContext(context.Background(),
+			"SELECT indexdef FROM pg_indexes WHERE tablename = 'resources' AND indexname = $1", tc.index).Scan(&def)
+		if err != nil {
+			t.Errorf("%s not created by initSchema: %v", tc.index, err)
+			continue
+		}
+		if !strings.HasSuffix(def, tc.columns) {
+			t.Errorf("%s is %q, want it to end in %q", tc.index, def, tc.columns)
+		}
+	}
+}
+
+// TestRelistReadsRowsInOrderFromAnIndex_Integration pins the shape of the relist that runs
+// on every write to a kind: the rows must arrive in resource-version order from an index.
+// Without one the planner sorts them, and that sort is what spills to disk once a kind
+// holds more rows than work_mem can hold. The two queries are the ones the broadcaster and
+// a catching-up watcher actually issue.
+func TestRelistReadsRowsInOrderFromAnIndex_Integration(t *testing.T) {
+	backend := relistIndexBackend(t)
+	ctx := context.Background()
+	maxRV := seedRelistIndexProbe(ctx, t, backend)
+
+	watcher := &postgresWatcher{kind: relistIndexProbeKind}
+	watcher.lastSeenRV.Store(maxRV)
+	watcherQuery, watcherArgs := watcher.buildRelistQuery()
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		args  []interface{}
+	}{
+		{
+			name:  "broadcaster relist",
+			query: broadcasterRelistQuery,
+			args:  []interface{}{relistIndexProbeKind, maxRV - relistIndexLookback},
+		},
+		{
+			name:  "watcher catch-up relist",
+			query: watcherQuery,
+			args:  watcherArgs,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainRelistQuery(ctx, t, backend, tc.query, tc.args...)
+			if strings.Contains(plan, "Sort Key: resource_version") {
+				t.Errorf("relist sorts its rows instead of reading them in order from an index:\n%s", plan)
+			}
+		})
+	}
+}
+
+// TestBookmarkRefreshDoesNotScanTheTable_Integration covers the max-resource-version query
+// behind the bookmark refresh, which runs every 10s for the lifetime of the process.
+func TestBookmarkRefreshDoesNotScanTheTable_Integration(t *testing.T) {
+	backend := relistIndexBackend(t)
+	ctx := context.Background()
+	seedRelistIndexProbe(ctx, t, backend)
+
+	plan := explainRelistQuery(ctx, t, backend, "SELECT MAX(resource_version) FROM resources")
+	if !strings.Contains(plan, "Index Only Scan Backward using idx_resources_rv") {
+		t.Errorf("bookmark refresh does not read the highest resource version straight off an index:\n%s", plan)
+	}
+}
+
+// seedRelistIndexProbe fills the table the way a real deployment holds it: several kinds
+// interleaved in resource-version order, so `kind = $1` is a selective predicate and the
+// planner has real alternatives to choose between. Returns the max resource version.
+func seedRelistIndexProbe(ctx context.Context, t *testing.T, backend *PostgreSQLBackend) int64 {
+	t.Helper()
+
+	deleteProbe := func() {
+		if _, err := backend.db.ExecContext(ctx,
+			"DELETE FROM resources WHERE namespace = 'relist-index-probe'"); err != nil {
+			t.Fatalf("delete probe rows: %v", err)
+		}
+	}
+	deleteProbe()
+	t.Cleanup(deleteProbe)
+
+	if _, err := backend.db.ExecContext(ctx, `
+		INSERT INTO resources (kind, namespace, name, uid, spec)
+		SELECT CASE WHEN g % $2 = 0 THEN $1 ELSE $1 || (g % $2)::text END,
+		       'relist-index-probe', 'probe-' || g, md5(g::text),
+		       jsonb_build_object('prompt', repeat('x', 400))
+		FROM generate_series(1, $3) g`,
+		relistIndexProbeKind, relistIndexProbeKinds, relistIndexProbeRows); err != nil {
+		t.Fatalf("seed probe rows: %v", err)
+	}
+	if _, err := backend.db.ExecContext(ctx, "ANALYZE resources"); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	maxRV, err := backend.getMaxResourceVersion()
+	if err != nil {
+		t.Fatalf("read max resource version: %v", err)
+	}
+	return maxRV
+}
+
+func explainRelistQuery(ctx context.Context, t *testing.T, backend *PostgreSQLBackend, query string, args ...interface{}) string {
+	t.Helper()
+
+	rows, err := backend.db.QueryContext(ctx, "EXPLAIN (ANALYZE, VERBOSE OFF, SUMMARY OFF) "+query, args...)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	return plan.String()
+}

--- a/ark/internal/storage/postgresql/relist_index_integration_test.go
+++ b/ark/internal/storage/postgresql/relist_index_integration_test.go
@@ -84,8 +84,13 @@ func TestRelistReadsRowsInOrderFromAnIndex_Integration(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			plan := explainRelistQuery(ctx, t, backend, tc.query, tc.args...)
-			if strings.Contains(plan, "Sort Key: resource_version") {
-				t.Errorf("relist sorts its rows instead of reading them in order from an index:\n%s", plan)
+			// Both indexes stream rows in resource-version order; the planner
+			// picks between them on selectivity. Anything else (seq scan,
+			// bitmap scan, a differently-ordered index) needs a Sort node and
+			// fails here.
+			if !strings.Contains(plan, "Index Scan using idx_resources_kind_rv") &&
+				!strings.Contains(plan, "Index Scan using idx_resources_rv") {
+				t.Errorf("relist does not read its rows in resource-version order from an rv index:\n%s", plan)
 			}
 		})
 	}
@@ -98,7 +103,7 @@ func TestBookmarkRefreshDoesNotScanTheTable_Integration(t *testing.T) {
 	ctx := context.Background()
 	seedRelistIndexProbe(ctx, t, backend)
 
-	plan := explainRelistQuery(ctx, t, backend, "SELECT MAX(resource_version) FROM resources")
+	plan := explainRelistQuery(ctx, t, backend, maxResourceVersionQuery)
 	if !strings.Contains(plan, "Index Only Scan Backward using idx_resources_rv") {
 		t.Errorf("bookmark refresh does not read the highest resource version straight off an index:\n%s", plan)
 	}

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -79,6 +79,7 @@ On first start, `ark-apiserver` creates:
 
 - A single table, `resources`, with one row per Ark resource (Agent, Model, Query, Team, …). Columns include `kind`, `namespace`, `name`, `uid`, `resource_version`, JSONB columns for `spec`, `status`, `labels`, `annotations`, `finalizers`, `owner_references`, plus timestamps and a soft-delete flag (`deleted_at`).
 - Indexes on `(kind, namespace)`, `(kind, namespace, name)`, a GIN index on `labels`, and a unique partial index on active (non-deleted) rows.
+- Indexes on `(kind, resource_version)` and `(resource_version)`, which serve the watch path: watches read changes as a resource-version range within a kind, and the bookmark refresh reads the highest resource version in the table.
 - A publication and a logical replication slot, both named `ark_cdc`. The slot is what powers `kubectl get -w` and controller informers.
 
 The slot is **persistent**: it survives apiserver restarts. It is dropped automatically on `helm uninstall` — see [Uninstall and cleanup](#uninstall-and-cleanup) below.
@@ -96,6 +97,8 @@ FROM pg_replication_slots WHERE slot_name = 'ark_cdc';
 ```
 
 `retained` should stay small. Sustained growth means no replica is consuming the slot — check that a pod holds the `ark-apiserver-leader` lease and that `active` is true. Setting `max_slot_wal_keep_size` caps the damage: Postgres invalidates the slot instead of filling the disk, and the apiserver recreates it on the next restart.
+
+Upgrading an existing deployment creates any index the schema is missing on the next apiserver start. Each build holds a write lock on `resources` until it completes — under half a second for a table of 100k rows, proportionally longer for a larger one.
 
 ## Installing PostgreSQL mode
 


### PR DESCRIPTION
## Summary

- Add `idx_resources_kind_rv` on `resources(kind, resource_version)`. Both relists on the watch path — the broadcaster's, which runs once per write to a kind, and a watcher's own catch-up — filter on exactly this shape and order by `resource_version`. Without the index the planner reads every row of the kind and sorts the result; that sort spills to disk once a kind holds more rows than `work_mem`.
- Add `idx_resources_rv` on `resources(resource_version)` for the `MAX(resource_version)` behind the bookmark refresh, which runs every 10s for the lifetime of the process. The composite index cannot serve it — that query has no `kind` predicate, so `resource_version` is never a leading column — which is why this is a second index rather than a wider one.
- Hoist the broadcaster's relist SQL to a package const so the new test explains the production query rather than a copy of it.
- Document both indexes and the one-time build at upgrade in the operations guide.

Fixes #3025.

### Measured

kind cluster, `postgres:16-alpine` at the shipped 500m CPU cap, `work_mem = 4MB`, 100,001 rows / 165 MB across five kinds. Same data and same instant in both columns — the indexes were dropped and recreated in place, so nothing else differs.

| query | without | with |
|---|---|---|
| relist at the stream head, runs per write to a kind | 4.9 ms — bitmap scan over every index entry of the kind, then a 3.5 MB quicksort | **2.1 ms** — ordered index scan, no sort |
| `MAX(resource_version)`, runs every 10 s | 18.2 ms — `Seq Scan` of 100k rows | **0.16 ms** — `Index Only Scan Backward`, one row |
| relist of a whole kind, runs on every `Watch()` | 185 ms — parallel seq scan plus `external merge` writing 5.4 + 7.7 + 6.2 MB of temp files | **22.8 ms** — ordered index scan, no temp files |

The relist is on the critical path for every event of a kind and is single-threaded per kind, and it is bounded by a 30 s timeout after which fan-out to every subscriber of that kind is dropped for that round, so its cost is worth bounding by rows returned rather than rows stored.

### Why inline `CREATE INDEX` rather than `CONCURRENTLY`

Building both indexes on the populated 165 MB table took **0.42 s** with writes blocked (341 ms + 83 ms), so they are created alongside the rest of the schema, inside the existing advisory-lock transaction. `CONCURRENTLY` cannot run in a transaction, needs its own connection, and leaves an `INVALID` index behind on failure — machinery that would buy nothing at this cost. The upgrade note in the docs states the lock explicitly, since the build time scales with table size.

Write-side cost of the two extra B-trees measured at roughly +7% on a 20k-row bulk insert, within run-to-run variance at that scale. `resource_version` is monotonic, so both indexes take right-edge appends.

### Verification

- Three new integration tests, each confirmed to fail with the two `CREATE INDEX` lines removed: the indexes exist with the right column order; both relist queries read rows in resource-version order from an index instead of sorting them; the bookmark query reads off `idx_resources_rv` instead of scanning the table.
- The whole-kind relist's disk spill is deliberately *not* asserted in a test — whether the planner spills depends on table size and `work_mem`, so a small-scale assertion would pass for the wrong reason. It is reported above as a measurement instead.
- Verified in-cluster on an existing populated table: the shipped code path added both indexes on apiserver startup, the APIService stayed `Available`, and a create-then-watch delivered events afterwards.
- `make test` exit 0. `make lint` clean. `golangci-lint --build-tags integration` on the package reports 26 issues on this branch and 26 on `main` — the new file adds none.
- Full package integration suite shows the identical five failures on this branch and on pristine `main` (the `watch_validation_test.go` suite that #3013 addresses); no new failures.

Related: #2680 (Watch ignoring `resourceVersion` is what makes the whole-kind relist run on every watch establishment; this change makes that query 8× cheaper regardless), #2721, #3018.

@Nab-0 @skazinka — review welcome. The judgement call worth a second opinion is the two-index shape: `MAX(resource_version)` genuinely needs `resource_version` leading, and I would rather not change that query's semantics to avoid the second B-tree.