### PR TITLE
fix(completions): serve Model reads from a watch-backed cache

### DIFF
--- a/ark/cmd/completions/main.go
+++ b/ark/cmd/completions/main.go
@@ -16,7 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
@@ -24,6 +23,7 @@ import (
 	completions "mckinsey.com/ark/executors/completions"
 	eventingconfig "mckinsey.com/ark/internal/eventing/config"
 	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
+	"mckinsey.com/ark/internal/telemetry/routing"
 )
 
 var (
@@ -80,13 +80,14 @@ func main() {
 	log.Info("starting ark completions engine", "version", Version, "commit", GitCommit)
 
 	restConfig := ctrl.GetConfigOrDie()
-	k8sClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+
+	ctx := context.Background()
+	k8sClient, err := completions.NewModelCachingClient(ctx, restConfig, scheme, routing.DiscoveryNamespace())
 	if err != nil {
 		log.Error(err, "failed to create kubernetes client")
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
 	telemetryProvider := telemetryconfig.NewProvider(ctx, k8sClient)
 	eventingProvider := eventingconfig.NewProviderWithClient(ctx, k8sClient)
 

--- a/ark/executors/completions/model.go
+++ b/ark/executors/completions/model.go
@@ -3,8 +3,6 @@ package completions
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/openai/openai-go/option"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,15 +14,6 @@ import (
 	"mckinsey.com/ark/internal/eventing"
 	"mckinsey.com/ark/internal/telemetry"
 )
-
-const modelCRDCacheTTL = 5 * time.Minute
-
-type modelCRDCacheEntry struct {
-	crd       *arkv1alpha1.Model
-	expiresAt time.Time
-}
-
-var modelCRDCache sync.Map
 
 const defaultModelName = "default"
 
@@ -111,20 +100,11 @@ func LoadModel(ctx context.Context, k8sClient client.Client, modelSpec interface
 }
 
 func loadModelCRD(ctx context.Context, k8sClient client.Client, name, namespace string) (*arkv1alpha1.Model, error) {
-	cacheKey := namespace + "/" + name
-	if v, ok := modelCRDCache.Load(cacheKey); ok {
-		entry := v.(*modelCRDCacheEntry)
-		if time.Now().Before(entry.expiresAt) {
-			return entry.crd, nil
-		}
-	}
-
 	var modelCRD arkv1alpha1.Model
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &modelCRD); err != nil {
 		return nil, fmt.Errorf("failed to get Model %s/%s: %w", namespace, name, err)
 	}
 
-	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{crd: &modelCRD, expiresAt: time.Now().Add(modelCRDCacheTTL)})
 	return &modelCRD, nil
 }
 

--- a/ark/executors/completions/model_client.go
+++ b/ark/executors/completions/model_client.go
@@ -1,0 +1,65 @@
+package completions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+const modelCacheSyncTimeout = 30 * time.Second
+
+type modelCachingClient struct {
+	client.Client
+	models client.Reader
+}
+
+func (c *modelCachingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*arkv1alpha1.Model); ok {
+		return c.models.Get(ctx, key, obj, opts...)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func NewModelCachingClient(ctx context.Context, restConfig *rest.Config, scheme *runtime.Scheme, discoveryNamespace string) (client.Client, error) {
+	direct, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	options := cache.Options{Scheme: scheme}
+	if discoveryNamespace != "" {
+		options.DefaultNamespaces = map[string]cache.Config{discoveryNamespace: {}}
+	}
+
+	modelCache, err := cache.New(restConfig, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Model cache: %w", err)
+	}
+
+	if _, err := modelCache.GetInformer(ctx, &arkv1alpha1.Model{}, cache.BlockUntilSynced(false)); err != nil {
+		return nil, fmt.Errorf("failed to create Model informer: %w", err)
+	}
+
+	go func() {
+		if err := modelCache.Start(ctx); err != nil {
+			logf.FromContext(ctx).Error(err, "Model cache stopped")
+		}
+	}()
+
+	syncCtx, cancelSync := context.WithTimeout(ctx, modelCacheSyncTimeout)
+	defer cancelSync()
+
+	if !modelCache.WaitForCacheSync(syncCtx) {
+		return nil, fmt.Errorf("timed out after %s syncing the Model cache", modelCacheSyncTimeout)
+	}
+
+	return &modelCachingClient{Client: direct, models: modelCache}, nil
+}

--- a/ark/executors/completions/model_client_envtest_test.go
+++ b/ark/executors/completions/model_client_envtest_test.go
@@ -1,0 +1,74 @@
+package completions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	eventnoop "mckinsey.com/ark/internal/eventing/noop"
+	telenoop "mckinsey.com/ark/internal/telemetry/noop"
+)
+
+func TestNewModelCachingClient_ObservesModelUpdates(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS is not set; run via make test")
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	restConfig, err := testEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testEnv.Stop()) })
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, arkv1alpha1.AddToScheme(scheme))
+
+	writer, err := client.New(restConfig, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	name, ns := "envtest-model", "default"
+	require.NoError(t, writer.Create(context.Background(), openAIModelWithBaseURL(name, ns, "http://old.example.com/v1")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	routed, err := NewModelCachingClient(ctx, restConfig, scheme, "")
+	require.NoError(t, err)
+
+	loadBaseURL := func() string {
+		loaded, err := LoadModel(ctx, routed, &arkv1alpha1.AgentModelRef{Name: name, Namespace: ns},
+			ns, nil, telenoop.NewModelRecorder(), eventnoop.NewModelRecorder())
+		if err != nil {
+			return ""
+		}
+		provider, ok := loaded.Provider.(*OpenAIProvider)
+		if !ok {
+			return ""
+		}
+		return provider.BaseURL
+	}
+
+	require.Eventually(t, func() bool { return loadBaseURL() == "http://old.example.com/v1" },
+		20*time.Second, 100*time.Millisecond, "cached client should serve the created Model")
+
+	var stored arkv1alpha1.Model
+	require.NoError(t, writer.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, &stored))
+	stored.Spec.Config.OpenAI.BaseURL = arkv1alpha1.ValueSource{Value: "http://new.example.com/v1"}
+	require.NoError(t, writer.Update(context.Background(), &stored))
+
+	require.Eventually(t, func() bool { return loadBaseURL() == "http://new.example.com/v1" },
+		20*time.Second, 100*time.Millisecond, "cached client must observe the updated baseURL via its watch")
+}

--- a/ark/executors/completions/model_client_test.go
+++ b/ark/executors/completions/model_client_test.go
@@ -1,0 +1,63 @@
+package completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	eventnoop "mckinsey.com/ark/internal/eventing/noop"
+	telenoop "mckinsey.com/ark/internal/telemetry/noop"
+)
+
+func TestModelCachingClient_ServesModelReadsFromCache(t *testing.T) {
+	name, ns := "routed-model", defaultNamespace
+	cached := setupModelTestClient([]client.Object{openAIModelWithBaseURL(name, ns, "http://from-cache/v1")})
+	direct := setupModelTestClient([]client.Object{openAIModelWithBaseURL(name, ns, "http://from-direct/v1")})
+
+	routed := &modelCachingClient{Client: direct, models: cached}
+
+	var got arkv1alpha1.Model
+	require.NoError(t, routed.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, &got))
+	require.Equal(t, "http://from-cache/v1", got.Spec.Config.OpenAI.BaseURL.Value)
+}
+
+func TestModelCachingClient_ServesOtherReadsFromDirectClient(t *testing.T) {
+	ns := defaultNamespace
+	inDirect := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "direct-secret", Namespace: ns}}
+	inCache := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cache-secret", Namespace: ns}}
+
+	routed := &modelCachingClient{
+		Client: setupModelTestClient([]client.Object{inDirect}),
+		models: setupModelTestClient([]client.Object{inCache}),
+	}
+
+	var found corev1.Secret
+	require.NoError(t, routed.Get(context.Background(), types.NamespacedName{Name: "direct-secret", Namespace: ns}, &found))
+
+	var missing corev1.Secret
+	err := routed.Get(context.Background(), types.NamespacedName{Name: "cache-secret", Namespace: ns}, &missing)
+	require.True(t, apierrors.IsNotFound(err), "non-Model reads must not be served by the Model cache")
+}
+
+func TestLoadModel_UsesCachedModelReader(t *testing.T) {
+	name, ns := "cached-reader-model", defaultNamespace
+	routed := &modelCachingClient{
+		Client: setupModelTestClient(nil),
+		models: setupModelTestClient([]client.Object{openAIModelWithBaseURL(name, ns, "http://from-cache/v1")}),
+	}
+
+	loaded, err := LoadModel(context.Background(), routed, &arkv1alpha1.AgentModelRef{Name: name, Namespace: ns},
+		ns, nil, telenoop.NewModelRecorder(), eventnoop.NewModelRecorder())
+	require.NoError(t, err)
+
+	provider, ok := loaded.Provider.(*OpenAIProvider)
+	require.True(t, ok)
+	require.Equal(t, "http://from-cache/v1", provider.BaseURL)
+}

--- a/ark/executors/completions/model_test.go
+++ b/ark/executors/completions/model_test.go
@@ -5,16 +5,18 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	eventnoop "mckinsey.com/ark/internal/eventing/noop"
+	telenoop "mckinsey.com/ark/internal/telemetry/noop"
 )
 
 const defaultNamespace = "default"
@@ -92,10 +94,6 @@ func setupModelTestClient(objects []client.Object) client.Client {
 
 func TestLoadModelCRD_ConcurrentAccess(t *testing.T) {
 	name, ns := "concurrent-model", defaultNamespace
-	cacheKey := ns + "/" + name
-	modelCRDCache.Delete(cacheKey)
-	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
-
 	model := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
 	fakeClient := setupModelTestClient([]client.Object{model})
 
@@ -179,57 +177,61 @@ func TestResolveModelHeaders_FromQueryParameter(t *testing.T) {
 	require.Equal(t, "user-123", got["X-User-ID"])
 }
 
-func TestLoadModelCRD_CacheHit(t *testing.T) {
-	cacheKey := defaultNamespace + "/cached-model"
-	cached := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: defaultNamespace}}
-	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{
-		crd:       cached,
-		expiresAt: time.Now().Add(modelCRDCacheTTL),
-	})
-	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
-
-	fakeClient := setupModelTestClient(nil)
-
-	got, err := loadModelCRD(context.Background(), fakeClient, "cached-model", defaultNamespace)
-	require.NoError(t, err)
-	require.Same(t, cached, got)
-}
-
-func TestLoadModelCRD_CacheMiss(t *testing.T) {
-	name, ns := "miss-model", defaultNamespace
-	cacheKey := ns + "/" + name
-	modelCRDCache.Delete(cacheKey)
-	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
-
+func TestLoadModelCRD_Found(t *testing.T) {
+	name, ns := "found-model", defaultNamespace
 	model := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
 	fakeClient := setupModelTestClient([]client.Object{model})
 
 	got, err := loadModelCRD(context.Background(), fakeClient, name, ns)
 	require.NoError(t, err)
 	require.Equal(t, name, got.Name)
-
-	v, ok := modelCRDCache.Load(cacheKey)
-	require.True(t, ok)
-	require.Equal(t, name, v.(*modelCRDCacheEntry).crd.Name)
 }
 
-func TestLoadModelCRD_ExpiredEntry(t *testing.T) {
-	name, ns := "expired-model", defaultNamespace
-	cacheKey := ns + "/" + name
+func TestLoadModelCRD_NotFound(t *testing.T) {
+	fakeClient := setupModelTestClient(nil)
 
-	stale := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
-	modelCRDCache.Store(cacheKey, &modelCRDCacheEntry{
-		crd:       stale,
-		expiresAt: time.Now().Add(-time.Second),
-	})
-	t.Cleanup(func() { modelCRDCache.Delete(cacheKey) })
+	_, err := loadModelCRD(context.Background(), fakeClient, "absent-model", defaultNamespace)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get Model")
+}
 
-	fresh := &arkv1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
-	fakeClient := setupModelTestClient([]client.Object{fresh})
+func openAIModelWithBaseURL(name, ns, baseURL string) *arkv1alpha1.Model {
+	return &arkv1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: arkv1alpha1.ModelSpec{
+			Model:    arkv1alpha1.ValueSource{Value: "gpt-4o"},
+			Provider: ProviderOpenAI,
+			Config: arkv1alpha1.ModelConfig{
+				OpenAI: &arkv1alpha1.OpenAIModelConfig{
+					BaseURL: arkv1alpha1.ValueSource{Value: baseURL},
+					APIKey:  arkv1alpha1.ValueSource{Value: "sk-test"},
+				},
+			},
+		},
+	}
+}
 
-	got, err := loadModelCRD(context.Background(), fakeClient, name, ns)
-	require.NoError(t, err)
-	require.NotSame(t, stale, got)
+func TestLoadModel_ReflectsBaseURLUpdate(t *testing.T) {
+	name, ns := "updated-model", defaultNamespace
+	fakeClient := setupModelTestClient([]client.Object{openAIModelWithBaseURL(name, ns, "http://old.example.com/v1")})
+
+	loadBaseURL := func() string {
+		loaded, err := LoadModel(context.Background(), fakeClient, &arkv1alpha1.AgentModelRef{Name: name, Namespace: ns},
+			ns, nil, telenoop.NewModelRecorder(), eventnoop.NewModelRecorder())
+		require.NoError(t, err)
+		provider, ok := loaded.Provider.(*OpenAIProvider)
+		require.True(t, ok)
+		return provider.BaseURL
+	}
+
+	require.Equal(t, "http://old.example.com/v1", loadBaseURL())
+
+	var stored arkv1alpha1.Model
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, &stored))
+	stored.Spec.Config.OpenAI.BaseURL = arkv1alpha1.ValueSource{Value: "http://new.example.com/v1"}
+	require.NoError(t, fakeClient.Update(context.Background(), &stored))
+
+	require.Equal(t, "http://new.example.com/v1", loadBaseURL())
 }
 
 func TestResolveModelHeaders_QueryParameterWithoutContext(t *testing.T) {

--- a/ark/internal/telemetry/routing/discovery_scope.go
+++ b/ark/internal/telemetry/routing/discovery_scope.go
@@ -14,11 +14,18 @@ import (
 // central ark-system install are unchanged.
 const discoveryNamespaceEnv = "ARK_DISCOVERY_NAMESPACE"
 
+// DiscoveryNamespace returns the namespace discovery is scoped to, or "" when
+// discovery is cluster-wide. Callers that build their own informers or List
+// calls use this so their scope matches the pod's RBAC.
+func DiscoveryNamespace() string {
+	return os.Getenv(discoveryNamespaceEnv)
+}
+
 // scopedListOptions returns the List options used by broker and target
 // discovery. When ARK_DISCOVERY_NAMESPACE is set, the list is scoped to that
 // namespace; otherwise it is cluster-wide (nil options).
 func scopedListOptions() []client.ListOption {
-	if ns := os.Getenv(discoveryNamespaceEnv); ns != "" {
+	if ns := DiscoveryNamespace(); ns != "" {
 		return []client.ListOption{client.InNamespace(ns)}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Updating a Model's `baseUrl` from the dashboard did not reach running agents: the completions executor kept resolving queries against the previous spec for up to 5 minutes. This replaces the TTL cache responsible for that staleness with a watch-backed informer, so Model reads stay local (no per-query API call) while always reflecting the current spec.

## Problem

`loadModelCRD` cached the Model CRD in a process-global `sync.Map` with a 5 minute TTL and no invalidation — the only `Delete` calls were in tests. `LoadModel` runs on every query (`agent.go` via `MakeAgent`, and `handler.go` for direct model queries), so every interaction inside that window used the stale spec, `baseUrl` included.

The dashboard looked correct throughout, which is what made this awkward to diagnose: ark-api reads the Model CRD straight from the API server, so the Models page showed the new value immediately while only the executor was behind.

Same cache, three secondary effects worth knowing about:

- With multiple executor replicas, each pod holds an independent cache with an independent expiry, so during the window responses can alternate between the old and new `baseUrl` depending on which pod serves the request.
- `probeModel` in the controller calls the same `LoadModel`, so the controller process had its own copy of the cache. On a `baseUrl` update the reconcile probed the *old* endpoint and could publish a misleading `ModelAvailable` condition.
- Only a direct `value:` was affected. `ResolveValueSource` re-resolves `valueFrom` on every call, so a `baseUrl` sourced from a Secret or ConfigMap propagated immediately. The dashboard writes a plain string, which is the affected path.

Staleness was bounded at 5 minutes per pod and self-healing, so this was a correctness window rather than a permanent misconfiguration.

## Why not simply drop the cache, or shorten the TTL

The cache was added deliberately in #2358 to avoid a per-query API round-trip. That premise holds for the executor but not for the controller, and the asymmetry is the reason this change has two halves:

- the executor builds its client with `client.New`, which is **uncached** — every `Get` is a real API call, so removing the cache outright would regress #2358;
- the controller uses `mgr.GetClient()`, which is **informer-backed** — there the same map layered staleness on top of an already-local, already-fresh read, for no gain at all.

Shortening the TTL would only narrow the window while preserving the failure mode. Giving the executor an informer for Model addresses the cause instead: reads stay local, and freshness is driven by the watch.

## Implementation notes

`NewModelCachingClient` builds the direct client plus a `cache.Cache` and wraps them in a `modelCachingClient` that routes only `*arkv1alpha1.Model` reads to the informer. Everything else — Secrets, ConfigMaps, Queries, Agents — still goes to the direct client, so no informers are started for high-cardinality or sensitive types.

Two details that would otherwise have broken this at deploy time:

**Discovery scope.** The executor supports `namespaceScopedDiscovery=true`, where it is authorized by a namespaced Role. A cluster-wide Model watch would be rejected there and the pod would never become ready. The cache is therefore scoped to `ARK_DISCOVERY_NAMESPACE` when set, reusing the existing convention rather than duplicating the env var name — hence the small exported `routing.DiscoveryNamespace()` helper. Existing RBAC already grants `get/list/watch` on `models`, so the chart is unchanged.

**Informer startup.** `GetInformer` only blocks for sync when the cache is already started, so registering and waiting in the obvious order leaves a race where the boot-time check can return before the cache is populated. Reads would still be correct, because the reader itself waits for sync, but the fail-fast intent would be silently lost. The informer is now registered before `Start`, and `WaitForCacheSync` is bounded by a 30s timeout, so insufficient RBAC surfaces as a clear startup failure instead of a hang.

## Review guide

- `ark/executors/completions/model.go:102` — `loadModelCRD` reduced to a plain `Get`; the TTL map and its entry type are gone.
- `ark/executors/completions/model_client.go:25` — the routing predicate, the line that decides what the cache is allowed to serve.
- `ark/executors/completions/model_client.go:47-62` — informer registration, start, and the bounded sync wait.
- `ark/cmd/completions/main.go:84` — the cache receives a `context.Background()` that deliberately outlives SIGTERM, so in-flight requests can still resolve Models while the server drains.
- `ark/internal/telemetry/routing/discovery_scope.go` — extracted accessor, no behaviour change.

## Tests

`TestLoadModel_ReflectsBaseURLUpdate` covers the reported path end to end, up to `OpenAIProvider.BaseURL`. It was confirmed to fail against the previous implementation (`expected new / actual old`) before being kept, so it will catch a reintroduction rather than passing vacuously.

`TestNewModelCachingClient_ObservesModelUpdates` (envtest, skipped without `KUBEBUILDER_ASSETS`) covers what unit tests cannot: that the informer really observes an update through its watch against a live API server.

The four tests asserting the removed TTL behaviour were replaced.

## Note

There is no tracking issue for this one — happy to open one and link it if you would prefer that.