### PR TITLE
chore(fark): remove committed golangci-lint binary from tools/fark/bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 scratch.md
 .ark.env
 .env
-tools/fark/bin/fark
+tools/fark/bin/
 services/a2agw/a2agw
 .artifacts/
 local.mk


### PR DESCRIPTION
## Summary
- Remove `tools/fark/bin/golangci-lint-v1.61.0`, a 45.6 MB prebuilt binary committed in the initial open source preview and unreferenced by any build target or script.
- Broaden `.gitignore` from `tools/fark/bin/fark` to `tools/fark/bin/` so downloaded/built binaries in that dir aren't tracked.
- Clears the two stale Wiz Vulnerability alerts (#3383 / #3384, `go-viper/mapstructure/v2` CVE-2025-11065) that were embedded in the binary and un-fixable by a version bump.

Verified `go vet ./...` is clean and the fark module builds after removal; nothing references the binary (grep across Makefiles, `*.mk`, shell, and workflow YAML).

Closes #3210