### PR TITLE
fix(ark-broker): terminal query phase lost when a reordered non-terminal event raises the sequence watermark

### DIFF
--- a/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
@@ -807,6 +807,33 @@ describe('PostgresSessionsStorage', () => {
       expect(query.conversationId).toBe('conv-1');
     });
 
+    test('a higher-sequence non-terminal event should not suppress a later-applied done', async () => {
+      // Guard against the sessions-broker-postgres e2e flake. A non-terminal
+      // (running) event for the query is applied first carrying the higher
+      // sequence, so it sets the watermark to 2. The true QueryExecution
+      // Complete arrives with the lower sequence 1. Session must be set to
+      // Done even though it has the lower sequence.
+      await storage.applyEvent(
+        {
+          sessionId: 'sess-1',
+          queryName: 'query-1',
+          _reason: 'AgentExecutionStart',
+        },
+        2
+      );
+      await storage.applyEvent(
+        {
+          sessionId: 'sess-1',
+          queryName: 'query-1',
+          _reason: 'QueryExecutionComplete',
+        },
+        1
+      );
+
+      const query = (await storage.getSession('sess-1'))!.queries['query-1']!;
+      expect(query.phase).toBe('done');
+    });
+
     test('an out-of-order event still contributes fields the query is missing', async () => {
       // The completion event carries no agent or conversationId - only the
       // start event does, and it lost the race. Dropping it outright would

--- a/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
@@ -19,6 +19,7 @@ import {
   applyQueryPhase,
   buildQueryEntry,
   deriveParticipants,
+  isTerminalPhase,
   mergeQueryMetadata,
   normalizeEventData,
   recalculateSessionConversations,
@@ -57,6 +58,7 @@ type SessionQueryRow = {
   last_activity: Date;
   last_applied_event_sequence: string;
   last_applied_message_sequence: string;
+  last_phase_event_sequence: string;
 };
 
 function rowToQueryEntry(row: SessionQueryRow): QueryEntry {
@@ -296,15 +298,25 @@ export class PostgresSessionsStorage implements SessionsStorage {
       `;
       const existingRow = existingRows[0];
 
-      // Out of order, so its phase must not be applied - but its identity
-      // fields still can be, because filling them is first-write-wins and
-      // order-independent. Dropping the whole event would lose the agent and
-      // conversationId that only the earlier event carries, and a query with
-      // no conversationId never joins its conversation at all.
+      // Two independent watermarks. `stale` (the all-events one) guards
+      // metadata order and which query wins the session-status election. A
+      // separate phase watermark, advanced only by terminal events, guards the
+      // phase: a reordered non-terminal event bumps `last_applied_event_sequence`
+      // but not the phase watermark, so the query's own `done` - applied after
+      // it with a lower sequence - is not mistaken for a replay and dropped.
       const stale =
         existingRow !== undefined &&
         sequence !== undefined &&
         sequence <= Number(existingRow.last_applied_event_sequence);
+      const phaseStale =
+        existingRow !== undefined &&
+        sequence !== undefined &&
+        sequence <= Number(existingRow.last_phase_event_sequence);
+      // Only terminal events decide the phase, so only they move its watermark;
+      // GREATEST keeps it from regressing and a 0 from a non-terminal event
+      // leaves it untouched.
+      const terminal = isTerminalPhase(queryPhase);
+      const phaseSequence = terminal ? (sequence ?? 0) : 0;
 
       const now = new Date().toISOString();
       const entry = existingRow
@@ -318,25 +330,32 @@ export class PostgresSessionsStorage implements SessionsStorage {
           );
       if (existingRow) {
         const filled = mergeQueryMetadata(entry, normalizedEventData);
-        if (stale && !filled) return false;
-        // Deliberately leaves lastActivity alone when stale: it elects which
-        // query decides the session's status, and an event we already know is
-        // out of order has no business winning that election.
-        if (!stale) applyQueryPhase(entry, queryPhase, now, errorMsg);
+        // Nothing left to do only when the metadata is stale, adds no field, and
+        // this event decides no phase newer than the last one - a non-terminal
+        // event never decides a phase, so it qualifies whenever it is stale.
+        if (stale && !filled && (!terminal || phaseStale)) return false;
+        if (!stale) {
+          applyQueryPhase(entry, queryPhase, now, errorMsg);
+        } else if (terminal && !phaseStale) {
+          // Metadata-stale but newer than the last phase decision: write the
+          // phase without re-electing this query as the session's latest
+          // activity (a higher-sequence event already holds that election).
+          applyQueryPhase(entry, queryPhase, now, errorMsg, false);
+        }
       }
 
       await sql`
         INSERT INTO session_queries (
           session_id, query_id, namespace, conversation_id, agent,
           team, tool, target_type, phase, error, created_at, completed_at,
-          last_activity, last_applied_event_sequence
+          last_activity, last_applied_event_sequence, last_phase_event_sequence
         ) VALUES (
           ${sessionId}, ${queryName}, ${entry.namespace ?? null},
           ${entry.conversationId ?? null}, ${entry.agent ?? null},
           ${entry.team ?? null}, ${entry.tool ?? null}, ${entry.targetType},
           ${entry.phase}, ${entry.error ?? null}, ${entry.createdAt},
           ${entry.completedAt ?? null}, ${entry.lastActivity},
-          ${sequence ?? 0}
+          ${sequence ?? 0}, ${phaseSequence}
         )
         ON CONFLICT (session_id, query_id) DO UPDATE SET
           namespace = EXCLUDED.namespace,
@@ -354,6 +373,10 @@ export class PostgresSessionsStorage implements SessionsStorage {
           last_applied_event_sequence = GREATEST(
             session_queries.last_applied_event_sequence,
             COALESCE(${sequence ?? null}::bigint, 0)
+          ),
+          last_phase_event_sequence = GREATEST(
+            session_queries.last_phase_event_sequence,
+            ${phaseSequence}::bigint
           )
       `;
 

--- a/services/ark-broker/ark-broker/src/brokers/sessions/session-aggregate.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/session-aggregate.ts
@@ -114,18 +114,33 @@ export function mergeQueryMetadata(
   return filled;
 }
 
+/** A phase that closes the query: only these decide the final phase. */
+export function isTerminalPhase(phase: QueryPhase): boolean {
+  return (
+    phase === QueryPhases.Done ||
+    phase === QueryPhases.Error ||
+    phase === QueryPhases.Canceled
+  );
+}
+
 /**
  * The order-sensitive half. `done` clearing a prior `error` is the one rule that
- * is not monotonic, which is why an out-of-order event must not reach this -
- * an older `done` would erase a newer `error`.
+ * is not monotonic, which is why an out-of-order phase decision must not reach
+ * this - an older `done` would erase a newer `error`.
+ *
+ * `touchActivity` is false when a terminal event is applied out of metadata
+ * order (a reordered non-terminal event already advanced the activity
+ * watermark): its phase is still authoritative, but it must not re-elect this
+ * query as the session's latest activity.
  */
 export function applyQueryPhase(
   existing: QueryEntry,
   phase: QueryPhase,
   now: string,
-  errorMsg?: string
+  errorMsg?: string,
+  touchActivity = true
 ): void {
-  existing.lastActivity = now;
+  if (touchActivity) existing.lastActivity = now;
 
   if (phase === QueryPhases.Error) {
     existing.phase = QueryPhases.Error;

--- a/services/ark-broker/ark-broker/src/db/migrations/000005_query_phase_watermark.down.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000005_query_phase_watermark.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE session_queries
+  DROP COLUMN IF EXISTS last_phase_event_sequence;

--- a/services/ark-broker/ark-broker/src/db/migrations/000005_query_phase_watermark.up.sql
+++ b/services/ark-broker/ark-broker/src/db/migrations/000005_query_phase_watermark.up.sql
@@ -1,0 +1,8 @@
+-- last_applied_event_sequence advances on every event, so a non-terminal
+-- (running) event arriving with a higher sequence than its own
+-- QueryExecutionComplete makes the later-applied terminal event look stale and
+-- its done phase is dropped, leaving the query stuck at running. Track the
+-- sequence of the last phase-DECIDING (terminal) event separately: only a newer
+-- terminal event can suppress a done, a reordered non-terminal event cannot.
+ALTER TABLE session_queries
+  ADD COLUMN IF NOT EXISTS last_phase_event_sequence BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
TL;DR: the Postgres session backend was allowing a "running" phase that arrived after the "done" phase (despite presumably occuring before) to override the "done", and this fixes it.

## Summary
- Fixes #3205: in the Postgres sessions backend, a query's terminal `done` phase was permanently dropped when a non-terminal (`running`) event arrived with a higher event-stream sequence than its own `QueryExecutionComplete`. `last_applied_event_sequence` advances on every event, so the later-applied terminal event looked stale and its phase was never written — leaving the `session_queries` row stuck at `running`. Surfaces as the intermittent `sessions-broker-postgres` e2e failure `expected 2 done session_queries rows, got '1'`.
- Adds `last_phase_event_sequence` (migration `000005`, additive `ADD COLUMN ... DEFAULT 0`), advanced only by terminal events, and gates phase application on it. `last_applied_event_sequence` keeps its existing jobs (metadata-redelivery suppression + status re-election) unchanged.
- Adds `isTerminalPhase` and a `touchActivity` flag to `applyQueryPhase` so a reordered terminal event writes its phase without re-electing the query as the session's latest activity.
- First commit is a deterministic regression test (real Postgres via testcontainer) that reproduces the drop; the fix flips it green. Existing terminal-vs-terminal ordering guards (a late `done` must not erase a real `error`) remain intact.
- Introduced in #3004 (Phase 4 sessions on Postgres); opt-in, rc-only. Also explains the observation in #3177 (that "propagation lag" is, at least in this case, a permanent stale-drop, not lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)