### PR TITLE
fix(a2a): lift hardcoded 5m A2A ceiling and bound MCP connection setup

### DIFF
--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -57,11 +57,11 @@ func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace s
 		return nil, fmt.Errorf("unable to get A2AServer %v: %w", serverKey, err)
 	}
 
-	if a2aServer.Spec.Timeout != "" {
-		timeout, err := time.ParseDuration(a2aServer.Spec.Timeout)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse A2AServer timeout %q: %w", a2aServer.Spec.Timeout, err)
-		}
+	timeout, err := resolveA2AExecutionTimeout(ctx, &a2aServer)
+	if err != nil {
+		return nil, err
+	}
+	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
@@ -156,6 +156,22 @@ type a2aStreamContext struct {
 	agentName    string
 	namespace    string
 	queryName    string
+}
+
+const defaultA2AExecutionTimeout = 5 * time.Minute
+
+func resolveA2AExecutionTimeout(ctx context.Context, a2aServer *arkv1prealpha1.A2AServer) (time.Duration, error) {
+	if a2aServer != nil && a2aServer.Spec.Timeout != "" {
+		timeout, err := time.ParseDuration(a2aServer.Spec.Timeout)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse A2AServer timeout %q: %w", a2aServer.Spec.Timeout, err)
+		}
+		return timeout, nil
+	}
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return 0, nil
+	}
+	return defaultA2AExecutionTimeout, nil
 }
 
 var defaultA2AStreamIdleTimeout = 8 * time.Minute

--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -167,7 +167,8 @@ func withA2AExecutionTimeout(ctx context.Context, a2aServer *arkv1prealpha1.A2AS
 		return nil, nil, err
 	}
 	if timeout <= 0 {
-		return ctx, func() {}, nil
+		ctx, cancel := context.WithCancel(ctx)
+		return ctx, cancel, nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/ark/executors/completions/a2a_execution.go
+++ b/ark/executors/completions/a2a_execution.go
@@ -57,15 +57,11 @@ func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace s
 		return nil, fmt.Errorf("unable to get A2AServer %v: %w", serverKey, err)
 	}
 
-	timeout, err := resolveA2AExecutionTimeout(ctx, &a2aServer)
+	ctx, cancel, err := withA2AExecutionTimeout(ctx, &a2aServer)
 	if err != nil {
 		return nil, err
 	}
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	defer cancel()
 
 	content := ""
 	if userInput.OfUser != nil && userInput.OfUser.Content.OfString.Value != "" {
@@ -95,16 +91,7 @@ func (e *A2AExecutionEngine) Execute(ctx context.Context, agentName, namespace s
 
 	responseMessage := NewAssistantMessage(a2aResponse.Content)
 
-	if eventStream != nil {
-		completionID := getQueryID(ctx)
-		chunk := NewContentChunk(completionID, modelID, a2aResponse.Content)
-		chunk.Choices[0].Delta.Role = RoleAssistant
-		chunk.Choices[0].FinishReason = "stop"
-		chunkWithMeta := WrapChunkWithMetadata(ctx, chunk, modelID, nil)
-		if err := eventStream.StreamChunk(ctx, chunkWithMeta); err != nil {
-			log.Error(err, "failed to send A2A response chunk to event stream")
-		}
-	}
+	streamFinalResponseChunk(ctx, eventStream, modelID, a2aResponse.Content)
 
 	e.eventingRecorder.Complete(ctx, "A2AExecution", "A2A execution completed successfully", operationData)
 
@@ -172,6 +159,19 @@ func resolveA2AExecutionTimeout(ctx context.Context, a2aServer *arkv1prealpha1.A
 		return 0, nil
 	}
 	return defaultA2AExecutionTimeout, nil
+}
+
+func withA2AExecutionTimeout(ctx context.Context, a2aServer *arkv1prealpha1.A2AServer) (context.Context, context.CancelFunc, error) {
+	timeout, err := resolveA2AExecutionTimeout(ctx, a2aServer)
+	if err != nil {
+		return nil, nil, err
+	}
+	if timeout <= 0 {
+		return ctx, func() {}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	return ctx, cancel, nil
 }
 
 var defaultA2AStreamIdleTimeout = 8 * time.Minute
@@ -307,6 +307,20 @@ func streamContentChunk(ctx context.Context, eventStream EventStreamInterface, c
 	chunkWithMeta := WrapChunkWithMetadata(ctx, chunk, modelID, nil)
 	if err := eventStream.StreamChunk(ctx, chunkWithMeta); err != nil {
 		logf.FromContext(ctx).Error(err, "failed to send A2A streaming chunk")
+	}
+}
+
+func streamFinalResponseChunk(ctx context.Context, eventStream EventStreamInterface, modelID, content string) {
+	if eventStream == nil {
+		return
+	}
+
+	chunk := NewContentChunk(getQueryID(ctx), modelID, content)
+	chunk.Choices[0].Delta.Role = RoleAssistant
+	chunk.Choices[0].FinishReason = "stop"
+	chunkWithMeta := WrapChunkWithMetadata(ctx, chunk, modelID, nil)
+	if err := eventStream.StreamChunk(ctx, chunkWithMeta); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to send A2A response chunk to event stream")
 	}
 }
 

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -206,6 +206,40 @@ func TestEffectiveIdleTimeout_ServerTimeoutLonger(t *testing.T) {
 	assert.Equal(t, defaultA2AStreamIdleTimeout, effectiveIdleTimeout(a2aServer))
 }
 
+func TestResolveA2AExecutionTimeout_ServerTimeoutWins(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "30m"},
+	}
+
+	timeout, err := resolveA2AExecutionTimeout(context.Background(), a2aServer)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, timeout)
+}
+
+func TestResolveA2AExecutionTimeout_InvalidServerTimeout(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "not-a-duration"},
+	}
+
+	_, err := resolveA2AExecutionTimeout(context.Background(), a2aServer)
+	require.Error(t, err)
+}
+
+func TestResolveA2AExecutionTimeout_InheritsCallerDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	timeout, err := resolveA2AExecutionTimeout(ctx, &arkv1prealpha1.A2AServer{})
+	require.NoError(t, err)
+	assert.Zero(t, timeout)
+}
+
+func TestResolveA2AExecutionTimeout_DefaultsWhenNoDeadline(t *testing.T) {
+	timeout, err := resolveA2AExecutionTimeout(context.Background(), &arkv1prealpha1.A2AServer{})
+	require.NoError(t, err)
+	assert.Equal(t, defaultA2AExecutionTimeout, timeout)
+}
+
 func TestStreamContentChunkSkipsEmpty(t *testing.T) {
 	ctx := context.Background()
 	stream := &mockEventStream{}

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -260,11 +260,14 @@ func TestWithA2AExecutionTimeout_PreservesCallerDeadline(t *testing.T) {
 
 	ctx, cancel, err := withA2AExecutionTimeout(callerCtx, &arkv1prealpha1.A2AServer{})
 	require.NoError(t, err)
-	defer cancel()
 
 	deadline, ok := ctx.Deadline()
 	require.True(t, ok)
 	assert.WithinDuration(t, time.Now().Add(20*time.Minute), deadline, time.Minute)
+
+	cancel()
+	require.Error(t, ctx.Err())
+	require.NoError(t, callerCtx.Err())
 }
 
 func TestWithA2AExecutionTimeout_InvalidServerTimeout(t *testing.T) {

--- a/ark/executors/completions/a2a_execution_test.go
+++ b/ark/executors/completions/a2a_execution_test.go
@@ -240,6 +240,52 @@ func TestResolveA2AExecutionTimeout_DefaultsWhenNoDeadline(t *testing.T) {
 	assert.Equal(t, defaultA2AExecutionTimeout, timeout)
 }
 
+func TestWithA2AExecutionTimeout_AppliesServerTimeout(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "30m"},
+	}
+
+	ctx, cancel, err := withA2AExecutionTimeout(context.Background(), a2aServer)
+	require.NoError(t, err)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, time.Now().Add(30*time.Minute), deadline, time.Minute)
+}
+
+func TestWithA2AExecutionTimeout_PreservesCallerDeadline(t *testing.T) {
+	callerCtx, callerCancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer callerCancel()
+
+	ctx, cancel, err := withA2AExecutionTimeout(callerCtx, &arkv1prealpha1.A2AServer{})
+	require.NoError(t, err)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, time.Now().Add(20*time.Minute), deadline, time.Minute)
+}
+
+func TestWithA2AExecutionTimeout_InvalidServerTimeout(t *testing.T) {
+	a2aServer := &arkv1prealpha1.A2AServer{
+		Spec: arkv1prealpha1.A2AServerSpec{Timeout: "not-a-duration"},
+	}
+
+	_, _, err := withA2AExecutionTimeout(context.Background(), a2aServer)
+	require.Error(t, err)
+}
+
+func TestStreamFinalResponseChunk(t *testing.T) {
+	stream := &mockEventStream{}
+
+	streamFinalResponseChunk(context.Background(), nil, "model-1", "hello")
+	assert.Empty(t, stream.chunks)
+
+	streamFinalResponseChunk(context.Background(), stream, "model-1", "hello")
+	require.Len(t, stream.chunks, 1)
+}
+
 func TestStreamContentChunkSkipsEmpty(t *testing.T) {
 	ctx := context.Background()
 	stream := &mockEventStream{}

--- a/ark/internal/a2a/a2a.go
+++ b/ark/internal/a2a/a2a.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -44,10 +45,51 @@ var (
 		otelhttp.WithSpanNameFormatter(func(_ string, _ *http.Request) string { return "a2a.discover" }),
 	)
 	sharedA2ASendClient = &http.Client{
-		Timeout:   a2aSendBackstopTimeout,
-		Transport: sharedA2ASendTransport,
+		Transport: &backstopTransport{
+			base:     sharedA2ASendTransport,
+			backstop: a2aSendBackstopTimeout,
+		},
 	}
 )
+
+// backstopTransport bounds requests that carry no deadline of their own. It is
+// deliberately not an http.Client.Timeout: that bounds every exchange
+// regardless of context, so it would cap a caller that asked for longer via
+// Query.spec.timeout or A2AServer.spec.timeout instead of backstopping one that
+// asked for nothing.
+type backstopTransport struct {
+	base     http.RoundTripper
+	backstop time.Duration
+}
+
+func (t *backstopTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, hasDeadline := req.Context().Deadline(); hasDeadline {
+		return t.base.RoundTrip(req)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), t.backstop)
+	resp, err := t.base.RoundTrip(req.WithContext(ctx))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	// The deadline must outlive RoundTrip to cover the body read, so ownership
+	// of cancel transfers to the body.
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}
 
 func getA2ADiscoveryTimeout() time.Duration {
 	if timeoutStr := os.Getenv("ARK_A2A_DISCOVERY_TIMEOUT"); timeoutStr != "" {

--- a/ark/internal/a2a/a2a.go
+++ b/ark/internal/a2a/a2a.go
@@ -28,6 +28,8 @@ import (
 
 const defaultA2ADiscoveryTimeoutSeconds = 30
 
+const a2aSendBackstopTimeout = 30 * time.Minute
+
 var sharedA2ABaseTransport = &http.Transport{
 	MaxIdleConns:        100,
 	MaxIdleConnsPerHost: 10,
@@ -42,7 +44,7 @@ var (
 		otelhttp.WithSpanNameFormatter(func(_ string, _ *http.Request) string { return "a2a.discover" }),
 	)
 	sharedA2ASendClient = &http.Client{
-		Timeout:   5 * time.Minute,
+		Timeout:   a2aSendBackstopTimeout,
 		Transport: sharedA2ASendTransport,
 	}
 )

--- a/ark/internal/a2a/a2a_timeout_test.go
+++ b/ark/internal/a2a/a2a_timeout_test.go
@@ -2,8 +2,11 @@ package a2a
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,9 +14,86 @@ import (
 )
 
 func TestSharedA2ASendClientDoesNotCapContextDeadline(t *testing.T) {
-	require.Equal(t, a2aSendBackstopTimeout, sharedA2ASendClient.Timeout)
-	require.Greater(t, sharedA2ASendClient.Timeout, 5*time.Minute,
-		"client timeout must stay above the 5m Query.spec.timeout default, or it caps the context deadline instead of backstopping it")
+	require.Zero(t, sharedA2ASendClient.Timeout,
+		"http.Client.Timeout bounds every exchange regardless of context, so it would cap a caller that asked for longer via Query.spec.timeout")
+	require.IsType(t, &backstopTransport{}, sharedA2ASendClient.Transport,
+		"the backstop must be applied per-request so it only covers deadline-less callers")
+}
+
+type recordingRoundTripper struct {
+	deadline    time.Time
+	hasDeadline bool
+	ctx         context.Context
+	body        io.ReadCloser
+	err         error
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.ctx = req.Context()
+	rt.deadline, rt.hasDeadline = req.Context().Deadline()
+	if rt.err != nil {
+		return nil, rt.err
+	}
+
+	body := rt.body
+	if body == nil {
+		body = io.NopCloser(strings.NewReader(""))
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+}
+
+func TestBackstopTransportLeavesCallerDeadlineUntouched(t *testing.T) {
+	recorder := &recordingRoundTripper{}
+	transport := &backstopTransport{base: recorder, backstop: 30 * time.Minute}
+
+	callerDeadline := time.Now().Add(time.Hour)
+	ctx, cancel := context.WithDeadline(t.Context(), callerDeadline)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	require.True(t, recorder.hasDeadline)
+	require.WithinDuration(t, callerDeadline, recorder.deadline, time.Second,
+		"a caller asking for an hour must not be cut to the backstop")
+}
+
+func TestBackstopTransportBoundsDeadlinelessRequest(t *testing.T) {
+	recorder := &recordingRoundTripper{}
+	transport := &backstopTransport{base: recorder, backstop: 30 * time.Minute}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.True(t, recorder.hasDeadline, "a request with no deadline must pick up the backstop")
+	require.WithinDuration(t, time.Now().Add(30*time.Minute), recorder.deadline, time.Minute)
+
+	require.NoError(t, recorder.ctx.Err(), "the deadline must outlive RoundTrip to cover the body read")
+	require.NoError(t, resp.Body.Close())
+	require.ErrorIs(t, recorder.ctx.Err(), context.Canceled, "closing the body must release the context")
+}
+
+func TestBackstopTransportReleasesContextOnError(t *testing.T) {
+	recorder := &recordingRoundTripper{err: errors.New("dial failed")}
+	transport := &backstopTransport{base: recorder, backstop: 30 * time.Minute}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, recorder.ctx.Err(), context.Canceled)
 }
 
 func TestSharedA2ASendClientHonoursContextDeadline(t *testing.T) {

--- a/ark/internal/a2a/a2a_timeout_test.go
+++ b/ark/internal/a2a/a2a_timeout_test.go
@@ -1,0 +1,39 @@
+package a2a
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedA2ASendClientDoesNotCapContextDeadline(t *testing.T) {
+	require.Equal(t, a2aSendBackstopTimeout, sharedA2ASendClient.Timeout)
+	require.Greater(t, sharedA2ASendClient.Timeout, 5*time.Minute,
+		"client timeout must stay above the 5m Query.spec.timeout default, or it caps the context deadline instead of backstopping it")
+}
+
+func TestSharedA2ASendClientHonoursContextDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	resp, err := sharedA2ASendClient.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), 30*time.Second)
+}

--- a/ark/internal/controller/a2atask_controller.go
+++ b/ark/internal/controller/a2atask_controller.go
@@ -31,6 +31,7 @@ const (
 	defaultTaskTimeout         = 12 * time.Hour
 	defaultTaskTTL             = 720 * time.Hour
 	maxPollBackoff             = 5 * time.Minute
+	pollRequestTimeout         = 30 * time.Second
 	rateLimitBackoffFloor      = 30 * time.Second
 	maxBackoffExponent         = 16
 )
@@ -205,6 +206,9 @@ func (r *A2ATaskReconciler) handlePollFailure(ctx context.Context, a2aTask *arkv
 
 // fetchA2ATaskStatus queries the A2A server for the current task status and updates the A2ATask
 func (r *A2ATaskReconciler) fetchA2ATaskStatus(ctx context.Context, a2aTask *arkv1alpha1.A2ATask) error {
+	ctx, cancel := context.WithTimeout(ctx, pollRequestTimeout)
+	defer cancel()
+
 	a2aClient, err := r.createA2AClient(ctx, a2aTask)
 	if err != nil {
 		return err

--- a/ark/internal/mcp/mcp.go
+++ b/ark/internal/mcp/mcp.go
@@ -205,6 +205,25 @@ func attemptMCPConnection(ctx context.Context, mcpClient *mcpsdk.Client, url str
 	return session, nil
 }
 
+// attemptMCPConnectionWithin bounds connection establishment by deadlineCtx
+// without tying the resulting session's lifetime to it. Passing deadlineCtx
+// straight to Connect would break SSE: SSEClientTransport binds its long-lived
+// hanging GET to the connect context, so cancelling it severs an established
+// session. Only cancel the connect context when the handshake fails.
+func attemptMCPConnectionWithin(ctx, deadlineCtx context.Context, mcpClient *mcpsdk.Client, url string, headers map[string]string, transportType string) (*mcpsdk.ClientSession, error) {
+	connectCtx, cancelConnect := context.WithCancel(ctx)
+	stopDeadlineWatch := context.AfterFunc(deadlineCtx, cancelConnect)
+
+	session, err := attemptMCPConnection(connectCtx, mcpClient, url, headers, transportType)
+	stopDeadlineWatch()
+	if err != nil {
+		cancelConnect()
+		return nil, err
+	}
+
+	return session, nil
+}
+
 func createMCPClientWithRetry(ctx context.Context, url string, headers map[string]string, transportType string, httpTimeout time.Duration, maxRetries int) (*MCPClient, error) {
 	mcpClient := createHTTPClient()
 
@@ -220,7 +239,7 @@ func createMCPClientWithRetry(ctx context.Context, url string, headers map[strin
 			}
 		}
 
-		session, err := attemptMCPConnection(ctx, mcpClient, url, headers, transportType)
+		session, err := attemptMCPConnectionWithin(ctx, retryCtx, mcpClient, url, headers, transportType)
 		if err == nil {
 			return &MCPClient{
 				URL:     url,

--- a/ark/internal/mcp/mcp_test.go
+++ b/ark/internal/mcp/mcp_test.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -205,6 +208,57 @@ func (m *mcpServerMock) sayHi(ctx context.Context, req *mcpsdk.CallToolRequest, 
 			&mcpsdk.TextContent{Text: "Hi " + args.Name},
 		},
 	}, nil, nil
+}
+
+func TestNewMCPClientBoundsConnectionByTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if bytes.Contains(body, []byte(`"method":"initialize"`)) {
+			<-r.Context().Done()
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	start := time.Now()
+	client, err := NewMCPClient(t.Context(), server.URL, nil, httpTransport, 300*time.Millisecond, MCPSettings{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.Less(t, elapsed, 30*time.Second, "connection establishment must be bounded by the configured timeout")
+}
+
+func TestNewMCPClientSessionOutlivesConnectTimeout(t *testing.T) {
+	for _, transportType := range []string{httpTransport, sseTransport} {
+		t.Run(transportType, func(t *testing.T) {
+			mcpServerMock := mcpServerMock{}.New(t, mcpConnectionOps{transport: transportType})
+
+			var handler http.Handler
+			switch transportType {
+			case sseTransport:
+				handler = mcpsdk.NewSSEHandler(mcpServerMock.getServerFn(), nil)
+			default:
+				handler = mcpsdk.NewStreamableHTTPHandler(mcpServerMock.getServerFn(), nil)
+			}
+
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+
+			connectTimeout := 500 * time.Millisecond
+			client, err := NewMCPClient(t.Context(), server.URL, nil, transportType, connectTimeout, MCPSettings{})
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			t.Cleanup(func() { _ = client.Client.Close() })
+
+			time.Sleep(2 * connectTimeout)
+
+			tools, err := client.ListTools(t.Context())
+			require.NoError(t, err, "session must survive expiry of the connection timeout")
+			require.Equal(t, "greet", tools[0].Name)
+		})
+	}
 }
 
 func TestCreateTransportHasNoClientTimeout(t *testing.T) {

--- a/docs/content/developer-guide/building-a2a-servers.mdx
+++ b/docs/content/developer-guide/building-a2a-servers.mdx
@@ -175,7 +175,7 @@ A2A execution automatically respects query timeouts:
 1. **Query.spec.timeout** (default: 5 minutes) sets the overall time limit
 2. **A2AServer.spec.timeout** (optional) can reduce the timeout for specific A2A servers
 
-The A2A execution uses Go's context deadline, so remaining time is automatically tracked as the query progresses.
+The A2A execution uses Go's context deadline, so remaining time is automatically tracked as the query progresses. Values above 5 minutes take effect: the HTTP client that carries A2A requests keeps only a 30 minute backstop for callers that set no deadline of their own.
 
 ### Configuring A2AServer Timeout
 

--- a/docs/content/reference/resources/a2aserver.mdx
+++ b/docs/content/reference/resources/a2aserver.mdx
@@ -35,7 +35,7 @@ spec:
             name: a2a-credentials
             key: token
   pollInterval: 1m                            # how often to poll the server; default '1m'
-  timeout: 5m                                 # A2A agent execution timeout; default '5m'
+  timeout: 5m                                 # A2A agent execution timeout; inherits Query.spec.timeout when unset
 ```
 
 ## Fields
@@ -46,7 +46,7 @@ spec:
 | `spec.headers[]` | list of `Header` | no | HTTP headers sent on every request to the server, typically for authentication. Each entry has a `name` and a `value` that is inline or sourced via `valueFrom` (`secretKeyRef`, `configMapKeyRef`, or `queryParameterRef`). |
 | `spec.description` | string | no | Human-readable description of the server. Propagated onto the Agent resources Ark creates. |
 | `spec.pollInterval` | duration | no | How often the controller polls the server for updates. Default `1m`. |
-| `spec.timeout` | duration | no | Timeout for A2A agent execution (`30s`, `5m`, `1h`). Default `5m`. |
+| `spec.timeout` | duration | no | Timeout for A2A agent execution (`30s`, `5m`, `1h`). When unset, execution inherits the deadline from [`Query.spec.timeout`](/reference/resources/query#timeout), falling back to `5m` if the caller set no deadline. |
 
 ## Discovery and created agents
 


### PR DESCRIPTION
## Summary

Parts A and B of #3032. Part C (a new `MCPServer.spec.toolCallTimeout` field plus corrected `timeout` docs) follows in a separate PR.

- **Lift the A2A ceiling.** `sharedA2ASendClient` carried `http.Client{Timeout: 5 * time.Minute}`, which bounds the entire exchange and so preempted any longer context deadline — `Query.spec.timeout: 30m` had no effect and `A2AServer.spec.timeout` was silently capped. Replaced with a 30m backstop; the context deadline is now authoritative.
- **Give the two deadline-less callers a deadline first.** `executeA2AAgent` resolves `A2AServer.spec.timeout`, otherwise inherits the caller's deadline, falling back to 5m only when the caller set none. `A2ATaskReconciler.fetchA2ATaskStatus` gets a 30s bound instead of running on the bare reconcile context.
- **Bound MCP connection establishment** by `MCPServer.spec.timeout`, which previously only sized the retry backoff window.
- Docs: `A2AServer.spec.timeout` no longer claims a `5m` default that was never implemented, and the A2A guide records that values above 5 minutes now take effect.

### Note on the MCP fix

The issue sketched this as passing `retryCtx` straight to `attemptMCPConnection`. That breaks SSE: `SSEClientTransport.Connect` binds its long-lived hanging GET to the connect context and hands `resp.Body` to the session (`go-sdk@v1.5.0/mcp/sse.go`), so `defer retryCancel()` severs the session the moment `NewMCPClient` returns. `StreamableClientTransport` is unaffected because it detaches. `attemptMCPConnectionWithin` therefore cancels the handshake context on failure but never on success, and `TestNewMCPClientSessionOutlivesConnectTimeout` guards it — that test fails on the `sse` case against the naive version.

One residual limit, upstream: a server that accepts TCP and never responds can still hang `Connect`, because on cancellation the SDK sends `notifications/cancelled` with a detached context over a client that intentionally has no `Timeout` (a client timeout would kill SSE streams — see `TestCreateTransportHasNoClientTimeout`).

The separate 1-minute ceiling in the dashboard/ark-api path (#914) is unchanged.

Refs #3032 — part C (the `toolCallTimeout` field) still outstanding, so this does not close the issue.

