### PR TITLE
fix(ark-api): require authorization to create API keys

### DIFF
--- a/docs/content/developer-guide/authentication.mdx
+++ b/docs/content/developer-guide/authentication.mdx
@@ -339,6 +339,8 @@ curl -X POST http://localhost:8000/v1/api-keys \
 
 **Note:** When impersonation is enabled (`AUTH_MODE=hybrid` or `sso`), creating an API key requires the same permission your identity would need to create a Secret directly in the namespace. This is checked with a `SelfSubjectAccessReview` against the requesting user, the same mechanism used elsewhere in the API.
 
+> **Breaking change:** In `AUTH_MODE=hybrid` deployments with impersonation enabled, API keys created before this authorization check was introduced have no recorded creator and will no longer authenticate. Recreate any such key through the endpoint above so it is minted under an identity with permission to create Secrets in the namespace, and update the credentials wherever the old key was in use. Deployments that don't combine `hybrid` mode with impersonation are unaffected.
+
 ### Using API Keys
 
 API keys use HTTP Basic Authentication where:
@@ -422,6 +424,7 @@ DELETE /v1/api-keys/{public_key}
 - **Usage Signal**: Successful API-key authentication updates `last_used_at` for monitoring and audit review
 - **Soft Delete**: Revoked API keys are marked inactive but retained for audit trails
 - **Creation Authorization**: With impersonation enabled, creating an API key requires the same permission as creating a Secret in the namespace, and listing/revoking keys is scoped to their creator
+- **Legacy Key Rejection**: In `hybrid` mode with impersonation enabled, keys with no recorded creator (minted before this authorization check existed) are rejected at authentication — see the breaking-change note above
 - **Per-Namespace Storage**: API keys are stored as Kubernetes secrets in their respective namespaces for true tenant isolation
 
 ## Security Features

--- a/docs/content/developer-guide/authentication.mdx
+++ b/docs/content/developer-guide/authentication.mdx
@@ -337,6 +337,8 @@ curl -X POST http://localhost:8000/v1/api-keys \
 
 **Note:** The API key will be stored in the current namespace only. You must authenticate against the ARK API instance in the same namespace where the API key was created.
 
+**Note:** When impersonation is enabled (`AUTH_MODE=hybrid` or `sso`), creating an API key requires the same permission your identity would need to create a Secret directly in the namespace. This is checked with a `SelfSubjectAccessReview` against the requesting user, the same mechanism used elsewhere in the API.
+
 ### Using API Keys
 
 API keys use HTTP Basic Authentication where:
@@ -389,6 +391,8 @@ GET /v1/api-keys
 
 The list response includes `last_used_at`. Ark updates this timestamp after successful API-key authentication, so operators can monitor for unexpected use of issued keys.
 
+When impersonation is enabled, listing and revoking API keys is scoped to the keys created by the requesting user.
+
 #### Create API Key
 ```bash
 # Create in current namespace
@@ -417,6 +421,7 @@ DELETE /v1/api-keys/{public_key}
 - **Expiration**: API keys can have optional expiration dates for enhanced security
 - **Usage Signal**: Successful API-key authentication updates `last_used_at` for monitoring and audit review
 - **Soft Delete**: Revoked API keys are marked inactive but retained for audit trails
+- **Creation Authorization**: With impersonation enabled, creating an API key requires the same permission as creating a Secret in the namespace, and listing/revoking keys is scoped to their creator
 - **Per-Namespace Storage**: API keys are stored as Kubernetes secrets in their respective namespaces for true tenant isolation
 
 ## Security Features

--- a/services/ark-api/ark-api/src/ark_api/api/v1/api_keys.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/api_keys.py
@@ -1,41 +1,86 @@
 """API key management endpoints."""
 
 import logging
-from fastapi import APIRouter, HTTPException, status
+from typing import Optional
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from kubernetes_asyncio import client
+
+from ark_sdk.impersonation import ImpersonationConfig
+from ark_sdk.k8s import get_context
+
+from ...auth.dependencies import require_api_key_owner
 from ...models.auth import (
     APIKeyCreateRequest,
     APIKeyCreateResponse,
-    APIKeyListResponse
+    APIKeyListResponse,
+    UserIdentity,
 )
 from ...services.api_keys import APIKeyService
+from .client_utils import get_impersonating_api_client
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
 
+async def _can_create_secrets(owner: UserIdentity, namespace: str) -> bool:
+    impersonation = ImpersonationConfig(username=owner.username, groups=owner.groups)
+    async with get_impersonating_api_client(impersonation) as api:
+        review = await client.AuthorizationV1Api(api).create_self_subject_access_review(
+            client.V1SelfSubjectAccessReview(
+                spec=client.V1SelfSubjectAccessReviewSpec(
+                    resource_attributes=client.V1ResourceAttributes(
+                        namespace=namespace, verb="create", resource="secrets"
+                    )
+                )
+            )
+        )
+    return bool(review.status and review.status.allowed)
+
+
+async def authorize_api_key_creation(
+    owner: Optional[UserIdentity] = Depends(require_api_key_owner),
+) -> Optional[UserIdentity]:
+    if owner is None:
+        return None
+
+    namespace = get_context()["namespace"]
+    try:
+        allowed = await _can_create_secrets(owner, namespace)
+    except Exception:
+        logger.warning("api-key creation permission probe failed", exc_info=True)
+        allowed = False
+
+    if not allowed:
+        raise HTTPException(status_code=403, detail="not authorized to create API keys")
+    return owner
+
+
 @router.post("", response_model=APIKeyCreateResponse, status_code=status.HTTP_201_CREATED)
 async def create_api_key(
-    body: APIKeyCreateRequest
+    body: APIKeyCreateRequest,
+    owner: Optional[UserIdentity] = Depends(authorize_api_key_creation),
 ) -> APIKeyCreateResponse:
     """
     Create a new API key for service-to-service authentication.
     API keys are namespace-scoped for tenant isolation and stored in the current namespace.
-    
+
     Args:
         body: API key creation request
-        
+
     Returns:
         APIKeyCreateResponse: The created API key with secret (only shown once)
     """
     try:
         api_key_service = APIKeyService()
-        result = await api_key_service.create_api_key(body)
-        
+        result = await api_key_service.create_api_key(
+            body, created_by=owner.username if owner else None
+        )
+
         logger.info(f"Created API key '{body.name}' with public key {result.public_key} in namespace {api_key_service.namespace}")
         return result
-        
+
     except Exception as e:
         logger.error(f"Error creating API key: {e}")
         raise HTTPException(
@@ -45,17 +90,21 @@ async def create_api_key(
 
 
 @router.get("", response_model=APIKeyListResponse)
-async def list_api_keys() -> APIKeyListResponse:
+async def list_api_keys(
+    owner: Optional[UserIdentity] = Depends(require_api_key_owner),
+) -> APIKeyListResponse:
     """
     List all active API keys in the current namespace (without secret keys).
     API keys are namespace-scoped for tenant isolation.
-    
+
     Returns:
         APIKeyListResponse: List of API keys in the current namespace
     """
     try:
         api_key_service = APIKeyService()
-        result = await api_key_service.list_api_keys()
+        result = await api_key_service.list_api_keys(
+            created_by=owner.username if owner else None
+        )
         logger.debug(f"Listed {result.count} API keys in namespace {api_key_service.namespace}")
         return result
         
@@ -68,18 +117,23 @@ async def list_api_keys() -> APIKeyListResponse:
 
 
 @router.delete("/{public_key}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_api_key(public_key: str):
+async def delete_api_key(
+    public_key: str,
+    owner: Optional[UserIdentity] = Depends(require_api_key_owner),
+):
     """
     Soft delete an API key in the current namespace by marking it as inactive.
     API keys are namespace-scoped for tenant isolation.
-    
+
     Args:
         public_key: The public key of the API key to delete
     """
     try:
         api_key_service = APIKeyService()
-        
-        success = await api_key_service.delete_api_key(public_key)
+
+        success = await api_key_service.delete_api_key(
+            public_key, created_by=owner.username if owner else None
+        )
         if not success:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
@@ -28,7 +28,7 @@ def require_api_key_owner(request: Request) -> Optional[UserIdentity]:
         return None
 
     identity = getattr(request.state, "user_identity", None)
-    if identity is None:
+    if identity is None or not identity.username:
         raise HTTPException(
             status_code=403,
             detail="API key management requires an authenticated user identity",

--- a/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
@@ -37,4 +37,4 @@ def require_api_key_owner(request: Request) -> Optional[UserIdentity]:
             status_code=403,
             detail="API key management requires an authenticated user identity",
         )
-    return identity
+    return UserIdentity(username=identity.username.strip(), groups=identity.groups)

--- a/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
@@ -28,7 +28,11 @@ def require_api_key_owner(request: Request) -> Optional[UserIdentity]:
         return None
 
     identity = getattr(request.state, "user_identity", None)
-    if identity is None or not identity.username:
+    if (
+        identity is None
+        or not isinstance(identity.username, str)
+        or not identity.username.strip()
+    ):
         raise HTTPException(
             status_code=403,
             detail="API key management requires an authenticated user identity",

--- a/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/dependencies.py
@@ -1,9 +1,12 @@
+import os
 from typing import Optional
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from ark_sdk.impersonation import ImpersonationConfig
+from .constants import AuthMode
 from .impersonation_config import ImpersonationSettings
+from ..models.auth import UserIdentity
 
 
 def get_impersonation_config(request: Request) -> Optional[ImpersonationConfig]:
@@ -16,3 +19,18 @@ def get_impersonation_config(request: Request) -> Optional[ImpersonationConfig]:
         return None
 
     return ImpersonationConfig(username=identity.username, groups=identity.groups)
+
+
+def require_api_key_owner(request: Request) -> Optional[UserIdentity]:
+    settings = ImpersonationSettings.from_env()
+    auth_mode = os.getenv("AUTH_MODE", "").lower()
+    if not settings.enabled or auth_mode not in (AuthMode.SSO, AuthMode.HYBRID):
+        return None
+
+    identity = getattr(request.state, "user_identity", None)
+    if identity is None:
+        raise HTTPException(
+            status_code=403,
+            detail="API key management requires an authenticated user identity",
+        )
+    return identity

--- a/services/ark-api/ark-api/src/ark_api/auth/middleware.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/middleware.py
@@ -200,12 +200,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
                     api_key_data = await self.api_key_service.verify_api_key(public_key, secret_key)
                     gate_requires_owner = self.impersonation_settings.enabled and auth_mode == AuthMode.HYBRID
-                    if api_key_data and not (gate_requires_owner and api_key_data.get("created_by") is None):
+                    # Same generic error for "no such key" and "key has no recorded owner" so a caller
+                    # can't distinguish a wrong secret from an orphaned key.
+                    key_rejected = not api_key_data or (gate_requires_owner and api_key_data.get("created_by") is None)
+                    if key_rejected:
+                        auth_error = f"Invalid API key credentials or key not found in namespace {self.api_key_service.namespace}"
+                    else:
                         auth_success = True
                         logger.debug(f"Basic auth successful for key: {public_key} in namespace {self.api_key_service.namespace}")
                         request.state.api_key = api_key_data
-                    else:
-                        auth_error = f"Invalid API key credentials or key not found in namespace {self.api_key_service.namespace}"
 
             except Exception as e:
                 logger.error(f"Basic auth error: {e}")

--- a/services/ark-api/ark-api/src/ark_api/auth/middleware.py
+++ b/services/ark-api/ark-api/src/ark_api/auth/middleware.py
@@ -199,7 +199,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     public_key, secret_key = credentials
 
                     api_key_data = await self.api_key_service.verify_api_key(public_key, secret_key)
-                    if api_key_data:
+                    gate_requires_owner = self.impersonation_settings.enabled and auth_mode == AuthMode.HYBRID
+                    if api_key_data and not (gate_requires_owner and api_key_data.get("created_by") is None):
                         auth_success = True
                         logger.debug(f"Basic auth successful for key: {public_key} in namespace {self.api_key_service.namespace}")
                         request.state.api_key = api_key_data

--- a/services/ark-api/ark-api/src/ark_api/services/api_keys.py
+++ b/services/ark-api/ark-api/src/ark_api/services/api_keys.py
@@ -147,17 +147,19 @@ class APIKeyService:
         created_at: datetime,
         expires_at: Optional[datetime] = None,
         last_used_at: Optional[datetime] = None,
-        deleted_at: Optional[datetime] = None
+        deleted_at: Optional[datetime] = None,
+        created_by: Optional[str] = None
     ) -> str:
         """Create JSON annotation for API key metadata.
-        
+
         Args:
             name: API key name
             created_at: Creation timestamp
             expires_at: Optional expiration timestamp
             last_used_at: Optional last used timestamp
             deleted_at: Optional deletion timestamp
-            
+            created_by: Optional identity of the user who created the key
+
         Returns:
             JSON string with API key metadata
         """
@@ -165,14 +167,16 @@ class APIKeyService:
             "name": name,
             "createdAt": self._format_datetime(created_at)
         }
-        
+
         if expires_at:
             metadata["expiresAt"] = self._format_datetime(expires_at)
         if last_used_at:
             metadata["lastUsedAt"] = self._format_datetime(last_used_at)
         if deleted_at:
             metadata["deletedAt"] = self._format_datetime(deleted_at)
-        
+        if created_by:
+            metadata["createdBy"] = created_by
+
         return json.dumps(metadata)
     
     def _parse_api_key_annotation(self, annotation_json: str) -> Dict[str, Any]:
@@ -191,7 +195,8 @@ class APIKeyService:
                 "created_at": self._parse_datetime(metadata.get("createdAt")),
                 "expires_at": self._parse_datetime(metadata.get("expiresAt")),
                 "last_used_at": self._parse_datetime(metadata.get("lastUsedAt")),
-                "deleted_at": self._parse_datetime(metadata.get("deletedAt"))
+                "deleted_at": self._parse_datetime(metadata.get("deletedAt")),
+                "created_by": metadata.get("createdBy")
             }
         except (json.JSONDecodeError, Exception) as e:
             logger.error(f"Error parsing API key annotation: {e}")
@@ -200,29 +205,34 @@ class APIKeyService:
                 "created_at": None,
                 "expires_at": None,
                 "last_used_at": None,
-                "deleted_at": None
+                "deleted_at": None,
+                "created_by": None
             }
     
-    async def create_api_key(self, request: APIKeyCreateRequest) -> APIKeyCreateResponse:
+    async def create_api_key(
+        self, request: APIKeyCreateRequest, created_by: Optional[str] = None
+    ) -> APIKeyCreateResponse:
         """Create a new API key.
-        
+
         Args:
             request: API key creation request
-            
+            created_by: Optional identity of the user creating the key
+
         Returns:
             API key creation response with secret key
         """
         # Generate key pair
         public_key, secret_key = self._generate_key_pair()
         secret_key_hash = self._hash_secret_key(secret_key)
-        
+
         # Prepare metadata
         now = datetime.now(timezone.utc)
-        
+
         api_key_json = self._create_api_key_annotation(
             name=request.name,
             created_at=now,
-            expires_at=request.expires_at
+            expires_at=request.expires_at,
+            created_by=created_by
         )
         
         annotations = {
@@ -270,9 +280,12 @@ class APIKeyService:
             expires_at=request.expires_at
         )
     
-    async def list_api_keys(self) -> APIKeyListResponse:
+    async def list_api_keys(self, created_by: Optional[str] = None) -> APIKeyListResponse:
         """List all active API keys (without secret keys).
-        
+
+        Args:
+            created_by: When given, only keys created by this identity are returned
+
         Returns:
             List of API key responses
         """
@@ -307,7 +320,11 @@ class APIKeyService:
                 # Skip soft-deleted keys
                 if deleted_at is not None or not is_active:
                     continue
-                
+
+                # Skip keys owned by someone else when scoping is requested
+                if created_by is not None and metadata.get("created_by") != created_by:
+                    continue
+
                 api_keys.append(APIKeyResponse(
                     id=str(secret.metadata.uid),
                     name=name,
@@ -326,12 +343,15 @@ class APIKeyService:
             count=len(api_keys)
         )
     
-    async def get_api_key_by_public_key(self, public_key: str) -> Optional[Dict[str, Any]]:
+    async def get_api_key_by_public_key(
+        self, public_key: str, created_by: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
         """Get API key data by public key for authentication.
-        
+
         Args:
             public_key: The public key to look up
-            
+            created_by: When given, the key must have been created by this identity
+
         Returns:
             Dictionary with API key data or None if not found
         """
@@ -369,12 +389,15 @@ class APIKeyService:
             deleted_at = metadata["deleted_at"]
             if not is_active or deleted_at is not None:
                 return None
-            
+
             # Check expiration
             expires_at = metadata["expires_at"]
             if expires_at and expires_at < datetime.now(timezone.utc):
                 return None
-            
+
+            if created_by is not None and metadata.get("created_by") != created_by:
+                return None
+
             return {
                 "id": str(secret.metadata.uid),
                 "name": metadata["name"],
@@ -446,7 +469,8 @@ class APIKeyService:
                     created_at=metadata["created_at"] or now,
                     expires_at=metadata["expires_at"],
                     last_used_at=now,
-                    deleted_at=metadata["deleted_at"]
+                    deleted_at=metadata["deleted_at"],
+                    created_by=metadata.get("created_by")
                 )
                 
                 # Update annotations
@@ -465,12 +489,15 @@ class APIKeyService:
         except Exception as e:
             logger.error(f"Error updating last used timestamp for {secret_name}: {e}")
     
-    async def delete_api_key(self, public_key: str) -> bool:
+    async def delete_api_key(
+        self, public_key: str, created_by: Optional[str] = None
+    ) -> bool:
         """Soft delete an API key by marking it as inactive.
-        
+
         Args:
             public_key: The public key of the API key to delete
-            
+            created_by: When given, the key must have been created by this identity
+
         Returns:
             True if deleted successfully, False otherwise
         """
@@ -492,14 +519,18 @@ class APIKeyService:
                 annotations = secret.metadata.annotations or {}
                 api_key_json = annotations.get(API_KEY_ANNOTATION, "{}")
                 metadata = self._parse_api_key_annotation(api_key_json)
-                
+
+                if created_by is not None and metadata.get("created_by") != created_by:
+                    return False
+
                 # Update deleted timestamp
                 updated_json = self._create_api_key_annotation(
                     name=metadata["name"],
                     created_at=metadata["created_at"] or now,
                     expires_at=metadata["expires_at"],
                     last_used_at=metadata["last_used_at"],
-                    deleted_at=now
+                    deleted_at=now,
+                    created_by=metadata.get("created_by")
                 )
                 
                 # Update to mark as deleted (soft delete)

--- a/services/ark-api/ark-api/src/ark_api/services/api_keys.py
+++ b/services/ark-api/ark-api/src/ark_api/services/api_keys.py
@@ -405,7 +405,8 @@ class APIKeyService:
                 "secret_key_hash": secret_key_hash,
                 "is_active": is_active,
                 "expires_at": expires_at,
-                "secret_name": secret_name
+                "secret_name": secret_name,
+                "created_by": metadata.get("created_by")
             }
             
         except client.rest.ApiException as e:

--- a/services/ark-api/ark-api/src/ark_api/services/api_keys.py
+++ b/services/ark-api/ark-api/src/ark_api/services/api_keys.py
@@ -174,7 +174,7 @@ class APIKeyService:
             metadata["lastUsedAt"] = self._format_datetime(last_used_at)
         if deleted_at:
             metadata["deletedAt"] = self._format_datetime(deleted_at)
-        if created_by:
+        if created_by is not None:
             metadata["createdBy"] = created_by
 
         return json.dumps(metadata)

--- a/services/ark-api/ark-api/tests/api/test_api_keys.py
+++ b/services/ark-api/ark-api/tests/api/test_api_keys.py
@@ -18,24 +18,40 @@ from ark_api.api.v1.api_keys import authorize_api_key_creation
 from ark_api.models.auth import UserIdentity
 
 
-@asynccontextmanager
-async def _fake_api_client(impersonation=None):
-    yield MagicMock()
+def _patch_ssar(can_create=None, side_effect=None):
+    """Patches the SSAR call chain and records what was actually sent.
 
-
-def _patch_ssar(can_create):
+    Returns (stack, impersonation_calls, review_calls): the impersonation
+    config passed to get_impersonating_api_client, and the
+    V1SelfSubjectAccessReview bodies passed to create_self_subject_access_review,
+    in call order.
+    """
     stack = ExitStack()
+    impersonation_calls = []
+    review_calls = []
+
+    @asynccontextmanager
+    async def fake_get_impersonating_api_client(impersonation=None):
+        impersonation_calls.append(impersonation)
+        yield MagicMock()
+
     stack.enter_context(
-        patch("ark_api.api.v1.api_keys.get_impersonating_api_client", _fake_api_client)
+        patch("ark_api.api.v1.api_keys.get_impersonating_api_client", fake_get_impersonating_api_client)
     )
+
     mock_auth = MagicMock()
-    mock_auth.create_self_subject_access_review = AsyncMock(
-        return_value=SimpleNamespace(status=SimpleNamespace(allowed=can_create))
-    )
+    if side_effect is not None:
+        mock_auth.create_self_subject_access_review = AsyncMock(side_effect=side_effect)
+    else:
+        async def _create_review(review):
+            review_calls.append(review)
+            return SimpleNamespace(status=SimpleNamespace(allowed=can_create))
+
+        mock_auth.create_self_subject_access_review = AsyncMock(side_effect=_create_review)
     stack.enter_context(
         patch("ark_api.api.v1.api_keys.client.AuthorizationV1Api", return_value=mock_auth)
     )
-    return stack
+    return stack, impersonation_calls, review_calls
 
 
 def _raise_no_identity():
@@ -390,12 +406,24 @@ class TestAPIKeyCreationAuthorization(unittest.TestCase):
         mock_response.name = "Test Key"
         mock_service.create_api_key = AsyncMock(return_value=mock_response)
 
-        with _patch_ssar(can_create=True):
+        stack, impersonation_calls, review_calls = _patch_ssar(can_create=True)
+        with stack:
             response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
 
         self.assertEqual(response.status_code, 201)
         mock_service.create_api_key.assert_called_once()
         self.assertEqual(mock_service.create_api_key.call_args[1]["created_by"], "alice@example.com")
+
+        # The SSAR must be evaluated as the requesting user, not the ark-api
+        # service account -- otherwise the probe always says "allowed".
+        self.assertEqual(len(impersonation_calls), 1)
+        self.assertEqual(impersonation_calls[0].username, "alice@example.com")
+        self.assertEqual(impersonation_calls[0].groups, ["viewers"])
+
+        self.assertEqual(len(review_calls), 1)
+        attrs = review_calls[0].spec.resource_attributes
+        self.assertEqual(attrs.verb, "create")
+        self.assertEqual(attrs.resource, "secrets")
 
     @patch('ark_api.api.v1.api_keys.APIKeyService')
     def test_gate_active_unauthorized_owner_denies_creation(self, mock_service_class):
@@ -408,7 +436,27 @@ class TestAPIKeyCreationAuthorization(unittest.TestCase):
         mock_service_class.return_value = mock_service
         mock_service.create_api_key = AsyncMock()
 
-        with _patch_ssar(can_create=False):
+        stack, impersonation_calls, _ = _patch_ssar(can_create=False)
+        with stack:
+            response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
+
+        self.assertEqual(response.status_code, 403)
+        mock_service.create_api_key.assert_not_called()
+        self.assertEqual(impersonation_calls[0].username, "alice@example.com")
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_gate_active_ssar_probe_error_denies_creation(self, mock_service_class):
+        """A probe failure must deny, not silently allow -- fail closed."""
+        self.app.dependency_overrides[require_api_key_owner] = (
+            lambda: UserIdentity(username="alice@example.com", groups=["viewers"])
+        )
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.create_api_key = AsyncMock()
+
+        stack, _, _ = _patch_ssar(side_effect=Exception("apiserver unreachable"))
+        with stack:
             response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
 
         self.assertEqual(response.status_code, 403)

--- a/services/ark-api/ark-api/tests/api/test_api_keys.py
+++ b/services/ark-api/ark-api/tests/api/test_api_keys.py
@@ -2,13 +2,44 @@
 
 import os
 import unittest
-from unittest.mock import Mock, patch, AsyncMock
+from contextlib import ExitStack, asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock, patch, AsyncMock, MagicMock
 from datetime import datetime, timezone, timedelta
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 # Set environment variable to skip authentication before importing the app
 from ark_api.auth.constants import AuthMode
 os.environ["AUTH_MODE"] = AuthMode.OPEN
+
+from ark_api.auth.dependencies import require_api_key_owner
+from ark_api.api.v1.api_keys import authorize_api_key_creation
+from ark_api.models.auth import UserIdentity
+
+
+@asynccontextmanager
+async def _fake_api_client(impersonation=None):
+    yield MagicMock()
+
+
+def _patch_ssar(can_create):
+    stack = ExitStack()
+    stack.enter_context(
+        patch("ark_api.api.v1.api_keys.get_impersonating_api_client", _fake_api_client)
+    )
+    mock_auth = MagicMock()
+    mock_auth.create_self_subject_access_review = AsyncMock(
+        return_value=SimpleNamespace(status=SimpleNamespace(allowed=can_create))
+    )
+    stack.enter_context(
+        patch("ark_api.api.v1.api_keys.client.AuthorizationV1Api", return_value=mock_auth)
+    )
+    return stack
+
+
+def _raise_no_identity():
+    raise HTTPException(status_code=403, detail="API key management requires an authenticated user identity")
 
 
 class TestAPIKeyEndpoints(unittest.TestCase):
@@ -234,7 +265,7 @@ class TestAPIKeyEndpoints(unittest.TestCase):
         self.assertEqual(response.status_code, 204)
         
         # Verify service was called correctly
-        mock_service.delete_api_key.assert_called_once_with(public_key)
+        mock_service.delete_api_key.assert_called_once_with(public_key, created_by=None)
     
     @patch('ark_api.api.v1.api_keys.APIKeyService')
     def test_delete_api_key_not_found(self, mock_service_class):
@@ -303,6 +334,144 @@ class TestAPIKeyEndpoints(unittest.TestCase):
                     # Other invalid keys should reach the service layer and return 404
                     # The actual validation happens in the service layer
                     self.assertIn(response.status_code, [404, 500])
+
+
+class TestAPIKeyCreationAuthorization(unittest.TestCase):
+    """Test cases for the create_api_key authorization gate and ownership scoping."""
+
+    def setUp(self):
+        from ark_api.main import app
+        self.app = app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_gate_inactive_allows_creation(self, mock_service_class):
+        self.app.dependency_overrides[require_api_key_owner] = lambda: None
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        now = datetime.now(timezone.utc)
+        mock_response = Mock(
+            id="test-id", public_key="pk-ark-test",
+            secret_key="sk-ark-test", created_at=now, expires_at=None
+        )
+        mock_response.name = "Test Key"
+        mock_service.create_api_key = AsyncMock(return_value=mock_response)
+
+        response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
+
+        self.assertEqual(response.status_code, 201)
+        mock_service.create_api_key.assert_called_once()
+        self.assertIsNone(mock_service.create_api_key.call_args[1]["created_by"])
+
+    def test_gate_active_no_identity_denies_before_route_body(self):
+        self.app.dependency_overrides[require_api_key_owner] = _raise_no_identity
+
+        response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
+
+        self.assertEqual(response.status_code, 403)
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_gate_active_authorized_owner_allows_creation(self, mock_service_class):
+        self.app.dependency_overrides[require_api_key_owner] = (
+            lambda: UserIdentity(username="alice@example.com", groups=["viewers"])
+        )
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        now = datetime.now(timezone.utc)
+        mock_response = Mock(
+            id="test-id", public_key="pk-ark-test",
+            secret_key="sk-ark-test", created_at=now, expires_at=None
+        )
+        mock_response.name = "Test Key"
+        mock_service.create_api_key = AsyncMock(return_value=mock_response)
+
+        with _patch_ssar(can_create=True):
+            response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
+
+        self.assertEqual(response.status_code, 201)
+        mock_service.create_api_key.assert_called_once()
+        self.assertEqual(mock_service.create_api_key.call_args[1]["created_by"], "alice@example.com")
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_gate_active_unauthorized_owner_denies_creation(self, mock_service_class):
+        """The identity denied `secrets:create` cannot obtain that access by minting a key."""
+        self.app.dependency_overrides[require_api_key_owner] = (
+            lambda: UserIdentity(username="alice@example.com", groups=["viewers"])
+        )
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.create_api_key = AsyncMock()
+
+        with _patch_ssar(can_create=False):
+            response = self.client.post("/v1/api-keys", json={"name": "Test Key"})
+
+        self.assertEqual(response.status_code, 403)
+        mock_service.create_api_key.assert_not_called()
+
+
+class TestAPIKeyListDeleteScoping(unittest.TestCase):
+    """Test cases for creator-scoped list/delete."""
+
+    def setUp(self):
+        from ark_api.main import app
+        self.app = app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_list_scoped_to_owner_when_gate_active(self, mock_service_class):
+        self.app.dependency_overrides[require_api_key_owner] = (
+            lambda: UserIdentity(username="alice@example.com", groups=[])
+        )
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_list_response = Mock(items=[], count=0)
+        mock_service.list_api_keys = AsyncMock(return_value=mock_list_response)
+
+        response = self.client.get("/v1/api-keys")
+
+        self.assertEqual(response.status_code, 200)
+        mock_service.list_api_keys.assert_called_once_with(created_by="alice@example.com")
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_list_unscoped_when_gate_inactive(self, mock_service_class):
+        self.app.dependency_overrides[require_api_key_owner] = lambda: None
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_list_response = Mock(items=[], count=0)
+        mock_service.list_api_keys = AsyncMock(return_value=mock_list_response)
+
+        response = self.client.get("/v1/api-keys")
+
+        self.assertEqual(response.status_code, 200)
+        mock_service.list_api_keys.assert_called_once_with(created_by=None)
+
+    @patch('ark_api.api.v1.api_keys.APIKeyService')
+    def test_delete_scoped_to_owner_when_gate_active(self, mock_service_class):
+        self.app.dependency_overrides[require_api_key_owner] = (
+            lambda: UserIdentity(username="bob@example.com", groups=[])
+        )
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.delete_api_key = AsyncMock(return_value=False)
+
+        response = self.client.delete("/v1/api-keys/pk-ark-someone-elses-key")
+
+        self.assertEqual(response.status_code, 404)
+        mock_service.delete_api_key.assert_called_once_with(
+            "pk-ark-someone-elses-key", created_by="bob@example.com"
+        )
 
 
 if __name__ == '__main__':

--- a/services/ark-api/ark-api/tests/api/test_routes.py
+++ b/services/ark-api/ark-api/tests/api/test_routes.py
@@ -352,7 +352,7 @@ class TestAPIKeyEndpoints(unittest.TestCase):
 
         # Assert response
         self.assertEqual(response.status_code, 204)
-        mock_service_instance.delete_api_key.assert_called_once_with("pk_test_123")
+        mock_service_instance.delete_api_key.assert_called_once_with("pk_test_123", created_by=None)
 
     @patch("ark_api.api.v1.api_keys.APIKeyService")
     def test_delete_api_key_not_found(self, mock_api_key_service):

--- a/services/ark-api/ark-api/tests/services/test_api_keys.py
+++ b/services/ark-api/ark-api/tests/services/test_api_keys.py
@@ -457,5 +457,160 @@ class TestAPIKeyNamespaceScoping(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(result_b)
 
 
+class TestAPIKeyOwnershipScoping(unittest.IsolatedAsyncioTestCase):
+    """Test that created_by is recorded and used to scope list/get/delete."""
+
+    @patch('ark_api.services.api_keys.get_context')
+    def setUp(self, mock_get_context):
+        mock_get_context.return_value = {"namespace": "test-namespace", "cluster": "test"}
+        self.service = APIKeyService()
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_create_api_key_records_created_by(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_secret = Mock()
+        mock_secret.metadata.uid = "test-uid-123"
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.create_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        request = APIKeyCreateRequest(name="Test API Key")
+        await self.service.create_api_key(request, created_by="alice@example.com")
+
+        secret_body = mock_api_instance.create_namespaced_secret.call_args[1]["body"]
+        annotation_data = json.loads(secret_body.metadata.annotations[API_KEY_ANNOTATION])
+        self.assertEqual(annotation_data["createdBy"], "alice@example.com")
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_last_used_update_preserves_created_by(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        secret_key = "sk-ark-test-secret"
+        hashed = self.service._hash_secret_key(secret_key)
+
+        mock_secret = Mock()
+        mock_secret.type = "ark.mckinsey.com/api-key"
+        mock_secret.metadata.uid = "test-uid-123"
+        mock_secret.metadata.annotations = {
+            API_KEY_ANNOTATION: json.dumps({
+                "name": "Test Key",
+                "createdAt": "2024-01-01T00:00:00+00:00",
+                "createdBy": "alice@example.com"
+            })
+        }
+        mock_secret.data = {
+            "public_key": base64.b64encode(b"pk-ark-test").decode(),
+            "secret_key_hash": base64.b64encode(hashed.encode()).decode(),
+            "is_active": base64.b64encode(b"true").decode()
+        }
+
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespaced_secret = AsyncMock(return_value=mock_secret)
+        mock_api_instance.patch_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        await self.service.verify_api_key("pk-ark-test", secret_key)
+
+        patched_secret = mock_api_instance.patch_namespaced_secret.call_args[1]["body"]
+        annotation_data = json.loads(patched_secret.metadata.annotations[API_KEY_ANNOTATION])
+        self.assertEqual(annotation_data["createdBy"], "alice@example.com")
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_list_api_keys_scoped_to_creator(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        def make_secret(uid, name, created_by):
+            secret = Mock()
+            secret.metadata.uid = uid
+            secret.metadata.annotations = {
+                API_KEY_ANNOTATION: json.dumps({
+                    "name": name,
+                    "createdAt": "2024-01-01T00:00:00+00:00",
+                    "createdBy": created_by
+                })
+            }
+            secret.data = {
+                "public_key": base64.b64encode(f"pk-ark-{uid}".encode()).decode(),
+                "is_active": base64.b64encode(b"true").decode()
+            }
+            return secret
+
+        mock_response = Mock()
+        mock_response.items = [
+            make_secret("alice-key", "Alice Key", "alice@example.com"),
+            make_secret("bob-key", "Bob Key", "bob@example.com"),
+        ]
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.list_namespaced_secret = AsyncMock(return_value=mock_response)
+
+        result = await self.service.list_api_keys(created_by="alice@example.com")
+
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.items[0].name, "Alice Key")
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_get_api_key_by_public_key_denies_other_creator(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_secret = Mock()
+        mock_secret.type = "ark.mckinsey.com/api-key"
+        mock_secret.metadata.uid = "test-uid"
+        mock_secret.metadata.annotations = {
+            API_KEY_ANNOTATION: json.dumps({
+                "name": "Test Key",
+                "createdAt": "2024-01-01T00:00:00+00:00",
+                "createdBy": "alice@example.com"
+            })
+        }
+        mock_secret.data = {
+            "public_key": base64.b64encode(b"pk-ark-test").decode(),
+            "secret_key_hash": base64.b64encode(b"hash").decode(),
+            "is_active": base64.b64encode(b"true").decode()
+        }
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        owned = await self.service.get_api_key_by_public_key("pk-ark-test", created_by="alice@example.com")
+        self.assertIsNotNone(owned)
+
+        not_owned = await self.service.get_api_key_by_public_key("pk-ark-test", created_by="bob@example.com")
+        self.assertIsNone(not_owned)
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_delete_api_key_denies_other_creator(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_secret = Mock()
+        mock_secret.metadata.annotations = {
+            API_KEY_ANNOTATION: json.dumps({
+                "name": "Test Key",
+                "createdAt": "2024-01-01T00:00:00+00:00",
+                "createdBy": "alice@example.com"
+            })
+        }
+        mock_secret.string_data = {}
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespaced_secret = AsyncMock(return_value=mock_secret)
+        mock_api_instance.patch_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        result = await self.service.delete_api_key("pk-ark-test", created_by="bob@example.com")
+
+        self.assertFalse(result)
+        mock_api_instance.patch_namespaced_secret.assert_not_called()
+
+        result = await self.service.delete_api_key("pk-ark-test", created_by="alice@example.com")
+        self.assertTrue(result)
+        mock_api_instance.patch_namespaced_secret.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/services/ark-api/ark-api/tests/services/test_api_keys.py
+++ b/services/ark-api/ark-api/tests/services/test_api_keys.py
@@ -611,6 +611,59 @@ class TestAPIKeyOwnershipScoping(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result)
         mock_api_instance.patch_namespaced_secret.assert_called_once()
 
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_get_api_key_by_public_key_reports_created_by(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_secret = Mock()
+        mock_secret.type = "ark.mckinsey.com/api-key"
+        mock_secret.metadata.uid = "test-uid"
+        mock_secret.metadata.annotations = {
+            API_KEY_ANNOTATION: json.dumps({
+                "name": "Test Key",
+                "createdAt": "2024-01-01T00:00:00+00:00",
+                "createdBy": "alice@example.com"
+            })
+        }
+        mock_secret.data = {
+            "public_key": base64.b64encode(b"pk-ark-test").decode(),
+            "secret_key_hash": base64.b64encode(b"hash").decode(),
+            "is_active": base64.b64encode(b"true").decode()
+        }
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        result = await self.service.get_api_key_by_public_key("pk-ark-test")
+        self.assertEqual(result["created_by"], "alice@example.com")
+
+    @patch('ark_api.services.api_keys.create_api_client')
+    @patch('ark_api.services.api_keys.client.CoreV1Api')
+    async def test_get_api_key_by_public_key_reports_no_creator_for_legacy_key(self, mock_v1_api, mock_api_client):
+        mock_api_client_instance = AsyncMock()
+        mock_api_client.return_value.__aenter__.return_value = mock_api_client_instance
+
+        mock_secret = Mock()
+        mock_secret.type = "ark.mckinsey.com/api-key"
+        mock_secret.metadata.uid = "test-uid"
+        mock_secret.metadata.annotations = {
+            API_KEY_ANNOTATION: json.dumps({
+                "name": "Test Key",
+                "createdAt": "2024-01-01T00:00:00+00:00"
+            })
+        }
+        mock_secret.data = {
+            "public_key": base64.b64encode(b"pk-ark-test").decode(),
+            "secret_key_hash": base64.b64encode(b"hash").decode(),
+            "is_active": base64.b64encode(b"true").decode()
+        }
+        mock_api_instance = mock_v1_api.return_value
+        mock_api_instance.read_namespaced_secret = AsyncMock(return_value=mock_secret)
+
+        result = await self.service.get_api_key_by_public_key("pk-ark-test")
+        self.assertIsNone(result["created_by"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/services/ark-api/ark-api/tests/test_client_pool.py
+++ b/services/ark-api/ark-api/tests/test_client_pool.py
@@ -211,6 +211,36 @@ class TestRequireApiKeyOwner(unittest.TestCase):
                 require_api_key_owner(request)
         self.assertEqual(ctx.exception.status_code, 403)
 
+    def test_hybrid_with_whitespace_only_username_raises(self):
+        import os
+        from fastapi import HTTPException
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username=" \t ", groups=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(HTTPException) as ctx:
+                require_api_key_owner(request)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_hybrid_with_non_string_username_raises(self):
+        import os
+        from fastapi import HTTPException
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username=12345, groups=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(HTTPException) as ctx:
+                require_api_key_owner(request)
+        self.assertEqual(ctx.exception.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/ark-api/ark-api/tests/test_client_pool.py
+++ b/services/ark-api/ark-api/tests/test_client_pool.py
@@ -241,6 +241,20 @@ class TestRequireApiKeyOwner(unittest.TestCase):
                 require_api_key_owner(request)
         self.assertEqual(ctx.exception.status_code, 403)
 
+    def test_hybrid_with_padded_username_is_normalized(self):
+        import os
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username=" alice ", groups=["team-a"])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            result = require_api_key_owner(request)
+        self.assertEqual(result.username, "alice")
+        self.assertEqual(result.groups, ["team-a"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/ark-api/ark-api/tests/test_client_pool.py
+++ b/services/ark-api/ark-api/tests/test_client_pool.py
@@ -130,5 +130,72 @@ class TestGetImpersonationConfig(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestRequireApiKeyOwner(unittest.TestCase):
+
+    def test_impersonation_disabled_returns_none(self):
+        import os
+        from ark_api.auth.dependencies import require_api_key_owner
+
+        request = MagicMock()
+        request.state.user_identity = MagicMock(username="jane@acme.com", groups=["a"])
+
+        env = {"IMPERSONATION_ENABLED": "false", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            result = require_api_key_owner(request)
+        self.assertIsNone(result)
+
+    def test_basic_only_mode_returns_none(self):
+        import os
+        from ark_api.auth.dependencies import require_api_key_owner
+
+        request = MagicMock(spec=[])
+        request.state = MagicMock(spec=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "basic"}
+        with patch.dict(os.environ, env, clear=False):
+            result = require_api_key_owner(request)
+        self.assertIsNone(result)
+
+    def test_hybrid_with_identity_returns_identity(self):
+        import os
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username="jane@acme.com", groups=["team-a"])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            result = require_api_key_owner(request)
+        self.assertEqual(result.username, "jane@acme.com")
+
+    def test_sso_with_identity_returns_identity(self):
+        import os
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username="jane@acme.com", groups=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "sso"}
+        with patch.dict(os.environ, env, clear=False):
+            result = require_api_key_owner(request)
+        self.assertEqual(result.username, "jane@acme.com")
+
+    def test_hybrid_without_identity_raises(self):
+        import os
+        from fastapi import HTTPException
+        from ark_api.auth.dependencies import require_api_key_owner
+
+        request = MagicMock(spec=[])
+        request.state = MagicMock(spec=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(HTTPException) as ctx:
+                require_api_key_owner(request)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/services/ark-api/ark-api/tests/test_client_pool.py
+++ b/services/ark-api/ark-api/tests/test_client_pool.py
@@ -196,6 +196,21 @@ class TestRequireApiKeyOwner(unittest.TestCase):
                 require_api_key_owner(request)
         self.assertEqual(ctx.exception.status_code, 403)
 
+    def test_hybrid_with_blank_username_raises(self):
+        import os
+        from fastapi import HTTPException
+        from ark_api.auth.dependencies import require_api_key_owner
+        from ark_api.models.auth import UserIdentity
+
+        request = MagicMock()
+        request.state.user_identity = UserIdentity(username="", groups=[])
+
+        env = {"IMPERSONATION_ENABLED": "true", "AUTH_MODE": "hybrid"}
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(HTTPException) as ctx:
+                require_api_key_owner(request)
+        self.assertEqual(ctx.exception.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/ark-api/ark-api/tests/test_middleware_dispatch.py
+++ b/services/ark-api/ark-api/tests/test_middleware_dispatch.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +13,11 @@ def _make_request(headers=None, path="/v1/agents", method="GET"):
     request.headers = Headers(headers or {})
     request.state = MagicMock(spec=[])
     return request
+
+
+def _basic_auth_header(public_key="pk-ark-test", secret_key="sk-ark-test"):
+    encoded = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    return f"Basic {encoded}"
 
 
 class TestMiddlewareDispatchImpersonationHeaders(unittest.IsolatedAsyncioTestCase):
@@ -199,6 +205,106 @@ class TestMiddlewareDispatchImpersonationHeaders(unittest.IsolatedAsyncioTestCas
         response = await middleware.dispatch(request, call_next)
 
         self.assertEqual(response.status_code, 401)
+
+
+class TestMiddlewareDispatchBasicAuthOwnership(unittest.IsolatedAsyncioTestCase):
+
+    @patch.dict(os.environ, {
+        "AUTH_MODE": "hybrid",
+        "OIDC_ISSUER_URL": "http://issuer",
+        "OIDC_APPLICATION_ID": "app",
+        "IMPERSONATION_ENABLED": "true",
+    })
+    @patch("ark_api.auth.middleware.APIKeyService")
+    @patch("ark_api.auth.middleware.TokenValidator")
+    async def test_hybrid_rejects_key_without_recorded_owner(self, mock_validator_cls, mock_api_key_svc):
+        from ark_api.auth.middleware import AuthMiddleware
+
+        mock_api_key_svc.return_value.verify_api_key = AsyncMock(return_value={
+            "public_key": "pk-ark-test", "created_by": None
+        })
+
+        app = MagicMock()
+        middleware = AuthMiddleware(app)
+        call_next = AsyncMock()
+
+        request = _make_request(headers={"authorization": _basic_auth_header()})
+        response = await middleware.dispatch(request, call_next)
+
+        self.assertEqual(response.status_code, 401)
+        call_next.assert_not_called()
+
+    @patch.dict(os.environ, {
+        "AUTH_MODE": "hybrid",
+        "OIDC_ISSUER_URL": "http://issuer",
+        "OIDC_APPLICATION_ID": "app",
+        "IMPERSONATION_ENABLED": "true",
+    })
+    @patch("ark_api.auth.middleware.APIKeyService")
+    @patch("ark_api.auth.middleware.TokenValidator")
+    async def test_hybrid_allows_key_with_recorded_owner(self, mock_validator_cls, mock_api_key_svc):
+        from ark_api.auth.middleware import AuthMiddleware
+
+        mock_api_key_svc.return_value.verify_api_key = AsyncMock(return_value={
+            "public_key": "pk-ark-test", "created_by": "alice@example.com"
+        })
+
+        app = MagicMock()
+        middleware = AuthMiddleware(app)
+        expected_response = MagicMock()
+        call_next = AsyncMock(return_value=expected_response)
+
+        request = _make_request(headers={"authorization": _basic_auth_header()})
+        response = await middleware.dispatch(request, call_next)
+
+        self.assertEqual(response, expected_response)
+        call_next.assert_called_once()
+
+    @patch.dict(os.environ, {
+        "AUTH_MODE": "hybrid",
+        "OIDC_ISSUER_URL": "http://issuer",
+        "OIDC_APPLICATION_ID": "app",
+        "IMPERSONATION_ENABLED": "false",
+    })
+    @patch("ark_api.auth.middleware.APIKeyService")
+    @patch("ark_api.auth.middleware.TokenValidator")
+    async def test_hybrid_allows_unowned_key_when_impersonation_disabled(self, mock_validator_cls, mock_api_key_svc):
+        from ark_api.auth.middleware import AuthMiddleware
+
+        mock_api_key_svc.return_value.verify_api_key = AsyncMock(return_value={
+            "public_key": "pk-ark-test", "created_by": None
+        })
+
+        app = MagicMock()
+        middleware = AuthMiddleware(app)
+        expected_response = MagicMock()
+        call_next = AsyncMock(return_value=expected_response)
+
+        request = _make_request(headers={"authorization": _basic_auth_header()})
+        response = await middleware.dispatch(request, call_next)
+
+        self.assertEqual(response, expected_response)
+        call_next.assert_called_once()
+
+    @patch.dict(os.environ, {"AUTH_MODE": "basic"})
+    @patch("ark_api.auth.middleware.APIKeyService")
+    async def test_basic_only_mode_allows_unowned_key(self, mock_api_key_svc):
+        from ark_api.auth.middleware import AuthMiddleware
+
+        mock_api_key_svc.return_value.verify_api_key = AsyncMock(return_value={
+            "public_key": "pk-ark-test", "created_by": None
+        })
+
+        app = MagicMock()
+        middleware = AuthMiddleware(app)
+        expected_response = MagicMock()
+        call_next = AsyncMock(return_value=expected_response)
+
+        request = _make_request(headers={"authorization": _basic_auth_header()})
+        response = await middleware.dispatch(request, call_next)
+
+        self.assertEqual(response, expected_response)
+        call_next.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `POST /v1/api-keys` had no authorization check, so any authenticated user could mint an API key and use it over HTTP Basic auth to act with the broader permissions of the `ark-api` service account.
- API keys stay exactly what they are today (machine identities bound to the `ark-api` service account, not delegated user credentials) — this only gates who is allowed to mint one and scopes who can see or revoke a key.
- Minting a key now requires the same permission as creating a Secret in the namespace, checked via a `SelfSubjectAccessReview` against the requesting user's impersonated identity.
- API keys now record their creator. Listing and revoking a key is scoped to its creator, and keys with no recorded creator are now also rejected at authentication time, not just hidden from list/delete.
- The gate only engages when impersonation is enabled under `AUTH_MODE=hybrid` (or `sso`) — `basic`-only and `open` deployments are unaffected.
- Breaking change, documented in `docs/content/developer-guide/authentication.mdx`: keys minted before this check was added have no recorded creator, so in `hybrid` deployments with impersonation enabled they will stop authenticating and need to be recreated.