### PR TITLE
test: fix flaky postgres broker test

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1026,3 +1026,24 @@ Use the shared `psql-query.sh` script to run SQL against `ark-storage-dev`:
 ```
 
 The script reads the password from the `ark-storage-dev-password` secret in `ark-system` and execs psql on the `ark-storage-dev` deployment.
+
+### Polling for async writes: use `psql-poll.sh`, not a shell retry loop
+
+Broker writes land asynchronously, so verify steps must poll until the rows appear. Do not loop over `psql-query.sh`: each call is three `kubectl` round-trips (namespace lookup, secret decode, exec), so an N-iteration loop pays that N times and, under CI Postgres contention, exceeds the step timeout and is killed. `signal: killed` in a chainsaw script means the step timeout was hit, not that an assertion failed.
+
+Use `psql-poll.sh`, which resolves the connection once and runs the whole retry loop inside a single `kubectl exec` against local psql. It polls `<sql>` until the trimmed result equals `<expected>`, then prints it; non-zero exit if it never matched:
+
+```yaml
+- script:
+    timeout: 60s
+    content: |
+      COUNT=$(bash ../shared/psql-poll.sh \
+        "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}' AND phase='done';" \
+        "2" 80 0.5) || { echo "expected 2, got '${COUNT}'"; exit 1; }
+```
+
+Arguments are `"<sql>" "<expected>" [attempts] [sleep_seconds]` (defaults 80 and 0.5, a 40s budget). Use `psql-query.sh` only for single reads once the poll has confirmed the data is present.
+
+### Derive per-run identifiers from `($namespace)`
+
+Hardcoded `sessionId`s (and similar identifiers) accumulate rows across runs on a persistent Postgres. CI is fresh each run, but local re-runs and any shared DB are not, so a fixed id breaks exact-count assertions on the second run. Set the id from `($namespace)` (unique per run) in the query manifests and reference the same value in verify steps, then delete the run's own rows in a `cleanup` step.

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -77,7 +77,7 @@ spec:
   - name: verify-events-in-postgres
     try:
     - script:
-        timeout: 30s
+        timeout: 120s
         env:
         - name: NAMESPACE
           value: ($namespace)
@@ -85,7 +85,7 @@ spec:
           QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
           bash ../shared/psql-poll.sh \
             "SELECT count(*) >= 1 FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
-            "t" 20 0.5 >/dev/null || { echo "expected at least 1 event with expires_at"; exit 1; }
+            "t" 180 0.5 >/dev/null || { echo "expected at least 1 event with expires_at"; exit 1; }
           COUNT=$(bash ../shared/psql-query.sh \
             "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
             | tr -d ' \n')
@@ -97,7 +97,7 @@ spec:
   - name: verify-event-ttl-in-postgres
     try:
     - script:
-        timeout: 30s
+        timeout: 120s
         env:
         - name: NAMESPACE
           value: ($namespace)
@@ -105,7 +105,7 @@ spec:
           QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
           bash ../shared/psql-poll.sh \
             "SELECT count(*) >= 1 FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
-            "t" 20 0.5 >/dev/null || { echo "no events with expires_at for ttl check"; exit 1; }
+            "t" 180 0.5 >/dev/null || { echo "no events with expires_at for ttl check"; exit 1; }
           TTL=$(bash ../shared/psql-query.sh \
             "SELECT EXTRACT(EPOCH FROM (expires_at - created_at))::int FROM events WHERE query_id='${QUERY_UID}' LIMIT 1;" \
             | tr -d ' \n')

--- a/tests/event-broker-postgres/chainsaw-test.yaml
+++ b/tests/event-broker-postgres/chainsaw-test.yaml
@@ -83,14 +83,12 @@ spec:
           value: ($namespace)
         content: |
           QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
-          COUNT=0
-          for i in $(seq 1 10); do
-            COUNT=$(bash ../shared/psql-query.sh \
-              "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
-              | tr -d ' \n')
-            [ "${COUNT}" -ge 1 ] && break
-            sleep 1
-          done
+          bash ../shared/psql-poll.sh \
+            "SELECT count(*) >= 1 FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
+            "t" 20 0.5 >/dev/null || { echo "expected at least 1 event with expires_at"; exit 1; }
+          COUNT=$(bash ../shared/psql-query.sh \
+            "SELECT count(*) FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
+            | tr -d ' \n')
           echo "events in Postgres: ${COUNT}"
           [ "${COUNT}" -ge 1 ] || { echo "expected at least 1 event, got ${COUNT}"; exit 1; }
     catch:
@@ -105,14 +103,12 @@ spec:
           value: ($namespace)
         content: |
           QUERY_UID=$(kubectl get query events-broker-query -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
-          TTL=""
-          for i in $(seq 1 10); do
-            TTL=$(bash ../shared/psql-query.sh \
-              "SELECT EXTRACT(EPOCH FROM (expires_at - created_at))::int FROM events WHERE query_id='${QUERY_UID}' LIMIT 1;" \
-              | tr -d ' \n')
-            [ -n "${TTL}" ] && break
-            sleep 1
-          done
+          bash ../shared/psql-poll.sh \
+            "SELECT count(*) >= 1 FROM events WHERE query_id='${QUERY_UID}' AND expires_at IS NOT NULL;" \
+            "t" 20 0.5 >/dev/null || { echo "no events with expires_at for ttl check"; exit 1; }
+          TTL=$(bash ../shared/psql-query.sh \
+            "SELECT EXTRACT(EPOCH FROM (expires_at - created_at))::int FROM events WHERE query_id='${QUERY_UID}' LIMIT 1;" \
+            | tr -d ' \n')
           echo "DB ttl_seconds: ${TTL}"
           [ "${TTL}" = "3600" ] || { echo "expected 3600, got '${TTL}'"; exit 1; }
     catch:

--- a/tests/sessions-broker-postgres/chainsaw-test.yaml
+++ b/tests/sessions-broker-postgres/chainsaw-test.yaml
@@ -103,18 +103,19 @@ spec:
   - name: verify-session-in-postgres
     try:
     - script:
-        timeout: 60s
+        timeout: 180s
         content: |
           # Two queries share one session, so their events serialize on the
           # same header row (by design - see PostgresSessionsStorage). Under
           # a busy CI runner, with the shared postgresql-matrix Postgres
           # instance also taking writes from every other postgresql-labelled
-          # test running concurrently, draining that backlog can take longer
-          # than a quick local run ever does - so poll in-pod for the rows to
-          # drain before asserting.
+          # test running concurrently, one query's row can take well over a
+          # minute to reach phase=done. The in-pod poll breaks as soon as both
+          # rows land, so a generous budget only costs wall-clock when the
+          # backlog is genuinely deep.
           QUERY_COUNT=$(bash ../shared/psql-poll.sh \
             "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}' AND phase='done';" \
-            "2" 80 0.5) || { echo "expected 2 done session_queries rows, got '${QUERY_COUNT}'"; exit 1; }
+            "2" 300 0.5) || { echo "expected 2 done session_queries rows, got '${QUERY_COUNT}'"; exit 1; }
           echo "done session_queries rows: ${QUERY_COUNT}"
 
           HEADER=$(bash ../shared/psql-query.sh \

--- a/tests/sessions-broker-postgres/chainsaw-test.yaml
+++ b/tests/sessions-broker-postgres/chainsaw-test.yaml
@@ -106,23 +106,17 @@ spec:
         timeout: 60s
         content: |
           SESSION_ID="e2e-sessions-broker-postgres"
-          QUERY_COUNT=""
           # Two queries share one session, so their events serialize on the
           # same header row (by design - see PostgresSessionsStorage). Under
           # a busy CI runner, with the shared postgresql-matrix Postgres
           # instance also taking writes from every other postgresql-labelled
           # test running concurrently, draining that backlog can take longer
-          # than a quick local run ever does - give it real margin rather
-          # than a tight retry budget tuned against an idle cluster.
-          for i in $(seq 1 40); do
-            QUERY_COUNT=$(bash ../shared/psql-query.sh \
-              "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}' AND phase='done';" \
-              | tr -d ' \n')
-            [ "${QUERY_COUNT}" = "2" ] && break
-            sleep 1
-          done
+          # than a quick local run ever does - so poll in-pod for the rows to
+          # drain before asserting.
+          QUERY_COUNT=$(bash ../shared/psql-poll.sh \
+            "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}' AND phase='done';" \
+            "2" 80 0.5) || { echo "expected 2 done session_queries rows, got '${QUERY_COUNT}'"; exit 1; }
           echo "done session_queries rows: ${QUERY_COUNT}"
-          [ "${QUERY_COUNT}" = "2" ] || { echo "expected 2 done session_queries rows, got ${QUERY_COUNT}"; exit 1; }
 
           HEADER=$(bash ../shared/psql-query.sh \
             "SELECT status || ',' || error_count || ',' || jsonb_array_length(conversations) FROM sessions WHERE session_id='${SESSION_ID}';" \

--- a/tests/sessions-broker-postgres/chainsaw-test.yaml
+++ b/tests/sessions-broker-postgres/chainsaw-test.yaml
@@ -105,7 +105,6 @@ spec:
     - script:
         timeout: 60s
         content: |
-          SESSION_ID="e2e-sessions-broker-postgres"
           # Two queries share one session, so their events serialize on the
           # same header row (by design - see PostgresSessionsStorage). Under
           # a busy CI runner, with the shared postgresql-matrix Postgres
@@ -136,6 +135,8 @@ spec:
         env:
         - name: NAMESPACE
           value: ($namespace)
+        - name: SESSION_ID
+          value: ($namespace)
     catch:
     - events: {}
     - script:
@@ -156,7 +157,7 @@ spec:
           RESULT=$(kubectl exec -n "$BROKER_NS" deployment/ark-broker -- \
             node -e "
               const h = require('http');
-              h.get('http://localhost:8080/sessions/e2e-sessions-broker-postgres', (r) => {
+              h.get('http://localhost:8080/sessions/${SESSION_ID}', (r) => {
                 let d = '';
                 r.on('data', (c) => { d += c; });
                 r.on('end', () => {
@@ -174,6 +175,8 @@ spec:
         env:
         - name: NAMESPACE
           value: ($namespace)
+        - name: SESSION_ID
+          value: ($namespace)
     catch:
     - events: {}
     - script:
@@ -184,6 +187,13 @@ spec:
           value: ($namespace)
 
     cleanup:
+    - script:
+        content: |
+          bash ../shared/psql-query.sh \
+            "DELETE FROM session_queries WHERE session_id='${SESSION_ID}'; DELETE FROM sessions WHERE session_id='${SESSION_ID}';" || true
+        env:
+        - name: SESSION_ID
+          value: ($namespace)
     - script:
         content: |
           helm uninstall mock-llm --namespace $NAMESPACE --wait --timeout=180s || true

--- a/tests/sessions-broker-postgres/manifests/a02-query-1.yaml
+++ b/tests/sessions-broker-postgres/manifests/a02-query-1.yaml
@@ -7,6 +7,6 @@ spec:
   target:
     type: agent
     name: sessions-postgres-agent-a
-  sessionId: e2e-sessions-broker-postgres
+  sessionId: ($namespace)
   conversationId: e2e-sessions-broker-postgres-conv
   ttl: "1h0m0s"

--- a/tests/sessions-broker-postgres/manifests/a03-query-2.yaml
+++ b/tests/sessions-broker-postgres/manifests/a03-query-2.yaml
@@ -7,6 +7,6 @@ spec:
   target:
     type: agent
     name: sessions-postgres-agent-b
-  sessionId: e2e-sessions-broker-postgres
+  sessionId: ($namespace)
   conversationId: e2e-sessions-broker-postgres-conv-2
   ttl: "1h0m0s"

--- a/tests/shared/psql-poll.sh
+++ b/tests/shared/psql-poll.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Usage: bash psql-poll.sh "<sql>" "<expected>" [attempts] [sleep_seconds]
-# Polls <sql> against ark-storage-dev postgres until its trimmed result equals
-# <expected>, looping inside one kubectl exec so connection overhead is paid
-# once. Prints the final result; exits non-zero if it never matched.
-# Auto-detects the namespace (ark-system in CI, default in devspace).
+# Polls <sql> against the broker's ark-storage-dev postgres until its trimmed
+# result equals <expected>, looping inside one kubectl exec so connection
+# overhead is paid once. Prints the final result; exits non-zero if it never
+# matched. Picks the ark-storage-dev whose DB holds the broker schema (CI keeps
+# it in ark-system, devspace in the broker's namespace).
 set -eu
 SQL="$1"
 EXPECTED="$2"
@@ -11,19 +12,17 @@ ATTEMPTS="${3:-80}"
 SLEEP="${4:-0.5}"
 NS=""
 for candidate in ark-system default; do
-  if kubectl -n "$candidate" get deployment ark-broker >/dev/null 2>&1; then
-    NS="$candidate"
-    break
-  fi
+  kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1 || continue
+  [ -z "$NS" ] && NS="$candidate"
+  PW=$(kubectl -n "$candidate" get secret ark-storage-dev-password \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+  [ -n "$PW" ] || continue
+  HAS=$(kubectl exec -n "$candidate" deployment/ark-storage-dev -- \
+    env "PGPASSWORD=$PW" sh -c \
+    "psql -U postgres -d ark -t -A -c \"SELECT to_regclass('public.messages') IS NOT NULL;\"" \
+    2>/dev/null | tr -d ' \n')
+  [ "$HAS" = "t" ] && { NS="$candidate"; break; }
 done
-if [ -z "$NS" ]; then
-  for candidate in ark-system default; do
-    if kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1; then
-      NS="$candidate"
-      break
-    fi
-  done
-fi
 NS=${NS:-ark-system}
 PGPASSWORD=$(kubectl -n "$NS" get secret ark-storage-dev-password \
   -o jsonpath='{.data.password}' | base64 -d)

--- a/tests/shared/psql-poll.sh
+++ b/tests/shared/psql-poll.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Usage: bash psql-poll.sh "<sql>" "<expected>" [attempts] [sleep_seconds]
+# Polls <sql> against ark-storage-dev postgres until its trimmed result equals
+# <expected>, looping inside one kubectl exec so connection overhead is paid
+# once. Prints the final result; exits non-zero if it never matched.
+# Auto-detects the namespace (ark-system in CI, default in devspace).
+set -eu
+SQL="$1"
+EXPECTED="$2"
+ATTEMPTS="${3:-80}"
+SLEEP="${4:-0.5}"
+NS=""
+for candidate in ark-system default; do
+  if kubectl -n "$candidate" get deployment ark-broker >/dev/null 2>&1; then
+    NS="$candidate"
+    break
+  fi
+done
+if [ -z "$NS" ]; then
+  for candidate in ark-system default; do
+    if kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1; then
+      NS="$candidate"
+      break
+    fi
+  done
+fi
+NS=${NS:-ark-system}
+PGPASSWORD=$(kubectl -n "$NS" get secret ark-storage-dev-password \
+  -o jsonpath='{.data.password}' | base64 -d)
+kubectl exec -n "$NS" deployment/ark-storage-dev -- \
+  env "PGPASSWORD=$PGPASSWORD" "SQL=$SQL" "EXPECTED=$EXPECTED" "ATTEMPTS=$ATTEMPTS" "SLEEP=$SLEEP" \
+  sh -c '
+    i=0
+    result=""
+    while :; do
+      result=$(psql -U postgres -d ark -t -A -c "$SQL" 2>/tmp/psql-poll-err | tr -d " \n")
+      [ "$result" = "$EXPECTED" ] && { printf "%s" "$result"; exit 0; }
+      i=$((i + 1))
+      [ "$i" -ge "$ATTEMPTS" ] && break
+      sleep "$SLEEP"
+    done
+    [ -s /tmp/psql-poll-err ] && cat /tmp/psql-poll-err >&2
+    printf "%s" "$result"
+    exit 1
+  '

--- a/tests/shared/psql-query.sh
+++ b/tests/shared/psql-query.sh
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
 # Usage: bash psql-query.sh "<sql>"
 # Runs a SQL query against the broker's ark-storage-dev postgres.
-# Targets the postgres co-located with the ark-broker deployment (its
-# DATABASE_URL uses the bare service name, so the DB is in the broker's
-# namespace) - ark-system in CI, default in devspace.
+# The broker's postgres is not always co-located with the broker (CI uses an
+# FQDN into ark-system; devspace uses a bare name in the broker's namespace),
+# so pick the ark-storage-dev whose DB actually holds the broker schema.
 set -eu
 NS=""
 for candidate in ark-system default; do
-  if kubectl -n "$candidate" get deployment ark-broker >/dev/null 2>&1; then
-    NS="$candidate"
-    break
-  fi
+  kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1 || continue
+  [ -z "$NS" ] && NS="$candidate"
+  PW=$(kubectl -n "$candidate" get secret ark-storage-dev-password \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+  [ -n "$PW" ] || continue
+  HAS=$(kubectl exec -n "$candidate" deployment/ark-storage-dev -- \
+    env "PGPASSWORD=$PW" sh -c \
+    "psql -U postgres -d ark -t -A -c \"SELECT to_regclass('public.messages') IS NOT NULL;\"" \
+    2>/dev/null | tr -d ' \n')
+  [ "$HAS" = "t" ] && { NS="$candidate"; break; }
 done
-if [ -z "$NS" ]; then
-  for candidate in ark-system default; do
-    if kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1; then
-      NS="$candidate"
-      break
-    fi
-  done
-fi
 NS=${NS:-ark-system}
 PGPASSWORD=$(kubectl -n "$NS" get secret ark-storage-dev-password \
   -o jsonpath='{.data.password}' | base64 -d)

--- a/tests/shared/psql-query.sh
+++ b/tests/shared/psql-query.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
 # Usage: bash psql-query.sh "<sql>"
-# Runs a SQL query against ark-storage-dev postgres.
-# Auto-detects the namespace (ark-system in CI, default in devspace).
+# Runs a SQL query against the broker's ark-storage-dev postgres.
+# Targets the postgres co-located with the ark-broker deployment (its
+# DATABASE_URL uses the bare service name, so the DB is in the broker's
+# namespace) - ark-system in CI, default in devspace.
 set -eu
-NS=$(kubectl get deployment --all-namespaces \
-  -o jsonpath='{range .items[?(@.metadata.name=="ark-storage-dev")]}{.metadata.namespace}{end}' 2>/dev/null)
+NS=""
+for candidate in ark-system default; do
+  if kubectl -n "$candidate" get deployment ark-broker >/dev/null 2>&1; then
+    NS="$candidate"
+    break
+  fi
+done
+if [ -z "$NS" ]; then
+  for candidate in ark-system default; do
+    if kubectl -n "$candidate" get deployment ark-storage-dev >/dev/null 2>&1; then
+      NS="$candidate"
+      break
+    fi
+  done
+fi
 NS=${NS:-ark-system}
 PGPASSWORD=$(kubectl -n "$NS" get secret ark-storage-dev-password \
   -o jsonpath='{.data.password}' | base64 -d)


### PR DESCRIPTION
## Summary
- Fix the `sessions-broker-postgres` and `event-broker-postgres` chainsaw tests, whose `verify-*-in-postgres` steps flaked in CI with `signal: killed` (step timeout).
- Root cause: each poll iteration called `psql-query.sh`, which is three `kubectl` round-trips (namespace lookup, secret decode, exec). A 40-iteration loop paid that ~40× and, under CI Postgres contention, blew past the step timeout.
- Add `tests/shared/psql-poll.sh`: resolves namespace/password once and runs the whole retry loop inside a single `kubectl exec` against local psql. Surfaces the underlying psql error on failure instead of a bare empty result. Both tests switched to it.
- Resolve the broker's Postgres by probing for the `ark-storage-dev` whose DB actually holds the broker schema (`public.messages`). This is correct whether the broker's DB is co-located (devspace, bare service name) or cross-namespace (CI, FQDN into `ark-system`), and when an unrelated apiserver Postgres coexists — replacing a `--all-namespaces`/broker-namespace heuristic that guessed wrong.
- Make `sessions-broker-postgres` isolated/idempotent: derive `sessionId` from the per-run chainsaw `($namespace)` instead of a fixed string, and add a cleanup step that deletes the run's own session rows.
- Widen the verify poll budgets (sessions 150s poll / 180s step; events 90s / 120s) to tolerate slow session/event propagation under CI contention. The in-pod poll breaks as soon as the rows land, so common-case runtime is unchanged (~20s).
- Document both lessons in `tests/CLAUDE.md` (in-pod polling with `psql-poll.sh`; per-run identifiers from `($namespace)`).

Validated locally against a Postgres-backed broker: both tests pass (~20s), back-to-back sessions runs pass with zero leftover rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)