### PR TITLE
docs: use Inter and Geist Mono to match the getark.ai landing

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1,3 +1,10 @@
+:root {
+  --x-font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --x-font-mono: var(--font-geist-mono), ui-monospace, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+}
+
 /* Custom styles to reduce sidebar spacing */
 
 /* Reduce padding on sidebar links */

--- a/docs/app/layout.jsx
+++ b/docs/app/layout.jsx
@@ -1,10 +1,23 @@
 import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Banner, Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
+import { Inter, Geist_Mono } from 'next/font/google'
 import 'nextra-theme-docs/style.css'
 import './globals.css'
 import SidebarActiveSync from './sidebar-active-sync'
- 
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap'
+})
+
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-geist-mono',
+  display: 'swap'
+})
+
 export const metadata = {
   // Define your metadata here
   // For more information on metadata API, see: https://nextjs.org/docs/app/building-your-application/optimizing/metadata
@@ -28,6 +41,7 @@ export default async function RootLayout({ children }) {
       lang="en"
       // Required to be set
       dir="ltr"
+      className={`${inter.variable} ${geistMono.variable}`}
       // Suggested by `next-themes` package https://github.com/pacocoursey/next-themes#with-app
       suppressHydrationWarning
     >


### PR DESCRIPTION
Load Inter (sans) and Geist Mono (mono) via next/font/google and override Nextra's --x-font-sans / --x-font-mono so body, headings, sidebar, code blocks and the search UI pick up the landing's type system.

Before
<img width="1440" height="1000" alt="before-light" src="https://github.com/user-attachments/assets/54b156af-677e-4aa8-8c4f-213220dfe672" />

After
<img width="1440" height="1000" alt="after-light" src="https://github.com/user-attachments/assets/348e8023-a8e8-4fd4-9bb8-0d058f176b14" />



Closes #2893

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 