### PR TITLE
feat(completions): carry tool-returned images to the model as image blocks

### DIFF
--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -195,6 +195,11 @@ func (a *Agent) processAssistantMessage(choice openai.ChatCompletionChoice) Mess
 }
 
 func (a *Agent) executeToolCall(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall) (Message, error) {
+	toolMessage, _, err := a.executeToolCallWithImages(ctx, toolCall)
+	return toolMessage, err
+}
+
+func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall) (Message, []ToolResultImage, error) {
 	result, err := a.Tools.ExecuteTool(ctx, ToolCall(toolCall))
 
 	// If the result has an error field set, use that as the message content
@@ -206,10 +211,10 @@ func (a *Agent) executeToolCall(ctx context.Context, toolCall openai.ChatComplet
 	toolMessage := ToolMessage(content, result.ID)
 
 	if err != nil {
-		return toolMessage, err
+		return toolMessage, nil, err
 	}
 
-	return toolMessage, nil
+	return toolMessage, result.Images, nil
 }
 
 func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCompletionMessageToolCall, agentMessages, newMessages *[]Message) error {
@@ -255,9 +260,16 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCom
 			return ctx.Err()
 		}
 
-		toolMessage, err := a.executeToolCall(ctx, tc)
+		toolMessage, images, err := a.executeToolCallWithImages(ctx, tc)
 		*agentMessages = append(*agentMessages, toolMessage)
 		*newMessages = append(*newMessages, toolMessage)
+
+		if len(images) > 0 {
+			imageMessage := NewUserImageMessage(
+				fmt.Sprintf("Image returned by the %s tool call.", tc.Function.Name), images)
+			*agentMessages = append(*agentMessages, imageMessage)
+			*newMessages = append(*newMessages, imageMessage)
+		}
 
 		if err != nil {
 			return err

--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -35,6 +35,7 @@ type Agent struct {
 	ExecutionEngine       *arkv1alpha1.ExecutionEngineRef
 	Annotations           map[string]string
 	OutputSchema          *runtime.RawExtension
+	ImagePolicy           *imagePolicy
 	client                client.Client
 	approvalRequiredTools map[string]*arkv1alpha1.ToolApprovalConfig
 }
@@ -194,6 +195,13 @@ func (a *Agent) processAssistantMessage(choice openai.ChatCompletionChoice) Mess
 	return assistantMessage
 }
 
+func (a *Agent) imagePolicy() *imagePolicy {
+	if a.ImagePolicy != nil {
+		return a.ImagePolicy
+	}
+	return defaultImagePolicy()
+}
+
 func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall, budget *imageTurnBudget) (Message, []ToolResultImage, error) {
 	result, err := a.Tools.ExecuteTool(ctx, ToolCall(toolCall))
 
@@ -252,7 +260,7 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCom
 	}
 
 	// No approval needed, execute normally
-	budget := newImageTurnBudget()
+	budget := a.imagePolicy().NewTurnBudget()
 	outcomes := make([]toolOutcome, 0, len(toolCalls))
 	for _, tc := range toolCalls {
 		if ctx.Err() != nil {

--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -194,11 +194,6 @@ func (a *Agent) processAssistantMessage(choice openai.ChatCompletionChoice) Mess
 	return assistantMessage
 }
 
-func (a *Agent) executeToolCall(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall) (Message, error) {
-	toolMessage, _, err := a.executeToolCallWithImages(ctx, toolCall, newImageTurnBudget())
-	return toolMessage, err
-}
-
 func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall, budget *imageTurnBudget) (Message, []ToolResultImage, error) {
 	result, err := a.Tools.ExecuteTool(ctx, ToolCall(toolCall))
 
@@ -258,26 +253,27 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCom
 
 	// No approval needed, execute normally
 	budget := newImageTurnBudget()
+	outcomes := make([]toolOutcome, 0, len(toolCalls))
 	for _, tc := range toolCalls {
 		if ctx.Err() != nil {
+			appendToolOutcomes(agentMessages, newMessages, outcomes)
 			return ctx.Err()
 		}
 
 		toolMessage, images, err := a.executeToolCallWithImages(ctx, tc, budget)
-		*agentMessages = append(*agentMessages, toolMessage)
-		*newMessages = append(*newMessages, toolMessage)
-
-		if len(images) > 0 {
-			imageMessage := NewUserImageMessage(
-				fmt.Sprintf("Image returned by the %s tool call.", tc.Function.Name), images)
-			*agentMessages = append(*agentMessages, imageMessage)
-			*newMessages = append(*newMessages, imageMessage)
-		}
+		outcomes = append(outcomes, toolOutcome{
+			toolName: tc.Function.Name,
+			message:  toolMessage,
+			images:   images,
+		})
 
 		if err != nil {
+			appendToolOutcomes(agentMessages, newMessages, outcomes)
 			return err
 		}
 	}
+
+	appendToolOutcomes(agentMessages, newMessages, outcomes)
 	return nil
 }
 
@@ -561,23 +557,25 @@ func (a *Agent) reconstructMessagesForResumption(
 	assistantMsgConverted := Message(assistantMsg.ToParam())
 	agentMessages = append(agentMessages, assistantMsgConverted)
 
-	// Append tool results as tool messages
-	toolResultMessages := []Message{}
+	// Append tool results as tool messages, followed by any images they returned
+	outcomes := make([]toolOutcome, 0, len(approvedResults))
 	for _, result := range approvedResults {
 		content := result.Content
 		if result.Error != "" {
 			content = result.Error
 		}
-		toolMsg := ToolMessage(content, result.ID)
-		agentMessages = append(agentMessages, toolMsg)
-		toolResultMessages = append(toolResultMessages, toolMsg)
+		outcomes = append(outcomes, toolOutcome{
+			toolName: result.Name,
+			message:  ToolMessage(content, result.ID),
+			images:   result.Images,
+		})
 	}
-
-	log.Info("Reconstructed conversation for resumption", "totalMessages", len(agentMessages), "toolResults", len(approvedResults))
 
 	// newMessages should contain the reconstructed messages so they get saved to memory
 	newMessages := []Message{assistantMsgConverted}
-	newMessages = append(newMessages, toolResultMessages...)
+	appendToolOutcomes(&agentMessages, &newMessages, outcomes)
+
+	log.Info("Reconstructed conversation for resumption", "totalMessages", len(agentMessages), "toolResults", len(approvedResults))
 	log.Info("Starting resumption with reconstructed messages in newMessages", "count", len(newMessages))
 
 	return agentMessages, newMessages, nil

--- a/ark/executors/completions/agent.go
+++ b/ark/executors/completions/agent.go
@@ -195,11 +195,11 @@ func (a *Agent) processAssistantMessage(choice openai.ChatCompletionChoice) Mess
 }
 
 func (a *Agent) executeToolCall(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall) (Message, error) {
-	toolMessage, _, err := a.executeToolCallWithImages(ctx, toolCall)
+	toolMessage, _, err := a.executeToolCallWithImages(ctx, toolCall, newImageTurnBudget())
 	return toolMessage, err
 }
 
-func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall) (Message, []ToolResultImage, error) {
+func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.ChatCompletionMessageToolCall, budget *imageTurnBudget) (Message, []ToolResultImage, error) {
 	result, err := a.Tools.ExecuteTool(ctx, ToolCall(toolCall))
 
 	// If the result has an error field set, use that as the message content
@@ -208,13 +208,15 @@ func (a *Agent) executeToolCallWithImages(ctx context.Context, toolCall openai.C
 	if result.Error != "" {
 		content = result.Error
 	}
-	toolMessage := ToolMessage(content, result.ID)
+
+	images, note := budget.admit(ctx, toolCall.Function.Name, result.Images)
+	toolMessage := ToolMessage(content+note, result.ID)
 
 	if err != nil {
 		return toolMessage, nil, err
 	}
 
-	return toolMessage, result.Images, nil
+	return toolMessage, images, nil
 }
 
 func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCompletionMessageToolCall, agentMessages, newMessages *[]Message) error {
@@ -255,12 +257,13 @@ func (a *Agent) executeToolCalls(ctx context.Context, toolCalls []openai.ChatCom
 	}
 
 	// No approval needed, execute normally
+	budget := newImageTurnBudget()
 	for _, tc := range toolCalls {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		toolMessage, images, err := a.executeToolCallWithImages(ctx, tc)
+		toolMessage, images, err := a.executeToolCallWithImages(ctx, tc, budget)
 		*agentMessages = append(*agentMessages, toolMessage)
 		*newMessages = append(*newMessages, toolMessage)
 

--- a/ark/executors/completions/anthropic_format.go
+++ b/ark/executors/completions/anthropic_format.go
@@ -96,10 +96,17 @@ type anthropicSystemBlock struct {
 	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 
-type anthropicMessageContent struct {
+type anthropicContentBlock struct {
 	Type         string                 `json:"type"`
-	Text         string                 `json:"text"`
+	Text         string                 `json:"text,omitempty"`
+	Source       *anthropicImageSource  `json:"source,omitempty"`
 	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 type anthropicMessage struct {
@@ -148,16 +155,17 @@ type anthropicContent struct {
 
 func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, []anthropicSystemBlock) {
 	type collectedMessage struct {
-		role string
-		text string
+		role   string
+		text   string
+		images []ToolResultImage
 	}
 
 	var collected []collectedMessage
 	var systemBlocks []anthropicSystemBlock
 
 	for _, msg := range messages {
-		content, role := extractMessageContent(msg)
-		if content == "" {
+		content, images, role := extractMessageParts(msg)
+		if content == "" && len(images) == 0 {
 			continue
 		}
 
@@ -175,7 +183,7 @@ func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, []anthr
 			if role == RoleTool {
 				msgRole = RoleUser
 			}
-			collected = append(collected, collectedMessage{role: msgRole, text: content})
+			collected = append(collected, collectedMessage{role: msgRole, text: content, images: images})
 		}
 	}
 
@@ -186,21 +194,39 @@ func convertMessagesToAnthropic(messages []Message) ([]anthropicMessage, []anthr
 
 	result := make([]anthropicMessage, len(collected))
 	for i, m := range collected {
-		if i == cacheIndex {
-			block := []anthropicMessageContent{
-				{
-					Type:         "text",
-					Text:         m.text,
-					CacheControl: &anthropicCacheControl{Type: "ephemeral"},
-				},
-			}
-			result[i] = anthropicMessage{Role: m.role, Content: mustMarshalRaw(block)}
-		} else {
-			result[i] = anthropicMessage{Role: m.role, Content: mustMarshalRaw(m.text)}
+		result[i] = anthropicMessage{
+			Role:    m.role,
+			Content: renderAnthropicContent(m.text, m.images, i == cacheIndex),
 		}
 	}
 
 	return result, systemBlocks
+}
+
+func renderAnthropicContent(text string, images []ToolResultImage, cached bool) json.RawMessage {
+	if len(images) == 0 && !cached {
+		return mustMarshalRaw(text)
+	}
+
+	blocks := make([]anthropicContentBlock, 0, len(images)+1)
+	for _, image := range images {
+		blocks = append(blocks, anthropicContentBlock{
+			Type: "image",
+			Source: &anthropicImageSource{
+				Type:      "base64",
+				MediaType: image.MediaType,
+				Data:      image.Base64(),
+			},
+		})
+	}
+	if text != "" || len(blocks) == 0 {
+		blocks = append(blocks, anthropicContentBlock{Type: "text", Text: text})
+	}
+	if cached {
+		blocks[len(blocks)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+	}
+
+	return mustMarshalRaw(blocks)
 }
 
 func convertAnthropicResponse(response anthropicResponse) *openai.ChatCompletion {

--- a/ark/executors/completions/anthropic_format.go
+++ b/ark/executors/completions/anthropic_format.go
@@ -1,12 +1,62 @@
 package completions
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"strings"
 
 	"github.com/openai/openai-go"
 )
 
 func extractMessageContent(msg Message) (string, string) {
+	text, _, role := extractMessageParts(msg)
+	return text, role
+}
+
+func extractMessageParts(msg Message) (string, []ToolResultImage, string) {
+	openaiMsg := openai.ChatCompletionMessageParamUnion(msg)
+
+	if userMsg := openaiMsg.OfUser; userMsg != nil {
+		if parts := userMsg.Content.OfArrayOfContentParts; len(parts) > 0 {
+			var text string
+			var images []ToolResultImage
+			for _, part := range parts {
+				switch {
+				case part.OfText != nil:
+					text += part.OfText.Text
+				case part.OfImageURL != nil:
+					if image, ok := imageFromDataURL(part.OfImageURL.ImageURL.URL); ok {
+						images = append(images, image)
+					}
+				}
+			}
+			return text, images, RoleUser
+		}
+	}
+
+	text, role := extractMessageString(msg)
+	return text, nil, role
+}
+
+func imageFromDataURL(url string) (ToolResultImage, bool) {
+	const prefix = "data:"
+	const marker = ";base64,"
+	if !strings.HasPrefix(url, prefix) {
+		return ToolResultImage{}, false
+	}
+	markerAt := strings.Index(url, marker)
+	if markerAt < 0 {
+		return ToolResultImage{}, false
+	}
+	mediaType := url[len(prefix):markerAt]
+	data, err := base64.StdEncoding.DecodeString(url[markerAt+len(marker):])
+	if err != nil || mediaType == "" || len(data) == 0 {
+		return ToolResultImage{}, false
+	}
+	return ToolResultImage{MediaType: mediaType, Data: data}, true
+}
+
+func extractMessageString(msg Message) (string, string) {
 	openaiMsg := openai.ChatCompletionMessageParamUnion(msg)
 
 	if systemMsg := openaiMsg.OfSystem; systemMsg != nil {

--- a/ark/executors/completions/anthropic_format.go
+++ b/ark/executors/completions/anthropic_format.go
@@ -1,9 +1,7 @@
 package completions
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"strings"
 
 	"github.com/openai/openai-go"
 )
@@ -36,27 +34,6 @@ func extractMessageParts(msg Message) (string, []ToolResultImage, string) {
 
 	text, role := extractMessageString(msg)
 	return text, nil, role
-}
-
-func imageFromDataURL(url string) (ToolResultImage, bool) {
-	const prefix = "data:"
-	const marker = ";base64,"
-	if !strings.HasPrefix(url, prefix) {
-		return ToolResultImage{}, false
-	}
-	markerAt := strings.Index(url, marker)
-	if markerAt < 0 {
-		return ToolResultImage{}, false
-	}
-	mediaType, ok := normalizeImageMediaType(url[len(prefix):markerAt])
-	if !ok {
-		return ToolResultImage{}, false
-	}
-	data, err := base64.StdEncoding.DecodeString(url[markerAt+len(marker):])
-	if err != nil || len(data) == 0 {
-		return ToolResultImage{}, false
-	}
-	return ToolResultImage{MediaType: mediaType, Data: data}, true
 }
 
 func extractMessageString(msg Message) (string, string) {
@@ -218,7 +195,7 @@ func renderAnthropicContent(text string, images []ToolResultImage, cached bool) 
 			Source: &anthropicImageSource{
 				Type:      "base64",
 				MediaType: image.MediaType,
-				Data:      image.Base64(),
+				Data:      image.B64,
 			},
 		})
 	}

--- a/ark/executors/completions/anthropic_format.go
+++ b/ark/executors/completions/anthropic_format.go
@@ -48,9 +48,12 @@ func imageFromDataURL(url string) (ToolResultImage, bool) {
 	if markerAt < 0 {
 		return ToolResultImage{}, false
 	}
-	mediaType := url[len(prefix):markerAt]
+	mediaType, ok := normalizeImageMediaType(url[len(prefix):markerAt])
+	if !ok {
+		return ToolResultImage{}, false
+	}
 	data, err := base64.StdEncoding.DecodeString(url[markerAt+len(marker):])
-	if err != nil || mediaType == "" || len(data) == 0 {
+	if err != nil || len(data) == 0 {
 		return ToolResultImage{}, false
 	}
 	return ToolResultImage{MediaType: mediaType, Data: data}, true

--- a/ark/executors/completions/anthropic_format_test.go
+++ b/ark/executors/completions/anthropic_format_test.go
@@ -49,7 +49,7 @@ func TestConvertMessagesToAnthropic(t *testing.T) {
 		result, _ := convertMessagesToAnthropic(messages)
 		require.Len(t, result, 3)
 
-		var blocks []anthropicMessageContent
+		var blocks []anthropicContentBlock
 		require.NoError(t, json.Unmarshal(result[1].Content, &blocks))
 		require.Len(t, blocks, 1)
 		assert.Equal(t, "Hello!", blocks[0].Text)

--- a/ark/executors/completions/chart/values.yaml
+++ b/ark/executors/completions/chart/values.yaml
@@ -90,16 +90,20 @@ podAnnotations: {}
 # attempt count or the wall-clock budget, whichever hits first.
 #
 # ARK_TOOL_IMAGE_* bound the images a tool can put in front of the model.
-# MAX_BYTES is per decoded image, MAX_PER_TOOL_CALL is how many one tool
-# result may carry, and MAX_BYTES_PER_TURN is the cumulative budget across
-# every tool call in one turn. An image over any of these is dropped and the
-# tool text says why, so the model is told rather than left guessing.
+# MAX_BYTES is per decoded image and MAX_PER_TOOL_CALL is how many one tool
+# result may carry, both applied where the tool result arrives.
+# MAX_BYTES_PER_TURN is the cumulative budget across every tool call in one
+# turn, and MAX_BYTES_PER_REQUEST bounds every image in an outbound request
+# including the ones replayed from earlier turns - without it a conversation
+# accumulates images without limit. An image over any of these is dropped and
+# the text says why, so the model is told rather than left guessing.
 env:
   ARK_MCP_TOOL_CALL_MAX_ATTEMPTS: "3"
   ARK_MCP_TOOL_CALL_RETRY_BUDGET_SECONDS: "30"
   ARK_TOOL_IMAGE_MAX_BYTES: "5242880"
   ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL: "4"
   ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN: "15728640"
+  ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST: "15728640"
 
 # Static replica count, exposed so per-tenant deployments can scale independently of the
 # central install. Ignored when autoscaling.enabled is true (the HPA owns the count).

--- a/ark/executors/completions/chart/values.yaml
+++ b/ark/executors/completions/chart/values.yaml
@@ -88,9 +88,18 @@ podAnnotations: {}
 # the retry of transient MCP tool-call errors (HTTP 429/500/502/503/504 and
 # requests that never reached the server). A tool call gives up after the
 # attempt count or the wall-clock budget, whichever hits first.
+#
+# ARK_TOOL_IMAGE_* bound the images a tool can put in front of the model.
+# MAX_BYTES is per decoded image, MAX_PER_TOOL_CALL is how many one tool
+# result may carry, and MAX_BYTES_PER_TURN is the cumulative budget across
+# every tool call in one turn. An image over any of these is dropped and the
+# tool text says why, so the model is told rather than left guessing.
 env:
   ARK_MCP_TOOL_CALL_MAX_ATTEMPTS: "3"
   ARK_MCP_TOOL_CALL_RETRY_BUDGET_SECONDS: "30"
+  ARK_TOOL_IMAGE_MAX_BYTES: "5242880"
+  ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL: "4"
+  ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN: "15728640"
 
 # Static replica count, exposed so per-tenant deployments can scale independently of the
 # central install. Ignored when autoscaling.enabled is true (the HPA owns the count).

--- a/ark/executors/completions/env.go
+++ b/ark/executors/completions/env.go
@@ -1,0 +1,13 @@
+package completions
+
+import (
+	"os"
+	"strconv"
+)
+
+func envInt(name string, fallback int) int {
+	if v, err := strconv.Atoi(os.Getenv(name)); err == nil && v > 0 {
+		return v
+	}
+	return fallback
+}

--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -945,7 +945,7 @@ func (h *Handler) handleResumption(ctx context.Context, state *executionState, a
 	// Convert parsed tool calls to openai format
 	toolCalls := make([]openai.ChatCompletionMessageToolCall, len(toolCallsData))
 	approvedResults := []ToolResult{}
-	imageBudget := newImageTurnBudget()
+	imageBudget := agent.imagePolicy().NewTurnBudget()
 
 	for i, tcData := range toolCallsData {
 		tc := openai.ChatCompletionMessageToolCall{

--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -945,6 +945,7 @@ func (h *Handler) handleResumption(ctx context.Context, state *executionState, a
 	// Convert parsed tool calls to openai format
 	toolCalls := make([]openai.ChatCompletionMessageToolCall, len(toolCallsData))
 	approvedResults := []ToolResult{}
+	imageBudget := newImageTurnBudget()
 
 	for i, tcData := range toolCallsData {
 		tc := openai.ChatCompletionMessageToolCall{
@@ -960,35 +961,31 @@ func (h *Handler) handleResumption(ctx context.Context, state *executionState, a
 		//nolint:nestif // TODO: Refactor to reduce nesting complexity
 		if isApproved {
 			// APPROVED: Execute the tool
-			result, err := agent.executeToolCall(ctx, tc)
+			result, images, err := agent.executeToolCallWithImages(ctx, tc, imageBudget)
 			if err != nil {
 				log.Error(err, "failed to execute approved tool call", "toolName", tc.Function.Name)
 				// Create error result
 				approvedResults = append(approvedResults, ToolResult{
 					ID:      tc.ID,
+					Name:    tc.Function.Name,
 					Content: fmt.Sprintf("Error executing tool: %v", err),
 				})
 			} else {
 				// Extract message content - result is a Message type (tool message)
 				// Convert to string content for tool result
+				content := fmt.Sprintf("%v", result)
 				if toolMsg := result.OfTool; toolMsg != nil {
-					if content := toolMsg.Content.OfString; content.Value != "" {
-						approvedResults = append(approvedResults, ToolResult{
-							ID:      tc.ID,
-							Content: content.Value,
-						})
-					} else {
-						approvedResults = append(approvedResults, ToolResult{
-							ID:      tc.ID,
-							Content: fmt.Sprintf("%v", toolMsg.Content),
-						})
+					content = fmt.Sprintf("%v", toolMsg.Content)
+					if text := toolMsg.Content.OfString; text.Value != "" {
+						content = text.Value
 					}
-				} else {
-					approvedResults = append(approvedResults, ToolResult{
-						ID:      tc.ID,
-						Content: fmt.Sprintf("%v", result),
-					})
 				}
+				approvedResults = append(approvedResults, ToolResult{
+					ID:      tc.ID,
+					Name:    tc.Function.Name,
+					Content: content,
+					Images:  images,
+				})
 			}
 		} else if isRejected {
 			// REJECTED: Return error result without executing

--- a/ark/executors/completions/image_alloc_test.go
+++ b/ark/executors/completions/image_alloc_test.go
@@ -1,0 +1,64 @@
+package completions
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func imageMessages(sizeBytes int) []Message {
+	return []Message{
+		NewUserMessage("read the receipt"),
+		NewUserImageMessage("Image returned by the read tool.",
+			[]ToolResultImage{newToolResultImage("image/png", make([]byte, sizeBytes))}),
+	}
+}
+
+func BenchmarkConvertMessagesToAnthropicWithImage(b *testing.B) {
+	messages := imageMessages(1 << 20)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, _ = convertMessagesToAnthropic(messages)
+	}
+}
+
+// The image is encoded once, where its bytes arrive. Building a request must not decode it
+// back and re-encode it, which is what made a multi-megabyte image cost several copies of
+// itself on every turn.
+func TestConvertMessagesToAnthropicDoesNotDecodeImages(t *testing.T) {
+	const imageBytes = 1 << 20
+	messages := imageMessages(imageBytes)
+
+	const runs = 5
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for range runs {
+		_, _ = convertMessagesToAnthropic(messages)
+	}
+	runtime.ReadMemStats(&after)
+
+	perRun := (after.TotalAlloc - before.TotalAlloc) / runs
+	t.Logf("allocated %d bytes per conversion of a %d byte image", perRun, imageBytes)
+
+	// Rendering necessarily writes the encoded payload into the JSON body, roughly 4/3 of the
+	// image. A decode plus a re-encode would add about 7/3 more on top.
+	assert.Less(t, perRun, uint64(3*imageBytes),
+		"a conversion should cost about one encoded copy of the image, not several")
+}
+
+func TestBase64DecodedLen(t *testing.T) {
+	for _, size := range []int{1, 2, 3, 4, 5, 100, 1023} {
+		encoded := newToolResultImage("image/png", make([]byte, size)).B64
+		decodedLen, ok := base64DecodedLen(encoded)
+		assert.True(t, ok, encoded)
+		assert.Equal(t, size, decodedLen, "size %d", size)
+	}
+
+	for _, invalid := range []string{"", "abc", "!!!!", "a===", "====", "ab=c"} {
+		_, ok := base64DecodedLen(invalid)
+		assert.False(t, ok, invalid)
+	}
+}

--- a/ark/executors/completions/image_budget.go
+++ b/ark/executors/completions/image_budget.go
@@ -1,0 +1,38 @@
+package completions
+
+import (
+	"context"
+	"fmt"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type imageTurnBudget struct {
+	total     int
+	remaining int
+}
+
+func newImageTurnBudget() *imageTurnBudget {
+	total := toolImageLimitsFromEnv().MaxBytesPerTurn
+	return &imageTurnBudget{total: total, remaining: total}
+}
+
+func (b *imageTurnBudget) admit(ctx context.Context, toolName string, images []ToolResultImage) ([]ToolResultImage, string) {
+	if len(images) == 0 {
+		return nil, ""
+	}
+
+	log := logf.FromContext(ctx)
+	var kept []ToolResultImage
+	var note string
+	for _, image := range images {
+		if len(image.Data) > b.remaining {
+			log.Info("dropping tool image beyond the per turn budget", "tool", toolName, "mediaType", image.MediaType, "bytes", len(image.Data), "remainingBytes", b.remaining, "maxBytesPerTurn", b.total)
+			note += fmt.Sprintf("[image returned: %s, %d bytes - the %d byte image budget for this turn is exhausted, not shown to the model]", image.MediaType, len(image.Data), b.total)
+			continue
+		}
+		b.remaining -= len(image.Data)
+		kept = append(kept, image)
+	}
+	return kept, note
+}

--- a/ark/executors/completions/image_budget.go
+++ b/ark/executors/completions/image_budget.go
@@ -12,9 +12,8 @@ type imageTurnBudget struct {
 	remaining int
 }
 
-func newImageTurnBudget() *imageTurnBudget {
-	total := toolImageLimitsFromEnv().MaxBytesPerTurn
-	return &imageTurnBudget{total: total, remaining: total}
+func newImageTurnBudget(maxBytes int) *imageTurnBudget {
+	return &imageTurnBudget{total: maxBytes, remaining: maxBytes}
 }
 
 func (b *imageTurnBudget) admit(ctx context.Context, toolName string, images []ToolResultImage) ([]ToolResultImage, string) {
@@ -28,7 +27,8 @@ func (b *imageTurnBudget) admit(ctx context.Context, toolName string, images []T
 	for _, image := range images {
 		if len(image.Data) > b.remaining {
 			log.Info("dropping tool image beyond the per turn budget", "tool", toolName, "mediaType", image.MediaType, "bytes", len(image.Data), "remainingBytes", b.remaining, "maxBytesPerTurn", b.total)
-			note += fmt.Sprintf("[image returned: %s, %d bytes - the %d byte image budget for this turn is exhausted, not shown to the model]", image.MediaType, len(image.Data), b.total)
+			note += imageDroppedNote(image.MediaType, len(image.Data),
+				fmt.Sprintf("the %d byte image budget for this turn is exhausted", b.total))
 			continue
 		}
 		b.remaining -= len(image.Data)

--- a/ark/executors/completions/image_budget.go
+++ b/ark/executors/completions/image_budget.go
@@ -23,7 +23,7 @@ func (b *imageTurnBudget) admit(ctx context.Context, toolName string, images []T
 	}
 
 	log := logf.FromContext(ctx)
-	var kept []ToolResultImage
+	kept := make([]ToolResultImage, 0, len(images))
 	var note string
 	for _, image := range images {
 		if len(image.Data) > b.remaining {

--- a/ark/executors/completions/image_budget.go
+++ b/ark/executors/completions/image_budget.go
@@ -25,13 +25,13 @@ func (b *imageTurnBudget) admit(ctx context.Context, toolName string, images []T
 	kept := make([]ToolResultImage, 0, len(images))
 	var note string
 	for _, image := range images {
-		if len(image.Data) > b.remaining {
-			log.Info("dropping tool image beyond the per turn budget", "tool", toolName, "mediaType", image.MediaType, "bytes", len(image.Data), "remainingBytes", b.remaining, "maxBytesPerTurn", b.total)
-			note += imageDroppedNote(image.MediaType, len(image.Data),
+		if image.Bytes > b.remaining {
+			log.Info("dropping tool image beyond the per turn budget", "tool", toolName, "mediaType", image.MediaType, "bytes", image.Bytes, "remainingBytes", b.remaining, "maxBytesPerTurn", b.total)
+			note += imageDroppedNote(image.MediaType, image.Bytes,
 				fmt.Sprintf("the %d byte image budget for this turn is exhausted", b.total))
 			continue
 		}
-		b.remaining -= len(image.Data)
+		b.remaining -= image.Bytes
 		kept = append(kept, image)
 	}
 	return kept, note

--- a/ark/executors/completions/image_budget_test.go
+++ b/ark/executors/completions/image_budget_test.go
@@ -57,10 +57,8 @@ func imagePartCount(t *testing.T, msg Message) int {
 }
 
 func TestImageTurnBudgetAdmit(t *testing.T) {
-	t.Setenv(toolImageMaxBytesPerTurnEnv, "100")
-
 	t.Run("images within the budget are all admitted", func(t *testing.T) {
-		budget := newImageTurnBudget()
+		budget := newImageTurnBudget(100)
 		kept, note := budget.admit(context.Background(), "read",
 			[]ToolResultImage{imageOfSize(t, 40), imageOfSize(t, 40)})
 
@@ -70,7 +68,7 @@ func TestImageTurnBudgetAdmit(t *testing.T) {
 	})
 
 	t.Run("an image that would exceed the budget is dropped", func(t *testing.T) {
-		budget := newImageTurnBudget()
+		budget := newImageTurnBudget(100)
 		kept, note := budget.admit(context.Background(), "read",
 			[]ToolResultImage{imageOfSize(t, 80), imageOfSize(t, 80)})
 
@@ -81,7 +79,7 @@ func TestImageTurnBudgetAdmit(t *testing.T) {
 	})
 
 	t.Run("a smaller image still fits after a larger one is dropped", func(t *testing.T) {
-		budget := newImageTurnBudget()
+		budget := newImageTurnBudget(100)
 		kept, _ := budget.admit(context.Background(), "read",
 			[]ToolResultImage{imageOfSize(t, 90), imageOfSize(t, 80), imageOfSize(t, 10)})
 
@@ -91,7 +89,7 @@ func TestImageTurnBudgetAdmit(t *testing.T) {
 	})
 
 	t.Run("no images means no note", func(t *testing.T) {
-		budget := newImageTurnBudget()
+		budget := newImageTurnBudget(100)
 		kept, note := budget.admit(context.Background(), "read", nil)
 
 		assert.Empty(t, kept)
@@ -100,8 +98,6 @@ func TestImageTurnBudgetAdmit(t *testing.T) {
 }
 
 func TestExecuteToolCallsAppliesTurnBudgetAcrossToolCalls(t *testing.T) {
-	t.Setenv(toolImageMaxBytesPerTurnEnv, "100")
-
 	registry := newTestRegistry()
 	registry.RegisterTool(ToolDefinition{Name: "first"}, &stubImageExecutor{
 		images: []ToolResultImage{imageOfSize(t, 80)},
@@ -110,7 +106,14 @@ func TestExecuteToolCallsAppliesTurnBudgetAcrossToolCalls(t *testing.T) {
 		images: []ToolResultImage{imageOfSize(t, 80)},
 	})
 
-	agent := &Agent{Name: "test-agent", Namespace: "default", Tools: registry}
+	agent := &Agent{
+		Name: "test-agent", Namespace: "default", Tools: registry,
+		ImagePolicy: testImagePolicy(toolImageLimits{
+			MaxBytes:        defaultToolImageMaxBytes,
+			MaxPerToolCall:  defaultToolImageMaxPerToolCall,
+			MaxBytesPerTurn: 100,
+		}),
+	}
 
 	var agentMessages []Message
 	var newMessages []Message

--- a/ark/executors/completions/image_budget_test.go
+++ b/ark/executors/completions/image_budget_test.go
@@ -25,7 +25,7 @@ func (s *stubImageExecutor) Execute(_ context.Context, call ToolCall) (ToolResul
 
 func imageOfSize(t *testing.T, size int) ToolResultImage {
 	t.Helper()
-	return ToolResultImage{MediaType: "image/png", Data: make([]byte, size)}
+	return newToolResultImage("image/png", make([]byte, size))
 }
 
 func toolCall(id, name string) openai.ChatCompletionMessageToolCall {
@@ -84,8 +84,8 @@ func TestImageTurnBudgetAdmit(t *testing.T) {
 			[]ToolResultImage{imageOfSize(t, 90), imageOfSize(t, 80), imageOfSize(t, 10)})
 
 		require.Len(t, kept, 2)
-		assert.Len(t, kept[0].Data, 90)
-		assert.Len(t, kept[1].Data, 10)
+		assert.Equal(t, 90, kept[0].Bytes)
+		assert.Equal(t, 10, kept[1].Bytes)
 	})
 
 	t.Run("no images means no note", func(t *testing.T) {

--- a/ark/executors/completions/image_budget_test.go
+++ b/ark/executors/completions/image_budget_test.go
@@ -121,9 +121,9 @@ func TestExecuteToolCallsAppliesTurnBudgetAcrossToolCalls(t *testing.T) {
 
 	require.Len(t, agentMessages, 3, "two tool messages plus one image message")
 	assert.Equal(t, agentMessages, newMessages)
-	assert.Equal(t, 1, imagePartCount(t, agentMessages[1]), "the first tool call fits the budget")
+	assert.Equal(t, 1, imagePartCount(t, agentMessages[2]), "the first tool call fits the budget")
 
-	secondToolText := toolMessageText(t, agentMessages[2])
+	secondToolText := toolMessageText(t, agentMessages[1])
 	assert.Contains(t, secondToolText, "the 100 byte image budget for this turn is exhausted")
 	assert.Contains(t, secondToolText, "done", "the tool text is kept alongside the note")
 }

--- a/ark/executors/completions/image_budget_test.go
+++ b/ark/executors/completions/image_budget_test.go
@@ -1,0 +1,143 @@
+package completions
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubImageExecutor struct {
+	images []ToolResultImage
+}
+
+func (s *stubImageExecutor) Execute(_ context.Context, call ToolCall) (ToolResult, error) {
+	return ToolResult{
+		ID:      call.ID,
+		Name:    call.Function.Name,
+		Content: "done",
+		Images:  s.images,
+	}, nil
+}
+
+func imageOfSize(t *testing.T, size int) ToolResultImage {
+	t.Helper()
+	return ToolResultImage{MediaType: "image/png", Data: make([]byte, size)}
+}
+
+func toolCall(id, name string) openai.ChatCompletionMessageToolCall {
+	return openai.ChatCompletionMessageToolCall{
+		ID:       id,
+		Function: openai.ChatCompletionMessageToolCallFunction{Name: name, Arguments: "{}"},
+	}
+}
+
+func imagePartCount(t *testing.T, msg Message) int {
+	t.Helper()
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion(msg))
+	require.NoError(t, err)
+
+	var payload struct {
+		Content []struct {
+			Type string `json:"type"`
+		} `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	count := 0
+	for _, part := range payload.Content {
+		if part.Type == "image_url" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestImageTurnBudgetAdmit(t *testing.T) {
+	t.Setenv(toolImageMaxBytesPerTurnEnv, "100")
+
+	t.Run("images within the budget are all admitted", func(t *testing.T) {
+		budget := newImageTurnBudget()
+		kept, note := budget.admit(context.Background(), "read",
+			[]ToolResultImage{imageOfSize(t, 40), imageOfSize(t, 40)})
+
+		require.Len(t, kept, 2)
+		assert.Empty(t, note)
+		assert.Equal(t, 20, budget.remaining)
+	})
+
+	t.Run("an image that would exceed the budget is dropped", func(t *testing.T) {
+		budget := newImageTurnBudget()
+		kept, note := budget.admit(context.Background(), "read",
+			[]ToolResultImage{imageOfSize(t, 80), imageOfSize(t, 80)})
+
+		require.Len(t, kept, 1)
+		assert.Contains(t, note, "the 100 byte image budget for this turn is exhausted")
+		assert.Contains(t, note, "not shown to the model")
+		assert.Equal(t, 20, budget.remaining)
+	})
+
+	t.Run("a smaller image still fits after a larger one is dropped", func(t *testing.T) {
+		budget := newImageTurnBudget()
+		kept, _ := budget.admit(context.Background(), "read",
+			[]ToolResultImage{imageOfSize(t, 90), imageOfSize(t, 80), imageOfSize(t, 10)})
+
+		require.Len(t, kept, 2)
+		assert.Len(t, kept[0].Data, 90)
+		assert.Len(t, kept[1].Data, 10)
+	})
+
+	t.Run("no images means no note", func(t *testing.T) {
+		budget := newImageTurnBudget()
+		kept, note := budget.admit(context.Background(), "read", nil)
+
+		assert.Empty(t, kept)
+		assert.Empty(t, note)
+	})
+}
+
+func TestExecuteToolCallsAppliesTurnBudgetAcrossToolCalls(t *testing.T) {
+	t.Setenv(toolImageMaxBytesPerTurnEnv, "100")
+
+	registry := newTestRegistry()
+	registry.RegisterTool(ToolDefinition{Name: "first"}, &stubImageExecutor{
+		images: []ToolResultImage{imageOfSize(t, 80)},
+	})
+	registry.RegisterTool(ToolDefinition{Name: "second"}, &stubImageExecutor{
+		images: []ToolResultImage{imageOfSize(t, 80)},
+	})
+
+	agent := &Agent{Name: "test-agent", Namespace: "default", Tools: registry}
+
+	var agentMessages []Message
+	var newMessages []Message
+	err := agent.executeToolCalls(context.Background(),
+		[]openai.ChatCompletionMessageToolCall{toolCall("call-1", "first"), toolCall("call-2", "second")},
+		&agentMessages, &newMessages)
+	require.NoError(t, err)
+
+	require.Len(t, agentMessages, 3, "two tool messages plus one image message")
+	assert.Equal(t, agentMessages, newMessages)
+	assert.Equal(t, 1, imagePartCount(t, agentMessages[1]), "the first tool call fits the budget")
+
+	secondToolText := toolMessageText(t, agentMessages[2])
+	assert.Contains(t, secondToolText, "the 100 byte image budget for this turn is exhausted")
+	assert.Contains(t, secondToolText, "done", "the tool text is kept alongside the note")
+}
+
+func toolMessageText(t *testing.T, msg Message) string {
+	t.Helper()
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion(msg))
+	require.NoError(t, err)
+
+	var payload struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.Equal(t, "tool", payload.Role)
+	return payload.Content
+}

--- a/ark/executors/completions/image_config.go
+++ b/ark/executors/completions/image_config.go
@@ -5,15 +5,23 @@ const (
 	toolImageMaxPerToolCallEnv  = "ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL"
 	toolImageMaxBytesPerTurnEnv = "ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN"
 
+	toolImageMaxBytesPerRequestEnv = "ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST"
+
 	defaultToolImageMaxBytes        = 5 * 1024 * 1024
 	defaultToolImageMaxPerToolCall  = 4
 	defaultToolImageMaxBytesPerTurn = 15 * 1024 * 1024
+
+	defaultToolImageMaxBytesPerRequest = 15 * 1024 * 1024
 )
 
 type toolImageLimits struct {
 	MaxBytes        int
 	MaxPerToolCall  int
 	MaxBytesPerTurn int
+
+	// MaxBytesPerRequest bounds every image in an outbound request, including images replayed
+	// from the conversation history. MaxBytesPerTurn only bounds images admitted this turn.
+	MaxBytesPerRequest int
 }
 
 func toolImageLimitsFromEnv() toolImageLimits {
@@ -21,5 +29,7 @@ func toolImageLimitsFromEnv() toolImageLimits {
 		MaxBytes:        envInt(toolImageMaxBytesEnv, defaultToolImageMaxBytes),
 		MaxPerToolCall:  envInt(toolImageMaxPerToolCallEnv, defaultToolImageMaxPerToolCall),
 		MaxBytesPerTurn: envInt(toolImageMaxBytesPerTurnEnv, defaultToolImageMaxBytesPerTurn),
+
+		MaxBytesPerRequest: envInt(toolImageMaxBytesPerRequestEnv, defaultToolImageMaxBytesPerRequest),
 	}
 }

--- a/ark/executors/completions/image_config.go
+++ b/ark/executors/completions/image_config.go
@@ -1,0 +1,40 @@
+package completions
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	toolImageMaxBytesEnv        = "ARK_TOOL_IMAGE_MAX_BYTES"
+	toolImageMaxPerToolCallEnv  = "ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL"
+	toolImageMaxBytesPerTurnEnv = "ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN"
+
+	defaultToolImageMaxBytes        = 5 * 1024 * 1024
+	defaultToolImageMaxPerToolCall  = 4
+	defaultToolImageMaxBytesPerTurn = 15 * 1024 * 1024
+)
+
+type toolImageLimits struct {
+	MaxBytes        int
+	MaxPerToolCall  int
+	MaxBytesPerTurn int
+}
+
+func toolImageLimitsFromEnv() toolImageLimits {
+	limits := toolImageLimits{
+		MaxBytes:        defaultToolImageMaxBytes,
+		MaxPerToolCall:  defaultToolImageMaxPerToolCall,
+		MaxBytesPerTurn: defaultToolImageMaxBytesPerTurn,
+	}
+	if v, err := strconv.Atoi(os.Getenv(toolImageMaxBytesEnv)); err == nil && v > 0 {
+		limits.MaxBytes = v
+	}
+	if v, err := strconv.Atoi(os.Getenv(toolImageMaxPerToolCallEnv)); err == nil && v > 0 {
+		limits.MaxPerToolCall = v
+	}
+	if v, err := strconv.Atoi(os.Getenv(toolImageMaxBytesPerTurnEnv)); err == nil && v > 0 {
+		limits.MaxBytesPerTurn = v
+	}
+	return limits
+}

--- a/ark/executors/completions/image_config.go
+++ b/ark/executors/completions/image_config.go
@@ -1,10 +1,5 @@
 package completions
 
-import (
-	"os"
-	"strconv"
-)
-
 const (
 	toolImageMaxBytesEnv        = "ARK_TOOL_IMAGE_MAX_BYTES"
 	toolImageMaxPerToolCallEnv  = "ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL"
@@ -22,19 +17,9 @@ type toolImageLimits struct {
 }
 
 func toolImageLimitsFromEnv() toolImageLimits {
-	limits := toolImageLimits{
-		MaxBytes:        defaultToolImageMaxBytes,
-		MaxPerToolCall:  defaultToolImageMaxPerToolCall,
-		MaxBytesPerTurn: defaultToolImageMaxBytesPerTurn,
+	return toolImageLimits{
+		MaxBytes:        envInt(toolImageMaxBytesEnv, defaultToolImageMaxBytes),
+		MaxPerToolCall:  envInt(toolImageMaxPerToolCallEnv, defaultToolImageMaxPerToolCall),
+		MaxBytesPerTurn: envInt(toolImageMaxBytesPerTurnEnv, defaultToolImageMaxBytesPerTurn),
 	}
-	if v, err := strconv.Atoi(os.Getenv(toolImageMaxBytesEnv)); err == nil && v > 0 {
-		limits.MaxBytes = v
-	}
-	if v, err := strconv.Atoi(os.Getenv(toolImageMaxPerToolCallEnv)); err == nil && v > 0 {
-		limits.MaxPerToolCall = v
-	}
-	if v, err := strconv.Atoi(os.Getenv(toolImageMaxBytesPerTurnEnv)); err == nil && v > 0 {
-		limits.MaxBytesPerTurn = v
-	}
-	return limits
 }

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -14,7 +14,7 @@ import (
 var pngBytes = []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe}
 
 func TestToolResultImageEncoding(t *testing.T) {
-	image := ToolResultImage{MediaType: "image/png", Data: pngBytes}
+	image := newToolResultImage("image/png", pngBytes)
 
 	t.Run("base64 is of the raw bytes", func(t *testing.T) {
 		assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), image.Base64())
@@ -28,7 +28,8 @@ func TestToolResultImageEncoding(t *testing.T) {
 		back, ok := imageFromDataURL(image.DataURL())
 		require.True(t, ok)
 		assert.Equal(t, "image/png", back.MediaType)
-		assert.Equal(t, pngBytes, back.Data)
+		assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), back.B64)
+		assert.Equal(t, len(pngBytes), back.Bytes)
 	})
 
 	t.Run("a non-data url is rejected rather than sent as text", func(t *testing.T) {
@@ -54,21 +55,21 @@ func TestMCPImageContentIsNotFlattened(t *testing.T) {
 	text, images := executor.collectContent(context.Background(), content)
 
 	require.Len(t, images, 1)
-	assert.Equal(t, pngBytes, images[0].Data)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), images[0].B64)
 	assert.Contains(t, text, "here is the page")
 	assert.NotContains(t, text, base64.StdEncoding.EncodeToString(pngBytes))
 }
 
 func TestNewUserImageMessageCarriesImageParts(t *testing.T) {
 	msg := NewUserImageMessage("Image returned by the read tool.",
-		[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}})
+		[]ToolResultImage{newToolResultImage("image/png", pngBytes)})
 
 	text, images, role := extractMessageParts(msg)
 	assert.Equal(t, RoleUser, role)
 	assert.Equal(t, "Image returned by the read tool.", text)
 	require.Len(t, images, 1)
 	assert.Equal(t, "image/png", images[0].MediaType)
-	assert.Equal(t, pngBytes, images[0].Data)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), images[0].B64)
 }
 
 func TestRenderAnthropicContent(t *testing.T) {
@@ -79,7 +80,7 @@ func TestRenderAnthropicContent(t *testing.T) {
 
 	t.Run("an image becomes an image block, not base64 text", func(t *testing.T) {
 		raw := renderAnthropicContent("what does this say?",
-			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, false)
+			[]ToolResultImage{newToolResultImage("image/png", pngBytes)}, false)
 
 		var blocks []map[string]any
 		require.NoError(t, json.Unmarshal(raw, &blocks))
@@ -99,7 +100,7 @@ func TestRenderAnthropicContent(t *testing.T) {
 
 	t.Run("an image with no caption is a lone image block", func(t *testing.T) {
 		raw := renderAnthropicContent("",
-			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, false)
+			[]ToolResultImage{newToolResultImage("image/png", pngBytes)}, false)
 
 		var blocks []map[string]any
 		require.NoError(t, json.Unmarshal(raw, &blocks))
@@ -109,7 +110,7 @@ func TestRenderAnthropicContent(t *testing.T) {
 
 	t.Run("a cached image message keeps its cache breakpoint", func(t *testing.T) {
 		raw := renderAnthropicContent("what does this say?",
-			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, true)
+			[]ToolResultImage{newToolResultImage("image/png", pngBytes)}, true)
 
 		var blocks []anthropicContentBlock
 		require.NoError(t, json.Unmarshal(raw, &blocks))
@@ -124,7 +125,7 @@ func TestConvertMessagesToAnthropicKeepsImages(t *testing.T) {
 	messages := []Message{
 		NewUserMessage("read receipt.png"),
 		NewUserImageMessage("Image returned by the read tool.",
-			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}),
+			[]ToolResultImage{newToolResultImage("image/png", pngBytes)}),
 		NewUserMessage("what does it say?"),
 	}
 

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -22,6 +22,25 @@ func TestToolResultImageEncoding(t *testing.T) {
 	t.Run("data url carries media type and base64", func(t *testing.T) {
 		assert.Equal(t, "data:image/png;base64,"+image.Base64(), image.DataURL())
 	})
+
+	t.Run("data url round-trips", func(t *testing.T) {
+		back, ok := imageFromDataURL(image.DataURL())
+		require.True(t, ok)
+		assert.Equal(t, "image/png", back.MediaType)
+		assert.Equal(t, pngBytes, back.Data)
+	})
+
+	t.Run("a non-data url is rejected rather than sent as text", func(t *testing.T) {
+		for _, url := range []string{
+			"https://example.com/cat.png",
+			"data:image/png,notbase64",
+			"data:;base64," + image.Base64(),
+			"data:image/png;base64,!!!not-base64!!!",
+		} {
+			_, ok := imageFromDataURL(url)
+			assert.False(t, ok, url)
+		}
+	})
 }
 
 func TestMCPImageContentIsNotFlattened(t *testing.T) {
@@ -45,5 +64,17 @@ func TestMCPImageContentIsNotFlattened(t *testing.T) {
 	assert.Equal(t, pngBytes, images[0].Data)
 	assert.Equal(t, "here is the page", text.String())
 	assert.NotContains(t, text.String(), base64.StdEncoding.EncodeToString(pngBytes))
+}
+
+func TestNewUserImageMessageCarriesImageParts(t *testing.T) {
+	msg := NewUserImageMessage("Image returned by the read tool.",
+		[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}})
+
+	text, images, role := extractMessageParts(msg)
+	assert.Equal(t, RoleUser, role)
+	assert.Equal(t, "Image returned by the read tool.", text)
+	require.Len(t, images, 1)
+	assert.Equal(t, "image/png", images[0].MediaType)
+	assert.Equal(t, pngBytes, images[0].Data)
 }
 

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -2,9 +2,10 @@ package completions
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
-	
+
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,3 +79,72 @@ func TestNewUserImageMessageCarriesImageParts(t *testing.T) {
 	assert.Equal(t, pngBytes, images[0].Data)
 }
 
+func TestRenderAnthropicContent(t *testing.T) {
+	t.Run("text only is a bare string", func(t *testing.T) {
+		raw := renderAnthropicContent("just text", nil, false)
+		assert.JSONEq(t, `"just text"`, string(raw))
+	})
+
+	t.Run("an image becomes an image block, not base64 text", func(t *testing.T) {
+		raw := renderAnthropicContent("what does this say?",
+			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, false)
+
+		var blocks []map[string]any
+		require.NoError(t, json.Unmarshal(raw, &blocks))
+		require.Len(t, blocks, 2)
+
+		assert.Equal(t, "image", blocks[0]["type"])
+		source, ok := blocks[0]["source"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "base64", source["type"])
+		assert.Equal(t, "image/png", source["media_type"])
+		assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), source["data"])
+		assert.NotContains(t, blocks[0], "text")
+
+		assert.Equal(t, "text", blocks[1]["type"])
+		assert.Equal(t, "what does this say?", blocks[1]["text"])
+	})
+
+	t.Run("an image with no caption is a lone image block", func(t *testing.T) {
+		raw := renderAnthropicContent("",
+			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, false)
+
+		var blocks []map[string]any
+		require.NoError(t, json.Unmarshal(raw, &blocks))
+		require.Len(t, blocks, 1)
+		assert.Equal(t, "image", blocks[0]["type"])
+	})
+
+	t.Run("a cached image message keeps its cache breakpoint", func(t *testing.T) {
+		raw := renderAnthropicContent("what does this say?",
+			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}, true)
+
+		var blocks []anthropicContentBlock
+		require.NoError(t, json.Unmarshal(raw, &blocks))
+		require.Len(t, blocks, 2)
+		assert.Nil(t, blocks[0].CacheControl)
+		require.NotNil(t, blocks[1].CacheControl)
+		assert.Equal(t, "ephemeral", blocks[1].CacheControl.Type)
+	})
+}
+
+func TestConvertMessagesToAnthropicKeepsImages(t *testing.T) {
+	messages := []Message{
+		NewUserMessage("read receipt.png"),
+		NewUserImageMessage("Image returned by the read tool.",
+			[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}}),
+		NewUserMessage("what does it say?"),
+	}
+
+	converted, _ := convertMessagesToAnthropic(messages)
+	require.Len(t, converted, 3, "the image message must not be dropped")
+
+	assert.JSONEq(t, `"read receipt.png"`, string(converted[0].Content))
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(converted[1].Content, &blocks))
+	assert.Equal(t, "image", blocks[0]["type"])
+	source, ok := blocks[0]["source"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), source["data"])
+}

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -1,0 +1,23 @@
+package completions
+
+import (
+	"encoding/base64"
+	"testing"
+	
+	"github.com/stretchr/testify/assert"
+)
+
+var pngBytes = []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe}
+
+func TestToolResultImageEncoding(t *testing.T) {
+	image := ToolResultImage{MediaType: "image/png", Data: pngBytes}
+
+	t.Run("base64 is of the raw bytes", func(t *testing.T) {
+		assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), image.Base64())
+	})
+
+	t.Run("data url carries media type and base64", func(t *testing.T) {
+		assert.Equal(t, "data:image/png;base64,"+image.Base64(), image.DataURL())
+	})
+}
+

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -2,9 +2,12 @@ package completions
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 	
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var pngBytes = []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe}
@@ -19,5 +22,28 @@ func TestToolResultImageEncoding(t *testing.T) {
 	t.Run("data url carries media type and base64", func(t *testing.T) {
 		assert.Equal(t, "data:image/png;base64,"+image.Base64(), image.DataURL())
 	})
+}
+
+func TestMCPImageContentIsNotFlattened(t *testing.T) {
+	content := []mcpsdk.Content{
+		&mcpsdk.TextContent{Text: "here is the page"},
+		&mcpsdk.ImageContent{MIMEType: "image/png", Data: pngBytes},
+	}
+
+	var text strings.Builder
+	var images []ToolResultImage
+	for _, part := range content {
+		switch typed := part.(type) {
+		case *mcpsdk.TextContent:
+			text.WriteString(typed.Text)
+		case *mcpsdk.ImageContent:
+			images = append(images, ToolResultImage{MediaType: typed.MIMEType, Data: typed.Data})
+		}
+	}
+
+	require.Len(t, images, 1)
+	assert.Equal(t, pngBytes, images[0].Data)
+	assert.Equal(t, "here is the page", text.String())
+	assert.NotContains(t, text.String(), base64.StdEncoding.EncodeToString(pngBytes))
 }
 

--- a/ark/executors/completions/image_content_test.go
+++ b/ark/executors/completions/image_content_test.go
@@ -1,9 +1,9 @@
 package completions
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -50,21 +50,13 @@ func TestMCPImageContentIsNotFlattened(t *testing.T) {
 		&mcpsdk.ImageContent{MIMEType: "image/png", Data: pngBytes},
 	}
 
-	var text strings.Builder
-	var images []ToolResultImage
-	for _, part := range content {
-		switch typed := part.(type) {
-		case *mcpsdk.TextContent:
-			text.WriteString(typed.Text)
-		case *mcpsdk.ImageContent:
-			images = append(images, ToolResultImage{MediaType: typed.MIMEType, Data: typed.Data})
-		}
-	}
+	executor := &MCPExecutor{ToolName: "read"}
+	text, images := executor.collectContent(context.Background(), content)
 
 	require.Len(t, images, 1)
 	assert.Equal(t, pngBytes, images[0].Data)
-	assert.Equal(t, "here is the page", text.String())
-	assert.NotContains(t, text.String(), base64.StdEncoding.EncodeToString(pngBytes))
+	assert.Contains(t, text, "here is the page")
+	assert.NotContains(t, text, base64.StdEncoding.EncodeToString(pngBytes))
 }
 
 func TestNewUserImageMessageCarriesImageParts(t *testing.T) {

--- a/ark/executors/completions/image_data_url.go
+++ b/ark/executors/completions/image_data_url.go
@@ -1,0 +1,63 @@
+package completions
+
+import "strings"
+
+const (
+	dataURLPrefix = "data:"
+	base64Marker  = ";base64,"
+)
+
+// imageFromDataURL parses the grammar DataURL writes. The payload is kept encoded: decoding a
+// multi-megabyte image only to re-encode it for the provider is the cost this avoids, so the
+// base64 is validated by a scan and its decoded length derived by arithmetic.
+func imageFromDataURL(url string) (ToolResultImage, bool) {
+	rest, ok := strings.CutPrefix(url, dataURLPrefix)
+	if !ok {
+		return ToolResultImage{}, false
+	}
+
+	mediaType, b64, ok := strings.Cut(rest, base64Marker)
+	if !ok {
+		return ToolResultImage{}, false
+	}
+
+	normalized, ok := normalizeImageMediaType(mediaType)
+	if !ok {
+		return ToolResultImage{}, false
+	}
+
+	decodedLen, ok := base64DecodedLen(b64)
+	if !ok {
+		return ToolResultImage{}, false
+	}
+
+	return ToolResultImage{MediaType: normalized, B64: b64, Bytes: decodedLen}, true
+}
+
+// base64DecodedLen validates standard padded base64 and returns the length it decodes to,
+// without allocating the decoded bytes.
+func base64DecodedLen(s string) (int, bool) {
+	if s == "" || len(s)%4 != 0 {
+		return 0, false
+	}
+
+	padding := 0
+	for len(s) > 0 && s[len(s)-1] == '=' {
+		padding++
+		s = s[:len(s)-1]
+	}
+	if padding > 2 {
+		return 0, false
+	}
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '+', c == '/':
+		default:
+			return 0, false
+		}
+	}
+
+	return (len(s)+padding)/4*3 - padding, true
+}

--- a/ark/executors/completions/image_limits_test.go
+++ b/ark/executors/completions/image_limits_test.go
@@ -48,8 +48,10 @@ func TestToolImageLimitsFromEnv(t *testing.T) {
 }
 
 func TestCollectContentDropsOversizedImage(t *testing.T) {
-	t.Setenv(toolImageMaxBytesEnv, "10")
-	executor := &MCPExecutor{ToolName: "read"}
+	executor := &MCPExecutor{ToolName: "read", ImagePolicy: testImagePolicy(toolImageLimits{
+		MaxBytes:       10,
+		MaxPerToolCall: defaultToolImageMaxPerToolCall,
+	})}
 
 	t.Run("an image over the limit is dropped with a breadcrumb", func(t *testing.T) {
 		oversized := make([]byte, 11)
@@ -75,8 +77,10 @@ func TestCollectContentDropsOversizedImage(t *testing.T) {
 }
 
 func TestCollectContentCapsImagesPerToolCall(t *testing.T) {
-	t.Setenv(toolImageMaxPerToolCallEnv, "4")
-	executor := &MCPExecutor{ToolName: "read"}
+	executor := &MCPExecutor{ToolName: "read", ImagePolicy: testImagePolicy(toolImageLimits{
+		MaxBytes:       defaultToolImageMaxBytes,
+		MaxPerToolCall: 4,
+	})}
 
 	want := make([][]byte, 0, 5)
 	contents := make([]mcpsdk.Content, 0, 5)
@@ -96,8 +100,10 @@ func TestCollectContentCapsImagesPerToolCall(t *testing.T) {
 }
 
 func TestCollectContentLimitsAreConfigurable(t *testing.T) {
-	t.Setenv(toolImageMaxPerToolCallEnv, "1")
-	executor := &MCPExecutor{ToolName: "read"}
+	executor := &MCPExecutor{ToolName: "read", ImagePolicy: testImagePolicy(toolImageLimits{
+		MaxBytes:       defaultToolImageMaxBytes,
+		MaxPerToolCall: 1,
+	})}
 
 	text, images := executor.collectContent(context.Background(), []mcpsdk.Content{
 		&mcpsdk.ImageContent{MIMEType: "image/png", Data: pngBytes},
@@ -106,4 +112,11 @@ func TestCollectContentLimitsAreConfigurable(t *testing.T) {
 
 	require.Len(t, images, 1)
 	assert.Contains(t, text, fmt.Sprintf("image limit of %d per tool call reached", 1))
+}
+
+func testImagePolicy(limits toolImageLimits) *imagePolicy {
+	if limits.MaxBytesPerTurn == 0 {
+		limits.MaxBytesPerTurn = defaultToolImageMaxBytesPerTurn
+	}
+	return newImagePolicy(limits)
 }

--- a/ark/executors/completions/image_limits_test.go
+++ b/ark/executors/completions/image_limits_test.go
@@ -1,0 +1,109 @@
+package completions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolImageLimitsFromEnv(t *testing.T) {
+	t.Run("defaults apply when the variables are absent", func(t *testing.T) {
+		t.Setenv(toolImageMaxBytesEnv, "")
+		t.Setenv(toolImageMaxPerToolCallEnv, "")
+		t.Setenv(toolImageMaxBytesPerTurnEnv, "")
+
+		limits := toolImageLimitsFromEnv()
+		assert.Equal(t, defaultToolImageMaxBytes, limits.MaxBytes)
+		assert.Equal(t, defaultToolImageMaxPerToolCall, limits.MaxPerToolCall)
+		assert.Equal(t, defaultToolImageMaxBytesPerTurn, limits.MaxBytesPerTurn)
+	})
+
+	t.Run("a valid override is applied", func(t *testing.T) {
+		t.Setenv(toolImageMaxBytesEnv, "1024")
+		t.Setenv(toolImageMaxPerToolCallEnv, "2")
+		t.Setenv(toolImageMaxBytesPerTurnEnv, "4096")
+
+		limits := toolImageLimitsFromEnv()
+		assert.Equal(t, 1024, limits.MaxBytes)
+		assert.Equal(t, 2, limits.MaxPerToolCall)
+		assert.Equal(t, 4096, limits.MaxBytesPerTurn)
+	})
+
+	t.Run("an unusable override falls back to the default", func(t *testing.T) {
+		for _, value := range []string{"", "0", "-1", "many"} {
+			t.Setenv(toolImageMaxBytesEnv, value)
+			t.Setenv(toolImageMaxPerToolCallEnv, value)
+			t.Setenv(toolImageMaxBytesPerTurnEnv, value)
+
+			limits := toolImageLimitsFromEnv()
+			assert.Equal(t, defaultToolImageMaxBytes, limits.MaxBytes, value)
+			assert.Equal(t, defaultToolImageMaxPerToolCall, limits.MaxPerToolCall, value)
+			assert.Equal(t, defaultToolImageMaxBytesPerTurn, limits.MaxBytesPerTurn, value)
+		}
+	})
+}
+
+func TestCollectContentDropsOversizedImage(t *testing.T) {
+	t.Setenv(toolImageMaxBytesEnv, "10")
+	executor := &MCPExecutor{ToolName: "read"}
+
+	t.Run("an image over the limit is dropped with a breadcrumb", func(t *testing.T) {
+		oversized := make([]byte, 11)
+		text, images := executor.collectContent(context.Background(), []mcpsdk.Content{
+			&mcpsdk.ImageContent{MIMEType: "image/png", Data: oversized},
+		})
+
+		assert.Empty(t, images, "an oversized image must not reach the provider")
+		assert.Contains(t, text, "11 bytes")
+		assert.Contains(t, text, "exceeds the 10 byte limit")
+		assert.Contains(t, text, "not shown to the model")
+	})
+
+	t.Run("an image exactly at the limit is kept", func(t *testing.T) {
+		exact := make([]byte, 10)
+		_, images := executor.collectContent(context.Background(), []mcpsdk.Content{
+			&mcpsdk.ImageContent{MIMEType: "image/png", Data: exact},
+		})
+
+		require.Len(t, images, 1)
+		assert.Equal(t, exact, images[0].Data)
+	})
+}
+
+func TestCollectContentCapsImagesPerToolCall(t *testing.T) {
+	t.Setenv(toolImageMaxPerToolCallEnv, "4")
+	executor := &MCPExecutor{ToolName: "read"}
+
+	want := make([][]byte, 0, 5)
+	contents := make([]mcpsdk.Content, 0, 5)
+	for i := range 5 {
+		data := []byte{0x89, 'P', 'N', 'G', byte(i)}
+		want = append(want, data)
+		contents = append(contents, &mcpsdk.ImageContent{MIMEType: "image/png", Data: data})
+	}
+
+	text, images := executor.collectContent(context.Background(), contents)
+
+	require.Len(t, images, 4, "the fifth image must be dropped")
+	for i := range images {
+		assert.Equal(t, want[i], images[i].Data)
+	}
+	assert.Contains(t, text, "image limit of 4 per tool call reached")
+}
+
+func TestCollectContentLimitsAreConfigurable(t *testing.T) {
+	t.Setenv(toolImageMaxPerToolCallEnv, "1")
+	executor := &MCPExecutor{ToolName: "read"}
+
+	text, images := executor.collectContent(context.Background(), []mcpsdk.Content{
+		&mcpsdk.ImageContent{MIMEType: "image/png", Data: pngBytes},
+		&mcpsdk.ImageContent{MIMEType: "image/png", Data: pngBytes},
+	})
+
+	require.Len(t, images, 1)
+	assert.Contains(t, text, fmt.Sprintf("image limit of %d per tool call reached", 1))
+}

--- a/ark/executors/completions/image_limits_test.go
+++ b/ark/executors/completions/image_limits_test.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestCollectContentDropsOversizedImage(t *testing.T) {
 		})
 
 		require.Len(t, images, 1)
-		assert.Equal(t, exact, images[0].Data)
+		assert.Equal(t, len(exact), images[0].Bytes)
 	})
 }
 
@@ -94,7 +95,7 @@ func TestCollectContentCapsImagesPerToolCall(t *testing.T) {
 
 	require.Len(t, images, 4, "the fifth image must be dropped")
 	for i := range images {
-		assert.Equal(t, want[i], images[i].Data)
+		assert.Equal(t, base64.StdEncoding.EncodeToString(want[i]), images[i].B64)
 	}
 	assert.Contains(t, text, "image limit of 4 per tool call reached")
 }

--- a/ark/executors/completions/image_media_type.go
+++ b/ark/executors/completions/image_media_type.go
@@ -1,6 +1,9 @@
 package completions
 
-import "strings"
+import (
+	"mime"
+	"strings"
+)
 
 var supportedImageMediaTypes = map[string]bool{
 	"image/jpeg": true,
@@ -10,8 +13,11 @@ var supportedImageMediaTypes = map[string]bool{
 }
 
 func normalizeImageMediaType(mediaType string) (string, bool) {
-	base, _, _ := strings.Cut(mediaType, ";")
-	base = strings.ToLower(strings.TrimSpace(base))
+	base, _, err := mime.ParseMediaType(mediaType)
+	if err != nil {
+		base, _, _ = strings.Cut(mediaType, ";")
+		base = strings.ToLower(strings.TrimSpace(base))
+	}
 	if base == "image/jpg" {
 		base = "image/jpeg"
 	}

--- a/ark/executors/completions/image_media_type.go
+++ b/ark/executors/completions/image_media_type.go
@@ -1,0 +1,22 @@
+package completions
+
+import "strings"
+
+var supportedImageMediaTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+func normalizeImageMediaType(mediaType string) (string, bool) {
+	base, _, _ := strings.Cut(mediaType, ";")
+	base = strings.ToLower(strings.TrimSpace(base))
+	if base == "image/jpg" {
+		base = "image/jpeg"
+	}
+	if !supportedImageMediaTypes[base] {
+		return "", false
+	}
+	return base, true
+}

--- a/ark/executors/completions/image_media_type_test.go
+++ b/ark/executors/completions/image_media_type_test.go
@@ -58,7 +58,7 @@ func TestImageFromDataURLNormalizesMediaType(t *testing.T) {
 		image, ok := imageFromDataURL("data:image/png;charset=utf-8;base64," + encoded)
 		require.True(t, ok)
 		assert.Equal(t, "image/png", image.MediaType)
-		assert.Equal(t, pngBytes, image.Data)
+		assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), image.B64)
 	})
 
 	t.Run("the informal jpeg spelling is normalized", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestCollectContentCarriesSupportedImages(t *testing.T) {
 
 	require.Len(t, images, 1)
 	assert.Equal(t, "image/png", images[0].MediaType)
-	assert.Equal(t, pngBytes, images[0].Data)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pngBytes), images[0].B64)
 	assert.Contains(t, text, "here is the page")
 	assert.NotContains(t, text, base64.StdEncoding.EncodeToString(pngBytes))
 }
@@ -104,7 +104,7 @@ func TestCollectContentDropsUnsupportedImage(t *testing.T) {
 
 func TestImageMessageWireShapeForOpenAIProviders(t *testing.T) {
 	msg := NewUserImageMessage("Image returned by the read tool.",
-		[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}})
+		[]ToolResultImage{newToolResultImage("image/png", pngBytes)})
 
 	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion(msg))
 	require.NoError(t, err)

--- a/ark/executors/completions/image_media_type_test.go
+++ b/ark/executors/completions/image_media_type_test.go
@@ -1,0 +1,132 @@
+package completions
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeImageMediaType(t *testing.T) {
+	supported := []struct {
+		in   string
+		want string
+	}{
+		{"image/png", "image/png"},
+		{"image/jpeg", "image/jpeg"},
+		{"image/gif", "image/gif"},
+		{"image/webp", "image/webp"},
+		{"image/png;charset=utf-8", "image/png"},
+		{"image/jpeg;foo=bar;baz=qux", "image/jpeg"},
+		{"IMAGE/PNG", "image/png"},
+		{"  image/png  ", "image/png"},
+		{"image/jpg", "image/jpeg"},
+		{"IMAGE/JPG;charset=utf-8", "image/jpeg"},
+	}
+	for _, tc := range supported {
+		got, ok := normalizeImageMediaType(tc.in)
+		assert.True(t, ok, tc.in)
+		assert.Equal(t, tc.want, got, tc.in)
+	}
+
+	unsupported := []string{
+		"",
+		";base64",
+		"image/svg+xml",
+		"image/bmp",
+		"image/tiff",
+		"application/pdf",
+		"text/plain",
+		"image",
+		"png",
+	}
+	for _, in := range unsupported {
+		_, ok := normalizeImageMediaType(in)
+		assert.False(t, ok, in)
+	}
+}
+
+func TestImageFromDataURLNormalizesMediaType(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString(pngBytes)
+
+	t.Run("a parameter is stripped rather than sent as the media type", func(t *testing.T) {
+		image, ok := imageFromDataURL("data:image/png;charset=utf-8;base64," + encoded)
+		require.True(t, ok)
+		assert.Equal(t, "image/png", image.MediaType)
+		assert.Equal(t, pngBytes, image.Data)
+	})
+
+	t.Run("the informal jpeg spelling is normalized", func(t *testing.T) {
+		image, ok := imageFromDataURL("data:image/jpg;base64," + encoded)
+		require.True(t, ok)
+		assert.Equal(t, "image/jpeg", image.MediaType)
+	})
+
+	t.Run("an unsupported media type is rejected", func(t *testing.T) {
+		for _, mediaType := range []string{"image/svg+xml", "image/bmp", "application/pdf"} {
+			_, ok := imageFromDataURL("data:" + mediaType + ";base64," + encoded)
+			assert.False(t, ok, mediaType)
+		}
+	})
+}
+
+func TestCollectContentCarriesSupportedImages(t *testing.T) {
+	executor := &MCPExecutor{ToolName: "read"}
+
+	text, images := executor.collectContent(context.Background(), []mcpsdk.Content{
+		&mcpsdk.TextContent{Text: "here is the page"},
+		&mcpsdk.ImageContent{MIMEType: "image/png;charset=utf-8", Data: pngBytes},
+	})
+
+	require.Len(t, images, 1)
+	assert.Equal(t, "image/png", images[0].MediaType)
+	assert.Equal(t, pngBytes, images[0].Data)
+	assert.Contains(t, text, "here is the page")
+	assert.NotContains(t, text, base64.StdEncoding.EncodeToString(pngBytes))
+}
+
+func TestCollectContentDropsUnsupportedImage(t *testing.T) {
+	executor := &MCPExecutor{ToolName: "render"}
+
+	text, images := executor.collectContent(context.Background(), []mcpsdk.Content{
+		&mcpsdk.ImageContent{MIMEType: "image/svg+xml", Data: pngBytes},
+	})
+
+	assert.Empty(t, images, "an unsupported image must not reach the provider")
+	assert.Contains(t, text, "image/svg+xml")
+	assert.Contains(t, text, "not shown to the model")
+}
+
+func TestImageMessageWireShapeForOpenAIProviders(t *testing.T) {
+	msg := NewUserImageMessage("Image returned by the read tool.",
+		[]ToolResultImage{{MediaType: "image/png", Data: pngBytes}})
+
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion(msg))
+	require.NoError(t, err)
+
+	var payload struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Type     string `json:"type"`
+			Text     string `json:"text"`
+			ImageURL struct {
+				URL string `json:"url"`
+			} `json:"image_url"`
+		} `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	assert.Equal(t, RoleUser, payload.Role)
+	require.Len(t, payload.Content, 2)
+	assert.Equal(t, "text", payload.Content[0].Type)
+	assert.Equal(t, "Image returned by the read tool.", payload.Content[0].Text)
+	assert.Equal(t, "image_url", payload.Content[1].Type)
+	assert.Equal(t,
+		"data:image/png;base64,"+base64.StdEncoding.EncodeToString(pngBytes),
+		payload.Content[1].ImageURL.URL)
+}

--- a/ark/executors/completions/image_policy.go
+++ b/ark/executors/completions/image_policy.go
@@ -1,0 +1,82 @@
+package completions
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type imagePolicy struct {
+	limits toolImageLimits
+}
+
+var (
+	defaultImagePolicyOnce sync.Once
+	cachedDefaultPolicy    *imagePolicy
+)
+
+func newImagePolicy(limits toolImageLimits) *imagePolicy {
+	return &imagePolicy{limits: limits}
+}
+
+// defaultImagePolicy resolves the limits from the environment once, so a tool call does not
+// re-read them on every result.
+func defaultImagePolicy() *imagePolicy {
+	defaultImagePolicyOnce.Do(func() {
+		cachedDefaultPolicy = newImagePolicy(toolImageLimitsFromEnv())
+	})
+	return cachedDefaultPolicy
+}
+
+func (p *imagePolicy) NewTurnBudget() *imageTurnBudget {
+	return newImageTurnBudget(p.limits.MaxBytesPerTurn)
+}
+
+func (p *imagePolicy) NewToolResultAdmitter() *toolImageAdmitter {
+	return &toolImageAdmitter{policy: p}
+}
+
+// toolImageAdmitter applies the per-image and per-tool-call limits across the images of one
+// tool result.
+type toolImageAdmitter struct {
+	policy   *imagePolicy
+	admitted int
+}
+
+// Admit reports whether an image may be carried. When it may not, the returned note says why,
+// so the model is never told it was shown an image it did not receive.
+func (a *toolImageAdmitter) Admit(ctx context.Context, toolName, mediaType string, data []byte) (ToolResultImage, string, bool) {
+	log := logf.FromContext(ctx)
+	limits := a.policy.limits
+
+	normalized, ok := normalizeImageMediaType(mediaType)
+	if !ok {
+		log.Info("dropping tool image with unsupported media type", "tool", toolName, "mediaType", mediaType)
+		return ToolResultImage{}, imageDroppedNote(mediaType, len(data), "unsupported media type"), false
+	}
+
+	if len(data) > limits.MaxBytes {
+		log.Info("dropping oversized tool image", "tool", toolName, "mediaType", normalized, "bytes", len(data), "maxBytes", limits.MaxBytes)
+		return ToolResultImage{}, imageDroppedNote(normalized, len(data),
+			fmt.Sprintf("exceeds the %d byte limit", limits.MaxBytes)), false
+	}
+
+	if a.admitted >= limits.MaxPerToolCall {
+		log.Info("dropping tool image beyond the per tool call limit", "tool", toolName, "mediaType", normalized, "bytes", len(data), "maxPerToolCall", limits.MaxPerToolCall)
+		return ToolResultImage{}, imageDroppedNote(normalized, len(data),
+			fmt.Sprintf("image limit of %d per tool call reached", limits.MaxPerToolCall)), false
+	}
+
+	a.admitted++
+	return ToolResultImage{MediaType: normalized, Data: data}, "", true
+}
+
+func imageReturnedNote(mediaType string, bytes int) string {
+	return fmt.Sprintf("[image returned: %s, %d bytes]", mediaType, bytes)
+}
+
+func imageDroppedNote(mediaType string, bytes int, reason string) string {
+	return fmt.Sprintf("[image returned: %s, %d bytes - %s, not shown to the model]", mediaType, bytes, reason)
+}

--- a/ark/executors/completions/image_policy.go
+++ b/ark/executors/completions/image_policy.go
@@ -34,6 +34,10 @@ func (p *imagePolicy) NewTurnBudget() *imageTurnBudget {
 	return newImageTurnBudget(p.limits.MaxBytesPerTurn)
 }
 
+func (p *imagePolicy) ApplyRequestBudget(messages []Message) []Message {
+	return applyImageRequestBudget(messages, p.limits.MaxBytesPerRequest)
+}
+
 func (p *imagePolicy) NewToolResultAdmitter() *toolImageAdmitter {
 	return &toolImageAdmitter{policy: p}
 }

--- a/ark/executors/completions/image_policy.go
+++ b/ark/executors/completions/image_policy.go
@@ -70,7 +70,7 @@ func (a *toolImageAdmitter) Admit(ctx context.Context, toolName, mediaType strin
 	}
 
 	a.admitted++
-	return ToolResultImage{MediaType: normalized, Data: data}, "", true
+	return newToolResultImage(normalized, data), "", true
 }
 
 func imageReturnedNote(mediaType string, bytes int) string {

--- a/ark/executors/completions/image_request_budget.go
+++ b/ark/executors/completions/image_request_budget.go
@@ -1,0 +1,87 @@
+package completions
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/openai/openai-go"
+)
+
+// applyImageRequestBudget bounds the image bytes in one outbound request. The per-turn budget
+// only covers images admitted this turn; images already in the history are replayed on every
+// subsequent turn, so without this the total grows without bound over a conversation.
+//
+// Newest messages keep their images: the image the model is being asked about is the one it
+// needs. An image that no longer fits is replaced by the same breadcrumb text a dropped image
+// gets elsewhere, so the model is never left assuming it saw something it did not.
+func applyImageRequestBudget(messages []Message, maxBytes int) []Message {
+	if maxBytes <= 0 {
+		return messages
+	}
+
+	remaining := maxBytes
+	var trimmed []Message
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		message, changed := trimImageParts(messages[i], maxBytes, &remaining)
+		if !changed {
+			continue
+		}
+		if trimmed == nil {
+			trimmed = slices.Clone(messages)
+		}
+		trimmed[i] = message
+	}
+
+	if trimmed == nil {
+		return messages
+	}
+	return trimmed
+}
+
+func trimImageParts(message Message, maxBytes int, remaining *int) (Message, bool) {
+	user := openai.ChatCompletionMessageParamUnion(message).OfUser
+	if user == nil {
+		return message, false
+	}
+
+	parts := user.Content.OfArrayOfContentParts
+	if len(parts) == 0 {
+		return message, false
+	}
+
+	changed := false
+	kept := make([]openai.ChatCompletionContentPartUnionParam, 0, len(parts))
+	for _, part := range parts {
+		image, ok := imagePartSize(part)
+		if !ok {
+			kept = append(kept, part)
+			continue
+		}
+
+		if image.Bytes <= *remaining {
+			*remaining -= image.Bytes
+			kept = append(kept, part)
+			continue
+		}
+
+		changed = true
+		kept = append(kept, openai.TextContentPart(imageDroppedNote(image.MediaType, image.Bytes,
+			fmt.Sprintf("the %d byte image budget for this request is exhausted", maxBytes))))
+	}
+
+	if !changed {
+		return message, false
+	}
+
+	rebuilt := openai.UserMessage(kept)
+	rebuilt.OfUser.Name = user.Name
+	return Message(rebuilt), true
+}
+
+func imagePartSize(part openai.ChatCompletionContentPartUnionParam) (ToolResultImage, bool) {
+	if part.OfImageURL == nil {
+		return ToolResultImage{}, false
+	}
+	return imageFromDataURL(part.OfImageURL.ImageURL.URL)
+}

--- a/ark/executors/completions/image_request_budget_test.go
+++ b/ark/executors/completions/image_request_budget_test.go
@@ -1,0 +1,133 @@
+package completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	eventingnoop "mckinsey.com/ark/internal/eventing/noop"
+	telemetrynoop "mckinsey.com/ark/internal/telemetry/noop"
+)
+
+const testImageBytes = 100
+
+func historyWithImages(turns int) []Message {
+	messages := make([]Message, 0, turns*2)
+	for range turns {
+		messages = append(messages,
+			NewUserMessage("read it"),
+			NewUserImageMessage("Image returned by the read tool.",
+				[]ToolResultImage{newToolResultImage("image/png", make([]byte, testImageBytes))}))
+	}
+	return messages
+}
+
+func totalImageBytes(t *testing.T, messages []Message) int {
+	t.Helper()
+	total := 0
+	for _, msg := range messages {
+		_, images, _ := extractMessageParts(msg)
+		for _, image := range images {
+			total += image.Bytes
+		}
+	}
+	return total
+}
+
+func TestApplyImageRequestBudget(t *testing.T) {
+	t.Run("a history within the budget is returned untouched", func(t *testing.T) {
+		messages := historyWithImages(3)
+		got := applyImageRequestBudget(messages, 1000)
+
+		assert.Equal(t, messages, got)
+		assert.Equal(t, 300, totalImageBytes(t, got))
+	})
+
+	t.Run("a text-only history is returned untouched", func(t *testing.T) {
+		messages := []Message{NewUserMessage("hello"), NewUserMessage("again")}
+		assert.Equal(t, messages, applyImageRequestBudget(messages, 10))
+	})
+
+	t.Run("the oldest images are dropped once the budget is exceeded", func(t *testing.T) {
+		messages := historyWithImages(5)
+		got := applyImageRequestBudget(messages, 250)
+
+		require.Len(t, got, len(messages))
+		assert.Equal(t, 200, totalImageBytes(t, got), "two of the five images fit")
+
+		_, newest, _ := extractMessageParts(got[len(got)-1])
+		assert.Len(t, newest, 1, "the newest image is the one the model is being asked about")
+
+		_, oldest, _ := extractMessageParts(got[1])
+		assert.Empty(t, oldest, "the oldest image is dropped first")
+	})
+
+	t.Run("a dropped image leaves a breadcrumb, not a silent gap", func(t *testing.T) {
+		got := applyImageRequestBudget(historyWithImages(2), 100)
+
+		text, images, _ := extractMessageParts(got[1])
+		assert.Empty(t, images)
+		assert.Contains(t, text, "100 bytes")
+		assert.Contains(t, text, "the 100 byte image budget for this request is exhausted")
+		assert.Contains(t, text, "not shown to the model")
+		assert.Contains(t, text, "Image returned by the read tool.", "the caption survives")
+	})
+
+	t.Run("the input is not mutated", func(t *testing.T) {
+		messages := historyWithImages(3)
+		applyImageRequestBudget(messages, 100)
+
+		assert.Equal(t, 300, totalImageBytes(t, messages),
+			"history handed to memory must not be trimmed in place")
+	})
+
+	t.Run("a non-positive budget disables the pass", func(t *testing.T) {
+		messages := historyWithImages(2)
+		assert.Equal(t, messages, applyImageRequestBudget(messages, 0))
+	})
+}
+
+func TestModelChatCompletionAppliesTheRequestBudget(t *testing.T) {
+	provider := &capturingProvider{response: &openai.ChatCompletion{
+		Choices: []openai.ChatCompletionChoice{{}},
+	}}
+
+	model := &Model{
+		Model:             "test-model",
+		Provider:          provider,
+		telemetryRecorder: telemetrynoop.NewProvider().ModelRecorder(),
+		eventingRecorder:  eventingnoop.NewProvider().ModelRecorder(),
+		ImagePolicy: newImagePolicy(toolImageLimits{
+			MaxBytes:           defaultToolImageMaxBytes,
+			MaxPerToolCall:     defaultToolImageMaxPerToolCall,
+			MaxBytesPerTurn:    defaultToolImageMaxBytesPerTurn,
+			MaxBytesPerRequest: 250,
+		}),
+	}
+
+	_, err := model.ChatCompletion(context.Background(), historyWithImages(5), nil, 1, nil, ToolChoice(""))
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, totalImageBytes(t, provider.captured),
+		"the provider must never see more image bytes than the request budget allows")
+}
+
+type capturingProvider struct {
+	response *openai.ChatCompletion
+	captured []Message
+}
+
+func (c *capturingProvider) ChatCompletion(_ context.Context, messages []Message, _ int64, _ []openai.ChatCompletionToolParam, _ ToolChoice) (*openai.ChatCompletion, error) {
+	c.captured = messages
+	return c.response, nil
+}
+
+func (c *capturingProvider) ChatCompletionStream(_ context.Context, messages []Message, _ int64, _ func(*openai.ChatCompletionChunk) error, _ []openai.ChatCompletionToolParam, _ ToolChoice) (*openai.ChatCompletion, error) {
+	c.captured = messages
+	return c.response, nil
+}
+
+func (c *capturingProvider) SetOutputSchema(_ *runtime.RawExtension, _ string) {}

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -56,6 +56,7 @@ func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 
 func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Content) (string, []ToolResultImage) {
 	log := logf.FromContext(ctx)
+	limits := toolImageLimitsFromEnv()
 	var result strings.Builder
 	var images []ToolResultImage
 	for _, content := range contents {
@@ -67,6 +68,16 @@ func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Cont
 			if !ok {
 				log.Info("dropping tool image with unsupported media type", "tool", m.ToolName, "mediaType", typed.MIMEType)
 				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - unsupported media type, not shown to the model]", typed.MIMEType, len(typed.Data)))
+				continue
+			}
+			if len(typed.Data) > limits.MaxBytes {
+				log.Info("dropping oversized tool image", "tool", m.ToolName, "mediaType", mediaType, "bytes", len(typed.Data), "maxBytes", limits.MaxBytes)
+				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - exceeds the %d byte limit, not shown to the model]", mediaType, len(typed.Data), limits.MaxBytes))
+				continue
+			}
+			if len(images) >= limits.MaxPerToolCall {
+				log.Info("dropping tool image beyond the per tool call limit", "tool", m.ToolName, "mediaType", mediaType, "bytes", len(typed.Data), "maxPerToolCall", limits.MaxPerToolCall)
+				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - image limit of %d per tool call reached, not shown to the model]", mediaType, len(typed.Data), limits.MaxPerToolCall))
 				continue
 			}
 			images = append(images, ToolResultImage{MediaType: mediaType, Data: typed.Data})

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -51,13 +51,18 @@ func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 	}
 	log.V(2).Info("tool call response", "tool", m.ToolName, "response", response)
 	var result strings.Builder
+	var images []ToolResultImage
 	for _, content := range response.Content {
-		if textContent, ok := content.(*mcpsdk.TextContent); ok {
-			result.WriteString(textContent.Text)
-		} else {
+		switch typed := content.(type) {
+		case *mcpsdk.TextContent:
+			result.WriteString(typed.Text)
+		case *mcpsdk.ImageContent:
+			images = append(images, ToolResultImage{MediaType: typed.MIMEType, Data: typed.Data})
+			result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes]", typed.MIMEType, len(typed.Data)))
+		default:
 			jsonBytes, _ := json.MarshalIndent(content, "", "  ")
 			result.WriteString(string(jsonBytes))
 		}
 	}
-	return ToolResult{ID: call.ID, Name: call.Function.Name, Content: result.String()}, nil
+	return ToolResult{ID: call.ID, Name: call.Function.Name, Content: result.String(), Images: images}, nil
 }

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -77,7 +77,7 @@ func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Cont
 				continue
 			}
 			images = append(images, image)
-			result.WriteString(imageReturnedNote(image.MediaType, len(image.Data)))
+			result.WriteString(imageReturnedNote(image.MediaType, image.Bytes))
 		default:
 			jsonBytes, _ := json.MarshalIndent(content, "", "  ")
 			result.WriteString(string(jsonBytes))

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -50,19 +50,31 @@ func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 		return ToolResult{ID: call.ID, Name: call.Function.Name, Content: ""}, err
 	}
 	log.V(2).Info("tool call response", "tool", m.ToolName, "response", response)
+	content, images := m.collectContent(ctx, response.Content)
+	return ToolResult{ID: call.ID, Name: call.Function.Name, Content: content, Images: images}, nil
+}
+
+func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Content) (string, []ToolResultImage) {
+	log := logf.FromContext(ctx)
 	var result strings.Builder
 	var images []ToolResultImage
-	for _, content := range response.Content {
+	for _, content := range contents {
 		switch typed := content.(type) {
 		case *mcpsdk.TextContent:
 			result.WriteString(typed.Text)
 		case *mcpsdk.ImageContent:
-			images = append(images, ToolResultImage{MediaType: typed.MIMEType, Data: typed.Data})
-			result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes]", typed.MIMEType, len(typed.Data)))
+			mediaType, ok := normalizeImageMediaType(typed.MIMEType)
+			if !ok {
+				log.Info("dropping tool image with unsupported media type", "tool", m.ToolName, "mediaType", typed.MIMEType)
+				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - unsupported media type, not shown to the model]", typed.MIMEType, len(typed.Data)))
+				continue
+			}
+			images = append(images, ToolResultImage{MediaType: mediaType, Data: typed.Data})
+			result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes]", mediaType, len(typed.Data)))
 		default:
 			jsonBytes, _ := json.MarshalIndent(content, "", "  ")
 			result.WriteString(string(jsonBytes))
 		}
 	}
-	return ToolResult{ID: call.ID, Name: call.Function.Name, Content: result.String(), Images: images}, nil
+	return result.String(), images
 }

--- a/ark/executors/completions/mcp.go
+++ b/ark/executors/completions/mcp.go
@@ -13,8 +13,16 @@ import (
 )
 
 type MCPExecutor struct {
-	MCPClient *arkmcp.MCPClient
-	ToolName  string
+	MCPClient   *arkmcp.MCPClient
+	ToolName    string
+	ImagePolicy *imagePolicy
+}
+
+func (m *MCPExecutor) imagePolicy() *imagePolicy {
+	if m.ImagePolicy != nil {
+		return m.ImagePolicy
+	}
+	return defaultImagePolicy()
 }
 
 func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, error) {
@@ -55,8 +63,7 @@ func (m *MCPExecutor) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 }
 
 func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Content) (string, []ToolResultImage) {
-	log := logf.FromContext(ctx)
-	limits := toolImageLimitsFromEnv()
+	admitter := m.imagePolicy().NewToolResultAdmitter()
 	var result strings.Builder
 	var images []ToolResultImage
 	for _, content := range contents {
@@ -64,24 +71,13 @@ func (m *MCPExecutor) collectContent(ctx context.Context, contents []mcpsdk.Cont
 		case *mcpsdk.TextContent:
 			result.WriteString(typed.Text)
 		case *mcpsdk.ImageContent:
-			mediaType, ok := normalizeImageMediaType(typed.MIMEType)
+			image, note, ok := admitter.Admit(ctx, m.ToolName, typed.MIMEType, typed.Data)
 			if !ok {
-				log.Info("dropping tool image with unsupported media type", "tool", m.ToolName, "mediaType", typed.MIMEType)
-				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - unsupported media type, not shown to the model]", typed.MIMEType, len(typed.Data)))
+				result.WriteString(note)
 				continue
 			}
-			if len(typed.Data) > limits.MaxBytes {
-				log.Info("dropping oversized tool image", "tool", m.ToolName, "mediaType", mediaType, "bytes", len(typed.Data), "maxBytes", limits.MaxBytes)
-				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - exceeds the %d byte limit, not shown to the model]", mediaType, len(typed.Data), limits.MaxBytes))
-				continue
-			}
-			if len(images) >= limits.MaxPerToolCall {
-				log.Info("dropping tool image beyond the per tool call limit", "tool", m.ToolName, "mediaType", mediaType, "bytes", len(typed.Data), "maxPerToolCall", limits.MaxPerToolCall)
-				result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes - image limit of %d per tool call reached, not shown to the model]", mediaType, len(typed.Data), limits.MaxPerToolCall))
-				continue
-			}
-			images = append(images, ToolResultImage{MediaType: mediaType, Data: typed.Data})
-			result.WriteString(fmt.Sprintf("[image returned: %s, %d bytes]", mediaType, len(typed.Data)))
+			images = append(images, image)
+			result.WriteString(imageReturnedNote(image.MediaType, len(image.Data)))
 		default:
 			jsonBytes, _ := json.MarshalIndent(content, "", "  ")
 			result.WriteString(string(jsonBytes))

--- a/ark/executors/completions/mcp_config.go
+++ b/ark/executors/completions/mcp_config.go
@@ -1,8 +1,6 @@
 package completions
 
 import (
-	"os"
-	"strconv"
 	"time"
 
 	arkmcp "mckinsey.com/ark/internal/mcp"
@@ -16,15 +14,8 @@ const (
 )
 
 func mcpToolCallRetryConfig() arkmcp.RetryConfig {
-	cfg := arkmcp.RetryConfig{
-		MaxAttempts: defaultMCPMaxAttempts,
-		Budget:      defaultMCPRetryBudgetSecs * time.Second,
+	return arkmcp.RetryConfig{
+		MaxAttempts: envInt(mcpMaxAttemptsEnv, defaultMCPMaxAttempts),
+		Budget:      time.Duration(envInt(mcpRetryBudgetSecondsEnv, defaultMCPRetryBudgetSecs)) * time.Second,
 	}
-	if v, err := strconv.Atoi(os.Getenv(mcpMaxAttemptsEnv)); err == nil && v > 0 {
-		cfg.MaxAttempts = v
-	}
-	if v, err := strconv.Atoi(os.Getenv(mcpRetryBudgetSecondsEnv)); err == nil && v > 0 {
-		cfg.Budget = time.Duration(v) * time.Second
-	}
-	return cfg
 }

--- a/ark/executors/completions/model_generic.go
+++ b/ark/executors/completions/model_generic.go
@@ -28,8 +28,16 @@ type Model struct {
 	Provider          ChatCompletionProvider
 	OutputSchema      *runtime.RawExtension
 	SchemaName        string
+	ImagePolicy       *imagePolicy
 	telemetryRecorder telemetry.ModelRecorder
 	eventingRecorder  eventing.ModelRecorder
+}
+
+func (m *Model) imagePolicy() *imagePolicy {
+	if m.ImagePolicy != nil {
+		return m.ImagePolicy
+	}
+	return defaultImagePolicy()
 }
 
 func (m *Model) ChatCompletion(ctx context.Context, messages []Message, eventStream EventStreamInterface, n int64, tools []openai.ChatCompletionToolParam, toolChoice ToolChoice) (*openai.ChatCompletion, error) {
@@ -45,6 +53,8 @@ func (m *Model) ChatCompletion(ctx context.Context, messages []Message, eventStr
 		"modelType": m.Type,
 	}
 	ctx = m.eventingRecorder.Start(ctx, "LLMCall", fmt.Sprintf("Calling model %s", m.Model), operationData)
+
+	messages = m.imagePolicy().ApplyRequestBudget(messages)
 
 	otelMessages := make([]openai.ChatCompletionMessageParamUnion, len(messages))
 	for i, msg := range messages {

--- a/ark/executors/completions/tool_turn.go
+++ b/ark/executors/completions/tool_turn.go
@@ -1,0 +1,26 @@
+package completions
+
+import "fmt"
+
+type toolOutcome struct {
+	toolName string
+	message  Message
+	images   []ToolResultImage
+}
+
+func appendToolOutcomes(agentMessages, newMessages *[]Message, outcomes []toolOutcome) {
+	for _, outcome := range outcomes {
+		*agentMessages = append(*agentMessages, outcome.message)
+		*newMessages = append(*newMessages, outcome.message)
+	}
+
+	for _, outcome := range outcomes {
+		if len(outcome.images) == 0 {
+			continue
+		}
+		imageMessage := NewUserImageMessage(
+			fmt.Sprintf("Image returned by the %s tool call.", outcome.toolName), outcome.images)
+		*agentMessages = append(*agentMessages, imageMessage)
+		*newMessages = append(*newMessages, imageMessage)
+	}
+}

--- a/ark/executors/completions/tool_turn_test.go
+++ b/ark/executors/completions/tool_turn_test.go
@@ -1,0 +1,159 @@
+package completions
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func messageRole(t *testing.T, msg Message) string {
+	t.Helper()
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion(msg))
+	require.NoError(t, err)
+
+	var payload struct {
+		Role string `json:"role"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	return payload.Role
+}
+
+func messageRoles(t *testing.T, messages []Message) []string {
+	t.Helper()
+	roles := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		roles = append(roles, messageRole(t, msg))
+	}
+	return roles
+}
+
+type toolTurnCase struct {
+	name   string
+	tools  []struct{ name, image string }
+	expect []string
+}
+
+// Both paths that build a tool turn must produce the same message sequence: every tool
+// message answering one assistant tool_calls block contiguous, image messages after them.
+func toolTurnCases() []toolTurnCase {
+	type tool = struct{ name, image string }
+	return []toolTurnCase{
+		{
+			name:   "no tool returns an image",
+			tools:  []tool{{name: "alpha"}, {name: "beta"}},
+			expect: []string{"tool", "tool"},
+		},
+		{
+			name:   "the first of two tool calls returns an image",
+			tools:  []tool{{name: "alpha", image: "image/png"}, {name: "beta"}},
+			expect: []string{"tool", "tool", "user"},
+		},
+		{
+			name:   "the last of two tool calls returns an image",
+			tools:  []tool{{name: "alpha"}, {name: "beta", image: "image/png"}},
+			expect: []string{"tool", "tool", "user"},
+		},
+		{
+			name:   "both tool calls return an image",
+			tools:  []tool{{name: "alpha", image: "image/png"}, {name: "beta", image: "image/png"}},
+			expect: []string{"tool", "tool", "user", "user"},
+		},
+		{
+			name:   "a single tool call returns an image",
+			tools:  []tool{{name: "alpha", image: "image/png"}},
+			expect: []string{"tool", "user"},
+		},
+	}
+}
+
+func TestToolTurnSequenceThroughTheAgentLoop(t *testing.T) {
+	for _, tc := range toolTurnCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := newTestRegistry()
+			calls := make([]openai.ChatCompletionMessageToolCall, 0, len(tc.tools))
+			for i, tool := range tc.tools {
+				stub := &stubImageExecutor{}
+				if tool.image != "" {
+					stub.images = []ToolResultImage{{MediaType: tool.image, Data: pngBytes}}
+				}
+				registry.RegisterTool(ToolDefinition{Name: tool.name}, stub)
+				calls = append(calls, toolCall(toolCallID(i), tool.name))
+			}
+
+			agent := &Agent{Name: "test-agent", Namespace: "default", Tools: registry}
+
+			var agentMessages []Message
+			var newMessages []Message
+			require.NoError(t, agent.executeToolCalls(context.Background(), calls, &agentMessages, &newMessages))
+
+			assert.Equal(t, tc.expect, messageRoles(t, agentMessages))
+			assert.Equal(t, agentMessages, newMessages)
+		})
+	}
+}
+
+func TestToolTurnSequenceThroughTheApprovalResumePath(t *testing.T) {
+	for _, tc := range toolTurnCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := make([]openai.ChatCompletionMessageToolCall, 0, len(tc.tools))
+			results := make([]ToolResult, 0, len(tc.tools))
+			for i, tool := range tc.tools {
+				calls = append(calls, toolCall(toolCallID(i), tool.name))
+				result := ToolResult{ID: toolCallID(i), Name: tool.name, Content: "done"}
+				if tool.image != "" {
+					result.Images = []ToolResultImage{{MediaType: tool.image, Data: pngBytes}}
+				}
+				results = append(results, result)
+			}
+
+			agent := &Agent{Name: "test-agent", Namespace: "default"}
+
+			agentMessages, newMessages, err := agent.reconstructMessagesForResumption(
+				context.Background(), calls, results, &stubMemory{}, nil)
+			require.NoError(t, err)
+
+			expect := append([]string{"assistant"}, tc.expect...)
+			assert.Equal(t, expect, messageRoles(t, agentMessages),
+				"an approved tool call must produce the same sequence as an unapproved one")
+			assert.Equal(t, agentMessages, newMessages)
+		})
+	}
+}
+
+func TestToolTurnImageMessagesKeepToolCallOrder(t *testing.T) {
+	registry := newTestRegistry()
+	registry.RegisterTool(ToolDefinition{Name: "first"}, &stubImageExecutor{
+		images: []ToolResultImage{imageOfSize(t, 10)},
+	})
+	registry.RegisterTool(ToolDefinition{Name: "second"}, &stubImageExecutor{
+		images: []ToolResultImage{imageOfSize(t, 20)},
+	})
+
+	agent := &Agent{Name: "test-agent", Namespace: "default", Tools: registry}
+
+	var agentMessages []Message
+	var newMessages []Message
+	require.NoError(t, agent.executeToolCalls(context.Background(),
+		[]openai.ChatCompletionMessageToolCall{toolCall("call-0", "first"), toolCall("call-1", "second")},
+		&agentMessages, &newMessages))
+
+	require.Len(t, agentMessages, 4)
+
+	firstText, firstImages, _ := extractMessageParts(agentMessages[2])
+	assert.Contains(t, firstText, "first")
+	require.Len(t, firstImages, 1)
+	assert.Len(t, firstImages[0].Data, 10)
+
+	secondText, secondImages, _ := extractMessageParts(agentMessages[3])
+	assert.Contains(t, secondText, "second")
+	require.Len(t, secondImages, 1)
+	assert.Len(t, secondImages[0].Data, 20)
+}
+
+func toolCallID(i int) string {
+	return string(rune('a' + i))
+}

--- a/ark/executors/completions/tool_turn_test.go
+++ b/ark/executors/completions/tool_turn_test.go
@@ -78,7 +78,7 @@ func TestToolTurnSequenceThroughTheAgentLoop(t *testing.T) {
 			for i, tool := range tc.tools {
 				stub := &stubImageExecutor{}
 				if tool.image != "" {
-					stub.images = []ToolResultImage{{MediaType: tool.image, Data: pngBytes}}
+					stub.images = []ToolResultImage{newToolResultImage(tool.image, pngBytes)}
 				}
 				registry.RegisterTool(ToolDefinition{Name: tool.name}, stub)
 				calls = append(calls, toolCall(toolCallID(i), tool.name))
@@ -105,7 +105,7 @@ func TestToolTurnSequenceThroughTheApprovalResumePath(t *testing.T) {
 				calls = append(calls, toolCall(toolCallID(i), tool.name))
 				result := ToolResult{ID: toolCallID(i), Name: tool.name, Content: "done"}
 				if tool.image != "" {
-					result.Images = []ToolResultImage{{MediaType: tool.image, Data: pngBytes}}
+					result.Images = []ToolResultImage{newToolResultImage(tool.image, pngBytes)}
 				}
 				results = append(results, result)
 			}
@@ -146,12 +146,12 @@ func TestToolTurnImageMessagesKeepToolCallOrder(t *testing.T) {
 	firstText, firstImages, _ := extractMessageParts(agentMessages[2])
 	assert.Contains(t, firstText, "first")
 	require.Len(t, firstImages, 1)
-	assert.Len(t, firstImages[0].Data, 10)
+	assert.Equal(t, 10, firstImages[0].Bytes)
 
 	secondText, secondImages, _ := extractMessageParts(agentMessages[3])
 	assert.Contains(t, secondText, "second")
 	require.Len(t, secondImages, 1)
-	assert.Len(t, secondImages[0].Data, 20)
+	assert.Equal(t, 20, secondImages[0].Bytes)
 }
 
 func toolCallID(i int) string {

--- a/ark/executors/completions/types.go
+++ b/ark/executors/completions/types.go
@@ -33,6 +33,19 @@ func ToolMessage[T string | []openai.ChatCompletionContentPartTextParam](content
 	return Message(openai.ToolMessage(content, toolCallID))
 }
 
+func NewUserImageMessage(caption string, images []ToolResultImage) Message {
+	parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(images)+1)
+	if caption != "" {
+		parts = append(parts, openai.TextContentPart(caption))
+	}
+	for _, image := range images {
+		parts = append(parts, openai.ImageContentPart(
+			openai.ChatCompletionContentPartImageImageURLParam{URL: image.DataURL()},
+		))
+	}
+	return Message(openai.UserMessage(parts))
+}
+
 type TeamMember interface {
 	Execute(ctx context.Context, userInput Message, history []Message, memory MemoryInterface, eventStream EventStreamInterface, opts ExecuteOptions) (*ExecutionResult, error)
 	GetName() string

--- a/ark/executors/completions/types.go
+++ b/ark/executors/completions/types.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -40,10 +41,24 @@ type TeamMember interface {
 }
 
 type ToolResult struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Content string `json:"content,omitempty"`
-	Error   string `json:"error,omitempty"`
+	ID      string            `json:"id"`
+	Name    string            `json:"name"`
+	Content string            `json:"content,omitempty"`
+	Images  []ToolResultImage `json:"images,omitempty"`
+	Error   string            `json:"error,omitempty"`
+}
+
+type ToolResultImage struct {
+	MediaType string `json:"mediaType"`
+	Data      []byte `json:"data"`
+}
+
+func (i ToolResultImage) DataURL() string {
+	return "data:" + i.MediaType + ";base64," + base64.StdEncoding.EncodeToString(i.Data)
+}
+
+func (i ToolResultImage) Base64() string {
+	return base64.StdEncoding.EncodeToString(i.Data)
 }
 
 type ToolExecutor interface {

--- a/ark/executors/completions/types.go
+++ b/ark/executors/completions/types.go
@@ -61,17 +61,29 @@ type ToolResult struct {
 	Error   string            `json:"error,omitempty"`
 }
 
+// ToolResultImage holds an image already base64-encoded. Both wire formats that carry it
+// want base64 - an OpenAI data URL and an Anthropic image block - so it is encoded once,
+// where the bytes arrive, and never decoded again on the request path.
 type ToolResultImage struct {
 	MediaType string `json:"mediaType"`
-	Data      []byte `json:"data"`
+	B64       string `json:"b64"`
+	Bytes     int    `json:"bytes"`
+}
+
+func newToolResultImage(mediaType string, data []byte) ToolResultImage {
+	return ToolResultImage{
+		MediaType: mediaType,
+		B64:       base64.StdEncoding.EncodeToString(data),
+		Bytes:     len(data),
+	}
 }
 
 func (i ToolResultImage) DataURL() string {
-	return "data:" + i.MediaType + ";base64," + base64.StdEncoding.EncodeToString(i.Data)
+	return dataURLPrefix + i.MediaType + base64Marker + i.B64
 }
 
 func (i ToolResultImage) Base64() string {
-	return base64.StdEncoding.EncodeToString(i.Data)
+	return i.B64
 }
 
 type ToolExecutor interface {

--- a/docs/content/user-guide/files.mdx
+++ b/docs/content/user-guide/files.mdx
@@ -59,6 +59,8 @@ To upload a file, drag and drop it into the upload area or click to browse. Ente
 
 The File Gateway service enforces a 1MB limit for file uploads, see the [File Gateway Service documentation](https://mckinsey.github.io/agents-at-scale-marketplace/services/file-gateway/#file-size-limitations) for more.
 
+This is separate from the limits Ark applies when a tool returns an image to a model. The completions executor caps each image at 5MB, allows four images per tool result, and allows 15MB of images across all tool calls in one turn. An image over any of these is dropped and the tool result says why, so the model is told rather than left to assume it saw the image. Override the defaults with `ARK_TOOL_IMAGE_MAX_BYTES`, `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` and `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` in the executor's chart values.
+
 ## Connecting Files to Agents
 
 To give agents access to uploaded files, configure the [filesystem MCP server](/user-guide/tools) in your agent definitions.

--- a/docs/content/user-guide/files.mdx
+++ b/docs/content/user-guide/files.mdx
@@ -59,7 +59,16 @@ To upload a file, drag and drop it into the upload area or click to browse. Ente
 
 The File Gateway service enforces a 1MB limit for file uploads, see the [File Gateway Service documentation](https://mckinsey.github.io/agents-at-scale-marketplace/services/file-gateway/#file-size-limitations) for more.
 
-This is separate from the limits Ark applies when a tool returns an image to a model. The completions executor caps each image at 5MB, allows four images per tool result, and allows 15MB of images across all tool calls in one turn. An image over any of these is dropped and the tool result says why, so the model is told rather than left to assume it saw the image. Override the defaults with `ARK_TOOL_IMAGE_MAX_BYTES`, `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` and `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` in the executor's chart values.
+This is separate from the limits Ark applies when a tool returns an image to a model. The completions executor enforces four, each at a different point:
+
+| Limit | Applies to | Default | Variable |
+| --- | --- | --- | --- |
+| Bytes per image | One image in a tool result | 5MB | `ARK_TOOL_IMAGE_MAX_BYTES` |
+| Images per tool call | One tool result | 4 | `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` |
+| Bytes per turn | Every tool call in one turn | 15MB | `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` |
+| Bytes per request | Every image sent to the model, including images replayed from earlier turns | 15MB | `ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST` |
+
+The first three bound what a turn may add. The per-request limit bounds what the model actually receives, so a long conversation does not accumulate images without limit; when it is reached the newest images are kept and older ones are replaced by their description. An image dropped by any limit says why in the text, so the model is told rather than left to assume it saw the image. Override the defaults in the executor's chart values.
 
 ## Connecting Files to Agents
 

--- a/openspec/changes/tool-image-content-blocks/.openspec.yaml
+++ b/openspec/changes/tool-image-content-blocks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/tool-image-content-blocks/design.md
+++ b/openspec/changes/tool-image-content-blocks/design.md
@@ -9,12 +9,13 @@ The two places that need to change are the MCP boundary, where the bytes are cur
 **Goals**
 - An agent can answer a question about an image an MCP tool returned.
 - Text-only requests keep their existing wire format.
+- Image ingress is bounded, so a large or repeated image cannot fail the request or exhaust the context window.
 
 **Non-Goals**
 - Images from non-MCP tools (HTTP, built-in). They return no image content today.
 - Images through the human-in-the-loop approval resume path in `handler.go`, which rebuilds a `ToolResult` from the tool message text.
 - Audio or other non-text modalities.
-- Image resizing, re-encoding, or token budgeting.
+- Image resizing or re-encoding. An image is carried as returned or not at all.
 
 ## Decisions
 
@@ -33,18 +34,26 @@ This was already true before this change: prompt caching renders the breakpoint 
 **A non-base64 image URL is dropped, not passed on.**
 The Anthropic base64 image source cannot carry a remote URL. Emitting the URL as text would put a link in the prompt that the model would either hallucinate about or try to browse. Dropping it is the honest failure.
 
+**Three limits, enforced at two points.**
+`ARK_TOOL_IMAGE_MAX_BYTES` (5 MiB) and `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` (4) are enforced in `collectContent`, where the decoded bytes first arrive. `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` (15 MiB) is a cumulative budget held across every tool call in one turn, enforced in `executeToolCalls` where the loop already sits. The per-image default is set against the binding provider constraint — Anthropic accepts roughly 5 MB per image, OpenAI roughly 20 MB — and file-gateway, the tool that motivated this feature, caps its own uploads at 1 MB, so the default is generous for legitimate traffic while keeping a single image from failing the request.
+
+Alternative — one total byte limit — cannot distinguish "one absurd image" from "forty reasonable ones", and the two failure modes want different messages to the model. Alternative — capping across the whole agentic loop rather than per turn — needs an eviction policy for images already in the history and is deferred.
+
+**A dropped image is reported, not hidden.**
+Every drop reuses the breadcrumb path already built for an unsupported media type: a line in the tool message text naming the size, the limit, and that the image was not shown. A silently missing image makes the model assert things about an image it never saw. Budget drops write their note into the tool message the image came from rather than a separate message, so the reason sits next to the result that produced it.
+
 ## Risks / Trade-offs
 
-- **Context cost.** An image is still large. It is now spent on something the model can use, and the base64 no longer appears twice (once in the tool text, once nowhere useful). No budgeting is added here.
+- **Context cost.** An image is still large. It is now spent on something the model can use, the base64 no longer appears twice, and the per-turn budget puts a ceiling on it. Images accumulated across many turns are still unbounded — see Open Questions.
 - **Extra base64 round-trip** per image on the Anthropic path → bounded by one encode and one decode per image per request; negligible next to the API call.
 - **The HITL approval path drops images** → out of scope and called out in the proposal; behaviour there is unchanged, not newly broken.
 - **A provider that rejects image blocks** would now receive them where before it received text → only the shared Anthropic format encoder emits blocks, and both providers on it (Anthropic, Bedrock) accept image blocks in the Messages API.
 
 ## Migration Plan
 
-No CRD, config, or API change. The executor image is the only artefact. Rollback is redeploying the previous image; nothing persisted changes shape, and a conversation stored mid-flight replays as an ordinary user message with an image part.
+No CRD or API change. The three image limits are optional executor environment variables with defaults, exposed in the chart values, so an install that sets none behaves as the defaults describe. The executor image and its chart are the only artefacts. Rollback is redeploying the previous image; nothing persisted changes shape, and a conversation stored mid-flight replays as an ordinary user message with an image part.
 
 ## Open Questions
 
 - Should a tool be able to opt out of image pass-through (for example a tool returning a thumbnail purely as an artefact)? Not needed by any current tool.
-- Should images be capped in count or bytes per turn before they reach the provider?
+- Should the byte budget span the whole agentic loop rather than a single turn? A long loop can still accumulate images across turns. Doing so needs a policy for evicting images already in the history, which the per-turn budget does not.

--- a/openspec/changes/tool-image-content-blocks/design.md
+++ b/openspec/changes/tool-image-content-blocks/design.md
@@ -37,16 +37,30 @@ The Anthropic base64 image source cannot carry a remote URL. Emitting the URL as
 **Three limits, enforced at two points.**
 `ARK_TOOL_IMAGE_MAX_BYTES` (5 MiB) and `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` (4) are enforced in `collectContent`, where the decoded bytes first arrive. `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` (15 MiB) is a cumulative budget held across every tool call in one turn, enforced in `executeToolCalls` where the loop already sits. The per-image default is set against the binding provider constraint — Anthropic accepts roughly 5 MB per image, OpenAI roughly 20 MB — and file-gateway, the tool that motivated this feature, caps its own uploads at 1 MB, so the default is generous for legitimate traffic while keeping a single image from failing the request.
 
-Alternative — one total byte limit — cannot distinguish "one absurd image" from "forty reasonable ones", and the two failure modes want different messages to the model. Alternative — capping across the whole agentic loop rather than per turn — needs an eviction policy for images already in the history and is deferred.
+Alternative — one total byte limit — cannot distinguish "one absurd image" from "forty reasonable ones", and the two failure modes want different messages to the model.
+
+A fourth limit, `ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST` (15 MiB), bounds the assembled request. The three ingress limits bound what one turn admits; only this one bounds what the model receives, because the image user message is replayed from history on every later turn. Its eviction policy is newest-first retention, with an omitted image replaced by the breadcrumb text.
+
+**Each concern has one owner.**
+Review of the first implementation found six defects that shared a cause: the feature was written as point edits at each site the bytes pass through, so image policy, message ordering and the image representation were each decided at whichever call site noticed them first. Four owners replace those call sites. `imagePolicy` resolves the limits once and makes every admission decision, including the wording of a drop. `appendToolOutcomes` owns the message sequence a tool run produces and is used by both the agent loop and the approval resume path. `ToolResultImage` holds one encoding. `applyImageRequestBudget` owns the per-request ceiling. Alternative — fixing each finding where it was reported — leaves the same six call sites free to drift apart again.
+
+**Tool messages for one `tool_calls` block stay contiguous.**
+OpenAI rejects a request in which another role interrupts the tool messages answering one assistant `tool_calls` block, and parallel tool calls are the default. Image messages are therefore buffered and appended after the whole tool run rather than after the tool message they came from. Alternative — attaching the image to the tool message's own content parts — is not available: OpenAI does not accept an image part in a `tool` role message.
+
+**An image is encoded once, where its bytes arrive.**
+`ToolResultImage` carries the base64 payload and the decoded length, not the raw bytes. Both wire formats that consume it want base64, so nothing on the request path decodes. The earlier shape encoded on the way in, decoded in `imageFromDataURL`, and re-encoded when rendering, costing roughly two extra copies of every image on every turn. The decoded length is derived by arithmetic after a non-allocating validity scan.
+
+**The per-request budget is enforced where the request is assembled.**
+`Model.ChatCompletion` is the one point every provider and both the streaming and non-streaming paths pass through, so the ceiling is applied once rather than in each encoder. Newest images are kept: the image the model is being asked about is the one it needs. The stored conversation is untouched — only the outbound copy is trimmed — so a later turn under a raised budget still has the image.
 
 **A dropped image is reported, not hidden.**
 Every drop reuses the breadcrumb path already built for an unsupported media type: a line in the tool message text naming the size, the limit, and that the image was not shown. A silently missing image makes the model assert things about an image it never saw. Budget drops write their note into the tool message the image came from rather than a separate message, so the reason sits next to the result that produced it.
 
 ## Risks / Trade-offs
 
-- **Context cost.** An image is still large. It is now spent on something the model can use, the base64 no longer appears twice, and the per-turn budget puts a ceiling on it. Images accumulated across many turns are still unbounded — see Open Questions.
+- **Context cost.** An image is still large. It is now spent on something the model can use, the base64 no longer appears twice, and the per-turn and per-request budgets put a ceiling on it.
 - **Extra base64 round-trip** per image on the Anthropic path → bounded by one encode and one decode per image per request; negligible next to the API call.
-- **The HITL approval path drops images** → out of scope and called out in the proposal; behaviour there is unchanged, not newly broken.
+- **A long conversation loses its older images** to the per-request budget → the alternative is a request the provider rejects; the omission is stated in the text the model reads, and the stored conversation keeps the image.
 - **A provider that rejects image blocks** would now receive them where before it received text → only the shared Anthropic format encoder emits blocks, and both providers on it (Anthropic, Bedrock) accept image blocks in the Messages API.
 
 ## Migration Plan
@@ -56,4 +70,4 @@ No CRD or API change. The three image limits are optional executor environment v
 ## Open Questions
 
 - Should a tool be able to opt out of image pass-through (for example a tool returning a thumbnail purely as an artefact)? Not needed by any current tool.
-- Should the byte budget span the whole agentic loop rather than a single turn? A long loop can still accumulate images across turns. Doing so needs a policy for evicting images already in the history, which the per-turn budget does not.
+- Should an image omitted by the per-request budget be summarised by the model before it is dropped, rather than reduced to a breadcrumb? That needs a model call per eviction and is not obviously worth it.

--- a/openspec/changes/tool-image-content-blocks/design.md
+++ b/openspec/changes/tool-image-content-blocks/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`MCPExecutor.Execute` builds the tool message by walking the MCP content parts: text parts are appended, and every other part is `json.MarshalIndent`-ed into the same string. An `ImageContent` part therefore reaches the model as a JSON object with a base64 `data` field inside the tool message text. The model cannot see it, and a page-sized PNG costs tens of thousands of tokens to say nothing.
+
+The two places that need to change are the MCP boundary, where the bytes are currently lost, and the Anthropic request encoder, which only knows how to write a message whose content is a string.
+
+## Goals / Non-Goals
+
+**Goals**
+- An agent can answer a question about an image an MCP tool returned.
+- Text-only requests keep their existing wire format.
+
+**Non-Goals**
+- Images from non-MCP tools (HTTP, built-in). They return no image content today.
+- Images through the human-in-the-loop approval resume path in `handler.go`, which rebuilds a `ToolResult` from the tool message text.
+- Audio or other non-text modalities.
+- Image resizing, re-encoding, or token budgeting.
+
+## Decisions
+
+**Images ride on `ToolResult`, not in its `Content`.**
+`ToolResult` gains `Images []ToolResultImage` holding the media type and raw bytes. `Content` keeps a one-line note (`[image returned: image/png, 20481 bytes]`) so the transcript still records that something came back. Alternative — encoding the image into `Content` in a form the encoder later parses out — makes the tool text a wire format and breaks the moment a tool legitimately returns that text.
+
+**The image becomes a user message, not part of the tool message.**
+The OpenAI schema allows only text parts in the `tool` role, so a tool message cannot carry an image in either the OpenAI or the Anthropic API. `NewUserImageMessage` builds a user message with one `ImageContentPart` per image plus a caption naming the tool, appended immediately after the tool message. This shape is native OpenAI, so the OpenAI and Azure providers need no change at all; only the Anthropic encoder has to learn it.
+
+**Images travel between the two points as an OpenAI data URL.**
+`NewUserImageMessage` writes `data:<media type>;base64,<data>`, and `imageFromDataURL` reads it back when converting to Anthropic. This keeps the in-memory message a plain OpenAI message — so memory, streaming, and the OpenAI providers keep working untouched — at the cost of one base64 round-trip. Alternative — a parallel image field on the internal `Message` type — would fork `Message` away from `openai.ChatCompletionMessageParamUnion` and touch every consumer.
+
+**`anthropicMessage.Content` becomes `json.RawMessage`.**
+This was already true before this change: prompt caching renders the breakpoint message as a block array. The change extends the block type with an optional `source` so one block type covers text, cached text, and images, and folds the two rendering paths into `renderAnthropicContent(text, images, cached)`. A text-only, uncached message still marshals to a bare JSON string, so the request bytes are unchanged.
+
+**A non-base64 image URL is dropped, not passed on.**
+The Anthropic base64 image source cannot carry a remote URL. Emitting the URL as text would put a link in the prompt that the model would either hallucinate about or try to browse. Dropping it is the honest failure.
+
+## Risks / Trade-offs
+
+- **Context cost.** An image is still large. It is now spent on something the model can use, and the base64 no longer appears twice (once in the tool text, once nowhere useful). No budgeting is added here.
+- **Extra base64 round-trip** per image on the Anthropic path → bounded by one encode and one decode per image per request; negligible next to the API call.
+- **The HITL approval path drops images** → out of scope and called out in the proposal; behaviour there is unchanged, not newly broken.
+- **A provider that rejects image blocks** would now receive them where before it received text → only the shared Anthropic format encoder emits blocks, and both providers on it (Anthropic, Bedrock) accept image blocks in the Messages API.
+
+## Migration Plan
+
+No CRD, config, or API change. The executor image is the only artefact. Rollback is redeploying the previous image; nothing persisted changes shape, and a conversation stored mid-flight replays as an ordinary user message with an image part.
+
+## Open Questions
+
+- Should a tool be able to opt out of image pass-through (for example a tool returning a thumbnail purely as an artefact)? Not needed by any current tool.
+- Should images be capped in count or bytes per turn before they reach the provider?

--- a/openspec/changes/tool-image-content-blocks/proposal.md
+++ b/openspec/changes/tool-image-content-blocks/proposal.md
@@ -7,6 +7,7 @@ An MCP tool that returns an image reaches the model as text. The completions exe
 - Carry image bytes from an MCP tool result through `ToolResult.Images` instead of flattening them into the tool message text
 - Append a user message holding those images after the tool message, so the model is shown the image on the next turn
 - Emit Anthropic `image` content blocks for messages that carry images; message content becomes a JSON string *or* a block array
+- Bound the image bytes in an outbound request, so a conversation replaying its history does not accumulate images without limit
 - Text-only requests keep their existing wire format, byte for byte
 
 ## Capabilities
@@ -21,4 +22,4 @@ An MCP tool that returns an image reaches the model as text. The completions exe
 - **Go executor** (`ark/executors/completions/`): `mcp.go` (image content parts), `types.go` (`ToolResult.Images`, `ToolResultImage`, `NewUserImageMessage`), `agent.go` (image message after a tool call), `anthropic_format.go` (image blocks, part extraction)
 - **Providers**: Anthropic and Bedrock share `anthropic_format.go` and both gain image blocks. OpenAI/Azure carry the OpenAI-native image content part with no provider change.
 - **No CRD, API, Dashboard, or CLI change.** No new dependencies.
-- **Not covered**: the human-in-the-loop approval resume path in `handler.go` rebuilds a `ToolResult` from the tool message and drops images; tools other than MCP (HTTP, built-in) return no images.
+- **Not covered**: tools other than MCP (HTTP, built-in) return no images.

--- a/openspec/changes/tool-image-content-blocks/proposal.md
+++ b/openspec/changes/tool-image-content-blocks/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+An MCP tool that returns an image reaches the model as text. The completions executor JSON-marshals every non-text MCP content part into the tool message, so an image arrives as a base64 string the model cannot see — it either invents a reading of a picture it never saw or blows the context limit. The only workaround today is a tool backed by its own pod that fetches the file and calls a vision API itself, so every tool that reads an image pays for its own deployment and credentials.
+
+## What Changes
+
+- Carry image bytes from an MCP tool result through `ToolResult.Images` instead of flattening them into the tool message text
+- Append a user message holding those images after the tool message, so the model is shown the image on the next turn
+- Emit Anthropic `image` content blocks for messages that carry images; message content becomes a JSON string *or* a block array
+- Text-only requests keep their existing wire format, byte for byte
+
+## Capabilities
+
+### New Capabilities
+- `tool-image-content`: images returned by a tool reach the model as image content rather than text
+
+### Modified Capabilities
+
+## Impact
+
+- **Go executor** (`ark/executors/completions/`): `mcp.go` (image content parts), `types.go` (`ToolResult.Images`, `ToolResultImage`, `NewUserImageMessage`), `agent.go` (image message after a tool call), `anthropic_format.go` (image blocks, part extraction)
+- **Providers**: Anthropic and Bedrock share `anthropic_format.go` and both gain image blocks. OpenAI/Azure carry the OpenAI-native image content part with no provider change.
+- **No CRD, API, Dashboard, or CLI change.** No new dependencies.
+- **Not covered**: the human-in-the-loop approval resume path in `handler.go` rebuilds a `ToolResult` from the tool message and drops images; tools other than MCP (HTTP, built-in) return no images.

--- a/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
+++ b/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
@@ -87,6 +87,34 @@ An image SHALL be carried only when its normalised media type is one of `image/j
 - **WHEN** an image content part carries a data URL whose media type is not supported
 - **THEN** no image block SHALL be emitted for it
 
+### Requirement: Tool images are bounded in size and count
+The completions executor SHALL bound the images a tool can put in front of the model, because an unbounded image is either rejected by the provider or silently consumes the context window. Three limits apply, each configurable and each defaulting to a value inside every supported provider's documented ceiling: decoded bytes per image (`ARK_TOOL_IMAGE_MAX_BYTES`, default 5 MiB), images per tool result (`ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL`, default 4), and cumulative decoded bytes across all tool calls in one turn (`ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN`, default 15 MiB).
+
+#### Scenario: Image exceeds the per-image limit
+- **WHEN** an MCP tool returns an image whose decoded size exceeds the per-image limit
+- **THEN** no image SHALL be recorded on `ToolResult.Images` for it
+- **AND** the tool message text SHALL state its size, the limit, and that it was not shown to the model
+
+#### Scenario: Image is exactly at the per-image limit
+- **WHEN** an MCP tool returns an image whose decoded size equals the per-image limit
+- **THEN** the image SHALL be carried
+
+#### Scenario: Tool result carries more images than the per-tool-call limit
+- **WHEN** an MCP tool result contains more supported images than the per-tool-call limit
+- **THEN** the executor SHALL carry images up to that limit in the order returned
+- **AND** the tool message text SHALL note, for each image beyond it, that the limit was reached and the image was not shown to the model
+
+#### Scenario: Turn budget is exhausted across tool calls
+- **WHEN** several tool calls in one turn return images whose cumulative decoded size exceeds the per-turn budget
+- **THEN** the executor SHALL carry images while the budget allows and drop each image that would exceed the remainder
+- **AND** a later, smaller image that still fits the remainder SHALL be carried
+- **AND** the note for a dropped image SHALL be appended to the text of the tool message it came from
+
+#### Scenario: Limit is overridden
+- **WHEN** a limit's environment variable holds a positive integer
+- **THEN** that value SHALL be used in place of the default
+- **AND** an absent, non-numeric or non-positive value SHALL leave the default in force
+
 ### Requirement: Images reach OpenAI-compatible providers unchanged
 The user message carrying the images SHALL be an OpenAI-format message holding one `image_url` content part per image, whose URL is a base64 data URL, so that the OpenAI and Azure providers pass the images through without provider-specific encoding.
 

--- a/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
+++ b/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: MCP image content is carried as image data
+The completions executor SHALL carry an image returned by an MCP tool as image bytes on the tool result rather than serialising it into the tool message text.
+
+#### Scenario: Tool returns an image part
+- **WHEN** an MCP tool result contains an `ImageContent` part
+- **THEN** the executor SHALL record the part's MIME type and raw bytes on `ToolResult.Images`
+- **AND** the tool message text SHALL contain a one-line note that an image was returned, not the image's base64 encoding
+
+#### Scenario: Tool returns text and an image
+- **WHEN** an MCP tool result contains both a `TextContent` and an `ImageContent` part
+- **THEN** the tool message text SHALL contain the text part
+- **AND** the image SHALL be carried on `ToolResult.Images`
+
+#### Scenario: Tool returns neither text nor an image
+- **WHEN** an MCP tool result contains a content part that is neither text nor an image
+- **THEN** the executor SHALL serialise it into the tool message text as before
+
+### Requirement: Images returned by a tool are shown to the model
+The completions executor SHALL append a user message carrying the images to the conversation after the tool message they came from, because the `tool` role cannot hold an image content part.
+
+#### Scenario: Image message follows the tool message
+- **WHEN** a tool call returns one or more images
+- **THEN** the executor SHALL append the tool message followed by a user message holding one image content part per image and a caption naming the tool
+- **AND** both messages SHALL be added to the conversation history
+
+#### Scenario: Tool returns no image
+- **WHEN** a tool call returns no image
+- **THEN** the executor SHALL append only the tool message, unchanged from previous behaviour
+
+### Requirement: Anthropic requests carry images as image blocks
+The Anthropic request format SHALL express a message's content as either a JSON string or an array of content blocks, and SHALL emit an `image` block for each image the message carries.
+
+#### Scenario: Text-only message is unchanged
+- **WHEN** a message carries text and no image and is not the prompt-cache breakpoint
+- **THEN** its `content` SHALL be a bare JSON string, identical to the format sent before this change
+
+#### Scenario: Message with an image
+- **WHEN** a message carries one or more images
+- **THEN** its `content` SHALL be an array containing one `image` block per image, each with `source.type` `base64`, the image's media type, and its base64 data
+- **AND** the text SHALL follow the images as a `text` block
+
+#### Scenario: Image message is not dropped
+- **WHEN** a message carries an image and no text
+- **THEN** the message SHALL be included in the request with its image block
+
+#### Scenario: Prompt cache breakpoint on a message with an image
+- **WHEN** the message selected as the prompt-cache breakpoint carries an image
+- **THEN** `cache_control` SHALL be set on the last block of that message's content array
+
+### Requirement: Non-base64 image URLs are rejected
+A message content part whose image URL is not a base64 data URL SHALL be omitted from the Anthropic request rather than passed on as text.
+
+#### Scenario: Remote image URL
+- **WHEN** a user message carries an image content part with an `https://` URL
+- **THEN** no image block SHALL be emitted for it
+
+#### Scenario: Malformed data URL
+- **WHEN** an image content part carries a data URL with no media type, no base64 marker, or undecodable data
+- **THEN** no image block SHALL be emitted for it

--- a/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
+++ b/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
@@ -59,3 +59,37 @@ A message content part whose image URL is not a base64 data URL SHALL be omitted
 #### Scenario: Malformed data URL
 - **WHEN** an image content part carries a data URL with no media type, no base64 marker, or undecodable data
 - **THEN** no image block SHALL be emitted for it
+
+### Requirement: Image media types are normalised
+A data URL media type SHALL be reduced to its base type before it is used, because RFC 2397 permits parameters between the media type and the base64 marker and a parameter carried through would not be a media type any provider accepts.
+
+#### Scenario: Media type carries a parameter
+- **WHEN** an image content part carries `data:image/png;charset=utf-8;base64,<data>`
+- **THEN** the image SHALL be carried with media type `image/png`
+
+#### Scenario: Media type differs in case
+- **WHEN** an image content part carries a media type such as `IMAGE/PNG`
+- **THEN** the image SHALL be carried with media type `image/png`
+
+#### Scenario: Media type is the informal JPEG spelling
+- **WHEN** an image is carried with media type `image/jpg`
+- **THEN** it SHALL be carried with media type `image/jpeg`
+
+### Requirement: Only media types every provider accepts are carried
+An image SHALL be carried only when its normalised media type is one of `image/jpeg`, `image/png`, `image/gif` or `image/webp`, the set the Anthropic and OpenAI APIs both document. An unsupported media type SHALL cause the image to be dropped rather than sent, because a provider rejects the whole request over one unusable image block.
+
+#### Scenario: MCP tool returns an unsupported image
+- **WHEN** an MCP tool result contains an `ImageContent` part whose MIME type is not a supported media type
+- **THEN** no image SHALL be recorded on `ToolResult.Images`
+- **AND** the tool message text SHALL note that the image was not shown to the model, so the model does not assume it saw one
+
+#### Scenario: Data URL carries an unsupported media type
+- **WHEN** an image content part carries a data URL whose media type is not supported
+- **THEN** no image block SHALL be emitted for it
+
+### Requirement: Images reach OpenAI-compatible providers unchanged
+The user message carrying the images SHALL be an OpenAI-format message holding one `image_url` content part per image, whose URL is a base64 data URL, so that the OpenAI and Azure providers pass the images through without provider-specific encoding.
+
+#### Scenario: Image message sent to an OpenAI-compatible provider
+- **WHEN** the conversation carries a user message built for a tool's images
+- **THEN** each image SHALL appear as an `image_url` part whose URL is `data:<media type>;base64,<data>`

--- a/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
+++ b/openspec/changes/tool-image-content-blocks/specs/tool-image-content/spec.md
@@ -18,16 +18,36 @@ The completions executor SHALL carry an image returned by an MCP tool as image b
 - **THEN** the executor SHALL serialise it into the tool message text as before
 
 ### Requirement: Images returned by a tool are shown to the model
-The completions executor SHALL append a user message carrying the images to the conversation after the tool message they came from, because the `tool` role cannot hold an image content part.
+The completions executor SHALL append a user message carrying the images to the conversation after the tool messages for the turn, because the `tool` role cannot hold an image content part. Every tool message answering one assistant `tool_calls` block SHALL be contiguous, because the OpenAI API rejects a request in which another role interrupts them.
 
-#### Scenario: Image message follows the tool message
+#### Scenario: Image message follows the tool messages
 - **WHEN** a tool call returns one or more images
-- **THEN** the executor SHALL append the tool message followed by a user message holding one image content part per image and a caption naming the tool
+- **THEN** the executor SHALL append a user message holding one image content part per image and a caption naming the tool
 - **AND** both messages SHALL be added to the conversation history
+
+#### Scenario: A non-final tool call returns an image
+- **WHEN** an assistant turn emits two tool calls and only the first returns an image
+- **THEN** both tool messages SHALL be appended before the image message
+- **AND** no message of another role SHALL sit between them
+
+#### Scenario: Several tool calls return images
+- **WHEN** more than one tool call in a turn returns an image
+- **THEN** the image messages SHALL follow the tool messages in tool-call order
 
 #### Scenario: Tool returns no image
 - **WHEN** a tool call returns no image
 - **THEN** the executor SHALL append only the tool message, unchanged from previous behaviour
+
+### Requirement: Images survive the human approval path
+A tool that returns an image SHALL show it to the model whether or not the tool required human approval, because the same tool producing the same output must not behave differently depending on whether approval was configured.
+
+#### Scenario: Approved tool call returns an image
+- **WHEN** a tool call held for human approval is approved and returns an image
+- **THEN** the resumed conversation SHALL carry the same tool message and image user message an unapproved call would produce
+
+#### Scenario: Approved tool calls share one turn budget
+- **WHEN** several approved tool calls in one resumption return images
+- **THEN** the per-turn budget SHALL apply across them, as it does for an unapproved turn
 
 ### Requirement: Anthropic requests carry images as image blocks
 The Anthropic request format SHALL express a message's content as either a JSON string or an array of content blocks, and SHALL emit an `image` block for each image the message carries.
@@ -88,7 +108,16 @@ An image SHALL be carried only when its normalised media type is one of `image/j
 - **THEN** no image block SHALL be emitted for it
 
 ### Requirement: Tool images are bounded in size and count
-The completions executor SHALL bound the images a tool can put in front of the model, because an unbounded image is either rejected by the provider or silently consumes the context window. Three limits apply, each configurable and each defaulting to a value inside every supported provider's documented ceiling: decoded bytes per image (`ARK_TOOL_IMAGE_MAX_BYTES`, default 5 MiB), images per tool result (`ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL`, default 4), and cumulative decoded bytes across all tool calls in one turn (`ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN`, default 15 MiB).
+The completions executor SHALL bound the images a tool can put in front of the model, because an unbounded image is either rejected by the provider or silently consumes the context window. Four limits apply, each configurable, each defaulting to a value inside every supported provider's documented ceiling, and each enforced at a named point:
+
+| Limit | Enforced on | Variable | Default |
+| --- | --- | --- | --- |
+| Decoded bytes per image | one image in a tool result | `ARK_TOOL_IMAGE_MAX_BYTES` | 5 MiB |
+| Images per tool result | one tool result | `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` | 4 |
+| Cumulative bytes per turn | every tool call in one turn | `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` | 15 MiB |
+| Cumulative bytes per request | every image in one outbound request | `ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST` | 15 MiB |
+
+The first three bound what one turn may admit. Only the per-request limit bounds what the model receives, because images admitted in earlier turns are replayed from the conversation history.
 
 #### Scenario: Image exceeds the per-image limit
 - **WHEN** an MCP tool returns an image whose decoded size exceeds the per-image limit
@@ -114,6 +143,23 @@ The completions executor SHALL bound the images a tool can put in front of the m
 - **WHEN** a limit's environment variable holds a positive integer
 - **THEN** that value SHALL be used in place of the default
 - **AND** an absent, non-numeric or non-positive value SHALL leave the default in force
+
+### Requirement: Total image bytes per request are bounded
+The completions executor SHALL bound the image bytes in an outbound request, counting images replayed from the conversation history as well as images admitted this turn, because the image user message is persisted and re-sent on every subsequent turn and would otherwise accumulate without limit. The bound SHALL be applied once, where the request is assembled, so it holds for every provider.
+
+#### Scenario: History fits the request budget
+- **WHEN** the images across a conversation total no more than the per-request budget
+- **THEN** every image SHALL be sent, and a request carrying no image SHALL be unchanged
+
+#### Scenario: History exceeds the request budget
+- **WHEN** the images across a conversation exceed the per-request budget
+- **THEN** the executor SHALL keep the newest images that fit and omit the older ones
+- **AND** each omitted image SHALL be replaced by text stating its media type, its size, the budget, and that it was not shown to the model
+- **AND** the text of the message that carried it SHALL be preserved
+
+#### Scenario: The stored conversation is not altered
+- **WHEN** the executor omits an image from a request
+- **THEN** the conversation history retained for later turns SHALL still carry that image unmodified
 
 ### Requirement: Images reach OpenAI-compatible providers unchanged
 The user message carrying the images SHALL be an OpenAI-format message holding one `image_url` content part per image, whose URL is a base64 data URL, so that the OpenAI and Azure providers pass the images through without provider-specific encoding.

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -55,3 +55,35 @@
 - [x] 8.4 Confirm an oversized upload trips the per-image limit end to end rather than erroring the request
 - [x] 8.5 Not required — the s3-mode media type is `image/png`, identical to posix mode, so `http.DetectContentType` sniffing is unnecessary
 
+
+## 9. One Owner For The Tool-Turn Message Sequence
+
+- [x] 9.1 Add `tool_turn.go` with `toolOutcome` and `appendToolOutcomes`, appending every tool message before any image message so the tool messages for one `tool_calls` block stay contiguous
+- [x] 9.2 Collect outcomes in `executeToolCalls` and append them through the helper, flushing on the context-cancelled and tool-error returns
+- [x] 9.3 Carry images through the approval path — `executeToolCallWithImages` in `handler.go`, `Images` and `Name` on the rebuilt `ToolResult`, one `imageTurnBudget` across the loop
+- [x] 9.4 Build the resumed sequence in `reconstructMessagesForResumption` through the same helper, and delete the now-unused `executeToolCall`
+- [x] 9.5 Test the sequence invariants through both entry points from one table
+
+## 10. One Owner For Image Admission
+
+- [x] 10.1 Add `image_policy.go` with `imagePolicy`, `defaultImagePolicy` caching the limits behind a `sync.Once`, and `toolImageAdmitter` holding the per-image and per-tool-call decisions
+- [x] 10.2 Add `imageDroppedNote` and `imageReturnedNote`, replacing the four hand-written breadcrumbs
+- [x] 10.3 Add `envInt` and use it in `image_config.go` and `mcp_config.go`
+- [x] 10.4 Parse the media type with `mime.ParseMediaType`, keeping the `image/jpg` alias and the allowlist
+- [x] 10.5 Take the policy from an optional field on `MCPExecutor`, `Agent` and `Model`, defaulting to the cached one; inject limits in tests instead of setting environment variables
+
+## 11. Encode Once
+
+- [x] 11.1 `ToolResultImage` carries `B64` and `Bytes`; `newToolResultImage` encodes at the MCP boundary
+- [x] 11.2 Move the data URL grammar to `image_data_url.go`, shared by `DataURL` and `imageFromDataURL`
+- [x] 11.3 Derive the decoded length by arithmetic after a non-allocating validity scan, so the request path never decodes
+- [x] 11.4 Emit `image.B64` directly from `renderAnthropicContent`
+- [x] 11.5 Guard with an allocation assertion and a benchmark
+
+## 12. Per-Request Image Budget
+
+- [x] 12.1 Add `ARK_TOOL_IMAGE_MAX_BYTES_PER_REQUEST` (15 MiB) to `image_config.go` and the chart values
+- [x] 12.2 Add `applyImageRequestBudget` — newest-first retention, omitted images replaced by the breadcrumb, input never mutated
+- [x] 12.3 Apply it in `Model.ChatCompletion` so every provider and both the streaming and non-streaming paths are covered once
+- [x] 12.4 Tests — a history within budget, a history over it, the breadcrumb, the untouched input, and the budget seen by a provider
+- [x] 12.5 Document the four limits and their enforcement points in `docs/content/user-guide/files.mdx`

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add `ToolResultImage` (media type + raw bytes) with `DataURL()` and `Base64()` helpers to `ark/executors/completions/types.go`
 - [x] 1.2 Add `Images []ToolResultImage` to `ToolResult`
 - [ ] 1.3 Add `NewUserImageMessage(caption, images)` building a user message with one image content part per image
-- [ ] 1.4 Handle `*mcpsdk.ImageContent` in `MCPExecutor.Execute` (`mcp.go`) — collect the bytes, write a one-line note to the tool text, keep the JSON fallback for other part types
+- [x] 1.4 Handle `*mcpsdk.ImageContent` in `MCPExecutor.Execute` (`mcp.go`) — collect the bytes, write a one-line note to the tool text, keep the JSON fallback for other part types
 
 ## 2. Agent Loop
 

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -34,5 +34,23 @@
 
 ## 6. End-to-End Verification
 
-- [x] 5.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
-- [x] 5.2 Confirm a text-only query is unaffected
+- [x] 6.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
+- [x] 6.2 Confirm a text-only query is unaffected
+
+## 7. Size Limits
+
+- [x] 7.1 Add `image_config.go` with `toolImageLimitsFromEnv` reading `ARK_TOOL_IMAGE_MAX_BYTES` (5 MiB), `ARK_TOOL_IMAGE_MAX_PER_TOOL_CALL` (4) and `ARK_TOOL_IMAGE_MAX_BYTES_PER_TURN` (15 MiB), following the `mcp_config.go` pattern
+- [x] 7.2 Enforce the per-image and per-tool-call limits in `collectContent` (`mcp.go`), dropping with the breadcrumb text already used for an unsupported media type
+- [x] 7.3 Add `image_budget.go` with `imageTurnBudget`, admitting images greedily against the per-turn budget and returning the note for any it drops
+- [x] 7.4 Hold one budget per call of `executeToolCalls` (`agent.go`) and thread it through `executeToolCallWithImages`, appending the note to the tool message text
+- [x] 7.5 Expose the three limits in `chart/values.yaml`
+- [x] 7.6 Tests — env parsing and fallback, per-image drop and boundary, per-tool-call cap, and the turn budget across two tool calls through `executeToolCalls`
+- [x] 7.7 Distinguish the file-gateway 1 MB upload cap from the executor's per-image cap in `docs/content/user-guide/files.mdx`
+
+## 8. S3 Backend Verification
+
+- [ ] 8.1 Install file-gateway with `versitygw.backend=s3` against an in-cluster MinIO upstream and confirm `filesystem-mcp` runs with `STORAGE_BACKEND=s3`
+- [ ] 8.2 Re-run the image query for both the Anthropic and the OpenAI agent and confirm neither reports `NO IMAGE REACHED THE MODEL`
+- [ ] 8.3 Capture the actual `read-media-file` MCP payload — media type and byte length — as evidence that s3 mode returns an inline `ImageContent` part
+- [ ] 8.4 Confirm an oversized upload trips the per-image limit end to end rather than erroring the request
+- [ ] 8.5 If the s3-mode media type differs from posix mode, prefer `http.DetectContentType` over the declared type in `collectContent`

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -7,8 +7,8 @@
 
 ## 2. Agent Loop
 
-- [ ] 2.1 Add `executeToolCallWithImages` in `agent.go` returning the tool message plus its images; keep `executeToolCall` as the text-only wrapper used by the approval path in `handler.go`
-- [ ] 2.2 Append a `NewUserImageMessage` after the tool message in `executeToolCalls` when a tool returned images, to both `agentMessages` and `newMessages`
+- [x] 2.1 Add `executeToolCallWithImages` in `agent.go` returning the tool message plus its images; keep `executeToolCall` as the text-only wrapper used by the approval path in `handler.go`
+- [x] 2.2 Append a `NewUserImageMessage` after the tool message in `executeToolCalls` when a tool returned images, to both `agentMessages` and `newMessages`
 
 ## 3. Anthropic Request Format
 
@@ -22,9 +22,9 @@
 
 - [x] 4.1 Add `image_content_test.go` — data URL round-trip and rejection, MCP image part not flattened into text, `NewUserImageMessage` parts, `renderAnthropicContent` output, images preserved through `convertMessagesToAnthropic`
 - [x] 4.2 Update `anthropic_format_test.go` for the renamed content block type
-- [ ] 4.3 `make lint` and `make test` pass in `ark/`
+- [x] 4.3 `make lint` and `make test` pass in `ark/`
 
 ## 5. End-to-End Verification
 
-- [ ] 5.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
-- [ ] 5.2 Confirm a text-only query is unaffected
+- [x] 5.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
+- [x] 5.2 Confirm a text-only query is unaffected

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -24,7 +24,15 @@
 - [x] 4.2 Update `anthropic_format_test.go` for the renamed content block type
 - [x] 4.3 `make lint` and `make test` pass in `ark/`
 
-## 5. End-to-End Verification
+## 5. Media Type Normalisation and Validation
+
+- [x] 5.1 Add `normalizeImageMediaType` — strip RFC 2397 parameters, lower-case, alias `image/jpg` to `image/jpeg`, and reject anything outside the four media types Anthropic and OpenAI both accept
+- [x] 5.2 Apply it in `imageFromDataURL` (`anthropic_format.go`) so a parameterised media type is normalised and an unsupported one is rejected
+- [x] 5.3 Apply it in `MCPExecutor.Execute` (`mcp.go`) so an unsupported tool image is dropped, with the tool text saying it was not shown to the model
+- [x] 5.4 Tests for both entry points, including the OpenAI `image_url` wire shape
+- [x] 5.5 Extract `collectContent` from `MCPExecutor.Execute` so the MCP path is tested directly rather than through a copy of the loop
+
+## 6. End-to-End Verification
 
 - [x] 5.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
 - [x] 5.2 Confirm a text-only query is unaffected

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -1,0 +1,30 @@
+## 1. Tool Result Carries Images
+
+- [ ] 1.1 Add `ToolResultImage` (media type + raw bytes) with `DataURL()` and `Base64()` helpers to `ark/executors/completions/types.go`
+- [ ] 1.2 Add `Images []ToolResultImage` to `ToolResult`
+- [ ] 1.3 Add `NewUserImageMessage(caption, images)` building a user message with one image content part per image
+- [ ] 1.4 Handle `*mcpsdk.ImageContent` in `MCPExecutor.Execute` (`mcp.go`) — collect the bytes, write a one-line note to the tool text, keep the JSON fallback for other part types
+
+## 2. Agent Loop
+
+- [ ] 2.1 Add `executeToolCallWithImages` in `agent.go` returning the tool message plus its images; keep `executeToolCall` as the text-only wrapper used by the approval path in `handler.go`
+- [ ] 2.2 Append a `NewUserImageMessage` after the tool message in `executeToolCalls` when a tool returned images, to both `agentMessages` and `newMessages`
+
+## 3. Anthropic Request Format
+
+- [ ] 3.1 Add `extractMessageParts` returning text, images and role; keep `extractMessageContent` as the text-only wrapper
+- [ ] 3.2 Add `imageFromDataURL` parsing `data:<media type>;base64,<data>` and rejecting anything else
+- [ ] 3.3 Extend the message content block type with an optional `source` (`anthropicImageSource`), replacing `anthropicMessageContent`
+- [ ] 3.4 Replace the inline cache-block rendering in `convertMessagesToAnthropic` with `renderAnthropicContent(text, images, cached)` — bare JSON string when there is no image and no cache breakpoint, block array otherwise
+- [ ] 3.5 Keep a message that carries an image but no text (skip only when both are empty)
+
+## 4. Tests
+
+- [ ] 4.1 Add `image_content_test.go` — data URL round-trip and rejection, MCP image part not flattened into text, `NewUserImageMessage` parts, `renderAnthropicContent` output, images preserved through `convertMessagesToAnthropic`
+- [ ] 4.2 Update `anthropic_format_test.go` for the renamed content block type
+- [ ] 4.3 `make lint` and `make test` pass in `ark/`
+
+## 5. End-to-End Verification
+
+- [ ] 5.1 Deploy the built executor to a cluster with an MCP tool that returns an image and confirm the agent answers a question about it
+- [ ] 5.2 Confirm a text-only query is unaffected

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -14,14 +14,14 @@
 
 - [x] 3.1 Add `extractMessageParts` returning text, images and role; keep `extractMessageContent` as the text-only wrapper
 - [x] 3.2 Add `imageFromDataURL` parsing `data:<media type>;base64,<data>` and rejecting anything else
-- [ ] 3.3 Extend the message content block type with an optional `source` (`anthropicImageSource`), replacing `anthropicMessageContent`
-- [ ] 3.4 Replace the inline cache-block rendering in `convertMessagesToAnthropic` with `renderAnthropicContent(text, images, cached)` — bare JSON string when there is no image and no cache breakpoint, block array otherwise
-- [ ] 3.5 Keep a message that carries an image but no text (skip only when both are empty)
+- [x] 3.3 Extend the message content block type with an optional `source` (`anthropicImageSource`), replacing `anthropicMessageContent`
+- [x] 3.4 Replace the inline cache-block rendering in `convertMessagesToAnthropic` with `renderAnthropicContent(text, images, cached)` — bare JSON string when there is no image and no cache breakpoint, block array otherwise
+- [x] 3.5 Keep a message that carries an image but no text (skip only when both are empty)
 
 ## 4. Tests
 
-- [ ] 4.1 Add `image_content_test.go` — data URL round-trip and rejection, MCP image part not flattened into text, `NewUserImageMessage` parts, `renderAnthropicContent` output, images preserved through `convertMessagesToAnthropic`
-- [ ] 4.2 Update `anthropic_format_test.go` for the renamed content block type
+- [x] 4.1 Add `image_content_test.go` — data URL round-trip and rejection, MCP image part not flattened into text, `NewUserImageMessage` parts, `renderAnthropicContent` output, images preserved through `convertMessagesToAnthropic`
+- [x] 4.2 Update `anthropic_format_test.go` for the renamed content block type
 - [ ] 4.3 `make lint` and `make test` pass in `ark/`
 
 ## 5. End-to-End Verification

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -49,8 +49,9 @@
 
 ## 8. S3 Backend Verification
 
-- [ ] 8.1 Install file-gateway with `versitygw.backend=s3` against an in-cluster MinIO upstream and confirm `filesystem-mcp` runs with `STORAGE_BACKEND=s3`
-- [ ] 8.2 Re-run the image query for both the Anthropic and the OpenAI agent and confirm neither reports `NO IMAGE REACHED THE MODEL`
-- [ ] 8.3 Capture the actual `read-media-file` MCP payload — media type and byte length — as evidence that s3 mode returns an inline `ImageContent` part
-- [ ] 8.4 Confirm an oversized upload trips the per-image limit end to end rather than erroring the request
-- [ ] 8.5 If the s3-mode media type differs from posix mode, prefer `http.DetectContentType` over the declared type in `collectContent`
+- [x] 8.1 Install file-gateway with `versitygw.backend=s3` against an in-cluster MinIO upstream and confirm `filesystem-mcp` runs with `STORAGE_BACKEND=s3`
+- [x] 8.2 Re-run the image query for both the Anthropic and the OpenAI agent and confirm neither reports `NO IMAGE REACHED THE MODEL`
+- [x] 8.3 Capture the actual `read-media-file` MCP payload — media type and byte length — as evidence that s3 mode returns an inline `ImageContent` part
+- [x] 8.4 Confirm an oversized upload trips the per-image limit end to end rather than erroring the request
+- [x] 8.5 Not required — the s3-mode media type is `image/png`, identical to posix mode, so `http.DetectContentType` sniffing is unnecessary
+

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Tool Result Carries Images
 
-- [ ] 1.1 Add `ToolResultImage` (media type + raw bytes) with `DataURL()` and `Base64()` helpers to `ark/executors/completions/types.go`
-- [ ] 1.2 Add `Images []ToolResultImage` to `ToolResult`
+- [x] 1.1 Add `ToolResultImage` (media type + raw bytes) with `DataURL()` and `Base64()` helpers to `ark/executors/completions/types.go`
+- [x] 1.2 Add `Images []ToolResultImage` to `ToolResult`
 - [ ] 1.3 Add `NewUserImageMessage(caption, images)` building a user message with one image content part per image
 - [ ] 1.4 Handle `*mcpsdk.ImageContent` in `MCPExecutor.Execute` (`mcp.go`) — collect the bytes, write a one-line note to the tool text, keep the JSON fallback for other part types
 

--- a/openspec/changes/tool-image-content-blocks/tasks.md
+++ b/openspec/changes/tool-image-content-blocks/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Add `ToolResultImage` (media type + raw bytes) with `DataURL()` and `Base64()` helpers to `ark/executors/completions/types.go`
 - [x] 1.2 Add `Images []ToolResultImage` to `ToolResult`
-- [ ] 1.3 Add `NewUserImageMessage(caption, images)` building a user message with one image content part per image
+- [x] 1.3 Add `NewUserImageMessage(caption, images)` building a user message with one image content part per image
 - [x] 1.4 Handle `*mcpsdk.ImageContent` in `MCPExecutor.Execute` (`mcp.go`) — collect the bytes, write a one-line note to the tool text, keep the JSON fallback for other part types
 
 ## 2. Agent Loop
@@ -12,8 +12,8 @@
 
 ## 3. Anthropic Request Format
 
-- [ ] 3.1 Add `extractMessageParts` returning text, images and role; keep `extractMessageContent` as the text-only wrapper
-- [ ] 3.2 Add `imageFromDataURL` parsing `data:<media type>;base64,<data>` and rejecting anything else
+- [x] 3.1 Add `extractMessageParts` returning text, images and role; keep `extractMessageContent` as the text-only wrapper
+- [x] 3.2 Add `imageFromDataURL` parsing `data:<media type>;base64,<data>` and rejecting anything else
 - [ ] 3.3 Extend the message content block type with an optional `source` (`anthropicImageSource`), replacing `anthropicMessageContent`
 - [ ] 3.4 Replace the inline cache-block rendering in `convertMessagesToAnthropic` with `renderAnthropicContent(text, images, cached)` — bare JSON string when there is no image and no cache breakpoint, block array otherwise
 - [ ] 3.5 Keep a message that carries an image but no text (skip only when both are empty)


### PR DESCRIPTION
## Summary

- **Current:** An image returned by an MCP tool was JSON-marshalled into the tool message, so the model was shown base64 text it cannot read — it either invents a reading of a picture it never saw or blows the context limit

- **Target:**
  - Carry the bytes on `ToolResult.Images`
  - append them to the conversation as a user message after the tool message
  - emit Anthropic `image` content blocks
- Text-only requests are unchanged: a message with no image and no cache breakpoint still marshals to a bare JSON string

- Media types are normalised and validated before an image is carried. A data URL may legally hold RFC 2397 parameters, so `data:image/png;charset=utf-8;base64,...` previously produced the media type `image/png;charset=utf-8`, and an MCP server is free to return `image/svg+xml`; either makes the provider reject the whole request. Images are now carried only with one of the four media types the Anthropic and OpenAI APIs both document, and an unsupported tool image is dropped with a note in the tool text rather than silently implying the model saw it.

- The images reach **every** provider, not only Anthropic: they travel as an OpenAI-format user message holding `image_url` data URL parts, which the OpenAI and Azure providers pass through unchanged. Only the Anthropic and Bedrock path needs the explicit `image` block encoding.

- OpenSpec change: `openspec/changes/tool-image-content-blocks/` (`openspec validate --strict` passes)

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with &#34;@all-contributors please add  for &#34;
- [ ] Linked issues #eg101

## Verification

- `make lint` and `make test` pass in `ark/`
- Verified on a cluster running a build of this branch:  see demo


https://github.com/user-attachments/assets/ed8d38dc-f3e1-4f22-875b-8d5bdcfd482f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
