### PR TITLE
test(ark-dashboard): fix flaky selector-section dropdown tests

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/team-form/sections/selector-section.test.tsx
@@ -216,8 +216,12 @@ describe('SelectorSection', () => {
 
       await user.click(screen.getByRole('combobox'));
 
-      expect(screen.getByRole('option', { name: 'agent-1' })).toBeInTheDocument();
-      expect(screen.getByRole('option', { name: 'agent-2' })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', { name: 'agent-1' }),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', { name: 'agent-2' }),
+      ).toBeInTheDocument();
     });
 
     it('should include a None (Unset) option', async () => {
@@ -226,7 +230,9 @@ describe('SelectorSection', () => {
 
       await user.click(screen.getByRole('combobox'));
 
-      expect(screen.getByRole('option', { name: 'None (Unset)' })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', { name: 'None (Unset)' }),
+      ).toBeInTheDocument();
     });
 
     it('should be disabled when form is disabled', () => {
@@ -276,7 +282,9 @@ describe('SelectorSection', () => {
 
       await user.click(screen.getByRole('combobox'));
 
-      expect(screen.getByRole('option', { name: 'missing-agent (Unavailable)' })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', { name: 'missing-agent (Unavailable)' }),
+      ).toBeInTheDocument();
     });
 
     it('should not show the (Unavailable) option when the selected agent is available', async () => {
@@ -290,6 +298,7 @@ describe('SelectorSection', () => {
 
       await user.click(screen.getByRole('combobox'));
 
+      await screen.findByRole('option', { name: 'agent-1' });
       expect(screen.queryByText(/Unavailable/)).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- Fix flaky dropdown tests in `selector-section.test.tsx`. The Base UI Select (`@base-ui/react/select`) opens its options portal asynchronously, so the synchronous `getByRole('option')` lookups raced the render and failed intermittently under load (observed in CI run 31031804486).
- Switch the three affected assertions to async `findByRole`, and harden the negative "Unavailable option" test by awaiting the dropdown open before asserting absence.
- Test-only change; no production code touched. Verified stable across repeated local runs.