### PR TITLE
fix(security): bump nanoid to 3.3.18 in docs to fix CVE-2026-67213

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7174,9 +7174,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Bump `nanoid` 3.3.17 → 3.3.18 in `docs/package-lock.json` (transitive via `next` → `postcss`).
- Fixes Dependabot alert #777 — CVE-2026-67213 / GHSA-2v37-7h3g-55p8 (high): a custom generator called with `size` 0 loops indefinitely (DoS). Patched in 3.3.18.
- 3.3.18 is within postcss's `^3.3.x` range, so this is a lockfile-only change with no `package.json` edit.
- Distinct from CVE-2026-73086 (`XRAY-1051070`), the integer-overflow issue whitelisted as a false positive in #3206 — that reasoning does not cover this advisory, and 3.3.17 is genuinely affected.

Verified `npm ls nanoid` resolves to 3.3.18 and the lockfile is valid JSON.