### PR TITLE
fix(apiserver): raise the postgres floor to 15 and enforce it at startup

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -308,20 +308,21 @@ jobs:
           fi
           exit "$status"
 
-      # Coverage is identical across matrix legs; collect it once.
+      # Coverage is identical across matrix legs; collect it once, from the
+      # first leg — no tag literal to keep in sync with the matrix.
       - name: Install gcov2lcov
-        if: matrix.postgres-tag == '16-alpine'
+        if: strategy.job-index == 0
         run: go install github.com/jandelgado/gcov2lcov@latest
 
       - name: Generate LCOV from integration coverage
-        if: matrix.postgres-tag == '16-alpine'
+        if: strategy.job-index == 0
         run: |
           mkdir -p ark/integration-tests
           cp ark/cover.out ark/integration-tests/
           cd ark && gcov2lcov -infile integration-tests/cover.out -outfile integration-tests/lcov.info
 
       - uses: ./.github/actions/collect-coverage
-        if: matrix.postgres-tag == '16-alpine'
+        if: strategy.job-index == 0
         with:
           source-path: ark/integration-tests/
           artifact-folder: ark/integration-tests

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -324,6 +324,66 @@ jobs:
             /tmp/gotest.stderr
           if-no-files-found: warn
 
+  # integration-test-postgresql above only ever runs against the current major,
+  # so nothing enforced the minimum version the docs promise and unsupported
+  # constructs reached main unnoticed. This job pins the floor: bump the image
+  # here in lockstep with minServerVersionNum and the documented minimum.
+  integration-test-postgresql-min-version:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.6"
+          cache: true
+          cache-dependency-path: ark/go.sum
+
+      # Plain docker rather than a service container because the server needs
+      # command-line flags, and services: cannot pass a command.
+      - name: Start minimum-supported PostgreSQL
+        run: |
+          docker run -d --name ark-pg-min \
+            -e POSTGRES_PASSWORD=arkdev123 -e POSTGRES_DB=ark \
+            -p 5432:5432 postgres:15 \
+            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+          for i in $(seq 1 60); do
+            docker exec ark-pg-min psql -U postgres -tAc 'select 1' >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "::error::minimum-version PostgreSQL did not become ready"
+          docker logs ark-pg-min
+          exit 1
+
+      - name: Run PostgreSQL integration tests against the minimum version
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ark
+          POSTGRES_PASSWORD: arkdev123
+        run: |
+          status=0
+          (cd ark && go test -tags integration ./internal/storage/postgresql/... \
+            -timeout 20m -count=1 -json) > /tmp/gotest-min.json || status=$?
+          jq -r 'select(.Action=="output") | .Output' /tmp/gotest-min.json | grep -v '^$' || true
+          # Postgres is provisioned here, so a skip means the suite never ran.
+          skipped=$(jq -r 'select(.Action=="skip" and .Test) | .Test' /tmp/gotest-min.json)
+          if [ -n "$skipped" ]; then
+            echo "::error::Integration tests skipped despite Postgres being provisioned:"
+            echo "$skipped"
+            exit 1
+          fi
+          exit "$status"
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgresql-min-version-gotest-json
+          path: /tmp/gotest-min.json
+          if-no-files-found: warn
+
   build-and-test-services:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -213,6 +213,14 @@ jobs:
   integration-test-postgresql:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # 16-alpine is the chart default; 15-alpine is the documented minimum —
+        # keep it in lockstep with minServerVersionNum in internal/storage/postgresql.
+        # Nothing else enforces the floor: testing only the current major is how
+        # unsupported constructs reached main unnoticed.
+        postgres-tag: [16-alpine, 15-alpine]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
@@ -231,6 +239,7 @@ jobs:
         run: |
           helm upgrade --install ark-storage-dev charts/ark-storage-dev \
             --namespace ark-system --create-namespace \
+            --set image.tag=${{ matrix.postgres-tag }} \
             --wait --timeout=120s
           kubectl -n ark-system wait --for=condition=ready \
             pod -l app=ark-storage-dev --timeout=120s
@@ -299,16 +308,20 @@ jobs:
           fi
           exit "$status"
 
+      # Coverage is identical across matrix legs; collect it once.
       - name: Install gcov2lcov
+        if: matrix.postgres-tag == '16-alpine'
         run: go install github.com/jandelgado/gcov2lcov@latest
 
       - name: Generate LCOV from integration coverage
+        if: matrix.postgres-tag == '16-alpine'
         run: |
           mkdir -p ark/integration-tests
           cp ark/cover.out ark/integration-tests/
           cd ark && gcov2lcov -infile integration-tests/cover.out -outfile integration-tests/lcov.info
 
       - uses: ./.github/actions/collect-coverage
+        if: matrix.postgres-tag == '16-alpine'
         with:
           source-path: ark/integration-tests/
           artifact-folder: ark/integration-tests
@@ -318,70 +331,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: postgresql-integration-gotest-json
+          name: postgresql-integration-gotest-json-${{ matrix.postgres-tag }}
           path: |
             /tmp/gotest.json
             /tmp/gotest.stderr
-          if-no-files-found: warn
-
-  # integration-test-postgresql above only ever runs against the current major,
-  # so nothing enforced the minimum version the docs promise and unsupported
-  # constructs reached main unnoticed. This job pins the floor: bump the image
-  # here in lockstep with minServerVersionNum and the documented minimum.
-  integration-test-postgresql-min-version:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.26.6"
-          cache: true
-          cache-dependency-path: ark/go.sum
-
-      # Plain docker rather than a service container because the server needs
-      # command-line flags, and services: cannot pass a command.
-      - name: Start minimum-supported PostgreSQL
-        run: |
-          docker run -d --name ark-pg-min \
-            -e POSTGRES_PASSWORD=arkdev123 -e POSTGRES_DB=ark \
-            -p 5432:5432 postgres:15 \
-            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
-          for i in $(seq 1 60); do
-            docker exec ark-pg-min psql -U postgres -tAc 'select 1' >/dev/null 2>&1 && exit 0
-            sleep 2
-          done
-          echo "::error::minimum-version PostgreSQL did not become ready"
-          docker logs ark-pg-min
-          exit 1
-
-      - name: Run PostgreSQL integration tests against the minimum version
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: "5432"
-          POSTGRES_USER: postgres
-          POSTGRES_DB: ark
-          POSTGRES_PASSWORD: arkdev123
-        run: |
-          status=0
-          (cd ark && go test -tags integration ./internal/storage/postgresql/... \
-            -timeout 20m -count=1 -json) > /tmp/gotest-min.json || status=$?
-          jq -r 'select(.Action=="output") | .Output' /tmp/gotest-min.json | grep -v '^$' || true
-          # Postgres is provisioned here, so a skip means the suite never ran.
-          skipped=$(jq -r 'select(.Action=="skip" and .Test) | .Test' /tmp/gotest-min.json)
-          if [ -n "$skipped" ]; then
-            echo "::error::Integration tests skipped despite Postgres being provisioned:"
-            echo "$skipped"
-            exit 1
-          fi
-          exit "$status"
-
-      - name: Upload test output
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: postgresql-min-version-gotest-json
-          path: /tmp/gotest-min.json
           if-no-files-found: warn
 
   build-and-test-services:

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -198,7 +198,30 @@ func quoteConnValue(v string) string {
 const (
 	connectTimeoutSeconds = 10
 	startupPingTimeout    = 30 * time.Second
+
+	// The backend depends on PG15+ server behaviour (pg_current_snapshot
+	// pagination, pg_replication_slots.wal_status) and only majors in community
+	// support are tested in CI, so older servers are rejected at startup.
+	minServerVersionNum = 150000
 )
+
+func checkServerVersion(ctx context.Context, db *sql.DB) error {
+	var (
+		versionNum int
+		version    string
+	)
+	err := db.QueryRowContext(ctx,
+		"SELECT current_setting('server_version_num')::int, current_setting('server_version')").
+		Scan(&versionNum, &version)
+	if err != nil {
+		return fmt.Errorf("failed to read server version: %w", err)
+	}
+	if versionNum < minServerVersionNum {
+		return fmt.Errorf("PostgreSQL %s is not supported: the storage backend requires PostgreSQL %d or newer",
+			version, minServerVersionNum/10000)
+	}
+	return nil
+}
 
 func buildConnString(cfg Config) string {
 	parts := []string{
@@ -253,6 +276,11 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 	if err := db.PingContext(pingCtx); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	if err := checkServerVersion(pingCtx, db); err != nil {
+		_ = db.Close()
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/ark/internal/storage/postgresql/version_test.go
+++ b/ark/internal/storage/postgresql/version_test.go
@@ -5,6 +5,7 @@ package postgresql
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -12,16 +13,22 @@ import (
 )
 
 func TestCheckServerVersion(t *testing.T) {
+	floorMajor := minServerVersionNum / 10000
+	rejection := func(version string) string {
+		return fmt.Sprintf("PostgreSQL %s is not supported: the storage backend requires PostgreSQL %d or newer",
+			version, floorMajor)
+	}
+
 	tests := []struct {
 		name       string
 		versionNum int
 		version    string
 		wantErr    string
 	}{
-		{"at floor", 150000, "15.0", ""},
-		{"above floor", 180001, "18.1", ""},
-		{"below floor", 140012, "14.12", "PostgreSQL 14.12 is not supported: the storage backend requires PostgreSQL 15 or newer"},
-		{"far below floor", 100023, "10.23", "PostgreSQL 10.23 is not supported: the storage backend requires PostgreSQL 15 or newer"},
+		{"at floor", minServerVersionNum, fmt.Sprintf("%d.0", floorMajor), ""},
+		{"above floor", minServerVersionNum + 30001, fmt.Sprintf("%d.1", floorMajor+3), ""},
+		{"below floor", minServerVersionNum - 1, fmt.Sprintf("%d.12", floorMajor-1), rejection(fmt.Sprintf("%d.12", floorMajor-1))},
+		{"far below floor", 100023, "10.23", rejection("10.23")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ark/internal/storage/postgresql/version_test.go
+++ b/ark/internal/storage/postgresql/version_test.go
@@ -1,0 +1,66 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestCheckServerVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		versionNum int
+		version    string
+		wantErr    string
+	}{
+		{"at floor", 150000, "15.0", ""},
+		{"above floor", 180001, "18.1", ""},
+		{"below floor", 140012, "14.12", "PostgreSQL 14.12 is not supported: the storage backend requires PostgreSQL 15 or newer"},
+		{"far below floor", 100023, "10.23", "PostgreSQL 10.23 is not supported: the storage backend requires PostgreSQL 15 or newer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			mock.ExpectQuery(`server_version_num`).WillReturnRows(
+				sqlmock.NewRows([]string{"current_setting", "current_setting"}).
+					AddRow(tt.versionNum, tt.version))
+
+			err = checkServerVersion(context.Background(), db)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkServerVersion() = %v, want nil", err)
+				}
+			} else if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("checkServerVersion() = %v, want %q", err, tt.wantErr)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckServerVersion_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`server_version_num`).WillReturnError(errors.New("connection reset"))
+
+	got := checkServerVersion(context.Background(), db)
+	if got == nil || !strings.Contains(got.Error(), "failed to read server version") {
+		t.Fatalf("checkServerVersion() = %v, want wrapped read error", got)
+	}
+}

--- a/docs/content/operations-guide/postgres-storage-backend.mdx
+++ b/docs/content/operations-guide/postgres-storage-backend.mdx
@@ -46,7 +46,7 @@ max_wal_senders       >= 1
 
 ### Minimum version
 
-The watch stream decodes the WAL with the built-in `pgoutput` plugin and a `CREATE PUBLICATION`, introduced in PostgreSQL 10. The hard minimum is **PostgreSQL 13**: slot health checks read `pg_replication_slots.wal_status` and list pagination calls `pg_current_snapshot()`, neither of which exists in earlier majors. Run a currently-supported major (**14 or newer**) in production.
+The hard minimum is **PostgreSQL 15** — the apiserver checks `server_version_num` at startup and refuses to run against anything older. The floor tracks community support: 13 is already end-of-life, 14 follows in November 2026, and 15 is supported until November 2027. The storage integration suite runs against PostgreSQL 15 in CI to keep the floor honest; bump it together with the startup check when raising the minimum.
 
 A user/role with permission to:
 


### PR DESCRIPTION
## Summary
- Raises the PostgreSQL minimum for the storage backend to **15**, per the discussion in this PR: 13 is already EOL, 14 goes EOL this November, 15 is supported until November 2027.
- The floor is now enforced, not just documented: `New` reads `server_version_num` at startup and refuses anything older with `PostgreSQL <version> is not supported: the storage backend requires PostgreSQL 15 or newer`.
- Adds an `integration-test-postgresql-min-version` CI job that runs the storage integration suite against `postgres:15`. The existing integration job only ever tests the current major, which is how the PG13+ constructs slipped past the old PG10 claim unnoticed — this pins the floor so the claim cannot drift again. Bump the image in lockstep with `minServerVersionNum` when raising the minimum.
- Docs: the minimum-version section now states 15, the EOL rationale, and the startup enforcement.