### PR TITLE
fix(mcp): inject authorization bearer on the runtime MCP path

### DIFF
--- a/ark/api/v1alpha1/mcpserver_types.go
+++ b/ark/api/v1alpha1/mcpserver_types.go
@@ -73,6 +73,34 @@ type TokenSecretReference struct {
 	ClientSecretKey string `json:"clientSecretKey,omitempty"`
 }
 
+// Default Secret keys for TokenSecretReference. These mirror the
+// +kubebuilder:default markers above, which cannot reference constants.
+const (
+	DefaultAccessTokenKey  = "access_token"
+	DefaultRefreshTokenKey = "refresh_token"
+	DefaultExpiresAtKey    = "expires_at"
+	DefaultClientIDKey     = "client_id"
+	DefaultClientSecretKey = "client_secret"
+)
+
+// ResolvedAccessTokenKey returns the Secret key holding the access token. The
+// empty-value fallback matters for clients that bypass CRD defaulting, such as
+// the fake client used in unit tests.
+func (r TokenSecretReference) ResolvedAccessTokenKey() string {
+	if r.AccessTokenKey == "" {
+		return DefaultAccessTokenKey
+	}
+	return r.AccessTokenKey
+}
+
+// ResolvedExpiresAtKey returns the Secret key holding the token expiry.
+func (r TokenSecretReference) ResolvedExpiresAtKey() string {
+	if r.ExpiresAtKey == "" {
+		return DefaultExpiresAtKey
+	}
+	return r.ExpiresAtKey
+}
+
 // MCPServerAuthorizationState enumerates the observable authorization
 // states of an MCP server. An empty value (the absence of the
 // `authorization` sub-resource) means authorization is not required.

--- a/ark/executors/completions/agent_tools.go
+++ b/ark/executors/completions/agent_tools.go
@@ -137,14 +137,19 @@ func createMCPExecutor(ctx context.Context, k8sClient client.Client, tool *arkv1
 		return nil, fmt.Errorf("failed to build MCP server URL: %w", err)
 	}
 
-	headers := make(map[string]string)
-	for _, header := range mcpServerCRD.Spec.Headers {
-		value, err := ResolveHeaderValue(ctx, k8sClient, header, namespace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve header %s: %w", header.Name, err)
-		}
-		headers[header.Name] = value
+	headers, err := ResolveHeaders(ctx, k8sClient, mcpServerCRD.Spec.Headers, mcpServerNamespace)
+	if err != nil {
+		return nil, err
 	}
+
+	authMaterial, authWarnings, err := arkmcp.ResolveAuthorizationMaterial(ctx, k8sClient, &mcpServerCRD)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve authorization for MCP server %v: %w", mcpServerKey, err)
+	}
+	for _, warning := range authWarnings {
+		logf.FromContext(ctx).Info(warning, "mcpServer", mcpServerKey.String(), "tool", tool.Name)
+	}
+	authMaterial.ApplyBearer(headers)
 
 	// Parse timeout from MCPServer spec (default to 30s if not specified)
 	timeout := 30 * time.Second

--- a/ark/executors/completions/agent_tools.go
+++ b/ark/executors/completions/agent_tools.go
@@ -147,7 +147,7 @@ func createMCPExecutor(ctx context.Context, k8sClient client.Client, tool *arkv1
 		return nil, fmt.Errorf("failed to resolve authorization for MCP server %v: %w", mcpServerKey, err)
 	}
 	for _, warning := range authWarnings {
-		logf.FromContext(ctx).Info(warning, "mcpServer", mcpServerKey.String(), "tool", tool.Name)
+		logf.FromContext(ctx).V(1).Info(warning, "mcpServer", mcpServerKey.String(), "tool", tool.Name)
 	}
 	authMaterial.ApplyBearer(headers)
 

--- a/ark/executors/completions/mcp_auth_test.go
+++ b/ark/executors/completions/mcp_auth_test.go
@@ -1,0 +1,351 @@
+package completions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	arkmcp "mckinsey.com/ark/internal/mcp"
+)
+
+const (
+	authTestServerNS   = "mcp-ns"
+	authTestCallerNS   = "team-a"
+	authTestServerName = "test-server"
+	authTestSecretName = "mcp-token"
+	authTestToolName   = "greet-tool"
+	authTestToken      = "tok-good"
+)
+
+// newAuthGatedTestMCPServer serves a real MCP streamable HTTP handler exposing
+// a single `greet` tool, but only when the request carries
+// `Authorization: Bearer <expectedToken>`. Anything else gets an RFC 9728
+// challenge and a 401, which is what an OAuth-protected MCP server does to an
+// unauthenticated session initialize. Pass an empty expectedToken to serve
+// unauthenticated. The returned func reports every inbound Authorization value.
+func newAuthGatedTestMCPServer(t *testing.T, expectedToken string) (string, func() []string) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	mcpServer := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "auth-mcp", Version: "v0.1.0"}, nil)
+	mcpsdk.AddTool(mcpServer, &mcpsdk.Tool{Name: "greet", Description: "greet the caller"},
+		func(_ context.Context, _ *mcpsdk.CallToolRequest, _ any) (*mcpsdk.CallToolResult, any, error) {
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "Hi ark"}},
+			}, nil, nil
+		})
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return mcpServer },
+		&mcpsdk.StreamableHTTPOptions{Stateless: true, JSONResponse: true},
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		if expectedToken != "" && r.Header.Get("Authorization") != "Bearer "+expectedToken {
+			host := "http://" + r.Host
+			w.Header().Set("WWW-Authenticate",
+				`Bearer realm="OAuth", resource_metadata="`+host+`/.well-known/oauth-protected-resource/mcp", error="invalid_token"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_token"}`))
+			return
+		}
+		mcpHandler.ServeHTTP(w, r)
+	})
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		host := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              host + "/mcp",
+			"resource_name":         "Fake MCP (Test)",
+			"authorization_servers": []string{host},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		srv.CloseClientConnections()
+		srv.Close()
+	})
+
+	return srv.URL + "/mcp", func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), seen...)
+	}
+}
+
+func newAuthTestPool(t *testing.T) *arkmcp.MCPClientPool {
+	t.Helper()
+	pool := arkmcp.NewMCPClientPool()
+	t.Cleanup(func() { _ = pool.Close() })
+	return pool
+}
+
+func newAuthTestMCPServerCRD(url string, ref *arkv1alpha1.TokenSecretReference, headers []arkv1alpha1.Header) *arkv1alpha1.MCPServer {
+	server := &arkv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: authTestServerName, Namespace: authTestServerNS},
+		Spec: arkv1alpha1.MCPServerSpec{
+			Address:   arkv1alpha1.ValueSource{Value: url},
+			Transport: "http",
+			Headers:   headers,
+		},
+	}
+	if ref != nil {
+		server.Spec.Authorization = &arkv1alpha1.MCPServerAuthorizationSpec{TokenSecretRef: *ref}
+	}
+	return server
+}
+
+func newAuthTestTool(toolNamespace string) *arkv1alpha1.Tool {
+	return &arkv1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: authTestToolName, Namespace: toolNamespace},
+		Spec: arkv1alpha1.ToolSpec{
+			Type: "mcp",
+			MCP: &arkv1alpha1.MCPToolRef{
+				MCPServerRef: arkv1alpha1.MCPServerRef{
+					Name:      authTestServerName,
+					Namespace: authTestServerNS,
+				},
+				ToolName: "greet",
+			},
+		},
+	}
+}
+
+func newAuthTestSecret(namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: authTestSecretName, Namespace: namespace},
+		Data:       data,
+	}
+}
+
+func bearerHeadersSeen(seen []string) []string {
+	var out []string
+	for _, value := range seen {
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// The regression this whole change exists for: the executor must send the
+// bearer from spec.authorization.tokenSecretRef. The connection is established
+// eagerly inside GetOrCreateClient, so a missing bearer fails at session
+// initialize - before any tool call - which is why discovery-only coverage
+// never caught it.
+func TestCreateMCPExecutorInjectsBearerFromTokenSecretRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		ref        arkv1alpha1.TokenSecretReference
+		secretData map[string][]byte
+	}{
+		{
+			name:       "default access token key",
+			ref:        arkv1alpha1.TokenSecretReference{Name: authTestSecretName},
+			secretData: map[string][]byte{arkv1alpha1.DefaultAccessTokenKey: []byte(authTestToken)},
+		},
+		{
+			name: "custom access token key",
+			ref: arkv1alpha1.TokenSecretReference{
+				Name:           authTestSecretName,
+				AccessTokenKey: "MY_CUSTOM_ACCESS_TOKEN",
+			},
+			secretData: map[string][]byte{
+				"MY_CUSTOM_ACCESS_TOKEN":          []byte(authTestToken),
+				arkv1alpha1.DefaultAccessTokenKey: []byte("tok-wrong"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, seenAuth := newAuthGatedTestMCPServer(t, authTestToken)
+			k8sClient := setupTestClient([]client.Object{
+				newAuthTestMCPServerCRD(url, &tt.ref, nil),
+				newAuthTestSecret(authTestServerNS, tt.secretData),
+				newAuthTestTool(authTestServerNS),
+			})
+
+			executor, err := createMCPExecutor(context.Background(), k8sClient,
+				newAuthTestTool(authTestServerNS), authTestServerNS,
+				newAuthTestPool(t), nil)
+
+			require.NoError(t, err, "session initialize must succeed with the bearer applied")
+
+			result, err := executor.Execute(context.Background(), ToolCall{ID: "call-1"})
+			require.NoError(t, err, "the bearer must persist onto tools/call")
+			assert.Equal(t, "Hi ark", result.Content)
+
+			for _, value := range bearerHeadersSeen(seenAuth()) {
+				assert.Equal(t, "Bearer "+authTestToken, value)
+			}
+		})
+	}
+}
+
+func TestCreateMCPExecutorWithoutAuthorizationSendsNoBearer(t *testing.T) {
+	url, seenAuth := newAuthGatedTestMCPServer(t, "")
+	k8sClient := setupTestClient([]client.Object{
+		newAuthTestMCPServerCRD(url, nil, nil),
+		newAuthTestTool(authTestServerNS),
+	})
+
+	_, err := createMCPExecutor(context.Background(), k8sClient,
+		newAuthTestTool(authTestServerNS), authTestServerNS,
+		newAuthTestPool(t), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, bearerHeadersSeen(seenAuth()))
+}
+
+// A referenced-but-absent Secret, and a Secret with no usable token, are both
+// the expected pre-authorization state. Neither may harden into a registration
+// failure - the server is left to answer with 401 as it does today.
+func TestCreateMCPExecutorFallsThroughWhenNoTokenAvailable(t *testing.T) {
+	tests := []struct {
+		name       string
+		withSecret bool
+		secretData map[string][]byte
+	}{
+		{name: "secret missing", withSecret: false},
+		{name: "secret present but empty", withSecret: true, secretData: map[string][]byte{}},
+		{
+			name:       "access token key present but blank",
+			withSecret: true,
+			secretData: map[string][]byte{arkv1alpha1.DefaultAccessTokenKey: []byte("")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, seenAuth := newAuthGatedTestMCPServer(t, "")
+			ref := arkv1alpha1.TokenSecretReference{Name: authTestSecretName}
+			objects := []client.Object{
+				newAuthTestMCPServerCRD(url, &ref, nil),
+				newAuthTestTool(authTestServerNS),
+			}
+			if tt.withSecret {
+				objects = append(objects, newAuthTestSecret(authTestServerNS, tt.secretData))
+			}
+
+			_, err := createMCPExecutor(context.Background(), setupTestClient(objects),
+				newAuthTestTool(authTestServerNS), authTestServerNS,
+				newAuthTestPool(t), nil)
+
+			require.NoError(t, err)
+			assert.Empty(t, bearerHeadersSeen(seenAuth()))
+		})
+	}
+}
+
+// The token Secret belongs to the MCPServer's namespace, not the caller's. The
+// decoy proves it: if the caller namespace were used, the wrong token would be
+// sent and the gated server would reject the session.
+func TestCreateMCPExecutorResolvesTokenSecretInMCPServerNamespace(t *testing.T) {
+	url, seenAuth := newAuthGatedTestMCPServer(t, authTestToken)
+	ref := arkv1alpha1.TokenSecretReference{Name: authTestSecretName}
+	k8sClient := setupTestClient([]client.Object{
+		newAuthTestMCPServerCRD(url, &ref, nil),
+		newAuthTestSecret(authTestServerNS, map[string][]byte{
+			arkv1alpha1.DefaultAccessTokenKey: []byte(authTestToken),
+		}),
+		newAuthTestSecret(authTestCallerNS, map[string][]byte{
+			arkv1alpha1.DefaultAccessTokenKey: []byte("tok-decoy"),
+		}),
+		newAuthTestTool(authTestCallerNS),
+	})
+
+	executor, err := createMCPExecutor(context.Background(), k8sClient,
+		newAuthTestTool(authTestCallerNS), authTestCallerNS,
+		newAuthTestPool(t), nil)
+
+	require.NoError(t, err)
+
+	result, err := executor.Execute(context.Background(), ToolCall{ID: "call-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "Hi ark", result.Content)
+
+	for _, value := range bearerHeadersSeen(seenAuth()) {
+		assert.Equal(t, "Bearer "+authTestToken, value)
+	}
+}
+
+// spec.headers secrets follow the same rule as the token Secret, matching what
+// the controller already does during discovery.
+func TestCreateMCPExecutorResolvesSpecHeadersInMCPServerNamespace(t *testing.T) {
+	url, _ := newAuthGatedTestMCPServer(t, "")
+	headers := []arkv1alpha1.Header{{
+		Name: "X-Org-Id",
+		Value: arkv1alpha1.HeaderValue{
+			ValueFrom: &arkv1alpha1.HeaderValueSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: authTestSecretName},
+					Key:                  "org",
+				},
+			},
+		},
+	}}
+	k8sClient := setupTestClient([]client.Object{
+		newAuthTestMCPServerCRD(url, nil, headers),
+		newAuthTestSecret(authTestServerNS, map[string][]byte{"org": []byte("acme")}),
+		newAuthTestTool(authTestCallerNS),
+	})
+
+	_, err := createMCPExecutor(context.Background(), k8sClient,
+		newAuthTestTool(authTestCallerNS), authTestCallerNS,
+		newAuthTestPool(t), nil)
+
+	require.NoError(t, err, "the header secret lives in the MCPServer namespace, not the caller's")
+}
+
+// Precedence: spec.headers < spec.authorization bearer < agent/query overrides.
+// NewMCPClient copies the override headers last, so an explicit per-run
+// Authorization must still win over the shared token.
+func TestCreateMCPExecutorQueryOverrideBeatsTokenSecretRefBearer(t *testing.T) {
+	const overrideToken = "tok-override"
+
+	url, seenAuth := newAuthGatedTestMCPServer(t, overrideToken)
+	ref := arkv1alpha1.TokenSecretReference{Name: authTestSecretName}
+	k8sClient := setupTestClient([]client.Object{
+		newAuthTestMCPServerCRD(url, &ref, nil),
+		newAuthTestSecret(authTestServerNS, map[string][]byte{
+			arkv1alpha1.DefaultAccessTokenKey: []byte(authTestToken),
+		}),
+		newAuthTestTool(authTestServerNS),
+	})
+	mcpSettings := map[string]arkmcp.MCPSettings{
+		authTestServerNS + "/" + authTestServerName: {
+			Headers: map[string]string{"Authorization": "Bearer " + overrideToken},
+		},
+	}
+
+	_, err := createMCPExecutor(context.Background(), k8sClient,
+		newAuthTestTool(authTestServerNS), authTestServerNS,
+		newAuthTestPool(t), mcpSettings)
+
+	require.NoError(t, err)
+	for _, value := range bearerHeadersSeen(seenAuth()) {
+		assert.Equal(t, "Bearer "+overrideToken, value)
+	}
+}

--- a/ark/internal/controller/mcpserver_controller.go
+++ b/ark/internal/controller/mcpserver_controller.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -174,98 +172,23 @@ func (r *MCPServerReconciler) processServer(ctx context.Context, mcpServer arkv1
 	return r.finalizeMCPServerProcessing(ctx, mcpServer, len(mcpTools), toolsChanged)
 }
 
-// authorizationMaterial captures the token bearer header and expiry
-// derived from spec.authorization.tokenSecretRef. A nil value means
-// spec.authorization was not set; a non-nil value with an empty
-// accessToken means the referenced Secret exists but has no usable
-// token (treat as the no-token path — controller will land in Required
-// via the existing 401 flow).
-type authorizationMaterial struct {
-	accessToken string
-	expiresAt   *metav1.Time
-	secretName  string
-}
-
-func (r *MCPServerReconciler) resolveAuthorizationMaterial(ctx context.Context, mcpServer *arkv1alpha1.MCPServer) (*authorizationMaterial, error) {
-	if mcpServer.Spec.Authorization == nil {
-		return nil, nil
+// resolveAuthorizationMaterial delegates to the shared resolver and surfaces
+// each warning as an AuthorizationSecretUnresolvable event. The same resolver
+// backs the completions executor, so discovery and tool invocation cannot
+// diverge on which credential they use.
+func (r *MCPServerReconciler) resolveAuthorizationMaterial(ctx context.Context, mcpServer *arkv1alpha1.MCPServer) (*arkmcp.AuthorizationMaterial, error) {
+	material, warnings, err := arkmcp.ResolveAuthorizationMaterial(ctx, r.APIReader, mcpServer)
+	if err != nil {
+		return nil, err
 	}
 
 	log := logf.FromContext(ctx)
-	ref := mcpServer.Spec.Authorization.TokenSecretRef
-	material := &authorizationMaterial{secretName: ref.Name}
-
-	secret := &corev1.Secret{}
-	nn := types.NamespacedName{Name: ref.Name, Namespace: mcpServer.Namespace}
-	if err := r.APIReader.Get(ctx, nn, secret); err != nil {
-		if errors.IsNotFound(err) {
-			msg := fmt.Sprintf("Secret %q not found in namespace %q — referenced by spec.authorization.tokenSecretRef.name", ref.Name, mcpServer.Namespace)
-			log.Info(msg)
-			r.Eventing.MCPServerRecorder().AuthorizationSecretUnresolvable(ctx, mcpServer, msg)
-			return material, nil
-		}
-		return nil, fmt.Errorf("failed to read authorization secret %s: %w", ref.Name, err)
-	}
-
-	// Emit a Warning event whenever the user-configured (non-default) key
-	// name is absent from the Secret. Silent on default-key absence since
-	// an empty shell Secret is the expected pre-auth state.
-	r.warnOnMissingOverriddenKeys(ctx, mcpServer, secret, ref)
-
-	accessKey := ref.AccessTokenKey
-	if accessKey == "" {
-		accessKey = "access_token"
-	}
-	if raw, ok := secret.Data[accessKey]; ok {
-		material.accessToken = string(raw)
-	}
-
-	expiresKey := ref.ExpiresAtKey
-	if expiresKey == "" {
-		expiresKey = "expires_at"
-	}
-	if raw, ok := secret.Data[expiresKey]; ok && len(raw) > 0 {
-		parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(string(raw)))
-		if err != nil {
-			log.Info("unparseable expires_at in authorization secret, leaving status.authorization.expiresAt nil", "secret", ref.Name, "key", expiresKey, "error", err.Error())
-		} else {
-			t := metav1.NewTime(parsed)
-			material.expiresAt = &t
-		}
+	for _, warning := range warnings {
+		log.Info(warning)
+		r.Eventing.MCPServerRecorder().AuthorizationSecretUnresolvable(ctx, mcpServer, warning)
 	}
 
 	return material, nil
-}
-
-// warnOnMissingOverriddenKeys emits an AuthorizationSecretUnresolvable
-// event for each `*Key` override on TokenSecretReference whose configured
-// value differs from the default AND is absent from the Secret. Default
-// key absence is silent — it matches the expected shape of a freshly
-// provisioned, unpopulated shell Secret.
-func (r *MCPServerReconciler) warnOnMissingOverriddenKeys(ctx context.Context, mcpServer *arkv1alpha1.MCPServer, secret *corev1.Secret, ref arkv1alpha1.TokenSecretReference) {
-	overrides := []struct {
-		fieldName string
-		value     string
-		fallback  string
-	}{
-		{"accessTokenKey", ref.AccessTokenKey, "access_token"},
-		{"refreshTokenKey", ref.RefreshTokenKey, "refresh_token"},
-		{"expiresAtKey", ref.ExpiresAtKey, "expires_at"},
-		{"clientIDKey", ref.ClientIDKey, "client_id"},
-		{"clientSecretKey", ref.ClientSecretKey, "client_secret"},
-	}
-	for _, o := range overrides {
-		if o.value == "" || o.value == o.fallback {
-			continue
-		}
-		if _, ok := secret.Data[o.value]; ok {
-			continue
-		}
-		msg := fmt.Sprintf(
-			"Secret %q has no key %q — spec.authorization.tokenSecretRef.%s was overridden",
-			ref.Name, o.value, o.fieldName)
-		r.Eventing.MCPServerRecorder().AuthorizationSecretUnresolvable(ctx, mcpServer, msg)
-	}
 }
 
 // applyAuthorizationSuccess reconciles status.authorization after a
@@ -274,7 +197,7 @@ func (r *MCPServerReconciler) warnOnMissingOverriddenKeys(ctx context.Context, m
 // spec.authorization is set and a non-empty access token drove the
 // connection, status is transitioned to Authorized with expiresAt
 // derived from the Secret.
-func (r *MCPServerReconciler) applyAuthorizationSuccess(mcpServer *arkv1alpha1.MCPServer, material *authorizationMaterial) {
+func (r *MCPServerReconciler) applyAuthorizationSuccess(mcpServer *arkv1alpha1.MCPServer, material *arkmcp.AuthorizationMaterial) {
 	if material == nil {
 		if mcpServer.Status.Authorization != nil {
 			mcpServer.Status.Authorization = nil
@@ -282,7 +205,7 @@ func (r *MCPServerReconciler) applyAuthorizationSuccess(mcpServer *arkv1alpha1.M
 		return
 	}
 
-	if material.accessToken == "" {
+	if material.AccessToken == "" {
 		// No token yet — the 401 path owns Required state. Leave any
 		// prior discovery status alone.
 		return
@@ -295,7 +218,7 @@ func (r *MCPServerReconciler) applyAuthorizationSuccess(mcpServer *arkv1alpha1.M
 	}
 	auth.State = arkv1alpha1.MCPServerAuthorizationStateAuthorized
 	auth.Resource = mcpServer.Status.ResolvedAddress
-	auth.ExpiresAt = material.expiresAt
+	auth.ExpiresAt = material.ExpiresAt
 	auth.LastDiscovered = &now
 	mcpServer.Status.Authorization = auth
 }
@@ -557,7 +480,7 @@ func (r *MCPServerReconciler) updateStatus(ctx context.Context, mcpServer *arkv1
 	return err
 }
 
-func (r *MCPServerReconciler) createMCPClient(ctx context.Context, mcpServer *arkv1alpha1.MCPServer, authMaterial *authorizationMaterial) (*arkmcp.MCPClient, error) {
+func (r *MCPServerReconciler) createMCPClient(ctx context.Context, mcpServer *arkv1alpha1.MCPServer, authMaterial *arkmcp.AuthorizationMaterial) (*arkmcp.MCPClient, error) {
 	mcpURL, err := arkmcp.BuildMCPServerURL(ctx, r.Client, mcpServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build MCP server URL: %v", err)
@@ -572,9 +495,7 @@ func (r *MCPServerReconciler) createMCPClient(ctx context.Context, mcpServer *ar
 		headers = resolvedHeaders
 	}
 
-	if authMaterial != nil && authMaterial.accessToken != "" {
-		headers["Authorization"] = "Bearer " + authMaterial.accessToken
-	}
+	authMaterial.ApplyBearer(headers)
 
 	timeout := parseTimeout(mcpServer.Spec.Timeout)
 

--- a/ark/internal/mcp/authorization.go
+++ b/ark/internal/mcp/authorization.go
@@ -1,0 +1,119 @@
+/* Copyright 2025. McKinsey & Company */
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+// AuthorizationMaterial captures the bearer token and expiry derived from
+// spec.authorization.tokenSecretRef. A nil value means spec.authorization was
+// not set; a non-nil value with an empty AccessToken means the referenced
+// Secret is missing or has no usable token, in which case callers fall through
+// to the unauthenticated path and the existing 401 flow.
+type AuthorizationMaterial struct {
+	AccessToken string
+	ExpiresAt   *metav1.Time
+}
+
+// ResolveAuthorizationMaterial reads spec.authorization.tokenSecretRef from the
+// MCPServer's own namespace, so both the controller's discovery path and the
+// executor's tool-invocation path resolve the same credential.
+//
+// The returned warnings describe operator-actionable misconfigurations: a
+// missing Secret first, then one per overridden *Key absent from the Secret, in
+// field order. Callers surface them however they can - the controller as
+// AuthorizationSecretUnresolvable events, the executor as logs. An unparseable
+// expiry is logged here and is not a warning.
+func ResolveAuthorizationMaterial(ctx context.Context, reader client.Reader, mcpServer *arkv1alpha1.MCPServer) (*AuthorizationMaterial, []string, error) {
+	if mcpServer.Spec.Authorization == nil {
+		return nil, nil, nil
+	}
+
+	log := logf.FromContext(ctx)
+	ref := mcpServer.Spec.Authorization.TokenSecretRef
+	material := &AuthorizationMaterial{}
+
+	secret := &corev1.Secret{}
+	nn := types.NamespacedName{Name: ref.Name, Namespace: mcpServer.Namespace}
+	if err := reader.Get(ctx, nn, secret); err != nil {
+		if errors.IsNotFound(err) {
+			msg := fmt.Sprintf("Secret %q not found in namespace %q — referenced by spec.authorization.tokenSecretRef.name", ref.Name, mcpServer.Namespace)
+			return material, []string{msg}, nil
+		}
+		return nil, nil, fmt.Errorf("failed to read authorization secret %s: %w", ref.Name, err)
+	}
+
+	warnings := missingOverriddenKeyWarnings(secret, ref)
+
+	if raw, ok := secret.Data[ref.ResolvedAccessTokenKey()]; ok {
+		material.AccessToken = string(raw)
+	}
+
+	expiresKey := ref.ResolvedExpiresAtKey()
+	if raw, ok := secret.Data[expiresKey]; ok && len(raw) > 0 {
+		parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(string(raw)))
+		if err != nil {
+			log.Info("unparseable expires_at in authorization secret, leaving status.authorization.expiresAt nil", "secret", ref.Name, "key", expiresKey, "error", err.Error())
+		} else {
+			t := metav1.NewTime(parsed)
+			material.ExpiresAt = &t
+		}
+	}
+
+	return material, warnings, nil
+}
+
+// missingOverriddenKeyWarnings reports each `*Key` override on
+// TokenSecretReference whose configured value differs from the default AND is
+// absent from the Secret. Default key absence is silent — it matches the
+// expected shape of a freshly provisioned, unpopulated shell Secret.
+func missingOverriddenKeyWarnings(secret *corev1.Secret, ref arkv1alpha1.TokenSecretReference) []string {
+	overrides := []struct {
+		fieldName string
+		value     string
+		fallback  string
+	}{
+		{"accessTokenKey", ref.AccessTokenKey, arkv1alpha1.DefaultAccessTokenKey},
+		{"refreshTokenKey", ref.RefreshTokenKey, arkv1alpha1.DefaultRefreshTokenKey},
+		{"expiresAtKey", ref.ExpiresAtKey, arkv1alpha1.DefaultExpiresAtKey},
+		{"clientIDKey", ref.ClientIDKey, arkv1alpha1.DefaultClientIDKey},
+		{"clientSecretKey", ref.ClientSecretKey, arkv1alpha1.DefaultClientSecretKey},
+	}
+
+	warnings := make([]string, 0, len(overrides))
+	for _, o := range overrides {
+		if o.value == "" || o.value == o.fallback {
+			continue
+		}
+		if _, ok := secret.Data[o.value]; ok {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"Secret %q has no key %q — spec.authorization.tokenSecretRef.%s was overridden",
+			ref.Name, o.value, o.fieldName))
+	}
+	return warnings
+}
+
+// ApplyBearer sets the Authorization header from the resolved token,
+// overwriting any value supplied via spec.headers. It is a no-op when no token
+// was resolved.
+func (m *AuthorizationMaterial) ApplyBearer(headers map[string]string) {
+	if m == nil || m.AccessToken == "" {
+		return
+	}
+	headers["Authorization"] = "Bearer " + m.AccessToken
+}

--- a/ark/internal/mcp/authorization.go
+++ b/ark/internal/mcp/authorization.go
@@ -59,7 +59,7 @@ func ResolveAuthorizationMaterial(ctx context.Context, reader client.Reader, mcp
 	warnings := missingOverriddenKeyWarnings(secret, ref)
 
 	if raw, ok := secret.Data[ref.ResolvedAccessTokenKey()]; ok {
-		material.AccessToken = string(raw)
+		material.AccessToken = strings.TrimSpace(string(raw))
 	}
 
 	expiresKey := ref.ResolvedExpiresAtKey()

--- a/ark/internal/mcp/authorization_test.go
+++ b/ark/internal/mcp/authorization_test.go
@@ -1,0 +1,283 @@
+/* Copyright 2025. McKinsey & Company */
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+)
+
+const (
+	testAuthNamespace  = "mcp-ns"
+	testAuthSecretName = "mcp-token"
+)
+
+func newAuthTestReader(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = arkv1alpha1.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func newAuthTestMCPServer(ref *arkv1alpha1.TokenSecretReference) *arkv1alpha1.MCPServer {
+	server := &arkv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: testAuthNamespace},
+	}
+	if ref != nil {
+		server.Spec.Authorization = &arkv1alpha1.MCPServerAuthorizationSpec{TokenSecretRef: *ref}
+	}
+	return server
+}
+
+func newAuthTestSecret(data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testAuthSecretName, Namespace: testAuthNamespace},
+		Data:       data,
+	}
+}
+
+// A nil spec.authorization must short-circuit before the reader is touched.
+// The MCPServer reconciler is constructed without an APIReader in some tests,
+// so dereferencing it on this path would panic.
+func TestResolveAuthorizationMaterialNilSpecNeverReadsSecret(t *testing.T) {
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), nil, newAuthTestMCPServer(nil))
+
+	require.NoError(t, err)
+	assert.Nil(t, material)
+	assert.Empty(t, warnings)
+}
+
+func TestResolveAuthorizationMaterialDefaultKeys(t *testing.T) {
+	secret := newAuthTestSecret(map[string][]byte{
+		arkv1alpha1.DefaultAccessTokenKey: []byte("tok-abc"),
+		arkv1alpha1.DefaultExpiresAtKey:   []byte("2030-01-02T03:04:05Z"),
+	})
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(secret), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Equal(t, "tok-abc", material.AccessToken)
+	require.NotNil(t, material.ExpiresAt)
+	assert.Equal(t, 2030, material.ExpiresAt.Year())
+	assert.Empty(t, warnings)
+}
+
+func TestResolveAuthorizationMaterialCustomKeys(t *testing.T) {
+	secret := newAuthTestSecret(map[string][]byte{
+		"MY_TOKEN":                        []byte("tok-custom"),
+		"MY_EXPIRY":                       []byte("2031-06-07T08:09:10Z"),
+		arkv1alpha1.DefaultAccessTokenKey: []byte("tok-default-must-be-ignored"),
+	})
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{
+		Name:           testAuthSecretName,
+		AccessTokenKey: "MY_TOKEN",
+		ExpiresAtKey:   "MY_EXPIRY",
+	})
+
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(secret), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Equal(t, "tok-custom", material.AccessToken)
+	require.NotNil(t, material.ExpiresAt)
+	assert.Equal(t, 2031, material.ExpiresAt.Year())
+	assert.Empty(t, warnings)
+}
+
+// A missing Secret is the expected pre-authorization state, not an error - the
+// caller falls through to the unauthenticated path and lands in Required via
+// the 401 flow.
+func TestResolveAuthorizationMaterialSecretNotFound(t *testing.T) {
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Empty(t, material.AccessToken)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], testAuthSecretName)
+	assert.Contains(t, warnings[0], testAuthNamespace)
+	assert.Contains(t, warnings[0], "spec.authorization.tokenSecretRef.name")
+}
+
+func TestResolveAuthorizationMaterialOverriddenKeyWarnings(t *testing.T) {
+	tests := []struct {
+		name         string
+		ref          arkv1alpha1.TokenSecretReference
+		secretData   map[string][]byte
+		wantWarnings []string
+	}{
+		{
+			name:         "empty secret with default keys stays silent",
+			ref:          arkv1alpha1.TokenSecretReference{Name: testAuthSecretName},
+			secretData:   map[string][]byte{},
+			wantWarnings: nil,
+		},
+		{
+			name: "explicit default key values stay silent",
+			ref: arkv1alpha1.TokenSecretReference{
+				Name:            testAuthSecretName,
+				AccessTokenKey:  arkv1alpha1.DefaultAccessTokenKey,
+				RefreshTokenKey: arkv1alpha1.DefaultRefreshTokenKey,
+				ExpiresAtKey:    arkv1alpha1.DefaultExpiresAtKey,
+				ClientIDKey:     arkv1alpha1.DefaultClientIDKey,
+				ClientSecretKey: arkv1alpha1.DefaultClientSecretKey,
+			},
+			secretData:   map[string][]byte{},
+			wantWarnings: nil,
+		},
+		{
+			name: "overridden and absent key warns",
+			ref: arkv1alpha1.TokenSecretReference{
+				Name:           testAuthSecretName,
+				AccessTokenKey: "MY_CUSTOM_ACCESS_TOKEN",
+			},
+			secretData:   map[string][]byte{},
+			wantWarnings: []string{"MY_CUSTOM_ACCESS_TOKEN"},
+		},
+		{
+			name: "overridden and present key stays silent",
+			ref: arkv1alpha1.TokenSecretReference{
+				Name:           testAuthSecretName,
+				AccessTokenKey: "MY_CUSTOM_ACCESS_TOKEN",
+			},
+			secretData:   map[string][]byte{"MY_CUSTOM_ACCESS_TOKEN": []byte("tok")},
+			wantWarnings: nil,
+		},
+		{
+			name: "each absent override warns in field order",
+			ref: arkv1alpha1.TokenSecretReference{
+				Name:            testAuthSecretName,
+				AccessTokenKey:  "A_KEY",
+				ClientSecretKey: "CS_KEY",
+			},
+			secretData:   map[string][]byte{},
+			wantWarnings: []string{"A_KEY", "CS_KEY"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newAuthTestMCPServer(&tt.ref)
+			reader := newAuthTestReader(newAuthTestSecret(tt.secretData))
+
+			_, warnings, err := ResolveAuthorizationMaterial(context.Background(), reader, server)
+
+			require.NoError(t, err)
+			require.Len(t, warnings, len(tt.wantWarnings))
+			for i, want := range tt.wantWarnings {
+				assert.Contains(t, warnings[i], want)
+				assert.Contains(t, warnings[i], "was overridden")
+			}
+		})
+	}
+}
+
+func TestResolveAuthorizationMaterialUnparseableExpiresAt(t *testing.T) {
+	secret := newAuthTestSecret(map[string][]byte{
+		arkv1alpha1.DefaultAccessTokenKey: []byte("tok-abc"),
+		arkv1alpha1.DefaultExpiresAtKey:   []byte("not-a-timestamp"),
+	})
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(secret), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Equal(t, "tok-abc", material.AccessToken)
+	assert.Nil(t, material.ExpiresAt)
+	assert.Empty(t, warnings, "an unparseable expiry is logged, not surfaced as an operator warning")
+}
+
+func TestResolveAuthorizationMaterialTrimsExpiresAtWhitespace(t *testing.T) {
+	secret := newAuthTestSecret(map[string][]byte{
+		arkv1alpha1.DefaultAccessTokenKey: []byte("tok-abc"),
+		arkv1alpha1.DefaultExpiresAtKey:   []byte("  2030-01-02T03:04:05Z\n"),
+	})
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, _, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(secret), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material.ExpiresAt)
+	assert.Equal(t, 2030, material.ExpiresAt.Year())
+}
+
+func TestResolveAuthorizationMaterialGetErrorPropagates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = arkv1alpha1.AddToScheme(scheme)
+
+	reader := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, testAuthSecretName, assert.AnError)
+			},
+		}).Build()
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, warnings, err := ResolveAuthorizationMaterial(context.Background(), reader, server)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read authorization secret")
+	assert.Nil(t, material)
+	assert.Empty(t, warnings)
+}
+
+func TestApplyBearer(t *testing.T) {
+	tests := []struct {
+		name     string
+		material *AuthorizationMaterial
+		headers  map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "nil material leaves headers untouched",
+			material: nil,
+			headers:  map[string]string{"X-Org": "acme"},
+			want:     map[string]string{"X-Org": "acme"},
+		},
+		{
+			name:     "empty token leaves headers untouched",
+			material: &AuthorizationMaterial{},
+			headers:  map[string]string{"X-Org": "acme"},
+			want:     map[string]string{"X-Org": "acme"},
+		},
+		{
+			name:     "token is injected as a bearer",
+			material: &AuthorizationMaterial{AccessToken: "tok-abc"},
+			headers:  map[string]string{"X-Org": "acme"},
+			want:     map[string]string{"X-Org": "acme", "Authorization": "Bearer tok-abc"},
+		},
+		{
+			name:     "token overwrites an Authorization header from spec.headers",
+			material: &AuthorizationMaterial{AccessToken: "tok-abc"},
+			headers:  map[string]string{"Authorization": "Bearer stale"},
+			want:     map[string]string{"Authorization": "Bearer tok-abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.material.ApplyBearer(tt.headers)
+			assert.Equal(t, tt.want, tt.headers)
+		})
+	}
+}

--- a/ark/internal/mcp/authorization_test.go
+++ b/ark/internal/mcp/authorization_test.go
@@ -220,6 +220,19 @@ func TestResolveAuthorizationMaterialTrimsExpiresAtWhitespace(t *testing.T) {
 	assert.Equal(t, 2030, material.ExpiresAt.Year())
 }
 
+func TestResolveAuthorizationMaterialTrimsAccessTokenWhitespace(t *testing.T) {
+	secret := newAuthTestSecret(map[string][]byte{
+		arkv1alpha1.DefaultAccessTokenKey: []byte("  tok-abc\n"),
+	})
+	server := newAuthTestMCPServer(&arkv1alpha1.TokenSecretReference{Name: testAuthSecretName})
+
+	material, _, err := ResolveAuthorizationMaterial(context.Background(), newAuthTestReader(secret), server)
+
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Equal(t, "tok-abc", material.AccessToken)
+}
+
 func TestResolveAuthorizationMaterialGetErrorPropagates(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/docs/content/reference/resources/mcpserver.mdx
+++ b/docs/content/reference/resources/mcpserver.mdx
@@ -54,7 +54,7 @@ spec:
 | `spec.timeout` | duration | no | Maximum duration for MCP tool calls to this server (`30s`, `5m`, `10m`). Defaults to `30s`. Raise it for long-running operations. |
 | `spec.pollInterval` | duration | no | How often the controller re-discovers tools from the server. Defaults to `1m`. |
 | `spec.headers[]` | list | no | HTTP headers added to requests to the server. Each entry has a `name` and a `value` (either a literal `value` or `valueFrom` — `secretKeyRef`, `configMapKeyRef`, `queryParameterRef`). |
-| `spec.authorization` | object | no | OAuth configuration for servers protected per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). When unset, the controller does not attempt to inject `Authorization` headers. |
+| `spec.authorization` | object | no | OAuth configuration for servers protected per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). When set, the resolved access token is injected as `Authorization: Bearer` on both tool discovery and tool calls — see [Header precedence](#header-precedence). When unset, Ark does not inject `Authorization` headers. |
 | `spec.authorization.tokenSecretRef` | object | yes (within `authorization`) | References the Secret holding OAuth tokens and client credentials. The Secret **must** exist in the same namespace as the MCPServer. |
 | `spec.authorization.tokenSecretRef.name` | string | yes | Name of the Secret. |
 | `spec.authorization.tokenSecretRef.accessTokenKey` | string | no | Secret key holding the access token. Defaults to `access_token`. |
@@ -166,6 +166,20 @@ shell    True        1
 | `Required` | Server returned 401 and metadata discovery succeeded. Ready for an authorize flow. A 401 from an authorized server (expiry, revocation, refresh failure) also collapses back to `Required` and emits a `TokenRejected` event. |
 | `Authorized` | The controller successfully listed tools using a Bearer token resolved from `spec.authorization.tokenSecretRef`. |
 | `DiscoveryFailed` | Server returned 401 but no usable RFC 9728 metadata was found. The CLI cannot drive an OAuth flow against this server. |
+
+### Header precedence
+
+The access token from `spec.authorization.tokenSecretRef` authorizes both paths: the controller's tool discovery, and the tool calls an agent makes at query time. `status.authorization.state: Authorized` therefore means agents can call the server's tools, not just list them.
+
+Headers merge with this precedence (last wins):
+
+```
+spec.headers  <  spec.authorization  <  Agent.spec.overrides  <  Query.spec.overrides
+```
+
+So the resolved bearer replaces an `Authorization` entry in `spec.headers`, and an Agent or Query [override](/user-guide/overrides) replaces the bearer for that run. See [User authorised MCP servers](/tutorials/user-authorised-mcp-servers) for the per-user pattern.
+
+Both the Secret named by `tokenSecretRef` and any Secret or ConfigMap referenced from `spec.headers` are read from the **MCPServer's** namespace, not the caller's.
 
 ### Prerequisites
 

--- a/docs/content/tutorials/user-authorised-mcp-servers.mdx
+++ b/docs/content/tutorials/user-authorised-mcp-servers.mdx
@@ -17,13 +17,13 @@ By the end you'll have:
 
 ## How per-user auth works
 
-An `MCPServer` can carry static `spec.headers` (a shared token). On top of that, an Agent or a Query can set `spec.overrides` with `resourceType: mcpserver` to inject or replace headers for that specific run. The headers merge with this precedence (last wins):
+An `MCPServer` can carry static `spec.headers` (a shared token), or a bearer resolved from `spec.authorization.tokenSecretRef`. On top of either, an Agent or a Query can set `spec.overrides` with `resourceType: mcpserver` to inject or replace headers for that specific run. The headers merge with this precedence (last wins):
 
 ```
-MCPServer.spec.headers  <  Agent.spec.overrides  <  Query.spec.overrides
+MCPServer.spec.headers  <  MCPServer.spec.authorization  <  Agent.spec.overrides  <  Query.spec.overrides
 ```
 
-So a per-query `Authorization` override replaces the server's default token for that call — that's what makes the request "user authorised." The registration token on the `MCPServer` is only used to **discover** the server's tools; the token that actually authorises a tool *call* is whichever override is in effect.
+The `MCPServer`-level credential applies to both tool **discovery** and tool **calls**, so an agent can use the server with no override at all. A per-query `Authorization` override replaces it for that call — that's what makes the request "user authorised."
 
 ## Prerequisites
 
@@ -32,10 +32,10 @@ So a per-query `Authorization` override replaces the server's default token for 
 
 ## Step 1 — Register the GitHub MCP server
 
-The MCP controller connects to the server, discovers its tools, and creates a `Tool` per function. It needs a token to do that discovery — use a service/registration token here (any valid GitHub token works):
+The MCP controller connects to the server, discovers its tools, and creates a `Tool` per function. It needs a token to do that — use a service/registration token here (any valid GitHub token works). This token is also the fallback for tool calls that carry no override, so scope it accordingly:
 
 ```bash
-# Registration token, used only for tool discovery.
+# Registration token: used for tool discovery, and for any call without an override.
 kubectl create secret generic github-registration-token \
   --from-literal=token="Bearer $(gh auth token)"
 ```


### PR DESCRIPTION
## Summary

Fixes #3044.

`MCPServer.spec.authorization.tokenSecretRef` was read in exactly one place — the controller's tool-discovery path. The completions executor built its own MCP client headers from `spec.headers` alone, so tools discovered fine and `status.authorization.state` reported `Authorized`, then the first agent query 401'd. Every OAuth-protected MCP server was affected; the only workaround was duplicating the bearer into `spec.headers`, which left `spec.authorization` providing no value.

- Extract the controller's resolver into `internal/mcp` as `ResolveAuthorizationMaterial`, so discovery and tool invocation derive the credential from one place and cannot diverge again. Warnings come back as data rather than via a recorder: the controller surfaces them as `AuthorizationSecretUnresolvable` events, the executor as logs, since it deliberately emits no Kubernetes events.
- Apply the resolved bearer in `createMCPExecutor`, before the pool connects.
- Correct the namespace the executor resolves `spec.headers` in — see below.
- Add default-key constants and `Resolved*Key()` helpers alongside the `+kubebuilder:default` markers, which can't reference constants.
- Docs: correct the now-false "the registration token is only used to discover the server's tools" claim, and document the precedence chain.

No CRD, chart, RBAC or webhook changes — `make manifests` produces no diff.

### Two notes for review

**It fails at session initialize, not `tools/call`.** `NewMCPClient` connects eagerly, so an OAuth-protected server rejects the MCP session before any tool call happens. The tests assert on that boundary.

**The `spec.headers` namespace correction is a behaviour change beyond the reported bug.** The executor resolved `secretKeyRef`/`configMapKeyRef` in the *caller's* namespace rather than the MCPServer's. No working configuration depended on that: the controller's own discovery already resolves in the MCPServer namespace, so a cross-namespace reference that only worked under the old runtime behaviour would have failed discovery and produced no Tools to invoke. Worth calling out explicitly, though — because the default install grants cluster-wide secret read, the old path could instead silently pick up a *same-named* Secret from the caller's namespace, making the reference caller-controlled rather than owner-controlled.

### Precedence

```
spec.headers  <  spec.authorization  <  Agent.spec.overrides  <  Query.spec.overrides
```

The bearer overwrites an `Authorization` entry in `spec.headers`, matching what the controller already does. Agent/query overrides still win, so the per-user-token tutorial keeps working; there's a test locking that ordering.

### Verification

`internal/controller/mcpserver_auth_test.go` passes **unmodified** — that was the acceptance criterion for the extraction.

New: 17 resolver tests and 7 runtime tests. Reverting the fix turns 3 of the runtime tests red (bearer injection, token-Secret namespace, headers namespace); the rest are fall-through and precedence locks that correctly stay green either way.

Also verified against a live cluster by running the real executor code path against real CRs — the API server's CRD defaulting, a real Secret read, and a real bearer-gated MCP server over HTTP. The bearer appears on every request including `tools/call`, a decoy same-named Secret in the caller namespace is correctly ignored, and reverting the fix reproduces the reported symptom exactly (token resolves, `Authorization=""` on the wire, 401 at initialize).

Not covered: the full in-cluster `Query` → controller → A2A → executor pod chain, which needs a rebuilt image. That wiring is untouched by this change.

### Follow-ups (not this PR)

- Pool invalidation on token rotation — `GetOrCreateClient` keys on `namespace/name` only. Belongs with #3040, which owns cached-client invalidation. The key must be split before the pool is ever made long-lived.
- `mcpSettings` key skew: built with the agent/query namespace, looked up with the MCPServer namespace, so header overrides miss on cross-namespace refs.
- OpenSpec `mcp-auth-token-injection` scopes injection to "the controller" throughout and will contradict the code once this lands.
- `spec.timeout` parse divergence: `createMCPExecutor` hard-errors where the controller's `parseTimeout` silently defaults to 30s, so `timeout: "banana"` discovers fine then fails every agent load. Same class of controller/runtime divergence as this issue.
- No chainsaw e2e: `tests/shared/install-mock-llm.sh` ships no bearer-gated MCP endpoint, so one would mean adding a gating mock upstream.