### PR TITLE
feat(mcp): add MCPServer.spec.toolCallTimeout to bound individual tool calls

### DIFF
--- a/ark/api/v1alpha1/mcpserver_types.go
+++ b/ark/api/v1alpha1/mcpserver_types.go
@@ -11,12 +11,20 @@ type MCPServerSpec struct {
 	Address ValueSource `json:"address"`
 	// +kubebuilder:validation:Optional
 	Headers []Header `json:"headers,omitempty"`
-	// Timeout specifies the maximum duration for MCP tool calls to this server.
-	// Use this to support long-running operations (e.g., "5m", "10m", "30m").
+	// Timeout bounds establishing the connection to this server, including the
+	// connection retry window. It does not bound individual tool calls once the
+	// connection is established - use toolCallTimeout for that.
 	// Defaults to "30s" if not specified.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="30s"
 	Timeout string `json:"timeout,omitempty"`
+	// ToolCallTimeout bounds each individual tool call to this server
+	// (e.g., "30s", "5m", "10m"). Use this to support long-running operations.
+	// When unset, a tool call is bounded only by the execution budget of the
+	// query that triggered it.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	ToolCallTimeout string `json:"toolCallTimeout,omitempty"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=http;sse
 	// +kubebuilder:default="http"

--- a/ark/config/crd/bases/ark.mckinsey.com_mcpservers.yaml
+++ b/ark/config/crd/bases/ark.mckinsey.com_mcpservers.yaml
@@ -262,9 +262,18 @@ spec:
               timeout:
                 default: 30s
                 description: |-
-                  Timeout specifies the maximum duration for MCP tool calls to this server.
-                  Use this to support long-running operations (e.g., "5m", "10m", "30m").
+                  Timeout bounds establishing the connection to this server, including the
+                  connection retry window. It does not bound individual tool calls once the
+                  connection is established - use toolCallTimeout for that.
                   Defaults to "30s" if not specified.
+                type: string
+              toolCallTimeout:
+                description: |-
+                  ToolCallTimeout bounds each individual tool call to this server
+                  (e.g., "30s", "5m", "10m"). Use this to support long-running operations.
+                  When unset, a tool call is bounded only by the execution budget of the
+                  query that triggered it.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               transport:
                 default: http

--- a/ark/dist/chart/templates/crd/ark.mckinsey.com_mcpservers.yaml
+++ b/ark/dist/chart/templates/crd/ark.mckinsey.com_mcpservers.yaml
@@ -269,9 +269,18 @@ spec:
               timeout:
                 default: 30s
                 description: |-
-                  Timeout specifies the maximum duration for MCP tool calls to this server.
-                  Use this to support long-running operations (e.g., "5m", "10m", "30m").
+                  Timeout bounds establishing the connection to this server, including the
+                  connection retry window. It does not bound individual tool calls once the
+                  connection is established - use toolCallTimeout for that.
                   Defaults to "30s" if not specified.
+                type: string
+              toolCallTimeout:
+                description: |-
+                  ToolCallTimeout bounds each individual tool call to this server
+                  (e.g., "30s", "5m", "10m"). Use this to support long-running operations.
+                  When unset, a tool call is bounded only by the execution budget of the
+                  query that triggered it.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               transport:
                 default: http

--- a/ark/executors/completions/agent_tools.go
+++ b/ark/executors/completions/agent_tools.go
@@ -156,6 +156,12 @@ func createMCPExecutor(ctx context.Context, k8sClient client.Client, tool *arkv1
 		timeout = parsedTimeout
 	}
 
+	toolCallTimeout, err := arkmcp.ParseToolCallTimeout(mcpServerCRD.Spec.ToolCallTimeout)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "ignoring invalid MCPServer spec.toolCallTimeout; tool calls will inherit the query execution budget",
+			"mcpServer", mcpServerKey.String(), "tool", tool.Name)
+	}
+
 	mcpClient, err := mcpPool.GetOrCreateClient(
 		ctx,
 		arkmcp.MCPClientConfig{
@@ -165,6 +171,7 @@ func createMCPExecutor(ctx context.Context, k8sClient client.Client, tool *arkv1
 			Headers:         headers,
 			Transport:       mcpServerCRD.Spec.Transport,
 			Timeout:         timeout,
+			ToolCallTimeout: toolCallTimeout,
 		},
 		mcpSettings,
 	)

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -3,6 +3,7 @@ package completions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,6 +42,10 @@ func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 		Arguments: arguments,
 	})
 	if err != nil {
+		if errors.Is(err, arkmcp.ErrToolCallTimeout) {
+			log.Error(err, "tool call exceeded toolCallTimeout", "tool", m.ToolName)
+			return ToolResult{ID: call.ID, Name: call.Function.Name, Content: "", Error: err.Error()}, err
+		}
 		log.Info("tool call error", "tool", m.ToolName, "error", err, "errorType", fmt.Sprintf("%T", err))
 		return ToolResult{ID: call.ID, Name: call.Function.Name, Content: ""}, err
 	}

--- a/ark/executors/completions/mcp_test.go
+++ b/ark/executors/completions/mcp_test.go
@@ -1,0 +1,224 @@
+package completions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	arkmcp "mckinsey.com/ark/internal/mcp"
+)
+
+const (
+	testConnectTimeout  = 5 * time.Second
+	testToolCallTimeout = 200 * time.Millisecond
+	testCallSlack       = 30 * time.Second
+
+	testToolGreet = "greet"
+	testToolSlow  = "slow"
+)
+
+type greetParams struct {
+	Name string `json:"name"`
+}
+
+func newTestMCPServer(t *testing.T) string {
+	t.Helper()
+
+	release := make(chan struct{})
+	server := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "greeter", Version: "v0.0.1"}, nil)
+
+	mcpsdk.AddTool(server, &mcpsdk.Tool{Name: testToolGreet, Description: "say hi"},
+		func(ctx context.Context, req *mcpsdk.CallToolRequest, args greetParams) (*mcpsdk.CallToolResult, any, error) {
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "Hi " + args.Name}},
+			}, nil, nil
+		})
+
+	mcpsdk.AddTool(server, &mcpsdk.Tool{Name: testToolSlow, Description: "blocks until released"},
+		func(ctx context.Context, req *mcpsdk.CallToolRequest, args greetParams) (*mcpsdk.CallToolResult, any, error) {
+			select {
+			case <-release:
+				return &mcpsdk.CallToolResult{
+					Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "finally"}},
+				}, nil, nil
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
+		})
+
+	httpServer := httptest.NewServer(mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return server }, nil,
+	))
+
+	t.Cleanup(func() {
+		close(release)
+		httpServer.Close()
+	})
+
+	return httpServer.URL
+}
+
+func newTestMCPClient(t *testing.T, toolCallTimeout time.Duration) *arkmcp.MCPClient {
+	t.Helper()
+
+	mcpClient, err := arkmcp.NewMCPClient(t.Context(), newTestMCPServer(t), nil, "http", testConnectTimeout,
+		arkmcp.MCPSettings{}, arkmcp.WithToolCallTimeout(toolCallTimeout))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mcpClient.Client.Close() })
+
+	return mcpClient
+}
+
+func greetCall() ToolCall {
+	call := ToolCall{ID: "call-1"}
+	call.Function.Name = testToolGreet
+	call.Function.Arguments = `{"name":"ark"}`
+	return call
+}
+
+func TestMCPExecutorNilClient(t *testing.T) {
+	executor := &MCPExecutor{ToolName: testToolGreet}
+
+	result, err := executor.Execute(t.Context(), greetCall())
+
+	require.ErrorContains(t, err, "MCP client not initialized for tool greet")
+	require.Empty(t, result.Content)
+}
+
+func TestMCPExecutorNilSession(t *testing.T) {
+	executor := &MCPExecutor{MCPClient: &arkmcp.MCPClient{}, ToolName: testToolGreet}
+
+	result, err := executor.Execute(t.Context(), greetCall())
+
+	require.ErrorContains(t, err, "MCP client connection not initialized for tool greet")
+	require.Empty(t, result.Content)
+}
+
+func TestMCPExecutorSucceedsWithinToolCallTimeout(t *testing.T) {
+	executor := &MCPExecutor{
+		MCPClient: newTestMCPClient(t, testConnectTimeout),
+		ToolName:  testToolGreet,
+	}
+
+	result, err := executor.Execute(t.Context(), greetCall())
+
+	require.NoError(t, err)
+	require.Equal(t, "Hi ark", result.Content)
+	require.Empty(t, result.Error)
+}
+
+func TestMCPExecutorBoundsToolCallByToolCallTimeout(t *testing.T) {
+	executor := &MCPExecutor{
+		MCPClient: newTestMCPClient(t, testToolCallTimeout),
+		ToolName:  testToolSlow,
+	}
+
+	call := greetCall()
+	call.Function.Name = testToolSlow
+
+	start := time.Now()
+	result, err := executor.Execute(t.Context(), call)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, arkmcp.ErrToolCallTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, `tool "slow"`)
+	require.ErrorContains(t, err, testToolCallTimeout.String())
+	require.Less(t, elapsed, testCallSlack, "the call must be bounded, not left hanging")
+	require.Empty(t, result.Content)
+	require.Equal(t, err.Error(), result.Error, "the timeout must reach the tool message, not surface as a blank result")
+}
+
+func TestMCPExecutorSessionSurvivesToolCallTimeout(t *testing.T) {
+	mcpClient := newTestMCPClient(t, testToolCallTimeout)
+
+	slow := &MCPExecutor{MCPClient: mcpClient, ToolName: testToolSlow}
+	slowCall := greetCall()
+	slowCall.Function.Name = testToolSlow
+
+	_, err := slow.Execute(t.Context(), slowCall)
+	require.ErrorIs(t, err, arkmcp.ErrToolCallTimeout)
+
+	fast := &MCPExecutor{MCPClient: mcpClient, ToolName: testToolGreet}
+	result, err := fast.Execute(t.Context(), greetCall())
+	require.NoError(t, err, "a per-call deadline must not damage the shared session")
+	require.Equal(t, "Hi ark", result.Content)
+
+	tools, err := mcpClient.ListTools(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, tools)
+}
+
+func TestMCPExecutorWithoutToolCallTimeoutInheritsContext(t *testing.T) {
+	executor := &MCPExecutor{MCPClient: newTestMCPClient(t, 0), ToolName: testToolSlow}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testToolCallTimeout)
+	defer cancel()
+
+	call := greetCall()
+	call.Function.Name = testToolSlow
+
+	result, err := executor.Execute(ctx, call)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, arkmcp.ErrToolCallTimeout,
+		"a query budget expiry must not be reported as a per-server toolCallTimeout")
+	require.Empty(t, result.Error)
+}
+
+func TestCreateMCPExecutorResolvesToolCallTimeout(t *testing.T) {
+	tests := []struct {
+		name            string
+		toolCallTimeout string
+	}{
+		{name: "valid duration", toolCallTimeout: "90s"},
+		{name: "unset inherits the query budget", toolCallTimeout: ""},
+		{name: "unparseable value falls back without failing registration", toolCallTimeout: "banana"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverURL := newTestMCPServer(t)
+
+			mcpServer := &arkv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+				Spec: arkv1alpha1.MCPServerSpec{
+					Address:         arkv1alpha1.ValueSource{Value: serverURL},
+					Transport:       "http",
+					Timeout:         "5s",
+					ToolCallTimeout: tt.toolCallTimeout,
+				},
+			}
+			tool := &arkv1alpha1.Tool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-tool", Namespace: "default"},
+				Spec: arkv1alpha1.ToolSpec{
+					Type: "mcp",
+					MCP: &arkv1alpha1.MCPToolRef{
+						MCPServerRef: arkv1alpha1.MCPServerRef{Name: "test-server", Namespace: "default"},
+						ToolName:     testToolGreet,
+					},
+				},
+			}
+
+			k8sClient := setupTestClientForTools([]client.Object{mcpServer, tool})
+			pool := arkmcp.NewMCPClientPool()
+			t.Cleanup(func() { _ = pool.Close() })
+
+			executor, err := createMCPExecutor(t.Context(), k8sClient, tool, "default", pool, nil)
+			require.NoError(t, err, "an invalid toolCallTimeout must not fail tool registration")
+
+			mcpExecutor, ok := executor.(*MCPExecutor)
+			require.True(t, ok)
+			require.NotNil(t, mcpExecutor.MCPClient)
+		})
+	}
+}

--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -578,8 +578,13 @@ func (r *MCPServerReconciler) createMCPClient(ctx context.Context, mcpServer *ar
 
 	timeout := parseTimeout(mcpServer.Spec.Timeout)
 
+	toolCallTimeout, err := arkmcp.ParseToolCallTimeout(mcpServer.Spec.ToolCallTimeout)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "ignoring invalid MCPServer spec.toolCallTimeout", "mcpServer", mcpServer.Name)
+	}
+
 	// MCP settings are not needed for listing tools, etc.
-	mcpClient, err := arkmcp.NewMCPClient(ctx, mcpURL, headers, mcpServer.Spec.Transport, timeout, arkmcp.MCPSettings{})
+	mcpClient, err := arkmcp.NewMCPClient(ctx, mcpURL, headers, mcpServer.Spec.Transport, timeout, arkmcp.MCPSettings{}, arkmcp.WithToolCallTimeout(toolCallTimeout))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP client: %w", err)
 	}

--- a/ark/internal/mcp/calltool_test.go
+++ b/ark/internal/mcp/calltool_test.go
@@ -252,3 +252,31 @@ func TestCallToolHonorsRetryAfter(t *testing.T) {
 	require.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond)
 	require.Equal(t, 2, server.toolCalls())
 }
+
+func TestCallToolTimeoutBoundsWholeRetrySequence(t *testing.T) {
+	server := newFlakyMCPServer(t, -1, http.StatusTooManyRequests, "")
+	cfg := RetryConfig{MaxAttempts: 50, Budget: time.Minute, BaseDelay: 20 * time.Millisecond, MaxDelay: 40 * time.Millisecond}
+	client, err := NewMCPClient(context.Background(), server.URL, nil, httpTransport, 5*time.Second, MCPSettings{},
+		WithToolCallRetry(cfg), WithToolCallTimeout(200*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Client.Close() })
+
+	start := time.Now()
+	_, err = client.CallTool(context.Background(), echoParams())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 30*time.Second, "toolCallTimeout must bound the retry sequence, not just one attempt")
+	require.Less(t, server.toolCalls(), cfg.MaxAttempts, "the sequence must stop before exhausting the attempt budget")
+}
+
+func TestCallToolWithoutTimeoutRunsFullRetrySequence(t *testing.T) {
+	server := newFlakyMCPServer(t, 2, http.StatusTooManyRequests, "")
+	client := newRetryTestClient(t, server.URL, fastRetryConfig())
+
+	result, err := client.CallTool(context.Background(), echoParams())
+
+	require.NoError(t, err, "an unset toolCallTimeout must leave retry behaviour untouched")
+	require.NotNil(t, result)
+	require.Equal(t, 3, server.toolCalls())
+}

--- a/ark/internal/mcp/mcp.go
+++ b/ark/internal/mcp/mcp.go
@@ -25,11 +25,12 @@ type MCPSettings struct {
 }
 
 type MCPClient struct {
-	URL        string
-	Headers    map[string]string
-	Client     *mcpsdk.ClientSession
-	retry      RetryConfig
-	serverName string
+	URL             string
+	Headers         map[string]string
+	Client          *mcpsdk.ClientSession
+	retry           RetryConfig
+	toolCallTimeout time.Duration
+	serverName      string
 }
 
 type Option func(*MCPClient)
@@ -37,6 +38,12 @@ type Option func(*MCPClient)
 func WithToolCallRetry(cfg RetryConfig) Option {
 	return func(c *MCPClient) {
 		c.retry = cfg
+	}
+}
+
+func WithToolCallTimeout(timeout time.Duration) Option {
+	return func(c *MCPClient) {
+		c.toolCallTimeout = timeout
 	}
 }
 
@@ -57,6 +64,8 @@ var (
 	ErrConnectionRetryFailed = "context timeout while retrying MCP client creation for server"
 	ErrUnsupportedTransport  = "unsupported transport type"
 )
+
+var ErrToolCallTimeout = errors.New("mcp tool call timeout")
 
 // UnauthorizedError indicates the MCP server responded with HTTP 401. It
 // carries the WWW-Authenticate header so callers can perform RFC 9728

--- a/ark/internal/mcp/pool.go
+++ b/ark/internal/mcp/pool.go
@@ -14,6 +14,23 @@ type MCPClientConfig struct {
 	Headers         map[string]string
 	Transport       string
 	Timeout         time.Duration
+	ToolCallTimeout time.Duration
+}
+
+func ParseToolCallTimeout(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid toolCallTimeout %q: %w", raw, err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("invalid toolCallTimeout %q: must be positive", raw)
+	}
+
+	return timeout, nil
 }
 
 type MCPClientPool struct {
@@ -48,7 +65,7 @@ func (p *MCPClientPool) GetOrCreateClient(ctx context.Context, cfg MCPClientConf
 
 	mcpSetting := mcpSettings[key]
 
-	opts := append([]Option{WithServerName(key)}, p.opts...)
+	opts := append([]Option{WithServerName(key), WithToolCallTimeout(cfg.ToolCallTimeout)}, p.opts...)
 	mcpClient, err := NewMCPClient(ctx, cfg.ServerURL, cfg.Headers, cfg.Transport, cfg.Timeout, mcpSetting, opts...)
 	if err != nil {
 		return nil, err

--- a/ark/internal/mcp/pool_test.go
+++ b/ark/internal/mcp/pool_test.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMCPClientPool_GetOrCreateClient_ReturnsCachedClient(t *testing.T) {
@@ -40,4 +42,55 @@ func TestMCPClientPool_GetOrCreateClient_WritePath_UnsupportedTransport(t *testi
 
 	assert.ErrorContains(t, err, ErrUnsupportedTransport)
 	assert.Empty(t, p.clients)
+}
+
+func TestMCPClientPool_GetOrCreateClient_PropagatesToolCallTimeout(t *testing.T) {
+	server := newFlakyMCPServer(t, 0, 0, "")
+	p := NewMCPClientPool()
+	t.Cleanup(func() { _ = p.Close() })
+
+	client, err := p.GetOrCreateClient(t.Context(), MCPClientConfig{
+		ServerNamespace: "default",
+		ServerName:      "my-server",
+		ServerURL:       server.URL,
+		Transport:       httpTransport,
+		Timeout:         5 * time.Second,
+		ToolCallTimeout: 90 * time.Second,
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, 90*time.Second, client.toolCallTimeout)
+}
+
+func TestParseToolCallTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected time.Duration
+		errorMsg string
+	}{
+		{name: "unset means inherit the caller budget", raw: "", expected: 0},
+		{name: "minutes", raw: "5m", expected: 5 * time.Minute},
+		{name: "milliseconds", raw: "500ms", expected: 500 * time.Millisecond},
+		{name: "compound", raw: "1m30s", expected: 90 * time.Second},
+		{name: "unparseable unit", raw: "5min", errorMsg: `invalid toolCallTimeout "5min"`},
+		{name: "no unit", raw: "30", errorMsg: `invalid toolCallTimeout "30"`},
+		{name: "zero", raw: "0s", errorMsg: "must be positive"},
+		{name: "negative", raw: "-1s", errorMsg: "must be positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseToolCallTimeout(tt.raw)
+
+			if tt.errorMsg != "" {
+				require.ErrorContains(t, err, tt.errorMsg)
+				require.Zero(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
 }

--- a/ark/internal/mcp/retry.go
+++ b/ark/internal/mcp/retry.go
@@ -90,6 +90,23 @@ func (c *MCPClient) CallTool(ctx context.Context, params *mcpsdk.CallToolParams)
 		return nil, errors.New("MCP client session not initialized")
 	}
 
+	if c.toolCallTimeout <= 0 {
+		return c.callToolWithRetry(ctx, params)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, c.toolCallTimeout)
+	defer cancel()
+
+	result, err := c.callToolWithRetry(callCtx, params)
+	if err != nil && callCtx.Err() != nil && ctx.Err() == nil {
+		return nil, fmt.Errorf("%w: tool %q on MCP server %s exceeded the configured spec.toolCallTimeout of %s: %w",
+			ErrToolCallTimeout, params.Name, c.URL, c.toolCallTimeout, err)
+	}
+
+	return result, err
+}
+
+func (c *MCPClient) callToolWithRetry(ctx context.Context, params *mcpsdk.CallToolParams) (*mcpsdk.CallToolResult, error) {
 	log := logf.FromContext(ctx)
 	cfg := c.retry.withDefaults()
 	label := c.serverLabel()

--- a/docs/content/reference/resources/mcpserver.mdx
+++ b/docs/content/reference/resources/mcpserver.mdx
@@ -28,7 +28,8 @@ spec:
   # --- Common optional fields --------------------------------------------
   transport: http                             # http | sse (default 'http')
   description: "GitHub repository operations via MCP protocol"
-  timeout: 30s                                # max duration for tool calls (default '30s')
+  timeout: 30s                                # max duration to connect to the server (default '30s')
+  toolCallTimeout: 5m                         # max duration for each tool call (default: unbounded)
   pollInterval: 1m                            # tool re-discovery interval (default '1m')
   headers:                                    # extra HTTP headers sent to the server
     - name: X-Api-Key
@@ -51,7 +52,8 @@ spec:
 | `spec.address` | `ValueSource` | yes | Where the MCP server is reachable. Supports a direct `value`, or `valueFrom` with `serviceRef` (in-cluster service), `secretKeyRef`, `configMapKeyRef`, or `queryParameterRef`. Resolved value is published to `status.resolvedAddress`. |
 | `spec.transport` | enum (`http`, `sse`) | yes | Transport protocol. Defaults to `http`. |
 | `spec.description` | string | no | Human-readable description of the server. |
-| `spec.timeout` | duration | no | Maximum duration for MCP tool calls to this server (`30s`, `5m`, `10m`). Defaults to `30s`. Raise it for long-running operations. |
+| `spec.timeout` | duration | no | Maximum duration to establish a connection to this server, including the connection retry window. Defaults to `30s`. This does **not** bound tool calls — use `spec.toolCallTimeout` for that. |
+| `spec.toolCallTimeout` | duration | no | Maximum duration for each individual tool call to this server (`30s`, `5m`, `10m`), including any [transient error retries](#transient-error-retry). Raise it for long-running operations. When unset, a tool call is bounded only by the execution budget of the query that triggered it (`spec.timeout` on the Query). |
 | `spec.pollInterval` | duration | no | How often the controller re-discovers tools from the server. Defaults to `1m`. |
 | `spec.headers[]` | list | no | HTTP headers added to requests to the server. Each entry has a `name` and a `value` (either a literal `value` or `valueFrom` — `secretKeyRef`, `configMapKeyRef`, `queryParameterRef`). |
 | `spec.authorization` | object | no | OAuth configuration for servers protected per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). When unset, the controller does not attempt to inject `Authorization` headers. |
@@ -121,6 +123,8 @@ env:
   ARK_MCP_TOOL_CALL_MAX_ATTEMPTS: "3"
   ARK_MCP_TOOL_CALL_RETRY_BUDGET_SECONDS: "30"
 ```
+
+`spec.toolCallTimeout` bounds the whole call — every attempt plus the backoff between them — so it composes with the retry budget: whichever expires first ends the call.
 
 Retry activity is counted in the `ark_mcp_tool_call_retries_total{result, server}` metric on the completions executor's `/metrics` endpoint: `transient_error` for each scheduled retry, then one terminal `success`, `permanent_error`, or `exhausted` per call that needed retries.
 


### PR DESCRIPTION
## Summary
- Add optional `MCPServer.spec.toolCallTimeout` that bounds each individual tool call, applied as a child context inside `MCPClient.CallTool` so it covers both agent tool calls and setup-time MCP settings tool calls from a single place
- Correct the misleading `spec.timeout` description — it bounds connection establishment and the retry window, never tool calls
- The bound covers the whole call including the transient-error retries from #3049, so `toolCallTimeout` and the retry budget compose: whichever expires first ends the call. The retry loop already stops at the context deadline, so it needed no change
- Unset `toolCallTimeout` takes the identical code path as today; behaviour is unchanged for existing installs
- A kubebuilder pattern rejects bad durations at `kubectl apply`; at runtime an unparseable value is logged and ignored rather than failing tool registration for the entire agent
- Timeout errors are distinguished from query-budget expiry via `arkmcp.ErrToolCallTimeout` and populate `ToolResult.Error`, so the reason reaches the transcript instead of a blank tool message
- Unit tests cover the new bound, that it bounds the whole retry sequence rather than one attempt, that retry behaviour is untouched when unset, that the session survives a timed-out call, and that lenient parsing never breaks registration

Completes #3032 (parts A and B landed in #3047).

Closes #3032