### PR TITLE
fix(postgresql): pg_notify fast path for cross-replica watch delivery

### DIFF
--- a/ark/dist/chart-apiserver/README.md
+++ b/ark/dist/chart-apiserver/README.md
@@ -79,6 +79,7 @@ Before wiring either mechanism the apiserver runs a `SelfSubjectAccessReview` fo
 - `ark_apiserver_wal_consumer_active` — `1` on the replica running the WAL consumer; across a healthy deployment the sum is exactly `1`.
 - `ark_apiserver_wal_last_message_timestamp_seconds` — staleness means the consumer is wedged. `NaN` on replicas not running the consumer (including a leader that just lost the lease), so a `time() - ark_apiserver_wal_last_message_timestamp_seconds > 300` alert stays quiet on followers; if you scope it anyway, join on `ark_apiserver_wal_consumer_active == 1`.
 - `ark_apiserver_replication_slot_lag_bytes` — WAL pinned by the `ark_cdc` slot; a climbing value is the disk-filling condition described under "Replication slot lifecycle". Sampled every 30s on the leader; `NaN` elsewhere. The query reads `pg_replication_slots`, which works for the slot owner by default — a locked-down role needs `GRANT pg_monitor TO <role>`.
+- `ark_apiserver_notify_listener_connected` — `1` while the replica holds its `LISTEN ark_resource_change` connection. Every replica should read `1`; a `0` means that replica's watches have fallen back to the periodic relist. `ark_apiserver_notify_listener_reconnects_total` counts drops; `ark_apiserver_notify_received_total` counts nudges per kind.
 - `ark_apiserver_db_pool_*` — connection pool stats (`sql.DBStats`); `wait_count_total` rising means pool exhaustion.
 
 `metrics.secure=true` (default) serves HTTPS and requires a bearer token authorized via TokenReview/SubjectAccessReview; the RBAC is already covered by the `system:auth-delegator` binding. `metrics.serviceMonitor.enabled=true` renders a ServiceMonitor (requires the Prometheus Operator CRDs) scraping every `metrics.serviceMonitor.interval` (default `30s`).
@@ -99,7 +100,7 @@ If you redeploy the apiserver later, it detects the existing slot on startup and
 
 The chart defaults to a single replica — note that an unavailable aggregated apiserver degrades kube-apiserver discovery and garbage collection cluster-wide, so for production run `replicas=2` with `podDisruptionBudget.enabled=true`.
 
-All replicas serve API traffic; only the leader (`Lease/ark-apiserver-leader`) runs the WAL consumer, since the replication slot admits a single connection (the slot's `active` flag is a backstop). Non-leader replicas do not touch the slot and serve watches from a periodic relist (up to ~120s stale) until they acquire the lease.
+All replicas serve API traffic; only the leader (`Lease/ark-apiserver-leader`) runs the WAL consumer, since the replication slot admits a single connection (the slot's `active` flag is a backstop). Non-leader replicas do not touch the slot. Cross-replica watch delivery does not depend on the lease: every write emits a `pg_notify` after commit and every replica holds a `LISTEN` connection that wakes its watchers, so a watch served by any replica sees writes taken by any other typically well under a second; the periodic relist (~120s) remains as the backstop.
 
 ### Required PostgreSQL configuration
 

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -233,6 +233,7 @@ func (s *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create PostgreSQL backend: %w", err)
 	}
 	close(s.backendReady)
+	s.backend.StartNotifyListener()
 	klog.Infof("Using PostgreSQL storage backend: %s:%d/%s", cfg.Host, cfg.Port, cfg.Database)
 
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()

--- a/ark/internal/storage/postgresql/metrics.go
+++ b/ark/internal/storage/postgresql/metrics.go
@@ -89,6 +89,28 @@ var (
 			Help: "WAL bytes between pg_current_wal_lsn() and the ark_cdc slot's confirmed_flush_lsn; NaN on replicas not running the WAL consumer",
 		},
 	)
+
+	notifyReceivedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ark_apiserver_notify_received_total",
+			Help: "Number of cross-replica change notifications received by the LISTEN loop",
+		},
+		[]string{"kind"},
+	)
+
+	notifyListenerConnected = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ark_apiserver_notify_listener_connected",
+			Help: "1 while the cross-replica notify listener holds an active LISTEN connection, 0 otherwise",
+		},
+	)
+
+	notifyListenerReconnectsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ark_apiserver_notify_listener_reconnects_total",
+			Help: "Number of times the notify listener lost its connection and retried",
+		},
+	)
 )
 
 const slotLagSampleInterval = 30 * time.Second
@@ -204,6 +226,9 @@ func init() {
 		walConsumerActive,
 		walLastMessageTimestamp,
 		replicationSlotLagBytes,
+		notifyReceivedTotal,
+		notifyListenerConnected,
+		notifyListenerReconnectsTotal,
 		dbPoolCollector{},
 	)
 }

--- a/ark/internal/storage/postgresql/metrics_test.go
+++ b/ark/internal/storage/postgresql/metrics_test.go
@@ -52,6 +52,7 @@ func TestMetricsGatheredByControllerRuntimeRegistry(t *testing.T) {
 	broadcasterEventsDropped.WithLabelValues("RegistryTest")
 	watcherRelistFailures.WithLabelValues("RegistryTest")
 	broadcasterActiveWatchers.WithLabelValues("RegistryTest")
+	notifyReceivedTotal.WithLabelValues("RegistryTest")
 	swapDBPoolStats(t, func() sql.DBStats { return sql.DBStats{} })
 
 	families, err := ctrlmetrics.Registry.Gather()
@@ -73,6 +74,9 @@ func TestMetricsGatheredByControllerRuntimeRegistry(t *testing.T) {
 		"ark_apiserver_wal_consumer_active",
 		"ark_apiserver_wal_last_message_timestamp_seconds",
 		"ark_apiserver_replication_slot_lag_bytes",
+		"ark_apiserver_notify_received_total",
+		"ark_apiserver_notify_listener_connected",
+		"ark_apiserver_notify_listener_reconnects_total",
 		"ark_apiserver_db_pool_max_open_connections",
 		"ark_apiserver_db_pool_open_connections",
 		"ark_apiserver_db_pool_in_use_connections",

--- a/ark/internal/storage/postgresql/notify_listener.go
+++ b/ark/internal/storage/postgresql/notify_listener.go
@@ -1,0 +1,95 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"k8s.io/klog/v2"
+)
+
+// notifyChannel carries cross-replica watch nudges. The payload is the resource
+// kind only: receivers relist from the resources table, so a lost notification
+// costs latency (bounded by the broadcaster's periodic relist), never data.
+const notifyChannel = "ark_resource_change"
+
+func (p *PostgreSQLBackend) notifyResourceChange(ctx context.Context, kind string) {
+	if _, err := p.db.ExecContext(ctx, `SELECT pg_notify($1, $2)`, notifyChannel, kind); err != nil {
+		klog.Warningf("pg_notify %s for kind %s failed; watchers fall back to periodic relist: %v", notifyChannel, kind, err)
+	}
+}
+
+// StartNotifyListener starts the LISTEN loop that turns cross-replica write
+// notifications into broadcaster nudges. Unlike the WAL consumer it is not
+// leader-gated: NOTIFY fans out to every listening session, so each replica
+// runs its own. Repeated calls are no-ops.
+func (p *PostgreSQLBackend) StartNotifyListener() {
+	p.notifyOnce.Do(func() {
+		go p.startNotifyListener()
+	})
+}
+
+func (p *PostgreSQLBackend) startNotifyListener() {
+	backoff := time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
+
+		err := p.runNotifyListener()
+		if p.ctx.Err() != nil {
+			return
+		}
+
+		klog.Errorf("notify listener disconnected, retrying in %v: %v", backoff, err)
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+func (p *PostgreSQLBackend) runNotifyListener() error {
+	cfg, err := pgconn.ParseConfig(p.connStr)
+	if err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	cfg.OnNotification = func(_ *pgconn.PgConn, n *pgconn.Notification) {
+		p.handleNotification(n.Payload)
+	}
+
+	conn, err := pgconn.ConnectConfig(p.ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer func() { _ = conn.Close(p.ctx) }()
+
+	if _, err := conn.Exec(p.ctx, "LISTEN "+notifyChannel).ReadAll(); err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+
+	klog.Infof("notify listener started on channel %s", notifyChannel)
+	p.nudgeAllWatchers()
+
+	for {
+		if err := conn.WaitForNotification(p.ctx); err != nil {
+			return fmt.Errorf("wait for notification: %w", err)
+		}
+	}
+}
+
+func (p *PostgreSQLBackend) handleNotification(kind string) {
+	if kind == "" {
+		return
+	}
+	p.nudgeKind(kind)
+}

--- a/ark/internal/storage/postgresql/notify_listener.go
+++ b/ark/internal/storage/postgresql/notify_listener.go
@@ -3,7 +3,6 @@
 package postgresql
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -15,12 +14,6 @@ import (
 // kind only: receivers relist from the resources table, so a lost notification
 // costs latency (bounded by the broadcaster's periodic relist), never data.
 const notifyChannel = "ark_resource_change"
-
-func (p *PostgreSQLBackend) notifyResourceChange(ctx context.Context, kind string) {
-	if _, err := p.db.ExecContext(ctx, `SELECT pg_notify($1, $2)`, notifyChannel, kind); err != nil {
-		klog.Warningf("pg_notify %s for kind %s failed; watchers fall back to periodic relist: %v", notifyChannel, kind, err)
-	}
-}
 
 // StartNotifyListener starts the LISTEN loop that turns cross-replica write
 // notifications into broadcaster nudges. Unlike the WAL consumer it is not
@@ -49,6 +42,7 @@ func (p *PostgreSQLBackend) startNotifyListener() {
 		}
 
 		klog.Errorf("notify listener disconnected, retrying in %v: %v", backoff, err)
+		notifyListenerReconnectsTotal.Inc()
 		select {
 		case <-p.ctx.Done():
 			return
@@ -77,6 +71,9 @@ func (p *PostgreSQLBackend) runNotifyListener() error {
 		return fmt.Errorf("listen: %w", err)
 	}
 
+	notifyListenerConnected.Set(1)
+	defer notifyListenerConnected.Set(0)
+
 	klog.Infof("notify listener started on channel %s", notifyChannel)
 	p.nudgeAllWatchers()
 
@@ -91,5 +88,6 @@ func (p *PostgreSQLBackend) handleNotification(kind string) {
 	if kind == "" {
 		return
 	}
+	notifyReceivedTotal.WithLabelValues(kind).Inc()
 	p.nudgeKind(kind)
 }

--- a/ark/internal/storage/postgresql/notify_listener.go
+++ b/ark/internal/storage/postgresql/notify_listener.go
@@ -36,9 +36,13 @@ func (p *PostgreSQLBackend) startNotifyListener() {
 		default:
 		}
 
+		started := time.Now()
 		err := p.runNotifyListener()
 		if p.ctx.Err() != nil {
 			return
+		}
+		if time.Since(started) > maxBackoff {
+			backoff = time.Second
 		}
 
 		klog.Errorf("notify listener disconnected, retrying in %v: %v", backoff, err)
@@ -85,9 +89,12 @@ func (p *PostgreSQLBackend) runNotifyListener() error {
 }
 
 func (p *PostgreSQLBackend) handleNotification(kind string) {
-	if kind == "" {
+	p.mu.RLock()
+	b := p.broadcasters[kind]
+	p.mu.RUnlock()
+	if b == nil {
 		return
 	}
 	notifyReceivedTotal.WithLabelValues(kind).Inc()
-	p.nudgeKind(kind)
+	b.nudge()
 }

--- a/ark/internal/storage/postgresql/notify_listener_test.go
+++ b/ark/internal/storage/postgresql/notify_listener_test.go
@@ -8,7 +8,17 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"k8s.io/apimachinery/pkg/runtime"
+	"mckinsey.com/ark/internal/storage"
 )
+
+type stubConverter struct{ encoded string }
+
+func (c stubConverter) NewObject(string) runtime.Object               { return nil }
+func (c stubConverter) NewListObject(string) runtime.Object           { return nil }
+func (c stubConverter) Encode(runtime.Object) ([]byte, error)         { return []byte(c.encoded), nil }
+func (c stubConverter) Decode(string, []byte) (runtime.Object, error) { return nil, nil }
+func (c stubConverter) APIVersion(string) string                      { return "" }
 
 func TestStartNotifyListener_ConsumesOnce(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,49 +102,95 @@ func TestStartNotifyListener_RetriesThenStopsOnCancel(t *testing.T) {
 	}
 }
 
-func TestNotifyResourceChange_Emits(t *testing.T) {
+func TestCreate_EmitsNotifyInWriteStatement(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("INSERT INTO resources.*pg_notify").WithArgs(
+		"Agent", "ns", "a1", "u1", "{}", "{}", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), notifyChannel,
+	).WillReturnRows(sqlmock.NewRows([]string{"resource_version", "generation", "created_at", "pg_notify"}).AddRow(int64(1), int64(1), time.Now(), ""))
 
-	p := &PostgreSQLBackend{db: db}
-	p.notifyResourceChange(context.Background(), "Agent")
-
+	p := &PostgreSQLBackend{db: db, converter: stubConverter{encoded: `{"metadata":{"uid":"u1"},"spec":{},"status":{}}`}}
+	if err := p.Create(context.Background(), "Agent", "ns", "a1", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}
 }
 
-func TestNotifyResourceChange_ErrorIsNonFatal(t *testing.T) {
+func TestUpdate_EmitsNotifyInWriteStatement(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnError(context.DeadlineExceeded)
+	mock.ExpectQuery("UPDATE resources.*pg_notify").WillReturnRows(
+		sqlmock.NewRows([]string{"resource_version", "generation", "uid", "created_at", "updated", "pg_notify"}).
+			AddRow(int64(2), int64(1), "u1", time.Now(), true, ""))
 
-	p := &PostgreSQLBackend{db: db}
-	p.notifyResourceChange(context.Background(), "Agent")
-
+	p := &PostgreSQLBackend{db: db, converter: stubConverter{encoded: `{"metadata":{"resourceVersion":"1"},"spec":{},"status":{}}`}}
+	if err := p.Update(context.Background(), "Agent", "ns", "a1", nil); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}
 }
 
-func TestDelete_EmitsNotifyOnSuccess(t *testing.T) {
+func TestUpdate_ConflictExecutesNoNotify(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec("UPDATE resources").WithArgs("Agent", "ns", "a1").WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("UPDATE resources.*pg_notify").WillReturnRows(
+		sqlmock.NewRows([]string{"resource_version", "generation", "uid", "created_at", "updated", "pg_notify"}).
+			AddRow(int64(0), int64(0), "", time.Now(), false, nil))
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	p := &PostgreSQLBackend{db: db, converter: stubConverter{encoded: `{"metadata":{"resourceVersion":"1"},"spec":{},"status":{}}`}}
+	if err := p.Update(context.Background(), "Agent", "ns", "a1", nil); err != storage.ErrConflict {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateStatus_EmitsNotifyInWriteStatement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("UPDATE resources.*pg_notify").WillReturnRows(
+		sqlmock.NewRows([]string{"resource_version", "updated", "pg_notify"}).AddRow(int64(2), true, ""))
+
+	p := &PostgreSQLBackend{db: db, converter: stubConverter{encoded: `{"metadata":{"resourceVersion":"1"},"status":{}}`}}
+	if err := p.UpdateStatus(context.Background(), "Agent", "ns", "a1", nil); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDelete_EmitsNotifyInWriteStatement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("UPDATE resources.*pg_notify").WithArgs("Agent", "ns", "a1", notifyChannel).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_notify"}).AddRow(""))
 
 	p := &PostgreSQLBackend{db: db}
 	if err := p.Delete(context.Background(), "Agent", "ns", "a1"); err != nil {
@@ -145,18 +201,19 @@ func TestDelete_EmitsNotifyOnSuccess(t *testing.T) {
 	}
 }
 
-func TestDelete_NotFoundSkipsNotify(t *testing.T) {
+func TestDelete_NotFoundExecutesNoNotify(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec("UPDATE resources").WithArgs("Agent", "ns", "gone").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("UPDATE resources.*pg_notify").WithArgs("Agent", "ns", "gone", notifyChannel).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_notify"}))
 
 	p := &PostgreSQLBackend{db: db}
-	if err := p.Delete(context.Background(), "Agent", "ns", "gone"); err == nil {
-		t.Fatal("expected ErrNotFound")
+	if err := p.Delete(context.Background(), "Agent", "ns", "gone"); err != storage.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)

--- a/ark/internal/storage/postgresql/notify_listener_test.go
+++ b/ark/internal/storage/postgresql/notify_listener_test.go
@@ -1,0 +1,164 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestStartNotifyListener_ConsumesOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := &PostgreSQLBackend{ctx: ctx}
+
+	p.StartNotifyListener()
+	p.StartNotifyListener()
+
+	ran := false
+	p.notifyOnce.Do(func() { ran = true })
+	if ran {
+		t.Error("StartNotifyListener did not consume notifyOnce")
+	}
+}
+
+func TestHandleNotification_NudgesOnlyThatKind(t *testing.T) {
+	backend, bcs := newTestBackendWithBroadcasters("Agent", "Team")
+	defer backend.cancel()
+
+	backend.handleNotification("Agent")
+
+	if !nudged(bcs["Agent"]) {
+		t.Error("Agent broadcaster was not nudged")
+	}
+	if nudged(bcs["Team"]) {
+		t.Error("Team broadcaster was nudged for an Agent notification")
+	}
+}
+
+func TestHandleNotification_EmptyPayloadIgnored(t *testing.T) {
+	backend, bcs := newTestBackendWithBroadcasters("Agent")
+	defer backend.cancel()
+
+	backend.handleNotification("")
+
+	if nudged(bcs["Agent"]) {
+		t.Error("empty payload should not nudge any broadcaster")
+	}
+}
+
+func TestHandleNotification_UnknownKindIsNoop(t *testing.T) {
+	backend, bcs := newTestBackendWithBroadcasters("Agent")
+	defer backend.cancel()
+
+	backend.handleNotification("NoSuchKind")
+
+	if nudged(bcs["Agent"]) {
+		t.Error("unknown kind should not nudge other broadcasters")
+	}
+}
+
+func TestRunNotifyListener_BadConnString(t *testing.T) {
+	p := &PostgreSQLBackend{ctx: context.Background(), connStr: "=not-a-conn-string"}
+	if err := p.runNotifyListener(); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestStartNotifyListener_RetriesThenStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PostgreSQLBackend{
+		ctx:     ctx,
+		cancel:  cancel,
+		connStr: "host=127.0.0.1 port=1 user=x dbname=x sslmode=disable connect_timeout=1",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		p.startNotifyListener()
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startNotifyListener did not stop after context cancel")
+	}
+}
+
+func TestNotifyResourceChange_Emits(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	p := &PostgreSQLBackend{db: db}
+	p.notifyResourceChange(context.Background(), "Agent")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNotifyResourceChange_ErrorIsNonFatal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnError(context.DeadlineExceeded)
+
+	p := &PostgreSQLBackend{db: db}
+	p.notifyResourceChange(context.Background(), "Agent")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDelete_EmitsNotifyOnSuccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("UPDATE resources").WithArgs("Agent", "ns", "a1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("SELECT pg_notify").WithArgs(notifyChannel, "Agent").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	p := &PostgreSQLBackend{db: db}
+	if err := p.Delete(context.Background(), "Agent", "ns", "a1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDelete_NotFoundSkipsNotify(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("UPDATE resources").WithArgs("Agent", "ns", "gone").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	p := &PostgreSQLBackend{db: db}
+	if err := p.Delete(context.Background(), "Agent", "ns", "gone"); err == nil {
+		t.Fatal("expected ErrNotFound")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/ark/internal/storage/postgresql/notify_listener_test.go
+++ b/ark/internal/storage/postgresql/notify_listener_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"k8s.io/apimachinery/pkg/runtime"
 	"mckinsey.com/ark/internal/storage"
@@ -63,11 +65,15 @@ func TestHandleNotification_EmptyPayloadIgnored(t *testing.T) {
 func TestHandleNotification_UnknownKindIsNoop(t *testing.T) {
 	backend, bcs := newTestBackendWithBroadcasters("Agent")
 	defer backend.cancel()
+	series := testutil.CollectAndCount(notifyReceivedTotal)
 
 	backend.handleNotification("NoSuchKind")
 
 	if nudged(bcs["Agent"]) {
 		t.Error("unknown kind should not nudge other broadcasters")
+	}
+	if got := testutil.CollectAndCount(notifyReceivedTotal); got != series {
+		t.Errorf("unknown kind minted a metric series: %d -> %d", series, got)
 	}
 }
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -580,10 +580,13 @@ func (p *PostgreSQLBackend) Create(ctx context.Context, kind, namespace, name st
 	var rv, generation int64
 	var createdAt time.Time
 	err = p.db.QueryRowContext(ctx, `
-		INSERT INTO resources (kind, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references)
-		VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb)
-		RETURNING resource_version, generation, created_at
-	`, kind, namespace, name, resource.Metadata.UID, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON).Scan(&rv, &generation, &createdAt)
+		WITH ins AS (
+			INSERT INTO resources (kind, namespace, name, uid, spec, status, labels, annotations, finalizers, owner_references)
+			VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb)
+			RETURNING resource_version, generation, created_at
+		)
+		SELECT resource_version, generation, created_at, pg_notify($11, $1) FROM ins
+	`, kind, namespace, name, resource.Metadata.UID, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON, notifyChannel).Scan(&rv, &generation, &createdAt, new(sql.NullString))
 	if err != nil {
 		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
 			return storage.ErrAlreadyExists
@@ -591,7 +594,6 @@ func (p *PostgreSQLBackend) Create(ctx context.Context, kind, namespace, name st
 		return fmt.Errorf("failed to insert resource: %w", err)
 	}
 
-	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
@@ -917,10 +919,10 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 			WHERE kind = $8 AND namespace = $9 AND name = $10 AND resource_version = $11 AND deleted_at IS NULL
 			RETURNING resource_version, generation, uid, created_at
 		)
-		SELECT resource_version, generation, uid, created_at, true FROM upd
+		SELECT resource_version, generation, uid, created_at, true, pg_notify($12, $8) FROM upd
 		UNION ALL
-		SELECT 0, 0, '', NOW(), false WHERE NOT EXISTS (SELECT 1 FROM upd)
-	`, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON, deletionTS, kind, namespace, name, rv).Scan(&newRV, &newGen, &uid, &createdAt, &updated)
+		SELECT 0, 0, '', NOW(), false, NULL WHERE NOT EXISTS (SELECT 1 FROM upd)
+	`, specJSON, statusJSON, string(labelsJSON), string(annotationsJSON), string(finalizersJSON), ownerRefsJSON, deletionTS, kind, namespace, name, rv, notifyChannel).Scan(&newRV, &newGen, &uid, &createdAt, &updated, new(sql.NullString))
 	if err != nil {
 		return fmt.Errorf("failed to update resource: %w", err)
 	}
@@ -934,7 +936,6 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 		return storage.ErrNotFound
 	}
 
-	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
@@ -978,10 +979,10 @@ func (p *PostgreSQLBackend) UpdateStatus(ctx context.Context, kind, namespace, n
 			WHERE kind = $2 AND namespace = $3 AND name = $4 AND resource_version = $5 AND deleted_at IS NULL
 			RETURNING resource_version
 		)
-		SELECT resource_version, true FROM upd
+		SELECT resource_version, true, pg_notify($6, $2) FROM upd
 		UNION ALL
-		SELECT 0, false WHERE NOT EXISTS (SELECT 1 FROM upd)
-	`, statusJSON, kind, namespace, name, rv).Scan(&newRV, &updated)
+		SELECT 0, false, NULL WHERE NOT EXISTS (SELECT 1 FROM upd)
+	`, statusJSON, kind, namespace, name, rv, notifyChannel).Scan(&newRV, &updated, new(sql.NullString))
 	if err != nil {
 		return fmt.Errorf("failed to update resource status: %w", err)
 	}
@@ -995,26 +996,26 @@ func (p *PostgreSQLBackend) UpdateStatus(ctx context.Context, kind, namespace, n
 		return storage.ErrNotFound
 	}
 
-	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
 func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name string) error {
-	result, err := p.db.ExecContext(ctx, `
-		UPDATE resources
-		SET deleted_at = NOW(), resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
-		WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL
-	`, kind, namespace, name)
+	err := p.db.QueryRowContext(ctx, `
+		WITH del AS (
+			UPDATE resources
+			SET deleted_at = NOW(), resource_version = nextval('resources_resource_version_seq'), updated_at = NOW()
+			WHERE kind = $1 AND namespace = $2 AND name = $3 AND deleted_at IS NULL
+			RETURNING resource_version
+		)
+		SELECT pg_notify($4, $1) FROM del
+	`, kind, namespace, name, notifyChannel).Scan(new(sql.NullString))
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return storage.ErrNotFound
+		}
 		return fmt.Errorf("failed to delete resource: %w", err)
 	}
 
-	affected, _ := result.RowsAffected()
-	if affected == 0 {
-		return storage.ErrNotFound
-	}
-
-	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -191,6 +191,7 @@ type PostgreSQLBackend struct {
 	// reject too-old resume points without a DB round-trip.
 	cachedPurgeFloor atomic.Int64
 	walOnce          sync.Once
+	notifyOnce       sync.Once
 }
 
 var connValueEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
@@ -590,6 +591,7 @@ func (p *PostgreSQLBackend) Create(ctx context.Context, kind, namespace, name st
 		return fmt.Errorf("failed to insert resource: %w", err)
 	}
 
+	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
@@ -932,6 +934,7 @@ func (p *PostgreSQLBackend) Update(ctx context.Context, kind, namespace, name st
 		return storage.ErrNotFound
 	}
 
+	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
@@ -992,6 +995,7 @@ func (p *PostgreSQLBackend) UpdateStatus(ctx context.Context, kind, namespace, n
 		return storage.ErrNotFound
 	}
 
+	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 
@@ -1010,6 +1014,7 @@ func (p *PostgreSQLBackend) Delete(ctx context.Context, kind, namespace, name st
 		return storage.ErrNotFound
 	}
 
+	p.notifyResourceChange(ctx, kind)
 	return nil
 }
 

--- a/ark/internal/storage/postgresql/watch_validation_test.go
+++ b/ark/internal/storage/postgresql/watch_validation_test.go
@@ -713,3 +713,65 @@ drained3:
 		}
 	}
 }
+
+// TestNotifyListener_ReconnectRecovers kills the LISTEN backend, writes while
+// the listener is reconnecting, and asserts the write still reaches the watcher
+// quickly. The listener nudges all watchers on reconnect (notify_listener.go),
+// so a write that landed during the LISTEN gap is picked up by the post-reconnect
+// relist rather than waiting for the production ticker.
+func TestNotifyListener_ReconnectRecovers(t *testing.T) {
+	replicaA := newTestBackend(t)
+	defer replicaA.Close()
+	replicaB := newTestBackend(t)
+	defer replicaB.Close()
+	replicaB.StartNotifyListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kind := "NotifyReconnectTest"
+	ns := "notify-reconnect-test"
+
+	replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
+
+	w, err := replicaB.Watch(ctx, kind, ns, storage.WatchOptions{})
+	if err != nil {
+		t.Fatalf("Watch on replica B failed: %v", err)
+	}
+	defer w.Stop()
+
+	var pid int64
+	pidDeadline := time.After(10 * time.Second)
+	for {
+		row := replicaA.db.QueryRowContext(ctx, "SELECT pid FROM pg_stat_activity WHERE query = 'LISTEN "+notifyChannel+"'")
+		if err := row.Scan(&pid); err == nil {
+			break
+		}
+		select {
+		case <-pidDeadline:
+			t.Fatal("notify listener never opened a LISTEN session")
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+
+	if _, err := replicaA.db.ExecContext(ctx, "SELECT pg_terminate_backend($1)", pid); err != nil {
+		t.Fatalf("pg_terminate_backend failed: %v", err)
+	}
+
+	createTestResource(t, replicaA, kind, ns, "reconnect-probe")
+
+	start := time.Now()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-w.ResultChan():
+			if ev.Type == watch.Added {
+				t.Logf("Replica B recovered the write %v after the LISTEN backend was killed", time.Since(start))
+				replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
+				return
+			}
+		case <-deadline:
+			t.Fatal("Replica B did not recover the write within 5s of the LISTEN backend being killed")
+		}
+	}
+}

--- a/ark/internal/storage/postgresql/watch_validation_test.go
+++ b/ark/internal/storage/postgresql/watch_validation_test.go
@@ -416,12 +416,12 @@ collected:
 }
 
 func TestWatch_CrossReplicaDelivery(t *testing.T) {
-	withFastRelist(t, 2*time.Second)
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
 	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
+	replicaB.StartNotifyListener()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -473,11 +473,12 @@ drained:
 
 	t.Logf("Created %d resources on replica A, waiting for replica B watcher...", count)
 
-	// Replica B has no WAL consumer; its only signal is the broadcaster's
-	// safety-net relist (shortened via withFastRelist), so the deadline must
-	// exceed one tick.
+	// Replica B has no WAL consumer; its fast path is the pg_notify nudge from
+	// replica A's writes. The relist ticker keeps its production 120s cadence
+	// so the deadline below can only be met through the notify path.
+	start := time.Now()
 	received := 0
-	deadline := time.After(30 * time.Second)
+	deadline := time.After(15 * time.Second)
 	for received < count {
 		select {
 		case ev := <-w.ResultChan():
@@ -490,7 +491,7 @@ drained:
 	}
 timeout:
 
-	t.Logf("Replica B received %d/%d events", received, count)
+	t.Logf("Replica B received %d/%d events in %v", received, count, time.Since(start))
 
 	if received < count {
 		t.Errorf("Replica B received %d/%d events — cross-replica delivery incomplete", received, count)
@@ -500,12 +501,12 @@ timeout:
 }
 
 func TestWatch_CrossReplicaBurst(t *testing.T) {
-	withFastRelist(t, 2*time.Second)
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
 	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
+	replicaB.StartNotifyListener()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -560,7 +561,7 @@ drained2:
 	t.Logf("Created %d/%d resources on replica A, waiting for replica B...", actual, count)
 
 	seen := make(map[string]bool)
-	deadline := time.After(30 * time.Second)
+	deadline := time.After(15 * time.Second)
 	for len(seen) < actual {
 		select {
 		case ev := <-w.ResultChan():
@@ -591,12 +592,12 @@ timeout2:
 }
 
 func TestWatch_CrossReplicaDelete(t *testing.T) {
-	withFastRelist(t, 2*time.Second)
 	replicaA := newTestBackend(t)
 	defer replicaA.Close()
 	replicaA.StartWALConsumer()
 	replicaB := newTestBackend(t)
 	defer replicaB.Close()
+	replicaB.StartNotifyListener()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -634,14 +635,15 @@ func TestWatch_CrossReplicaDelete(t *testing.T) {
 		t.Fatalf("Delete on replica A failed: %v", err)
 	}
 
+	deleteStart := time.Now()
 	gotDelete := false
-	deadline := time.After(30 * time.Second)
+	deadline := time.After(15 * time.Second)
 	for {
 		select {
 		case ev := <-w.ResultChan():
 			if ev.Type == watch.Deleted {
 				obj := ev.Object.(*integrationTestObject)
-				t.Logf("Replica B received DELETED event for %s", obj.Metadata.Name)
+				t.Logf("Replica B received DELETED event for %s after %v", obj.Metadata.Name, time.Since(deleteStart))
 				gotDelete = true
 				goto done
 			}
@@ -658,4 +660,56 @@ done:
 	}
 
 	replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
+}
+
+// TestWatch_CrossReplicaNotifyLatency proves the notify path alone: the writer
+// runs no WAL consumer and the relist ticker keeps its production cadence, so
+// the only fast signal reaching replica B's watcher is the pg_notify nudge.
+func TestWatch_CrossReplicaNotifyLatency(t *testing.T) {
+	replicaA := newTestBackend(t)
+	defer replicaA.Close()
+	replicaB := newTestBackend(t)
+	defer replicaB.Close()
+	replicaB.StartNotifyListener()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kind := "NotifyLatencyTest"
+	ns := "notify-latency-test"
+
+	replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
+
+	w, err := replicaB.Watch(ctx, kind, ns, storage.WatchOptions{})
+	if err != nil {
+		t.Fatalf("Watch on replica B failed: %v", err)
+	}
+	defer w.Stop()
+
+	time.Sleep(2 * time.Second)
+	for {
+		select {
+		case <-w.ResultChan():
+		default:
+			goto drained3
+		}
+	}
+drained3:
+
+	start := time.Now()
+	createTestResource(t, replicaA, kind, ns, "latency-probe")
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-w.ResultChan():
+			if ev.Type == watch.Added {
+				t.Logf("Cross-replica notify latency: %v", time.Since(start))
+				replicaA.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1", kind)
+				return
+			}
+		case <-deadline:
+			t.Fatal("No ADDED event on replica B within 5s — the notify fast path is not working")
+		}
+	}
 }

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -498,8 +498,8 @@ For production, run two replicas and enable the disruption budget:
 How multiple replicas behave:
 
 - **API serving is active-active.** Every replica serves reads and writes directly against Postgres; the Service load-balances across them. Killing any one pod leaves the APIService available.
-- **The watch stream is single-consumer by design.** Only the replica holding the `ark-apiserver-leader` lease runs the WAL consumer that drives real-time watch events (the logical replication slot admits one connection; the slot's `active` flag is a backstop even without the lease). Non-leader replicas do not touch the slot.
-- **Watches served by non-leader replicas are relist-bound.** Without the WAL stream, a non-leader refreshes its watchers on a periodic relist (up to ~120 seconds stale). Controllers tolerate this — informers resync — but if consistently low watch latency matters, keep a single replica and accept the SPOF trade-off, or route watch-heavy clients through the kubectl path.
+- **The WAL stream is single-consumer by design.** Only the replica holding the `ark-apiserver-leader` lease runs the WAL consumer (the logical replication slot admits one connection; the slot's `active` flag is a backstop even without the lease). Non-leader replicas do not touch the slot.
+- **Cross-replica watch delivery is `pg_notify`-driven.** Every write emits a `pg_notify` on the `ark_resource_change` channel after commit, and every replica holds a `LISTEN` connection that wakes its watchers immediately — typically well under a second, regardless of which replica took the write. The notification carries only the resource kind; watchers are refreshed from the `resources` table, so a dropped notification delays delivery instead of losing it. The periodic relist (~120 seconds) remains as the backstop.
 - **Failover:** if the leader dies, a surviving replica acquires the lease (roughly the 15s lease duration) and starts the WAL consumer; the slot position is persistent, so no events are lost across the handover.
 
 ## Backups and restore

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -66,12 +66,13 @@ The connection settings the chart accepts are listed in [`ark/dist/chart-apiserv
 
 ### Connection pooling and PgBouncer
 
-The apiserver holds a dedicated logical replication connection for its watch stream in addition to its regular query pool. Route only the **query** traffic through an external pooler, and keep the replication connection direct:
+In addition to its regular query pool, the apiserver holds two session-scoped connections: a logical replication connection for the WAL stream (leader only) and a `LISTEN ark_resource_change` connection for cross-replica watch notifications (every replica). Route only the **query** traffic through an external pooler, and keep both of these direct:
 
 - **PgBouncer in transaction or statement pooling mode is incompatible with logical replication.** The replication connection must reach Postgres directly (or through a session-pooling/`session` mode pooler — for PgBouncer this requires version 1.21.0 or newer, which added replication-connection passthrough; older versions reject the replication protocol even in session mode). Point `ARK_POSTGRES_HOST` at a direct endpoint, or run a separate session-mode pooler for the apiserver.
-- Managed poolers (RDS Proxy, Cloud SQL connectors) have the same constraint — replication slots require a session-scoped connection.
+- **`LISTEN` is session state and fails silently behind a transaction-mode pooler.** The `LISTEN` command succeeds, but the server backend it registered on is handed to the next client at the end of the transaction, so notifications are never delivered: `ark_apiserver_notify_listener_connected` reads `1` while watches on that replica silently fall back to the ~120s relist.
+- Managed poolers (RDS Proxy, Cloud SQL connectors) have the same constraints — replication slots and `LISTEN` both require a session-scoped connection.
 
-The apiserver already pools its own query connections (`MaxOpenConns` defaults to 40); an external transaction-pooling layer in front of the query path is optional and must not carry the replication connection.
+The apiserver already pools its own query connections (`MaxOpenConns` defaults to 40); the replication and `LISTEN` connections are held outside that pool, so budget `MaxOpenConns + 2` per replica against `max_connections`. An external transaction-pooling layer in front of the query path is optional and must not carry either of the two session connections.
 
 ## Schema and replication slot
 


### PR DESCRIPTION
## Summary

- Fixes #3066: watchers on non-leader replicas waited for the 120s safety relist (measured 107s staleness on a 2-replica kind cluster); with this change the same probe takes 121ms end to end through kubectl, 7.7ms backend to backend.
- Every write emits `SELECT pg_notify('ark_resource_change', kind)` after commit; every replica runs a LISTEN loop (`notify_listener.go`, same backoff shape as the WAL consumer) that nudges the per-kind broadcaster. Not leader-gated: NOTIFY fans out to all listeners, there is no single-consumer constraint.
- The notification carries only the kind, never data. Receivers relist from the `resources` table, a full relist runs on every (re)connect, and the 120s ticker stays as backstop, so every pg_notify failure mode (dropped connection, DB restart, lost notification) degrades to bounded staleness instead of lost events. This is the difference from the trigger design #1763 removed, which put event payloads inside notifications.
- WAL consumer, leader election, broadcaster and watcher code are unchanged. No DDL, no chart or config changes, one extra Postgres connection per replica.
- The three cross-replica integration tests now run against the production 120s ticker with the listener enabled, so the notify path is what makes them pass (with `withFastRelist` they could not tell the fast path from a sped-up ticker); deadlines drop to 15s. New `TestWatch_CrossReplicaNotifyLatency` asserts sub-5s delivery with no WAL consumer running at all.
- Failure drills on kind (LISTEN connections killed mid-burst: delivered in 0.995s; Postgres pod deleted: reconnect 6s, next write 123ms; 200-write burst: 200/200, zero duplicates across 213 events) are written up in the [design proposal on the issue](https://github.com/mckinsey/agents-at-scale-ark/issues/3066#issuecomment-5194419819), with an [architecture diagram](https://github.com/mckinsey/agents-at-scale-ark/issues/3066#issuecomment-5202221371).
