### PR TITLE
docs: correct replication-slot uninstall behaviour, version floor and replication privilege in postgres guide

### DIFF
--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -81,7 +81,7 @@ On first start, `ark-apiserver` creates:
 - Indexes on `(kind, namespace)`, `(kind, namespace, name)`, a GIN index on `labels`, and a unique partial index on active (non-deleted) rows.
 - A publication and a logical replication slot, both named `ark_cdc`. The slot is what powers `kubectl get -w` and controller informers.
 
-The slot is **persistent**: it survives apiserver restarts and is not removed by `helm uninstall`. See [Uninstall and cleanup](#uninstall-and-cleanup) below.
+The slot is **persistent**: it survives apiserver restarts. It is dropped automatically on `helm uninstall` — see [Uninstall and cleanup](#uninstall-and-cleanup) below.
 
 ## Installing PostgreSQL mode
 
@@ -251,7 +251,14 @@ Treat the `resources` table like any other application table:
 
 `helm uninstall` runs a `post-delete` hook Job that drops the `ark_cdc` replication slot and publication. Without this cleanup, an orphaned slot would pin WAL retention and can fill the disk. The Job connects with the same credentials as the apiserver, so the password secret must still exist when you uninstall.
 
-If the hook Job could not run (for example the database was unreachable, or you removed the release with `--no-hooks`), drop the slot manually:
+Confirm in the database that the slot is gone rather than trusting the Job's log line — both queries should return no rows:
+
+```sql
+SELECT slot_name, active, wal_status FROM pg_replication_slots WHERE slot_name = 'ark_cdc';
+SELECT pubname FROM pg_publication WHERE pubname = 'ark_cdc';
+```
+
+If the hook Job could not run (for example the database was unreachable, you removed the release with `--no-hooks`, or the password secret was deleted first), drop the slot manually:
 
 ```sql
 SELECT pg_drop_replication_slot('ark_cdc');

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -46,12 +46,12 @@ max_wal_senders       >= 1
 
 ### Minimum version
 
-The watch stream decodes the WAL with the built-in `pgoutput` plugin and a `CREATE PUBLICATION`, both introduced in **PostgreSQL 10**, which is the hard minimum. Run a currently-supported major (**14 or newer**) in production.
+The watch stream decodes the WAL with the built-in `pgoutput` plugin and a `CREATE PUBLICATION`, introduced in PostgreSQL 10. The hard minimum is **PostgreSQL 13**: slot health checks read `pg_replication_slots.wal_status` and list pagination calls `pg_current_snapshot()`, neither of which exists in earlier majors. Run a currently-supported major (**14 or newer**) in production.
 
 A user/role with permission to:
 
 - `CREATE TABLE`, `CREATE INDEX`, `CREATE PUBLICATION` on the target database
-- `pg_replication_slots` access (typically the `REPLICATION` attribute or a member of `pg_create_logical_replication_slots`)
+- the **`REPLICATION`** attribute (`ALTER ROLE ark REPLICATION`). Postgres permits replication slots only to roles that hold this attribute, and no predefined role grants it. Managed services often withhold `ALTER ROLE` and expose an equivalent grant instead (for example `rds_replication` on AWS RDS) — check your provider's documentation.
 
 For managed services:
 


### PR DESCRIPTION
## Summary
- Fix the contradiction in `postgres-storage-backend.mdx`: the *Schema and replication slot* section claimed the `ark_cdc` slot "is not removed by `helm uninstall`" while linking at *Uninstall and cleanup*, which documents the `post-delete` hook Job from #2800. The first statement was stale pre-#2800 text.
- Add the SQL to confirm in the database that the slot and publication are actually gone, since the case that matters is a hook Job that silently failed leaving the orphaned slot that pins WAL retention.
- **Correct the stated PostgreSQL minimum from 10 to 13** — the documented floor is not attainable by the current code (details below).
- **Remove a reference to a PostgreSQL role that does not exist** (`pg_create_logical_replication_slots`).

Fixes #3163

## 1. Which of the two lines was true (the open question in #3163)

Line 252 (automatic cleanup) is correct. Verified rather than assumed:

- `chart-apiserver/templates/postgres-cleanup-job.yaml` carries `helm.sh/hook: post-delete` and runs `--role=postgres-cleanup` → `postgresql.DropReplicationArtifacts`.
- Ran the built `--role=postgres-cleanup` binary against a real Postgres 16 (`wal_level=logical`) with the slot and publication present. Both verification queries now added to the docs returned **0 rows** afterwards (`ark_cdc | f | reserved` → `(0 rows)`).
- The chart does **not** own the password secret (it only references it by name), so the secret survives the release deletion and the hook can authenticate — the documented caveat holds for the default install path.
- `dropReplicationArtifacts` terminates the active consumer and retries until the drop sticks, so it also survives a still-terminating apiserver pod recreating the slot.

## 2. The version floor is wrong, and this one is deployable-into-breakage

While verifying the above I checked the rest of the requirements section. The stated **"PostgreSQL 10 … which is the hard minimum"** cannot be met by the current code. Two independent PG13+ dependencies:

| Dependency | Location | Introduced |
|---|---|---|
| `pg_replication_slots.wal_status` | `wal_connection.go:149`, in `ensureReplicationSlot` — mandatory watch-startup path | PG 13 |
| `pg_current_snapshot()` | `postgresql.go:556,580`, list pagination | PG 13 |

Measured, same suite and settings, only the server major changed:

- **PG 12** → watch stream never starts, looping `ensure slot: inspect replication slot: pq: column "wal_status" does not exist`; **4 integration tests fail** (incl. `TestList_PaginationSnapshotConsistency_Integration` → `function pg_current_snapshot() does not exist`).
- **PG 13** → **9/9 pass**.
- **PG 16** → 9/9 pass.

Note the file already assumed PG13 semantics elsewhere: *Uninstall and cleanup* describes `wal_status = lost`. So this is a second self-contradiction of the same species as the one #3163 reported — but where the reported one only misleads, this one lets an operator follow the docs onto PG 10–12 and hit a hard failure.

**This PR documents reality (floor = 13).** If the intent is to genuinely support PG 10+, the alternative is to fix the code instead — read `wal_status` tolerantly (e.g. via `to_jsonb(s) ->> wal_status`) and replace `pg_current_snapshot()`. That is a support-policy call, so I have not made it; happy to follow up either way.

## 3. `pg_create_logical_replication_slots` does not exist

The privileges list offered it as an alternative to the `REPLICATION` attribute. It is not one of PostgreSQLs predefined roles, so the least-privilege path the docs suggest dead-ends:

```
postgres=# GRANT pg_create_logical_replication_slots TO ark;
ERROR:  role "pg_create_logical_replication_slots" does not exist

ark=> SELECT pg_create_logical_replication_slot(probe,pgoutput);   -- role without REPLICATION
ERROR:  permission denied to use replication slots
DETAIL:  Only roles with the REPLICATION attribute may use replication slots.
```

After `ALTER ROLE ark REPLICATION` the same call succeeds. Reworded to make `REPLICATION` the requirement.

> One caveat for reviewers: I added "for example `rds_replication` on AWS RDS" as the managed-service equivalent from AWSs documented behaviour, but I had **no live RDS instance to verify it against** — everything else above was measured locally. Worth a second pair of eyes if anyone has RDS handy.

## Gates

`docs`: `npm run build` ✅ · `npm run validate-yaml` ✅ (76 blocks) · `npm run check-links` ✅ (166 links)