### PR TITLE
fix(security): resolve Xray CVE violations (nanoid whitelist + Go 1.26.6 bump)

### DIFF
--- a/.github/actions/jfrog-xray-scan/tolerated_violations.txt
+++ b/.github/actions/jfrog-xray-scan/tolerated_violations.txt
@@ -9,3 +9,10 @@ XRAY-97724 - CVE-2018-20225
 - NOT EXPLOITABLE in Ark: Ark uses uv (not pip) for Python dependency management in all production services (ark-api, ark-mcp, simple-agent, retrieval-service, tool templates).
 - Evidence: All Python Dockerfiles use "uv sync --frozen" for dependency installation. pip is only present in base images and used to bootstrap uv itself ("pip install uv"), never for --extra-index-url operations.
 - No fix available: This is considered intended pip functionality per official response. Using uv eliminates the attack vector entirely.
+
+XRAY-1051070 - CVE-2026-73086 / GHSA-xwg4-73v4-xw9w (nanoid integer overflow)
+- nanoid(size) coerced size to a signed 32-bit int; 2147483648 wrapped to -2147483648 and corrupted the CSPRNG poolOffset, making tokens the deterministic string "uuuuuuuuuuuuuuuuuuuuu" until restart. Fixed on the 3.x line in 3.3.12 and on the 5.x line in 5.1.11.
+- FALSE POSITIVE: Ark ships patched nanoid — 3.3.17 (docs) and 3.3.18 (tools/ark-cli, services/ark-landing-page, services/ark-dashboard), both above the 3.3.12 fix. Xray's "fixed" metadata lists only 5.1.11 and omits 3.3.12, so it flags the patched 3.3.x releases anyway.
+- Verified at source, not just advisory data: nanoid 3.3.18 fillPool() still guards "if (bytes < 0) throw new RangeError", and nanoid()/random() feed it "(size |= 0)". The exploit input wraps to a negative value and is rejected before poolOffset is touched. Guard is unchanged since 3.3.12 (3.3.12->3.3.18 only relaxed the upper 1024 cap in the ESM build); not a regression. Matches OSV: affected = 3.3.0-3.3.11 and 4.0.0-5.1.10; 3.3.12-3.3.18 not affected.
+- Cannot upgrade to 5.1.11: nanoid is transitive, pulled only by postcss, which pins nanoid ^3.3.x (3.x line) even at its latest 8.5.26. nanoid 5.x is ESM-only and would break postcss's CommonJS require() and every Next.js/CLI build.
+- Remove this entry if Xray corrects its fixed-version metadata, or if nanoid moves onto a genuinely affected line.

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: ark/go.sum
 
@@ -343,7 +343,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: |
             ark/go.sum
@@ -1323,7 +1323,7 @@ jobs:
       - name: Setup Go for coverage tools
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           # Coverage tooling only; no project build, so module caching has no value here.
           cache: false
 
@@ -1581,7 +1581,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: "1.26.6"
           # goreleaser builds tools/fark; cache against its go.sum.
           cache-dependency-path: tools/fark/go.sum
 

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: tools/fark/go.sum
       - name: Stamp stable version
         run: |

--- a/.github/workflows/sonar_scan.yaml
+++ b/.github/workflows/sonar_scan.yaml
@@ -99,7 +99,7 @@ jobs:
         if: steps.check-coverage.outputs.found == 'false'
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
           cache-dependency-path: ark/go.sum
 

--- a/ark/Dockerfile
+++ b/ark/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.5-bookworm AS builder
+FROM golang:1.26.6-bookworm AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG ENABLE_COVERAGE=false

--- a/ark/Dockerfile.completions
+++ b/ark/Dockerfile.completions
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26.6-bookworm AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev

--- a/ark/go.mod
+++ b/ark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/images/ark-tools/Dockerfile
+++ b/images/ark-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS fark-builder
+FROM golang:1.26.6-alpine AS fark-builder
 
 WORKDIR /build
 

--- a/templates/mcp-server/Dockerfile
+++ b/templates/mcp-server/Dockerfile
@@ -63,7 +63,7 @@ ENTRYPOINT [ "/bin/bash", "-c", "mcp-proxy --debug --port 8080 --host 0.0.0.0 --
 {{- end }}
 
 {{- else if eq .Values.technology "go" }}
-FROM golang:1.26.5-alpine AS go-builder
+FROM golang:1.26.6-alpine AS go-builder
 {{- if .Values.packageSource }}
 {{- if eq .Values.packageSource "go-install" }}
 RUN go install {{ .Values.packageName }}@latest

--- a/tools/fark/Dockerfile
+++ b/tools/fark/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 

--- a/tools/fark/go.mod
+++ b/tools/fark/go.mod
@@ -1,6 +1,6 @@
 module mckinsey.com/ark/tools/fark
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Summary
- **Go toolchain 1.26.5 → 1.26.6** to fix the Go stdlib CVEs Xray flags on `go://github.com/golang/go:v1.26.5`: CVE-2026-39821 (Critical, `XRAY-988717`) and CVE-2026-46600 (High, `XRAY-1032014`). Both fixed in Go 1.26.6 per the Go vuln DB (GO-2026-5026, GO-2026-5942). Bumps all pins: go.mod directives (ark, fark), build images (ark, ark-completions, fark, ark-tools, mcp-server template), and CI `go-version` (cicd, sonar_scan, release-on-merge). Also clears a stale 1.26.4 pin in `Dockerfile.completions`. Closes #3007. 
- **Whitelist `XRAY-1051070` (CVE-2026-73086, nanoid)** as a false positive. Ark ships nanoid 3.3.17/3.3.18, both above the 3.3.12 fix; source-verified the overflow guard is intact and OSV lists 3.3.12–3.3.18 as not affected. Xray's fixed-version metadata omits the 3.x fix. Upgrading to 5.1.11 is not viable: nanoid is transitive via postcss, which pins `^3.3.x`, and nanoid 5.x is ESM-only. Closes #3203.

Gates: `ark` lint (0 issues) + tests pass, `fark` vet + tests pass, under Go 1.26.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)