### PR TITLE
fix(security): bump fast-uri to 3.1.5 to address CVE-2026-18446

### DIFF
--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -3807,9 +3807,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -94,7 +94,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "ws": "^8.21.0",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",


### PR DESCRIPTION
  ## Summary
  - Bump the `fast-uri` override in `tools/ark-cli/package.json` from `^3.1.4` to `^3.1.5` and refresh the lockfile
  - Clears CVE-2026-18446 (HIGH, CVSS 7.5, CWE-436) reported by the JFrog Xray watch as XRAY-1040077

closes https://github.com/mckinsey/agents-at-scale-ark/issues/3083