### PR TITLE
fix(deps): update js-yaml to version 4.3.1 across multiple packages

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -24,7 +24,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.10",
         "http-server": "^14.1.1",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "jsdom": "^29.1.1",
         "linkinator": "^7.6.1",
         "pagefind": "^1.5.2",
@@ -5339,9 +5339,9 @@
       "peer": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.10",
     "http-server": "^14.1.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "jsdom": "^29.1.1",
     "linkinator": "^7.6.1",
     "pagefind": "^1.5.2",

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -1524,9 +1524,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7103,9 +7103,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -74,9 +74,9 @@
     "node": ">=22.0.0"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^3.15.0"
+      "js-yaml": "^3.15.1"
     },
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",

--- a/services/ark-dashboard/ark-dashboard/package-lock.json
+++ b/services/ark-dashboard/ark-dashboard/package-lock.json
@@ -44,7 +44,7 @@
         "file-saver": "^2.0.5",
         "git-url-parse": "^16.1.0",
         "jotai": "^2.15.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
         "mermaid": "^11.15.0",
@@ -8898,9 +8898,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/services/ark-dashboard/ark-dashboard/package.json
+++ b/services/ark-dashboard/ark-dashboard/package.json
@@ -51,7 +51,7 @@
     "file-saver": "^2.0.5",
     "git-url-parse": "^16.1.0",
     "jotai": "^2.15.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",
     "mermaid": "^11.15.0",
@@ -108,7 +108,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "tar": "^7.5.11",
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",

--- a/services/ark-landing-page/package-lock.json
+++ b/services/ark-landing-page/package-lock.json
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5163,9 +5163,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/services/ark-landing-page/package.json
+++ b/services/ark-landing-page/package.json
@@ -33,9 +33,9 @@
     "typescript": "5.7.3"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^3.15.0"
+      "js-yaml": "^3.15.1"
     },
     "brace-expansion": ">=5.0.9",
     "ip-address": "^10.3.1",

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -4778,9 +4778,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -87,6 +87,7 @@
   "overrides": {
     "brace-expansion": ">=5.0.9",
     "ip-address": "^10.3.1",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.2.3",
     "rollup": "4.59.0",
     "hono": "^4.12.25",


### PR DESCRIPTION
## Summary
- Bump js-yaml to 4.3.1 across docs, ark-broker, ark-dashboard, ark-landing-page, and ark-cli to fix CVE-2026-59870