### PR TITLE
feat(devspace): add opt-in SSO mode with a local Dex provider

### DIFF
--- a/charts/ark-dex-dev/Chart.yaml
+++ b/charts/ark-dex-dev/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ark-dex-dev
+description: Dex OIDC provider with hardcoded users for Ark development
+type: application
+version: 0.1.0
+appVersion: "2.45.1"

--- a/charts/ark-dex-dev/README.md
+++ b/charts/ark-dex-dev/README.md
@@ -1,0 +1,66 @@
+# ark-dex-dev
+
+Development-only Dex chart. Provides a minimal OIDC provider with two hardcoded
+users so the Ark SSO path — dashboard login, JWT validation in ark-api, Kubernetes
+impersonation, RBAC — can be exercised locally.
+
+Not a production chart — HTTP only, in-memory storage, passwords in values.yaml.
+
+## Quickstart
+
+Deployed by the devspace SSO profile, not directly:
+
+```bash
+# One-time: make the issuer hostname resolve on your machine.
+echo "127.0.0.1  dex.default.svc.cluster.local" | sudo tee -a /etc/hosts
+
+ENABLE_SSO=true devspace dev
+```
+
+## Users
+
+Both use password `arkdev123`.
+
+| Login | Permissions in `default` |
+|-------|--------------------------|
+| `admin@ark.local` | Full access to Ark resources, plus secrets, configmaps, pods and events via the `ark-tenant` Role |
+| `viewer@ark.local` | `get`/`list`/`watch` on Ark resources only |
+
+The dashboard reads the effective permissions from `/v1/context`, which runs a
+`SelfSubjectRulesReview` as the impersonated user, so the viewer sees the resource
+lists with the create/edit/delete controls hidden.
+
+## Why the issuer is a Service FQDN
+
+Dex must answer at the same URL for the browser and for the pods: the dashboard
+performs discovery and the code-for-token exchange server-side, and ark-api fetches
+the JWKS. `dex.default.svc.cluster.local:5556` resolves in-cluster via CoreDNS and,
+on the developer machine, via `/etc/hosts` plus the port-forward the devspace
+profile starts.
+
+A `*.127.0.0.1.nip.io` hostname cannot serve both: nip.io resolves to `127.0.0.1`,
+which inside a pod is the pod itself.
+
+## Configuration
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `issuer` | `http://dex.default.svc.cluster.local:5556/dex` | Issuer URL. Used verbatim as the `iss` claim and as the discovery base; Dex serves its endpoints under the URL's path. |
+| `service.name` | `dex` | Service name. Fixed rather than release-derived because `issuer` embeds it. |
+| `client.id` | `ark-dashboard` | OAuth client id. Dex sets the token `aud` to this, so it must match ark-api's `OIDC_APPLICATION_ID`. |
+| `client.secret` | `ark-dashboard-dev-secret` | OAuth client secret, must match the dashboard's `OIDC_CLIENT_SECRET`. |
+| `client.redirectURIs` | dashboard `/api/auth/callback/dex` | Must match the dashboard's `OIDC_PROVIDER_ID`, which fixes the callback path. |
+| `users.password` | `arkdev123` | Documentation only — the effective credentials are the bcrypt hashes below. |
+| `users.admin.hash` / `users.viewer.hash` | bcrypt of the above | Minimum bcrypt cost is 10. Regenerate with `htpasswd -bnBC 10 "" <password> \| tr -d ':\n'`. |
+| `rbac.create` | `true` | Create the ClusterRoles and bindings for the two users. |
+| `rbac.bindArkTenantRole` | `true` | Also bind the admin to the `ark-tenant` Role, for secrets/configmaps/pods access. |
+
+## Notes
+
+- `DEX_EXPAND_ENV=false` is set on the container. The image entrypoint expands
+  `$VAR` references in the config file, and bcrypt hashes start with `$2y$10$`.
+- No `session` block is configured, so Dex keeps no SSO cookie and every
+  authorization request shows the login form. That is how you switch users: Dex
+  exposes no `end_session_endpoint`, so the dashboard clears its own session cookies
+  and logs a warning instead of driving RP-initiated logout.
+- Storage is in-memory: restarting the pod invalidates refresh tokens.

--- a/charts/ark-dex-dev/README.md
+++ b/charts/ark-dex-dev/README.md
@@ -52,6 +52,7 @@ which inside a pod is the pod itself.
 | `client.redirectURIs` | dashboard `/api/auth/callback/dex` | Must match the dashboard's `OIDC_PROVIDER_ID`, which fixes the callback path. |
 | `users.password` | `arkdev123` | Documentation only — the effective credentials are the bcrypt hashes below. |
 | `users.admin.hash` / `users.viewer.hash` | bcrypt of the above | Minimum bcrypt cost is 10. Regenerate with `htpasswd -bnBC 10 "" <password> \| tr -d ':\n'`. |
+| `refreshTokens.reuseInterval` | `3m` | Grace window in which a rotated refresh token is still accepted. Dex's default is `0`, meaning a rotated token dies immediately. |
 | `rbac.create` | `true` | Create the ClusterRoles and bindings for the two users. |
 | `rbac.bindArkTenantRole` | `true` | Also bind the admin to the `ark-tenant` Role, for secrets/configmaps/pods access. |
 
@@ -64,3 +65,13 @@ which inside a pod is the pod itself.
   exposes no `end_session_endpoint`, so the dashboard clears its own session cookies
   and logs a warning instead of driving RP-initiated logout.
 - Storage is in-memory: restarting the pod invalidates refresh tokens.
+- With `refreshTokens.reuseInterval` set, Dex does not rotate the refresh token on
+  every use. Inside the window repeated refreshes return the same token, and only
+  the first refresh after the window closes rotates; the token it supersedes then
+  stays claimable for one further window. That is what stops two concurrent
+  refreshes from leaving one caller with a dead token. The dashboard copes with
+  either behaviour — `lib/auth/token-manager.ts` overwrites the stored token only
+  when the response carries a new one.
+- Three minutes is a development convenience. It means the token rotates at most
+  once every three minutes and a leaked one stays replayable that long, so it is
+  not a value to carry into a real deployment.

--- a/charts/ark-dex-dev/templates/configmap.yaml
+++ b/charts/ark-dex-dev/templates/configmap.yaml
@@ -22,6 +22,12 @@ data:
       # Skip the consent screen — one less click per login when switching users.
       skipApprovalScreen: true
 
+    expiry:
+      refreshTokens:
+        # Window during which Dex keeps the refresh token stable instead of
+        # rotating it on every use.
+        reuseInterval: {{ .Values.refreshTokens.reuseInterval | quote }}
+
     # No `session` block on purpose: without sessions Dex keeps no SSO cookie of
     # its own, so every authorization request shows the login form again. That is
     # what makes switching between the two users possible, given the dashboard

--- a/charts/ark-dex-dev/templates/configmap.yaml
+++ b/charts/ark-dex-dev/templates/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  labels:
+    app: {{ .Release.Name }}
+data:
+  # Dex serves under the issuer URL's path, so these endpoints live at
+  # /dex/auth, /dex/token and /dex/keys.
+  config.yaml: |
+    issuer: {{ .Values.issuer }}
+
+    # In-memory store: no PVC, no migrations. Refresh tokens are lost on restart,
+    # which for local development means logging in again.
+    storage:
+      type: memory
+
+    web:
+      http: 0.0.0.0:{{ .Values.service.port }}
+
+    oauth2:
+      # Skip the consent screen — one less click per login when switching users.
+      skipApprovalScreen: true
+
+    # No `session` block on purpose: without sessions Dex keeps no SSO cookie of
+    # its own, so every authorization request shows the login form again. That is
+    # what makes switching between the two users possible, given the dashboard
+    # cannot drive RP-initiated logout against Dex (no end_session_endpoint).
+    staticClients:
+      - id: {{ .Values.client.id }}
+        name: Ark Dashboard
+        secret: {{ .Values.client.secret }}
+        redirectURIs:
+          {{- toYaml .Values.client.redirectURIs | nindent 10 }}
+
+    enablePasswordDB: true
+    staticPasswords:
+      - email: {{ .Values.users.admin.email }}
+        hash: {{ .Values.users.admin.hash | quote }}
+        username: {{ .Values.users.admin.username }}
+        userID: {{ .Values.users.admin.userID }}
+      - email: {{ .Values.users.viewer.email }}
+        hash: {{ .Values.users.viewer.hash | quote }}
+        username: {{ .Values.users.viewer.username }}
+        userID: {{ .Values.users.viewer.userID }}

--- a/charts/ark-dex-dev/templates/deployment.yaml
+++ b/charts/ark-dex-dev/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+      annotations:
+        # Roll the pod when the config changes: Dex reads the file once at startup.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: dex
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          args:
+            - dex
+            - serve
+            - /etc/dex/config.yaml
+          env:
+            # The image entrypoint expands $VAR references in the config file.
+            # bcrypt hashes start with "$2y$10$", so leaving expansion on
+            # mangles every password hash into an empty string.
+            - name: DEX_EXPAND_ENV
+              value: "false"
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: {{ (urlParse .Values.issuer).path }}/healthz
+              port: {{ .Values.service.port }}
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: {{ (urlParse .Values.issuer).path }}/healthz
+              port: {{ .Values.service.port }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-config

--- a/charts/ark-dex-dev/templates/rbac.yaml
+++ b/charts/ark-dex-dev/templates/rbac.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.rbac.create }}
+# RBAC for the two hardcoded Dex users. ark-api impersonates the authenticated
+# user (IMPERSONATION_USERNAME_CLAIM=email), so these bindings are what actually
+# decides what each login can do.
+#
+# Subjects are Users, not Groups: Dex's static password store has no groups field,
+# so its tokens carry no `groups` claim and the group-based bindings in
+# samples/rbac-test-bindings.yaml would never match.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ark-sso-dev-editor
+  labels:
+    app: {{ .Release.Name }}
+rules:
+  - apiGroups: ["ark.mckinsey.com"]
+    resources: ["agents", "models", "queries", "teams", "tools", "memories", "mcpservers", "a2aservers", "a2atasks", "executionengines"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ark-sso-dev-viewer
+  labels:
+    app: {{ .Release.Name }}
+rules:
+  - apiGroups: ["ark.mckinsey.com"]
+    resources: ["agents", "models", "queries", "teams", "tools", "memories", "mcpservers", "a2aservers", "a2atasks", "executionengines"]
+    verbs: ["get", "list", "watch"]
+---
+# Namespaces are cluster-scoped, so this cannot live in a namespaced Role.
+# GET /v1/namespaces lists them as the impersonated user and the dashboard calls it
+# to populate the namespace selector — without this both users get a broken picker.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ark-sso-dev-namespace-reader
+  labels:
+    app: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ark-sso-dev-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: User
+    name: {{ .Values.users.admin.email }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ark-sso-dev-editor
+  apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.bindArkTenantRole }}
+---
+# Adds secrets, configmaps, pods and events on top of the Ark resources above, so
+# the admin can manage model provider credentials and marketplace sources. This also
+# restores the marketplace-source write path, which dev/marketplace-source-editor-binding.yaml
+# grants to ark-api-sa — no longer the effective identity once impersonation is on.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ark-sso-dev-admin-tenant
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: User
+    name: {{ .Values.users.admin.email }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: {{ .Values.rbac.arkTenantRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ark-sso-dev-viewer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: User
+    name: {{ .Values.users.viewer.email }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ark-sso-dev-viewer
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ark-sso-dev-namespace-reader
+  labels:
+    app: {{ .Release.Name }}
+subjects:
+  - kind: User
+    name: {{ .Values.users.admin.email }}
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: {{ .Values.users.viewer.email }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: ark-sso-dev-namespace-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/ark-dex-dev/templates/service.yaml
+++ b/charts/ark-dex-dev/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Fixed name, not .Release.Name: the issuer URL embeds this DNS name.
+  name: {{ .Values.service.name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/charts/ark-dex-dev/values.yaml
+++ b/charts/ark-dex-dev/values.yaml
@@ -1,0 +1,63 @@
+image:
+  repository: ghcr.io/dexidp/dex
+  tag: v2.45.1
+
+# Service name is fixed rather than derived from the release name: the issuer URL
+# below embeds it, and both the browser and the in-cluster pods must reach Dex at
+# that exact URL. Renaming the release would silently break token validation.
+service:
+  name: dex
+  port: 5556
+
+# Issuer URL, used verbatim as the `iss` claim and as the discovery base.
+# `dex.default.svc.cluster.local` resolves in-cluster via CoreDNS and, on the
+# developer machine, via an /etc/hosts entry pointing at the port-forward — the
+# same URL works from both sides. A *.127.0.0.1.nip.io host cannot: nip.io
+# resolves to 127.0.0.1, which inside a pod is the pod itself.
+issuer: http://dex.default.svc.cluster.local:5556/dex
+
+# OAuth client for the dashboard. clientId must match ark-api's
+# OIDC_APPLICATION_ID: Dex sets the token's `aud` to the client id.
+client:
+  id: ark-dashboard
+  secret: ark-dashboard-dev-secret
+  # providerId in the dashboard fixes the callback path to
+  # /api/auth/callback/<providerId>, so these must stay in sync.
+  redirectURIs:
+    - http://dashboard.default.127.0.0.1.nip.io:8080/api/auth/callback/dex
+    - http://127.0.0.1.nip.io:8080/api/auth/callback/dex
+
+# Hardcoded users. Both share the same password; the bcrypt hashes differ only by
+# salt. Dex enforces a minimum bcrypt cost of 10.
+#
+# Dex's static password store has no groups field, so these identities carry no
+# `groups` claim and RBAC binds them by username (email) — see templates/rbac.yaml.
+users:
+  password: arkdev123
+  admin:
+    email: admin@ark.local
+    username: admin
+    userID: ark-dev-admin
+    hash: "$2y$10$PG/DEtGxkzg7y5Fai80sFuZC56pH.95WrAnr/XYrVX/TvBNPCV5/S"
+  viewer:
+    email: viewer@ark.local
+    username: viewer
+    userID: ark-dev-viewer
+    hash: "$2y$10$K7/2psZvb9qJRT06KLenuew5UeGlWadaDQr0HDfWTTssWk7bnpSei"
+
+rbac:
+  create: true
+  # Role installed by charts/ark-tenant, bound to the admin user on top of the
+  # Ark-resource ClusterRole so "full access" also covers secrets, configmaps and
+  # pods in the namespace. Skipped when the Role is absent (ENABLE_ARK_TENANT=false):
+  # a RoleBinding to a missing Role grants nothing, it does not error.
+  arkTenantRoleName: ark-tenant-role
+  bindArkTenantRole: true
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "256Mi"
+    cpu: "200m"

--- a/charts/ark-dex-dev/values.yaml
+++ b/charts/ark-dex-dev/values.yaml
@@ -45,6 +45,19 @@ users:
     userID: ark-dev-viewer
     hash: "$2y$10$K7/2psZvb9qJRT06KLenuew5UeGlWadaDQr0HDfWTTssWk7bnpSei"
 
+# How long Dex keeps a refresh token stable. Inside this window Dex does not
+# rotate at all: repeated refreshes return the same token, so two concurrent
+# refreshes cannot leave one caller holding a dead one. The first refresh after
+# the window closes rotates, and the token it supersedes stays claimable for one
+# further window.
+#
+# Dex's default is 0, which rotates on every single use. Three minutes is a
+# development convenience: it also means the token rotates at most once every
+# three minutes and a leaked one stays replayable that long, so this is not a
+# value to carry into a real deployment.
+refreshTokens:
+  reuseInterval: "3m"
+
 rbac:
   create: true
   # Role installed by charts/ark-tenant, bound to the admin user on top of the

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -38,6 +38,7 @@ dependencies:
 #        For example: ENABLE_CERT_MANAGER=false devspace dev
 #        For PostgreSQL controller backend: STORAGE_BACKEND=postgresql devspace dev
 #        For Postgres message backend: BROKER_MESSAGE_BACKEND=postgres devspace dev
+#        For SSO with a local Dex and two hardcoded users: ENABLE_SSO=true devspace dev
 vars:
   STORAGE_BACKEND:
     source: env
@@ -57,6 +58,19 @@ vars:
   ENABLE_ARGO:
     source: env
     default: false
+  ENABLE_SSO:
+    source: env
+    default: false
+  # Dex host and port. The issuer URL is composed from these as
+  # http://$SSO_DEX_HOST:$SSO_DEX_PORT/dex and must be identical here, in
+  # services/ark-api/devspace.yaml and in services/ark-dashboard/devspace.yaml:
+  # the browser and the pods both resolve that one URL, by different routes.
+  SSO_DEX_HOST:
+    source: env
+    default: "dex.default.svc.cluster.local"
+  SSO_DEX_PORT:
+    source: env
+    default: "5556"
 
 commands:
   routes:
@@ -71,6 +85,17 @@ commands:
       echo "Port-forward running in background (PID: $PID)"
     else
       echo "Failed to start port-forward. Is the gateway deployed?"
+    fi
+  sso-forward: |-
+    kill $(lsof -ti :${SSO_DEX_PORT}) 2>/dev/null || true
+    echo "Starting Dex port-forward on localhost:${SSO_DEX_PORT}..."
+    nohup kubectl port-forward service/dex ${SSO_DEX_PORT}:${SSO_DEX_PORT} > /dev/null 2>&1 &
+    sleep 1
+    PID=$(lsof -ti :${SSO_DEX_PORT})
+    if [ -n "$PID" ]; then
+      echo "Port-forward running in background (PID: $PID)"
+    else
+      echo "Failed to start port-forward. Is Dex deployed (ENABLE_SSO=true)?"
     fi
 
 profiles:
@@ -134,6 +159,25 @@ profiles:
         value:
           argo-workflows:
             path: ./services/argo-workflows
+  - name: enable-sso
+    activation:
+      - vars:
+          ENABLE_SSO: true
+    patches:
+      - op: add
+        path: deployments
+        value:
+          ark-dex-dev:
+            namespace: default
+            helm:
+              chart:
+                path: ./charts/ark-dex-dev
+              # Release name fixes the Deployment name the pipeline waits on.
+              # The Service name is fixed by the chart, not by the release.
+              releaseName: dex
+              upgradeArgs: [ "--install" ]
+              values:
+                issuer: "http://${SSO_DEX_HOST}:${SSO_DEX_PORT}/dex"
 
 functions:
   # Probe the cert-manager admission webhook end-to-end before deploying any
@@ -230,6 +274,27 @@ pipelines:
       create_deployments ark-tenant
     fi
 
+    # Dex must be up before ark-api: with AUTH_MODE=sso the auth middleware builds
+    # its token validator at startup. Deploying it here also keeps the login
+    # available for the whole session, not only once the dependencies are done.
+    if [ "${ENABLE_SSO}" == "true" ]; then
+      if ! grep -q "${SSO_DEX_HOST}" /etc/hosts; then
+        echo ""
+        echo "ERROR: SSO mode needs ${SSO_DEX_HOST} to resolve on this machine."
+        echo "The browser reaches Dex through a port-forward and the pods reach it"
+        echo "through cluster DNS, so both must use the same URL. Add the entry with:"
+        echo ""
+        echo "  echo \"127.0.0.1  ${SSO_DEX_HOST}\" | sudo tee -a /etc/hosts"
+        echo ""
+        exit 1
+      fi
+      create_deployments ark-dex-dev
+      kubectl rollout status deployment/dex -n "${DEVSPACE_NAMESPACE:-default}" --timeout=120s
+      kill $(lsof -ti :${SSO_DEX_PORT}) 2>/dev/null || true
+      nohup kubectl port-forward -n "${DEVSPACE_NAMESPACE:-default}" service/dex ${SSO_DEX_PORT}:${SSO_DEX_PORT} > /dev/null 2>&1 &
+      echo "SSO enabled. Log in as admin@ark.local or viewer@ark.local, password arkdev123."
+    fi
+
     if [ "${ENABLE_ARGO}" == "true" ]; then
       run_dependency_pipelines argo-workflows --pipeline=deploy
     fi
@@ -287,6 +352,27 @@ pipelines:
         ensure_tool_api
       fi
       create_deployments ark-tenant
+    fi
+
+    # Dex must be up before ark-api: with AUTH_MODE=sso the auth middleware builds
+    # its token validator at startup. Deploying it here also keeps the login
+    # available for the whole session, not only once the dependencies are done.
+    if [ "${ENABLE_SSO}" == "true" ]; then
+      if ! grep -q "${SSO_DEX_HOST}" /etc/hosts; then
+        echo ""
+        echo "ERROR: SSO mode needs ${SSO_DEX_HOST} to resolve on this machine."
+        echo "The browser reaches Dex through a port-forward and the pods reach it"
+        echo "through cluster DNS, so both must use the same URL. Add the entry with:"
+        echo ""
+        echo "  echo \"127.0.0.1  ${SSO_DEX_HOST}\" | sudo tee -a /etc/hosts"
+        echo ""
+        exit 1
+      fi
+      create_deployments ark-dex-dev
+      kubectl rollout status deployment/dex -n "${DEVSPACE_NAMESPACE:-default}" --timeout=120s
+      kill $(lsof -ti :${SSO_DEX_PORT}) 2>/dev/null || true
+      nohup kubectl port-forward -n "${DEVSPACE_NAMESPACE:-default}" service/dex ${SSO_DEX_PORT}:${SSO_DEX_PORT} > /dev/null 2>&1 &
+      echo "SSO enabled. Log in as admin@ark.local or viewer@ark.local, password arkdev123."
     fi
 
     if [ "${ENABLE_ARGO}" == "true" ]; then

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -89,7 +89,7 @@ commands:
   sso-forward: |-
     kill $(lsof -ti :${SSO_DEX_PORT}) 2>/dev/null || true
     echo "Starting Dex port-forward on localhost:${SSO_DEX_PORT}..."
-    nohup kubectl port-forward service/dex ${SSO_DEX_PORT}:${SSO_DEX_PORT} > /dev/null 2>&1 &
+    nohup kubectl port-forward -n default service/dex ${SSO_DEX_PORT}:${SSO_DEX_PORT} > /dev/null 2>&1 &
     sleep 1
     PID=$(lsof -ti :${SSO_DEX_PORT})
     if [ -n "$PID" ]; then

--- a/docs/content/developer-guide/authentication.mdx
+++ b/docs/content/developer-guide/authentication.mdx
@@ -561,6 +561,17 @@ See `samples/rbac-test-bindings.yaml` for a complete example covering all resour
 5. **Disable fallback** — Set `fallback: false`. K8s RBAC is now fully enforced.
 6. **Rollback** — Set `enabled: false` to revert to SA-based access.
 
+### Local development setup with Dex
+
+The quickest way to exercise the SSO path end to end is the DevSpace SSO profile, which deploys Dex with two hardcoded users and wires impersonation for you:
+
+```bash
+echo "127.0.0.1  dex.default.svc.cluster.local" | sudo tee -a /etc/hosts
+ENABLE_SSO=true devspace dev
+```
+
+See [Local Development](/developer-guide/local-development) for the users and what each can do. Note that Dex static passwords carry no `groups` claim, so the RBAC bindings match on username; use the Keycloak setup below to test group-based bindings such as `samples/rbac-test-bindings.yaml`.
+
 ### Local development setup with Keycloak
 
 For local testing, you can run Keycloak as an OIDC provider via Docker:

--- a/docs/content/developer-guide/local-development.mdx
+++ b/docs/content/developer-guide/local-development.mdx
@@ -51,6 +51,37 @@ Argo Workflows is opt-in. To enable it, set `ENABLE_ARGO`:
 ENABLE_ARGO=true devspace dev
 ```
 
+## SSO Mode
+
+SSO is opt-in. `ENABLE_SSO=true` deploys a local [Dex](https://dexidp.io) provider with two hardcoded users, puts ark-api and the dashboard in `AUTH_MODE=sso`, and turns on Kubernetes impersonation so RBAC applies to the logged-in user instead of the ark-api service account.
+
+One-time setup — the issuer hostname must resolve on your machine:
+
+```bash
+echo "127.0.0.1  dex.default.svc.cluster.local" | sudo tee -a /etc/hosts
+```
+
+```bash
+ENABLE_SSO=true devspace dev
+```
+
+Log in at `http://dashboard.default.127.0.0.1.nip.io:8080`. Both users share the password `arkdev123`:
+
+| User | Access to namespace `default` |
+|------|-------------------------------|
+| `admin@ark.local` | Full access to Ark resources, plus secrets, configmaps, pods and events |
+| `viewer@ark.local` | Read-only on Ark resources |
+
+The dashboard hides the write controls for the viewer. It reads the effective permissions from `/v1/context`, which runs a `SelfSubjectRulesReview` as the impersonated user.
+
+Dex holds no session of its own, so signing out and back in prompts for credentials again. That is how you switch between the two users.
+
+<Callout type="info">
+Dex answers at the same URL for the browser and for the pods, because the dashboard performs the code-for-token exchange server-side and ark-api fetches the JWKS. `dex.default.svc.cluster.local` resolves in-cluster through CoreDNS and, on your machine, through the `/etc/hosts` entry plus the port-forward DevSpace starts. A `127.0.0.1.nip.io` host cannot serve both: nip.io resolves to `127.0.0.1`, which inside a pod is the pod itself.
+</Callout>
+
+Configuration lives in `charts/ark-dex-dev` and in the `sso` profiles of the ark-api and ark-dashboard DevSpace configs. Restart the Dex port-forward with `devspace run sso-forward`.
+
 ## Storage Backend Selection
 
 The ark-controller supports two storage backends: etcd (default) and PostgreSQL. Use the `STORAGE_BACKEND` environment variable to select:

--- a/services/ark-api/devspace.yaml
+++ b/services/ark-api/devspace.yaml
@@ -97,8 +97,12 @@ profiles:
         value:
           - name: CORS_ORIGINS
             value: "*"
+          # The dashboard stays on sso: its GlobalProviders compares AUTH_MODE to
+          # the literal "sso", and that flag also gates the ContextProvider that
+          # loads the permissions driving the UI, so "hybrid" there would silently
+          # fall back to open-mode providers.
           - name: AUTH_MODE
-            value: "sso"
+            value: "hybrid"
           - name: OIDC_ISSUER_URL
             value: "http://${SSO_DEX_HOST}:${SSO_DEX_PORT}/dex"
           # Dex sets the token's `aud` to the client id, so this is the Dex

--- a/services/ark-api/devspace.yaml
+++ b/services/ark-api/devspace.yaml
@@ -5,6 +5,16 @@ vars:
   ARK_API_CALLBACK_PORT:
     source: env
     default: "34780"
+  ENABLE_SSO:
+    source: env
+    default: false
+  # Must match the values of the same name in the root devspace.yaml.
+  SSO_DEX_HOST:
+    source: env
+    default: "dex.default.svc.cluster.local"
+  SSO_DEX_PORT:
+    source: env
+    default: "5556"
 
 images:
   ark-api:
@@ -71,6 +81,62 @@ deployments:
                 - DAC_OVERRIDE
         httpRoute:
           enabled: true
+
+profiles:
+  - name: sso
+    activation:
+      - vars:
+          ENABLE_SSO: true
+    patches:
+      # Helm replaces list values rather than merging them, so app.env has to
+      # restate the chart defaults it is not changing. Dropping them would
+      # silently disable the MCP auth endpoints and misreport the A2A agent card
+      # URLs, making SSO mode differ from open mode in ways unrelated to auth.
+      - op: add
+        path: deployments.ark-api.helm.values.app.env
+        value:
+          - name: CORS_ORIGINS
+            value: "*"
+          - name: AUTH_MODE
+            value: "sso"
+          - name: OIDC_ISSUER_URL
+            value: "http://${SSO_DEX_HOST}:${SSO_DEX_PORT}/dex"
+          # Dex sets the token's `aud` to the client id, so this is the Dex
+          # staticClient id from charts/ark-dex-dev.
+          - name: OIDC_APPLICATION_ID
+            value: "ark-dashboard"
+          # Set explicitly to skip OIDC discovery: the token validator is built
+          # while the auth middleware is constructed, and discovery failure there
+          # crash-loops the pod if Dex is not up yet. With the URL known up front
+          # no request is made until the first token arrives.
+          - name: OIDC_JWKS_URL
+            value: "http://${SSO_DEX_HOST}:${SSO_DEX_PORT}/dex/keys"
+          - name: PROXY_TIMEOUT
+            value: "10.0"
+          - name: ARK_A2A_AGENT_CARD_PORT
+            value: "8000"
+          - name: ARK_A2A_AGENT_CARD_HOST
+            value: "ark-api.127.0.0.1.nip.io"
+          - name: ARK_A2A_AGENT_CARD_PROTOCOL
+            value: "http"
+          - name: READ_ONLY_MODE
+            value: "false"
+          - name: ARK_API_PUBLIC_CALLBACK_URL
+            value: "http://127.0.0.1:${ARK_API_CALLBACK_PORT}/v1/mcp/auth/callback"
+          - name: ARK_API_DASHBOARD_URL
+            value: "http://dashboard.default.127.0.0.1.nip.io:8080"
+      # Apply RBAC to the logged-in user instead of ark-api-sa. Also grants the
+      # service account the cluster-scoped impersonate verb it needs to do so.
+      # Dex static passwords carry no groups claim, so groupsClaim resolves to an
+      # empty list and the bindings in charts/ark-dex-dev match on username.
+      - op: add
+        path: deployments.ark-api.helm.values.impersonation
+        value:
+          enabled: true
+          fallback: false
+          usernameClaim: email
+          groupsClaim: groups
+          prefix: ""
 
 dev:
   ark-api:

--- a/services/ark-dashboard/devspace.yaml
+++ b/services/ark-dashboard/devspace.yaml
@@ -1,6 +1,23 @@
 # DevSpace configuration for ark-dashboard service
 version: v2beta1
 
+vars:
+  ENABLE_SSO:
+    source: env
+    default: false
+  # Must match the values of the same name in the root devspace.yaml.
+  SSO_DEX_HOST:
+    source: env
+    default: "dex.default.svc.cluster.local"
+  SSO_DEX_PORT:
+    source: env
+    default: "5556"
+  # Host the browser uses. AUTH_URL derives from it, and the callback path it
+  # produces must be registered as a redirect URI in charts/ark-dex-dev.
+  SSO_DASHBOARD_URL:
+    source: env
+    default: "http://dashboard.default.127.0.0.1.nip.io:8080"
+
 images:
   ark-dashboard:
     image: ark-dashboard
@@ -73,6 +90,50 @@ deployments:
     kubectl:
       manifests:
         - dev/marketplace-source-editor-binding.yaml
+
+profiles:
+  - name: sso
+    activation:
+      - vars:
+          ENABLE_SSO: true
+    patches:
+      # Helm replaces list values rather than merging them, so app.env has to
+      # restate the chart defaults it is not changing.
+      - op: add
+        path: deployments.ark-dashboard.helm.values.app.env
+        value:
+          - name: AUTH_MODE
+            value: "sso"
+          - name: BASE_URL
+            value: "${SSO_DASHBOARD_URL}"
+          - name: AUTH_URL
+            value: "${SSO_DASHBOARD_URL}/api/auth"
+          # Signs the session cookie that wraps the Dex tokens. Fixed value so
+          # restarting the dashboard does not invalidate an open session.
+          - name: AUTH_SECRET
+            value: "ark-devspace-sso-secret-not-for-production"
+          - name: OIDC_ISSUER_URL
+            value: "http://${SSO_DEX_HOST}:${SSO_DEX_PORT}/dex"
+          - name: OIDC_CLIENT_ID
+            value: "ark-dashboard"
+          - name: OIDC_CLIENT_SECRET
+            value: "ark-dashboard-dev-secret"
+          - name: OIDC_PROVIDER_NAME
+            value: "Dex"
+          # Fixes the callback path to /api/auth/callback/dex, which must appear
+          # verbatim in the Dex staticClient redirect URIs.
+          - name: OIDC_PROVIDER_ID
+            value: "dex"
+          # offline_access is required: Dex only issues a refresh token when the
+          # scope is requested, and without one the periodic token refresh fails.
+          - name: OIDC_SCOPES
+            value: "openid email profile offline_access"
+          - name: SESSION_MAX_AGE
+            value: ""
+          - name: NEXT_PUBLIC_TOKEN_REFRESH_INTERVAL_MS
+            value: "600000"
+          - name: NEXT_PUBLIC_FALLBACK_INACTIVITY_TIMEOUT
+            value: "1800000"
 
 dev:
   ark-dashboard:


### PR DESCRIPTION
## Summary

Adds an opt-in SSO mode to the devspace stack. `ENABLE_SSO=true devspace dev` deploys a local Dex with two hardcoded users, switches ark-api to `hybrid` and the dashboard to `sso`, and turns on Kubernetes impersonation so RBAC applies to the logged-in user rather than to `ark-api-sa`. Without the variable nothing changes.

Ark already had the whole SSO path — OIDC in the dashboard, JWKS validation in ark-api, impersonation, and a permissions gate driven by `SelfSubjectRulesReview`. What was missing was an identity provider, so exercising any of it locally meant configuring an external IdP by hand. This adds the provider and the wiring; no Go, Python or TypeScript source is touched.

## Users

Both use the password `arkdev123`.

| Login | Access to namespace `default` |
|-------|-------------------------------|
| `admin@ark.local` | Full access to Ark resources, plus secrets, configmaps, pods and events via the `ark-tenant` Role |
| `viewer@ark.local` | `get`/`list`/`watch` on Ark resources only |

The bindings are on `kind: User`, not `kind: Group`: Dex's static password store has no groups field, so its tokens carry no `groups` claim and the group-based bindings in `samples/rbac-test-bindings.yaml` would never match. Those remain the way to exercise group RBAC, with the Keycloak setup already documented in the authentication guide.

## The issuer URL

Dex has to answer at the same URL for the browser and for the pods, because the dashboard performs OIDC discovery and the code-for-token exchange server-side while ark-api fetches the JWKS. No `*.127.0.0.1.nip.io` host can do both: nip.io resolves to `127.0.0.1`, which inside a pod is the pod itself.

The issuer is therefore the Service FQDN, `http://dex.default.svc.cluster.local:5556/dex`, which resolves in-cluster through CoreDNS and on the developer machine through one `/etc/hosts` entry plus the port-forward the pipeline starts. The pipeline checks for that entry and fails early with the exact command to run, since without it the login breaks after the redirect rather than before it. The two alternatives — rewriting CoreDNS in `kube-system`, or adding a split-horizon authorization-endpoint override to the dashboard's auth code — were rejected as too invasive for a development convenience.

## Review guide

`charts/ark-dex-dev/` is the new chart: Dex, its config, and the RBAC for the two users. Three details in it are non-obvious and carry comments explaining why:

- `templates/deployment.yaml` sets `DEX_EXPAND_ENV=false`. The image entrypoint expands `$VAR` in the config file and bcrypt hashes begin with `$2y$10$`.
- `values.yaml` sets `refreshTokens.reuseInterval: 3m`. Dex's default of `0` rotates the refresh token on every use and kills the superseded one immediately, so two concurrent refreshes cost the loser its session. Inside the window Dex does not rotate at all and returns the same token. Three minutes is far wider than the races it covers and is called out in the chart README as a development-only value.
- `templates/service.yaml` fixes the Service name rather than deriving it from the release, because the issuer URL embeds that DNS name.

`services/ark-api/devspace.yaml:105` uses `AUTH_MODE=hybrid`, so both bearer token and basic credentials are accepted. `services/ark-dashboard/devspace.yaml:106` stays on `sso` deliberately: `providers/GlobalProviders.tsx:17` compares `AUTH_MODE` to the literal `"sso"`, and that same flag gates the `ContextProvider` which loads the permissions the UI uses to hide write controls — `hybrid` there would quietly fall back to the open-mode providers.

`services/ark-api/devspace.yaml:116` sets `OIDC_JWKS_URL` explicitly even though discovery would find it. `AuthMiddleware.__init__` builds the token validator while the middleware is constructed, so a failed discovery at that point crash-loops the pod when Dex is not yet up. With the URL known up front no request is made until the first token arrives. The root pipeline still deploys Dex before the service dependencies.

Both `app.env` patches restate the chart defaults they do not change, because Helm replaces list values instead of merging them. Dropping the untouched entries would disable the MCP auth endpoints and misreport the A2A agent card URLs, making SSO mode differ from open mode in ways unrelated to auth.

## Verification

Verified end to end on a local Kind cluster. Both users log in through the browser. Dex discovery resolves from the host and the JWKS endpoint returns 200 from inside the ark-api pod, which are the two sides the issuer choice depends on. ark-api starts with `mode: hybrid` and impersonation enabled.

RBAC discriminates as intended, using real tokens against the deployed API:

```
admin@ark.local    GET /v1/agents 200   DELETE 404   verbs: create,delete,get,list,patch,update,watch
viewer@ark.local   GET /v1/agents 200   DELETE 403   verbs: get,list,watch
```

`DELETE` targets a name that does not exist, so `404` means the permission was granted and only the resource was missing. The verb lists come from `/v1/context`, which is what the dashboard reads to decide whether to render write controls. Requests with no token return `401`, and requests carrying a client-supplied `Impersonate-*` header return `403`.
