### PR TITLE
fix: bump undici to 7.29.0 in docs and ark-broker for CVE-2026-13697

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "y",
       "version": "0.1.67",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@napi-rs/simple-git": "^0.1.19",
         "@theguild/remark-mermaid": "^0.3.0",
@@ -9063,9 +9063,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -9670,9 +9670,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Bump transitive `undici` dependency from 7.28.0 to 7.29.0 in `docs/package-lock.json` and `services/ark-broker/ark-broker/package-lock.json` to resolve CVE-2026-13697 (XRAY-1038201, High severity)

Closes https://github.com/mckinsey/agents-at-scale-ark/issues/3050