### PR TITLE
fix(tests): scan asset attributes in dashboard basepath probe

### DIFF
--- a/tests/dashboard-runtime-basepath/README.md
+++ b/tests/dashboard-runtime-basepath/README.md
@@ -4,10 +4,18 @@ Verifies the published `ark-dashboard` image honours `ARK_DASHBOARD_BASE_PATH` a
 
 ## What it tests
 - Installing the chart with `app.config.basePath=/tenant-a` produces a pod that serves at `/tenant-a` and returns 404 at `/`.
-- Static asset URLs emitted in the rendered HTML are prefixed with `/tenant-a/`.
+- Every `/_next/` asset referenced from a `src`/`href` attribute is prefixed with `/tenant-a/` and returns HTTP 200.
 - No sentinel string (`/__ark_base_path__`) leaks into the served HTML.
 
 The empty-basepath case is implicitly covered by every other dashboard usage (`devspace deploy`, `ark dashboard`) and isn't duplicated here.
+
+### Why asset checks scan attributes, not raw HTML
+
+Next.js inlines the RSC flight payload as a series of `self.__next_f.push([1,"…"])` scripts and splits that payload at arbitrary byte offsets, including mid-string. A boundary landing inside an asset URL leaves a fragment like `nant-a/_next/static/chunks/x.js` in the raw HTML, even though the browser concatenates the pushes before parsing and the URL is intact at runtime.
+
+An earlier version of this test scrubbed `/tenant-a/_next/…` from the whole response and grepped the remainder for `/_next/`. That produced false failures whenever a boundary happened to land after `/te`, which any change to dashboard page content can cause by shifting byte offsets. It also could not distinguish a healthy page from a genuinely broken one — both reported a single leftover.
+
+Scanning `src`/`href` attributes avoids this: attribute values are always emitted whole. Fetching each one additionally verifies the asset actually resolves under the prefix, which is the property that matters.
 
 ## Running
 ```bash

--- a/tests/dashboard-runtime-basepath/chainsaw-test.yaml
+++ b/tests/dashboard-runtime-basepath/chainsaw-test.yaml
@@ -81,13 +81,43 @@ spec:
             curl -sS http://ark-dashboard-prefixed:3000/tenant-a)
           echo "$BODY" | grep -q '<title>Ark Dashboard</title>'
 
-          # Every emitted /_next/ reference must be prefixed with /tenant-a.
-          # Scrub /tenant-a/_next/... first, then anything matching /_next/ is unprefixed.
-          UNPREFIXED=$(printf '%s' "$BODY" | sed 's|/tenant-a/_next/[^"\\ ]*||g' | grep -c '/_next/' || true)
-          if [ "$UNPREFIXED" != "0" ]; then
-            echo "FAIL: $UNPREFIXED unprefixed /_next/ reference(s) found in HTML"
+          # Every /_next/ asset must be prefixed with /tenant-a and must resolve.
+          # Only src/href attributes are scanned; the inlined RSC payload splits
+          # URLs across self.__next_f.push() boundaries at arbitrary offsets.
+          ASSETS=$(printf '%s' "$BODY" \
+            | grep -oE '(src|href)="[^"]*/_next/[^"]*"' \
+            | sed 's/^[a-z]*="//; s/"$//' \
+            | sort -u)
+          if [ -z "$ASSETS" ]; then
+            echo "FAIL: no /_next/ asset references found in HTML"
             exit 1
           fi
+          echo "found $(printf '%s\n' "$ASSETS" | wc -l | tr -d ' ') distinct /_next/ asset(s)"
+
+          UNPREFIXED=0
+          for URL in $ASSETS; do
+            case "$URL" in
+              /tenant-a/_next/*) ;;
+              *)
+                echo "FAIL: asset not prefixed with /tenant-a: $URL"
+                UNPREFIXED=1
+                ;;
+            esac
+          done
+          [ "$UNPREFIXED" = "0" ]
+
+          printf '%s\n' "$ASSETS" | kubectl exec -i -n $NAMESPACE dashboard-probe -- sh -c '
+            RC=0
+            while IFS= read -r URL; do
+              [ -n "$URL" ] || continue
+              CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://ark-dashboard-prefixed:3000$URL")
+              if [ "$CODE" != "200" ]; then
+                echo "FAIL: $URL -> $CODE"
+                RC=1
+              fi
+            done
+            exit $RC
+          '
 
           # No sentinel residue
           if echo "$BODY" | grep -q '__ark_base_path__'; then


### PR DESCRIPTION
## Summary

- Fix false failures in the `dashboard-runtime-basepath` E2E test, which blocked dashboard PRs while `main` stayed green
- The probe text-scanned raw HTML for unprefixed `/_next/` references, but Next.js splits the inlined RSC flight payload across `self.__next_f.push()` boundaries at arbitrary byte offsets. A split inside an asset URL leaves a fragment the scrub cannot match, so the grep counted it — even though the browser rejoins the pushes and the asset loads fine
- Because the trigger is a byte offset, any change to dashboard page content could flip the result, which is why it correlated with PR size rather than with any basePath change
- Scan `src`/`href` attributes instead (always emitted whole) and fetch each asset to assert it returns 200 under the prefix

Verified against a locally built dashboard image: all 36 assets return 200, no sentinel residue, and the old assertion reproduces the CI failure exactly. The new check passes the healthy page and still fails a genuinely unprefixed asset — the old one reported the same result for both.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 