### PR TITLE
test(broker): cover the memory delete and conversation routes against Postgres

### DIFF
--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -508,6 +508,22 @@ describe('PostgresMessageStream', () => {
 
       expect(ids.sort()).toEqual([convA, convB].sort());
     });
+
+    it('excludes conversations whose messages have all expired', async () => {
+      const suffix = Math.random().toString(36).slice(2);
+      const expiredConversation = 'conv-expired-' + suffix;
+      const liveConversation = 'conv-live-' + suffix;
+      await stream.append(
+        makeMessageData({conversationId: expiredConversation}),
+        1
+      );
+      await stream.append(makeMessageData({conversationId: liveConversation}));
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      expect(await stream.distinctConversationIds()).toEqual([
+        liveConversation,
+      ]);
+    });
   });
 
   describe('conversationStats', () => {

--- a/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/stream/__tests__/postgres-message-stream.test.ts
@@ -399,6 +399,44 @@ describe('PostgresMessageStream', () => {
       expect(all[0]!.sequenceNumber).toBe(survivor.sequenceNumber);
     });
 
+    it('combines conversationId and queryId as AND, sparing rows that match only one', async () => {
+      const suffix = Math.random().toString(36).slice(2);
+      const targetConversation = 'conv-target-' + suffix;
+      const otherConversation = 'conv-other-' + suffix;
+      const targetQuery = 'q-target-' + suffix;
+      const otherQuery = 'q-other-' + suffix;
+
+      await stream.append(
+        makeMessageData({
+          conversationId: targetConversation,
+          queryId: targetQuery,
+        })
+      );
+      const sameConversationOtherQuery = await stream.append(
+        makeMessageData({
+          conversationId: targetConversation,
+          queryId: otherQuery,
+        })
+      );
+      const otherConversationSameQuery = await stream.append(
+        makeMessageData({
+          conversationId: otherConversation,
+          queryId: targetQuery,
+        })
+      );
+
+      await stream.deleteBy({
+        conversationId: targetConversation,
+        queryId: targetQuery,
+      });
+
+      const all = await stream.all();
+      expect(all.map((item) => item.sequenceNumber)).toEqual([
+        sameConversationOtherQuery.sequenceNumber,
+        otherConversationSameQuery.sequenceNumber,
+      ]);
+    });
+
     it('removes rows regardless of expiry (ignores TTL)', async () => {
       const conversationId = 'conv-' + Math.random().toString(36).slice(2);
       const item = await stream.append(makeMessageData({conversationId}), 1);

--- a/services/ark-broker/ark-broker/test/memory-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/memory-broker.test.ts
@@ -175,6 +175,18 @@ describe('MemoryBroker', () => {
       expect(allMessages).toHaveLength(1);
       expect(allMessages[0].data.queryId).toBe('query2');
     });
+
+    test('should leave the same query untouched in other conversations', async () => {
+      await broker.addMessage('conv1', 'query1', 'message1');
+      await broker.addMessage('conv2', 'query1', 'message2');
+
+      await broker.deleteQuery('conv1', 'query1');
+
+      const allMessages = await broker.all();
+      expect(allMessages).toHaveLength(1);
+      expect(allMessages[0].data.conversationId).toBe('conv2');
+      expect(allMessages[0].data.queryId).toBe('query1');
+    });
   });
 
   describe('deleteByQuery', () => {

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -358,6 +358,132 @@ describeIntegration('postgres backend — HTTP integration', () => {
     ).toEqual(['scoped-conv-1/other-q', 'scoped-conv-2/scoped-q']);
   });
 
+  it('GET /conversations lists each conversation once across several messages', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'list-conv-1',
+        query_id: 'q1',
+        messages: ['a', 'b'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'list-conv-1', query_id: 'q2', messages: ['c']})
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'list-conv-2', query_id: 'q3', messages: ['d']})
+      .expect(200);
+
+    const res = await request(app).get('/conversations').expect(200);
+
+    expect([...res.body.conversations].sort()).toEqual([
+      'list-conv-1',
+      'list-conv-2',
+    ]);
+  });
+
+  it('GET /conversations/:conversationId returns only that conversation, in sequence order', async () => {
+    const first = {role: 'user', content: 'first'};
+    const second = {role: 'assistant', content: 'second'};
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'detail-conv',
+        query_id: 'q1',
+        messages: [first, second],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'other-conv',
+        query_id: 'q2',
+        messages: [{role: 'user', content: 'other'}],
+      })
+      .expect(200);
+
+    const res = await request(app)
+      .get('/conversations/detail-conv')
+      .expect(200);
+
+    expect(res.body.conversation_id).toBe('detail-conv');
+    expect(
+      res.body.messages.map((item: {message: unknown}) => item.message)
+    ).toEqual([first, second]);
+    expect(
+      res.body.messages.map((item: {sequence: number}) => item.sequence)
+    ).toEqual([1, 2]);
+
+    await request(app).get('/conversations/missing-conv').expect(404);
+  });
+
+  it('DELETE /messages purges every row without resetting the sequence', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'purge-conv',
+        query_id: 'q1',
+        messages: ['a', 'b'],
+      })
+      .expect(200);
+
+    const deleteRes = await request(app).delete('/messages').expect(200);
+    expect(deleteRes.body.message).toBe('Memory purged');
+
+    const emptyRes = await request(app).get('/messages').expect(200);
+    expect(emptyRes.body.items).toEqual([]);
+
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'purge-conv', query_id: 'q2', messages: ['c']})
+      .expect(200);
+
+    const afterRes = await request(app).get('/messages').expect(200);
+    expect(afterRes.body.items).toHaveLength(1);
+    expect(afterRes.body.items[0].sequence).toBe(3);
+  });
+
+  it('DELETE /conversations/:conversationId removes only that conversation', async () => {
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'drop-conv', query_id: 'q1', messages: ['a']})
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'keep-conv', query_id: 'q2', messages: ['b']})
+      .expect(200);
+
+    await request(app).delete('/conversations/drop-conv').expect(200);
+
+    const res = await request(app).get('/messages').expect(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].conversation_id).toBe('keep-conv');
+
+    await request(app).get('/conversations/drop-conv').expect(404);
+  });
+
+  it('DELETE /conversations purges every conversation', async () => {
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'wipe-conv-1', query_id: 'q1', messages: ['a']})
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({conversation_id: 'wipe-conv-2', query_id: 'q2', messages: ['b']})
+      .expect(200);
+
+    const deleteRes = await request(app).delete('/conversations').expect(200);
+    expect(deleteRes.body.message).toBe('All conversations deleted');
+
+    const listRes = await request(app).get('/conversations').expect(200);
+    expect(listRes.body.conversations).toEqual([]);
+
+    const messagesRes = await request(app).get('/messages').expect(200);
+    expect(messagesRes.body.items).toEqual([]);
+  });
+
   it('GET /memory-status aggregates per-conversation counts via a single query', async () => {
     await request(app)
       .post('/messages')

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -419,7 +419,7 @@ describeIntegration('postgres backend — HTTP integration', () => {
     await request(app).get('/conversations/missing-conv').expect(404);
   });
 
-  it('DELETE /messages purges every row without resetting the sequence', async () => {
+  it('DELETE /messages purges every row without resetting the Postgres sequence', async () => {
     await request(app)
       .post('/messages')
       .send({

--- a/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
+++ b/services/ark-broker/ark-broker/test/postgres-backend.integration.test.ts
@@ -319,6 +319,45 @@ describeIntegration('postgres backend — HTTP integration', () => {
     expect(res.body.items[0].query_id).toBe('keep-q');
   });
 
+  it('DELETE /conversations/:conversationId/queries/:queryId/messages removes only rows in that conversation', async () => {
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'scoped-conv-1',
+        query_id: 'scoped-q',
+        messages: ['a'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'scoped-conv-1',
+        query_id: 'other-q',
+        messages: ['b'],
+      })
+      .expect(200);
+    await request(app)
+      .post('/messages')
+      .send({
+        conversation_id: 'scoped-conv-2',
+        query_id: 'scoped-q',
+        messages: ['c'],
+      })
+      .expect(200);
+
+    await request(app)
+      .delete('/conversations/scoped-conv-1/queries/scoped-q/messages')
+      .expect(200);
+
+    const res = await request(app).get('/messages').expect(200);
+    expect(
+      res.body.items.map(
+        (item: {conversation_id: string; query_id: string}) =>
+          `${item.conversation_id}/${item.query_id}`
+      )
+    ).toEqual(['scoped-conv-1/other-q', 'scoped-conv-2/scoped-q']);
+  });
+
   it('GET /memory-status aggregates per-conversation counts via a single query', async () => {
     await request(app)
       .post('/messages')


### PR DESCRIPTION
## Context

The memory surface of ark-broker runs on two interchangeable backends: the default in-memory stream, and the Postgres stream added in #2424 (part of #2153). The Postgres integration suite grew alongside the features that motivated it — durable writes, TTL snapshots, index plans — so it covers the read and write paths thoroughly but had only ever touched one of the five delete routes. Everything conversation-scoped was verified against the in-memory backend alone, and one route was not verified anywhere.

That distribution is easy to miss because the suite is green either way. What follows is what auditing it turned up.

## Problem

`DELETE /conversations/{conversationId}/queries/{queryId}/messages` had no test on any backend. It is not a dormant endpoint: the dashboard's per-query delete dialog calls it through ark-api, so it sits on a live user-facing path.

More subtly, the one test that did exercise the same broker method (`deleteQuery`) created all its messages inside a single conversation. A predicate that ignored `conversationId` entirely would have satisfied it. That is precisely the difference between `deleteQuery`, which is scoped to one conversation, and `deleteByQuery`, which spans all of them — so nothing in the suite distinguished the two. Rewiring the route to the wrong one would have deleted other conversations' messages with CI still green. The `deleteBy` suite reinforced the blind spot: it had a case for `conversationId` alone and one for `queryId` alone, but never both together, even though `filterBy` did.

Two smaller gaps came out of the same pass: on Postgres only 4 of the 11 memory routes had HTTP coverage, and `distinctConversationIds` filters on `expires_at` with nothing asserting that expired rows are actually hidden.

To be clear about what this PR is not: none of the above was broken. Every one of these routes behaves correctly today, and the new tests pass against unmodified production code. What was missing was the coverage that would catch it if that stopped being true.

## What this adds

Nine tests, no production code changes.

The conversation-scoped delete is now pinned at all three layers: the SQL predicate combining both fields, the broker method that composes it, and the HTTP route end to end against real Postgres. The broker case now spans two conversations sharing a query id, so the conversation scope has to hold for it to pass.

The remaining memory routes gain Postgres HTTP coverage, each aimed at what the SQL does and the in-memory backend does not — `SELECT DISTINCT` deduplicating, JSONB payloads surviving the round trip as objects, and scoping on delete. The purge case asserts that the sequence keeps climbing afterwards, which pins the deliberate choice of `DELETE FROM messages` over `TRUNCATE ... RESTART IDENTITY`.

`POST /conversations` is left alone on purpose: it returns `randomUUID()` without touching the stream, so a Postgres test would prove nothing the in-memory one doesn't.

## How the tests were validated

Passing on correct code says little about whether a test would catch a regression, so each new assertion was checked by deliberately breaking the code and confirming it fails. The most telling result: dropping the conversation scope from `MemoryBroker.deleteQuery` leaves the pre-existing test green and fails only the new one, which is the coverage gap made visible. Replacing `DELETE FROM messages` with `TRUNCATE ... RESTART IDENTITY` fails the sequence assertion, and removing the `expires_at` filter makes the expired conversation reappear alongside the live one. All mutations were reverted; the diff touches test files only.

Suite goes from 392 to 401 tests, `make lint` and `make test` green in `services/ark-broker`.

## Review guide

- `test/memory-broker.test.ts:179` — the case that distinguishes `deleteQuery` from `deleteByQuery`; worth reading against the test just above it, which cannot.
- `src/brokers/stream/__tests__/postgres-message-stream.test.ts:402` — three rows where two match one field each; only the row matching both is removed.
- `src/brokers/stream/__tests__/postgres-message-stream.test.ts:512` — expired and live conversation paired, so it fails in both directions. The older equivalent on `conversationStats` asserts an empty result from a single expired row, which a wholly broken query would also satisfy.
- `test/postgres-backend.integration.test.ts:322` — the route that had no coverage at all.
- `test/postgres-backend.integration.test.ts:422` — the purge case carrying the `DELETE` vs `TRUNCATE` assertion.

## Deliberately not here

No chainsaw test. The one thing an e2e would uniquely catch is a path mismatch between ark-api and the broker, since ark-api's tests mock `httpx` and the broker knows nothing of ark-api. What blocks it is that ark-api is not installed in the e2e environment — `setup-local.sh` brings up the controller, apiserver, broker, storage and mock-llm, and no chainsaw test exercises its REST surface today. Adding one means extending the e2e setup, which is infrastructure work rather than a test. Worth being explicit that #3013 has since made the PostgreSQL lanes blocking, so such a test would now genuinely gate — that raises its value, but not enough to fold an e2e setup change into a test-only PR. The contract gap is knowingly left open.

Separately, `delete_query_messages` in `services/ark-api/ark-api/src/ark_api/api/v1/conversations.py:190` treats only a 500 from the broker as an error. A 404 increments nothing and raises nothing, so the final guard is skipped and the handler returns 200 with `deleted from 0 memory service(s)` — the dashboard would report success while the messages are still there. Untouched here since it is a behaviour change on the ark-api side, but it deserves its own fix.
