### PR TITLE
fix: update brace-expansion dependency to version 5.0.9 across multiple packages

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2991,9 +2991,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,7 +45,7 @@
     "@napi-rs/simple-git-linux-x64-musl": "^1.1.0"
   },
   "overrides": {
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "undici": "^7.28.0",
     "rollup": "4.59.0",
     "minimatch": "^10.2.3",

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -3531,9 +3531,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -87,7 +87,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "esbuild": "^0.28.1",
     "ws": "^8.21.0",
     "form-data": "^4.0.6",

--- a/services/ark-dashboard/ark-dashboard/package-lock.json
+++ b/services/ark-dashboard/ark-dashboard/package-lock.json
@@ -5462,9 +5462,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/services/ark-dashboard/ark-dashboard/package.json
+++ b/services/ark-dashboard/ark-dashboard/package.json
@@ -120,7 +120,7 @@
     "uuid": "^14.0.0",
     "postcss": "^8.5.18",
     "ws": "^8.21.0",
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",
     "vite": "^8.0.16",

--- a/services/ark-landing-page/package-lock.json
+++ b/services/ark-landing-page/package-lock.json
@@ -2706,9 +2706,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/services/ark-landing-page/package.json
+++ b/services/ark-landing-page/package.json
@@ -37,7 +37,7 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^3.15.0"
     },
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "ip-address": "^10.3.1",
     "jsonpath-plus": "^10.3.0",
     "tough-cookie": "^4.1.3",

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -85,7 +85,7 @@
     "node": ">=18.0.0"
   },
   "overrides": {
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "ip-address": "^10.3.1",
     "minimatch": "^10.2.3",
     "rollup": "4.59.0",


### PR DESCRIPTION
## Summary
- Resolve JFrog Xray violation XRAY-1039160 (High): DoS via unbounded intermediate arrays in `brace-expansion`, which bypasses the GHSA-mh99-v99m-4gvg mitigation shipped in 5.0.8
- Bump `brace-expansion` from 5.0.8 to 5.0.9 in the five affected lockfiles: `docs`, `tools/ark-cli`, `ark-broker`, `ark-dashboard`, `ark-landing-page`
- Raise the `brace-expansion` override from `>=5.0.7` to `>=5.0.9` in the same five packages, so a future `npm install` cannot re-resolve down to 5.0.8
- 5.0.9 was published 2026-07-30 10:00 UTC, five hours before the scan that flagged it. The existing `>=5.0.7` overrides could not pick the patch up because the lockfiles freeze resolution

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 