### PR TITLE
feat(argo-workflows): support conversation-id in ark-query template

### DIFF
--- a/services/argo-workflows/chart/files/ark-query.py
+++ b/services/argo-workflows/chart/files/ark-query.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 
 FILES = {
     "query": "/tmp/query.json",  # NOSONAR - single-app container, no other users share /tmp
@@ -88,6 +89,8 @@ def main(): # NOSONAR - main function of a script.
     if os.environ["ARK_TTL"]:
         spec["ttl"] = os.environ["ARK_TTL"]
     spec["sessionId"] = os.environ["ARK_SESSION_ID"] or "wf-" + workflow
+    conversation_id = os.environ["ARK_CONVERSATION_ID"] or str(uuid.uuid4())
+    spec["conversationId"] = conversation_id
     if os.environ["ARK_MEMORY"]:
         spec["memory"] = {"name": os.environ["ARK_MEMORY"]}
     if os.environ["ARK_SERVICE_ACCOUNT"]:
@@ -132,7 +135,7 @@ def main(): # NOSONAR - main function of a script.
 
     write_file("phase", phase)
     write_file("response", (status.get("response") or {}).get("content", ""))
-    write_file("conversation", status.get("conversationId", ""))
+    write_file("conversation", conversation_id)
 
     if phase == "done":
         print("Query " + query_name + " completed: done")

--- a/services/argo-workflows/chart/templates/ark-query-template.yaml
+++ b/services/argo-workflows/chart/templates/ark-query-template.yaml
@@ -37,6 +37,8 @@ data:
                 value: "[]"
               - name: session-id
                 value: ""
+              - name: conversation-id
+                value: ""
               - name: memory
                 value: ""
               - name: query-name
@@ -73,6 +75,8 @@ data:
                 value: {{ "{{inputs.parameters.parameters}}" | quote }}
               - name: ARK_SESSION_ID
                 value: {{ "{{inputs.parameters.session-id}}" | quote }}
+              - name: ARK_CONVERSATION_ID
+                value: {{ "{{inputs.parameters.conversation-id}}" | quote }}
               - name: ARK_MEMORY
                 value: {{ "{{inputs.parameters.memory}}" | quote }}
               - name: ARK_QUERY_NAME


### PR DESCRIPTION
## Summary
- Add a `conversation-id` input parameter to the shipped `ark-query` WorkflowTemplate
- Auto-generate a collision-free UUID conversation id when the input is not provided, so every query gets a unique conversation by default
- Set the resolved conversation id (passed-in or generated) on the Query `spec.conversationId`, and return it via the existing `conversation-id` output so downstream steps can reuse it to continue a conversation

Pairs with the marketplace change that teaches the argo-make-author agent when to reuse vs. generate a conversation id.