### PR TITLE
fix(docs): bump @xmldom/xmldom to 0.9.11 for XRAY-1050796/799/801

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2792,9 +2792,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,7 @@
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
-    "@xmldom/xmldom": "0.9.10",
+    "@xmldom/xmldom": "0.9.11",
     "speech-rule-engine": "4.1.4",
     "uuid": "^14.0.0",
     "lodash-es": "4.18.1",


### PR DESCRIPTION
## Summary
- Bump `@xmldom/xmldom` `0.9.10` → `0.9.11` in the `docs` overrides to clear three new High-severity JFrog Xray violations (XRAY-1050796/799/801): attribute and element name injection bypassing `requireWellFormed`, and PI-grammar ReDoS.
- Transitive dependency of `speech-rule-engine` (via `mathjax-full` / `nextra`); all three advisories are fixed in 0.9.11.
- Surfaced as "new since last main scan" on an unrelated PR; not caused by that PR. Verified: `0.9.11` loads and parses, docs vitest passes (43/43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)