### PR TITLE
fix(auth): fail closed on a misconfigured OIDC_APPLICATION_ID

### DIFF
--- a/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/ark_sdk/auth/validator.py
@@ -46,6 +46,26 @@ def _parse_audiences(value):
     return parts[0] if len(parts) == 1 else parts
 
 
+def _validate_audience_config(raw):
+    """Fail closed when a configured audience has content but no usable value.
+
+    An unset audience (``None``, empty, or whitespace-only) intentionally
+    leaves ``aud`` verification off. A value with content that still yields no
+    audiences — e.g. ``","`` from templating ``join "," <empty-list>`` — is a
+    misconfiguration that must raise rather than silently disable ``aud``
+    verification (which would accept tokens minted for any audience of the same
+    issuer). ``None`` when raw is unset/whitespace-only, otherwise the value.
+    """
+    if raw is None or raw.strip() == "":
+        return
+    if _parse_audiences(raw) is None:
+        raise TokenValidationError(
+            f"OIDC_APPLICATION_ID is set to {raw!r} but contains no usable "
+            f"audiences. Leave it unset to disable audience verification, or "
+            f"provide one or more comma-separated audiences."
+        )
+
+
 class TokenValidator:
     """Validates JWT tokens using JWKS."""
     
@@ -75,6 +95,7 @@ class TokenValidator:
         """
         issuer = os.getenv("OIDC_ISSUER_URL")
         audience = os.getenv("OIDC_APPLICATION_ID")
+        _validate_audience_config(audience)
         jwks_url = os.getenv("OIDC_JWKS_URL") or None
         if not jwks_url and issuer:
             jwks_url = self._discover_jwks_url(issuer)

--- a/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
+++ b/lib/ark-sdk/gen_sdk/overlay/python/test_overlay/test_validator.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch, Mock, AsyncMock, MagicMock
 import jwt
 from jwt.exceptions import InvalidTokenError as JWTInvalidTokenError, ExpiredSignatureError, InvalidAudienceError
-from ark_sdk.auth.validator import TokenValidator, _parse_audiences
+from ark_sdk.auth.validator import TokenValidator, _parse_audiences, _validate_audience_config
 from ark_sdk.auth.config import AuthConfig
 from ark_sdk.auth.exceptions import (
     TokenValidationError,
@@ -464,6 +464,40 @@ class TestParseAudiences(unittest.TestCase):
     def test_list_input_is_normalized(self):
         self.assertEqual(_parse_audiences(["app-a", " app-b "]), ["app-a", "app-b"])
         self.assertEqual(_parse_audiences(["app-a"]), "app-a")
+
+
+class TestValidateAudienceConfig(unittest.TestCase):
+    """Fail closed on a configured-but-unusable audience (e.g. join over []).
+
+    An all-separator value normalizes to None, which sets verify_aud=False and
+    would silently disable aud verification. Such a value has content but no
+    usable audience, so it must raise rather than fall through to no-check.
+    """
+
+    def test_unset_or_empty_is_allowed(self):
+        # None / empty / whitespace-only = intentionally unset (aud optional).
+        for raw in (None, "", "   ", "\t\n"):
+            _validate_audience_config(raw)  # must not raise
+
+    def test_separators_only_raises(self):
+        for raw in (",", ",,", " , ", " ,, "):
+            with self.assertRaises(TokenValidationError):
+                _validate_audience_config(raw)
+
+    def test_valid_audiences_are_allowed(self):
+        for raw in ("app-a", "app-a,app-b", "app-a,", ",app-a"):
+            _validate_audience_config(raw)  # must not raise
+
+    @patch.dict('os.environ', {'OIDC_APPLICATION_ID': ',,'}, clear=True)
+    def test_create_config_from_env_raises_on_separators_only(self):
+        with self.assertRaises(TokenValidationError):
+            TokenValidator()
+
+    @patch.dict('os.environ', {'OIDC_APPLICATION_ID': ''}, clear=True)
+    def test_create_config_from_env_allows_empty(self):
+        # Empty audience with no issuer: no aud/jwks config, no raise.
+        validator = TokenValidator()
+        self.assertIsNone(validator.config.audience)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Fail closed when `OIDC_APPLICATION_ID` (or `ARK_AUDIENCE`) has content but yields no usable audiences after parsing — e.g. `","` produced by templating `join "," <empty-list>`. Such a value previously normalized to `None`, which set `verify_aud=False` and silently disabled audience verification (accepting tokens minted for any audience of the same issuer).
- Distinguish an intentionally-unset audience (`None` / empty / whitespace-only → aud verification stays optional, unchanged) from a configured-but-unusable one, and raise a clear error at config load in the latter case.
- Add boundary tests: separators-only values raise; unset/empty/whitespace and valid single/multi audiences behave as before.

Follow-up to #3232. Note: the plain empty-string / unset case is unchanged (aud has always been optional when unset); this only closes the "set but all-separators" gap.