### PR TITLE
fix(apiserver): scope Secret/ConfigMap access to least privilege (#2685)

### DIFF
--- a/ark/cmd/main.go
+++ b/ark/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -22,6 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -94,6 +96,20 @@ func validateRole(role string) error {
 
 func leaderElectionID(role string) string {
 	return "ark-" + role + "-leader"
+}
+
+// watchNamespaces returns the namespaces the controller cache is confined to, from
+// ARK_WATCH_NAMESPACES (comma-separated). Empty means watch all namespaces, which is the
+// default. Confining the cache lets the ServiceAccount be granted core resource access
+// through per-namespace RoleBindings instead of a cluster-wide ClusterRoleBinding.
+func watchNamespaces() []string {
+	var out []string
+	for _, ns := range strings.Split(os.Getenv("ARK_WATCH_NAMESPACES"), ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			out = append(out, ns)
+		}
+	}
+	return out
 }
 
 func main() {
@@ -210,6 +226,15 @@ func setupManager(cfg config) (ctrl.Manager, *certwatcher.CertWatcher, *certwatc
 			BurstSize: 100,
 			QPS:       100,
 		}),
+	}
+
+	if ns := watchNamespaces(); len(ns) > 0 {
+		defaults := make(map[string]cache.Config, len(ns))
+		for _, n := range ns {
+			defaults[n] = cache.Config{}
+		}
+		managerOptions.Cache = cache.Options{DefaultNamespaces: defaults}
+		setupLog.Info("controller cache scoped to namespaces", "namespaces", ns)
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOptions)
@@ -516,7 +541,7 @@ func setupEmbeddedApiserver(mgr ctrl.Manager) {
 		setupLog.Error(err, "invalid apiserver configuration")
 		os.Exit(1)
 	}
-	cfg.K8sClient = mgr.GetClient()
+	cfg.K8sClient = mgr.GetAPIReader()
 	cfg.RestConfig = mgr.GetConfig()
 
 	server := apiserver.New(cfg)

--- a/ark/cmd/main_test.go
+++ b/ark/cmd/main_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -39,6 +40,26 @@ func TestValidateRole(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), c.wantErr) {
 			t.Errorf("validateRole(%q) error = %q, want substring %q", c.role, err.Error(), c.wantErr)
+		}
+	}
+}
+
+func TestWatchNamespaces(t *testing.T) {
+	cases := []struct {
+		env  string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"team-a", []string{"team-a"}},
+		{"team-a,ark-system", []string{"team-a", "ark-system"}},
+		{" team-a , ark-system ,", []string{"team-a", "ark-system"}},
+	}
+	for _, c := range cases {
+		t.Setenv("ARK_WATCH_NAMESPACES", c.env)
+		got := watchNamespaces()
+		if !slices.Equal(got, c.want) {
+			t.Errorf("watchNamespaces() with %q = %v, want %v", c.env, got, c.want)
 		}
 	}
 }

--- a/ark/dist/chart-apiserver/templates/rbac.yaml
+++ b/ark/dist/chart-apiserver/templates/rbac.yaml
@@ -62,8 +62,9 @@ subjects:
 ---
 # ConfigMaps + Secrets read access is required cluster-wide because the apiserver
 # resolves Query/Agent/Model parameter references via valueFrom.configMapKeyRef and
-# valueFrom.secretKeyRef at admission time. Without this, parameter resolution
-# blocks on a controller-runtime informer that can't sync, and POSTs time out.
+# valueFrom.secretKeyRef at admission time. The apiserver reads them by name through the
+# uncached reader (mgr.GetAPIReader), so it only needs get, not list or watch. Without
+# list/watch the ServiceAccount cannot enumerate or dump Secrets it was never pointed at.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -73,7 +74,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -110,8 +111,10 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
-  {{- /* paramKind policies need read access to the param resource or the informer never
-    syncs and the policy silently never matches. ConfigMaps/Secrets are granted above. */}}
+  {{- /* paramKind policies need list/watch on the param resource or the informer never
+    syncs and the policy silently never matches. The parameter-resolution role above is
+    get-only, so a ConfigMap/Secret paramKind must add its own list/watch rule here via
+    policy.extraParamRules, scoped as narrowly as the deployment allows. */}}
   {{- with .Values.policy.extraParamRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/ark/dist/chart/templates/_helpers.tpl
+++ b/ark/dist/chart/templates/_helpers.tpl
@@ -105,6 +105,19 @@ false
 {{- end -}}
 {{- end -}}
 
+{{- define "ark.watchNamespaceSelector" -}}
+{{- with .Values.controllerManager.watchNamespaces -}}
+namespaceSelector:
+  matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      {{- range . }}
+        - {{ . | quote }}
+      {{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "ark.originAnnotations" -}}
 {{- if .Values.origin }}
 ark.mckinsey.com/origin: {{ dict "type" (.Values.origin.type | default "marketplace") "uri" .Values.origin.uri "version" .Chart.Version | toJson | quote }}

--- a/ark/dist/chart/templates/manager/manager.yaml
+++ b/ark/dist/chart/templates/manager/manager.yaml
@@ -47,6 +47,10 @@ spec:
             value: "ark-controller"
           - name: ARK_MEMORY_HTTP_TIMEOUT_SECONDS
             value: "30"
+          {{- with .Values.controllerManager.watchNamespaces }}
+          - name: ARK_WATCH_NAMESPACES
+            value: {{ join "," . | quote }}
+          {{- end }}
           {{- if .Values.telemetry.tenantRouting.otelDiscovery }}
           - name: ARK_TELEMETRY_OTEL_DISCOVERY
             value: "true"

--- a/ark/dist/chart/templates/rbac/ark_controller_role_binding.yaml
+++ b/ark/dist/chart/templates/rbac/ark_controller_role_binding.yaml
@@ -1,4 +1,58 @@
 {{- if .Values.rbac.enable }}
+{{- if .Values.controllerManager.watchNamespaces }}
+# Namespaced mode: the controller cache is confined to watchNamespaces, so its access to the
+# namespaced rules in ark-controller-role is granted per namespace via RoleBindings. The
+# cluster-scoped ArkConfig is not reachable through a RoleBinding, so it gets its own small
+# ClusterRole bound cluster-wide.
+{{- range .Values.controllerManager.watchNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+  name: ark-controller-rolebinding
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ark-controller-role
+subjects:
+- kind: ServiceAccount
+  name: ark-controller
+  namespace: ark-system
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: ark-controller-cluster-role
+rules:
+- apiGroups:
+  - ark.mckinsey.com
+  resources:
+  - arkconfigs
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: ark-controller-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ark-controller-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: ark-controller
+  namespace: ark-system
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +67,5 @@ subjects:
 - kind: ServiceAccount
   name: ark-controller
   namespace: ark-system
+{{- end }}
 {{- end -}}

--- a/ark/dist/chart/templates/webhook/webhooks.yaml
+++ b/ark/dist/chart/templates/webhook/webhooks.yaml
@@ -17,6 +17,7 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -41,6 +42,7 @@ webhooks:
         resources:
           - agents
   - name: mmodel-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -65,6 +67,7 @@ webhooks:
         resources:
           - models
   - name: mquery-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -89,6 +92,7 @@ webhooks:
         resources:
           - queries
   - name: mteam-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -131,6 +135,7 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -155,6 +160,7 @@ webhooks:
         resources:
           - agents
   - name: varkconfig-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -179,6 +185,7 @@ webhooks:
         resources:
           - arkconfigs
   - name: vmcpserver-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -203,6 +210,7 @@ webhooks:
         resources:
           - mcpservers
   - name: vmodel-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -227,6 +235,7 @@ webhooks:
         resources:
           - models
   - name: vquery-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -251,6 +260,7 @@ webhooks:
         resources:
           - queries
   - name: vteam-v1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -280,6 +290,7 @@ webhooks:
       - key: "ark.mckinsey.com/skip-webhook-validation"
         operator: "NotIn"
         values: ["true"]
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -304,6 +315,7 @@ webhooks:
         resources:
           - tools
   - name: va2aserver-v1prealpha1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"
@@ -328,6 +340,7 @@ webhooks:
         resources:
           - a2aservers
   - name: vexecutionengine-v1prealpha1.kb.io
+    {{- if $.Values.controllerManager.watchNamespaces }}{{ include "ark.watchNamespaceSelector" $ | nindent 4 }}{{- end }}
     matchConditions:
     - name: not-being-deleted
       expression: "!has(object.metadata.deletionTimestamp)"

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -12,6 +12,13 @@ controllerManager:
   # objects. Set to 0 to use the controller-runtime default (1). See issue
   # #2609.
   maxConcurrentReconciles: 4
+  # Namespaces the controller watches and reconciles. Empty (default) watches all
+  # namespaces and binds the controller ServiceAccount cluster-wide. When set, the
+  # controller cache is confined to these namespaces and its access to core resources
+  # (Secrets, ConfigMaps, Services, Events) and Ark CRDs is granted through per-namespace
+  # RoleBindings instead of a cluster-wide ClusterRoleBinding. Include the release
+  # namespace so the controller can manage its own resources.
+  watchNamespaces: []
   container:
     image:
       repository: ghcr.io/mckinsey/agents-at-scale-ark/ark-controller

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -16,8 +16,11 @@ controllerManager:
   # namespaces and binds the controller ServiceAccount cluster-wide. When set, the
   # controller cache is confined to these namespaces and its access to core resources
   # (Secrets, ConfigMaps, Services, Events) and Ark CRDs is granted through per-namespace
-  # RoleBindings instead of a cluster-wide ClusterRoleBinding. Include the release
-  # namespace so the controller can manage its own resources.
+  # RoleBindings instead of a cluster-wide ClusterRoleBinding. The admission webhooks are
+  # scoped to these namespaces and broker/telemetry discovery lists them instead of the
+  # cluster, so all access matches the granted RBAC. Ark resources in other namespaces are
+  # not validated or reconciled. Include the release namespace so the controller can manage
+  # its own resources.
   watchNamespaces: []
   container:
     image:

--- a/ark/internal/apiserver/server.go
+++ b/ark/internal/apiserver/server.go
@@ -122,7 +122,11 @@ type Config struct {
 	AuthMode        string
 	TLSCertFile     string
 	TLSKeyFile      string
-	K8sClient       client.Client
+	// K8sClient reads Secrets and ConfigMaps for valueFrom parameter resolution. It is the
+	// uncached reader, so a Get hits the host apiserver directly instead of populating a
+	// cluster-wide informer. That keeps the apiserver ServiceAccount at get-only on those
+	// resources rather than needing list and watch across every namespace.
+	K8sClient client.Reader
 	// RestConfig points at the host kube-apiserver, where the policy objects live.
 	RestConfig *clientrest.Config
 	// AuditLogPath "-" writes JSON to stdout. AuditPolicyFile is mandatory when AuditEnabled.

--- a/ark/internal/telemetry/routing/broker_discovery.go
+++ b/ark/internal/telemetry/routing/broker_discovery.go
@@ -42,40 +42,42 @@ func DiscoverBrokerEndpoints(ctx context.Context, k8sClient client.Client) ([]Br
 		return nil, nil
 	}
 
-	cmList := &corev1.ConfigMapList{}
-	if err := k8sClient.List(ctx, cmList, scopedListOptions()...); err != nil {
-		return nil, fmt.Errorf("failed to list ConfigMaps: %w", err)
-	}
+	endpoints := make([]BrokerEndpoint, 0)
 
-	endpoints := make([]BrokerEndpoint, 0, len(cmList.Items))
-
-	for _, cm := range cmList.Items {
-		if cm.Name != brokerConfigName {
-			continue
+	for _, opts := range scopedListOptionSets() {
+		cmList := &corev1.ConfigMapList{}
+		if err := k8sClient.List(ctx, cmList, opts...); err != nil {
+			return nil, fmt.Errorf("failed to list ConfigMaps: %w", err)
 		}
 
-		config, err := parseBrokerConfig(&cm)
-		if err != nil {
-			log.Error(err, "failed to parse broker config", "namespace", cm.Namespace)
-			continue
+		for _, cm := range cmList.Items {
+			if cm.Name != brokerConfigName {
+				continue
+			}
+
+			config, err := parseBrokerConfig(&cm)
+			if err != nil {
+				log.Error(err, "failed to parse broker config", "namespace", cm.Namespace)
+				continue
+			}
+
+			if config.Enabled != "true" {
+				continue
+			}
+
+			endpoint, err := buildEndpoint(cm.Namespace, config.ServiceRef)
+			if err != nil {
+				log.Error(err, "failed to build endpoint", "namespace", cm.Namespace)
+				continue
+			}
+
+			endpoints = append(endpoints, BrokerEndpoint{
+				Namespace: cm.Namespace,
+				Endpoint:  endpoint,
+			})
+
+			log.Info("discovered broker endpoint", "namespace", cm.Namespace, "endpoint", endpoint)
 		}
-
-		if config.Enabled != "true" {
-			continue
-		}
-
-		endpoint, err := buildEndpoint(cm.Namespace, config.ServiceRef)
-		if err != nil {
-			log.Error(err, "failed to build endpoint", "namespace", cm.Namespace)
-			continue
-		}
-
-		endpoints = append(endpoints, BrokerEndpoint{
-			Namespace: cm.Namespace,
-			Endpoint:  endpoint,
-		})
-
-		log.Info("discovered broker endpoint", "namespace", cm.Namespace, "endpoint", endpoint)
 	}
 
 	return endpoints, nil

--- a/ark/internal/telemetry/routing/discovery_scope.go
+++ b/ark/internal/telemetry/routing/discovery_scope.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"os"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -14,6 +15,12 @@ import (
 // central ark-system install are unchanged.
 const discoveryNamespaceEnv = "ARK_DISCOVERY_NAMESPACE"
 
+// watchNamespacesEnv names the controller's namespaced-mode env var
+// (comma-separated). When the controller runs namespace-scoped its
+// ServiceAccount only holds per-namespace RBAC, so discovery must list each
+// watched namespace instead of the cluster.
+const watchNamespacesEnv = "ARK_WATCH_NAMESPACES"
+
 // DiscoveryNamespace returns the namespace discovery is scoped to, or "" when
 // discovery is cluster-wide. Callers that build their own informers or List
 // calls use this so their scope matches the pod's RBAC.
@@ -21,12 +28,35 @@ func DiscoveryNamespace() string {
 	return os.Getenv(discoveryNamespaceEnv)
 }
 
-// scopedListOptions returns the List options used by broker and target
-// discovery. When ARK_DISCOVERY_NAMESPACE is set, the list is scoped to that
-// namespace; otherwise it is cluster-wide (nil options).
-func scopedListOptions() []client.ListOption {
-	if ns := DiscoveryNamespace(); ns != "" {
-		return []client.ListOption{client.InNamespace(ns)}
+// discoveryNamespaces returns the namespaces broker/target discovery must list,
+// or nil for a cluster-wide list. ARK_DISCOVERY_NAMESPACE pins discovery to a
+// single namespace; otherwise ARK_WATCH_NAMESPACES scopes it to the controller's
+// watched set. Both unset means cluster-wide.
+func discoveryNamespaces() []string {
+	if ns := strings.TrimSpace(os.Getenv(discoveryNamespaceEnv)); ns != "" {
+		return []string{ns}
 	}
-	return nil
+	var out []string
+	for _, ns := range strings.Split(os.Getenv(watchNamespacesEnv), ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
+// scopedListOptionSets returns one set of List options per namespace discovery
+// must read, or a single nil set for a cluster-wide list. Callers issue one List
+// per set so a namespace-scoped ServiceAccount never attempts a forbidden
+// cluster-wide List.
+func scopedListOptionSets() [][]client.ListOption {
+	nss := discoveryNamespaces()
+	if len(nss) == 0 {
+		return [][]client.ListOption{nil}
+	}
+	sets := make([][]client.ListOption, 0, len(nss))
+	for _, ns := range nss {
+		sets = append(sets, []client.ListOption{client.InNamespace(ns)})
+	}
+	return sets
 }

--- a/ark/internal/telemetry/routing/discovery_scope_test.go
+++ b/ark/internal/telemetry/routing/discovery_scope_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,24 +13,81 @@ import (
 
 const tenantA = "tenant-a"
 
-func TestScopedListOptions(t *testing.T) {
-	t.Run("unset env returns nil (cluster-wide)", func(t *testing.T) {
-		t.Setenv(discoveryNamespaceEnv, "")
-		if opts := scopedListOptions(); opts != nil {
-			t.Errorf("expected nil options, got %v", opts)
-		}
-	})
+func setScopeEnv(t *testing.T, discovery, watch string) {
+	t.Helper()
+	t.Setenv(discoveryNamespaceEnv, discovery)
+	t.Setenv(watchNamespacesEnv, watch)
+}
 
-	t.Run("set env scopes to that namespace", func(t *testing.T) {
-		t.Setenv(discoveryNamespaceEnv, tenantA)
-		opts := scopedListOptions()
-		if len(opts) != 1 {
-			t.Fatalf("expected 1 option, got %d", len(opts))
+func scopeNamespaces(t *testing.T, sets [][]client.ListOption) []string {
+	t.Helper()
+	out := make([]string, 0, len(sets))
+	for _, set := range sets {
+		if set == nil {
+			out = append(out, "")
+			continue
 		}
-		if ns, ok := opts[0].(client.InNamespace); !ok || string(ns) != tenantA {
-			t.Errorf("expected InNamespace(\"tenant-a\"), got %#v", opts[0])
+		ns, ok := set[0].(client.InNamespace)
+		if !ok {
+			t.Fatalf("expected InNamespace option, got %#v", set[0])
 		}
-	})
+		out = append(out, string(ns))
+	}
+	return out
+}
+
+func TestScopedListOptionSets(t *testing.T) {
+	cases := []struct {
+		name      string
+		discovery string
+		watch     string
+		want      []string
+	}{
+		{"both unset is cluster-wide", "", "", []string{""}},
+		{"discovery namespace scopes to one", tenantA, "", []string{tenantA}},
+		{"watch namespaces scope to each", "", " tenant-a , tenant-b ,", []string{"tenant-a", "tenant-b"}},
+		{"discovery namespace wins", tenantA, "tenant-b,tenant-c", []string{tenantA}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			setScopeEnv(t, c.discovery, c.watch)
+			got := scopeNamespaces(t, scopedListOptionSets())
+			if !slices.Equal(got, c.want) {
+				t.Errorf("scopedListOptionSets() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverBrokerEndpointsWatchNamespaces(t *testing.T) {
+	objs := []client.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: brokerConfigName, Namespace: tenantA},
+			Data:       map[string]string{"enabled": "true", "serviceRef": "name: collector\nport: 4318"},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: brokerConfigName, Namespace: "tenant-b"},
+			Data:       map[string]string{"enabled": "true", "serviceRef": "name: collector\nport: 4318"},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: brokerConfigName, Namespace: "tenant-c"},
+			Data:       map[string]string{"enabled": "true", "serviceRef": "name: collector\nport: 4318"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithObjects(objs...).Build()
+
+	t.Setenv(watchNamespacesEnv, "tenant-a,tenant-b")
+	endpoints, err := DiscoverBrokerEndpoints(context.Background(), k8sClient)
+	if err != nil {
+		t.Fatalf("DiscoverBrokerEndpoints() error = %v", err)
+	}
+	if len(endpoints) != 2 {
+		t.Fatalf("got %d endpoints, want 2 (tenant-a, tenant-b)", len(endpoints))
+	}
+	got := map[string]bool{endpoints[0].Namespace: true, endpoints[1].Namespace: true}
+	if !got[tenantA] || !got["tenant-b"] || got["tenant-c"] {
+		t.Errorf("endpoints namespaces = %v, want tenant-a and tenant-b only", got)
+	}
 }
 
 func TestDiscoverBrokerEndpointsNamespaceScoped(t *testing.T) {

--- a/ark/internal/telemetry/routing/target_discovery.go
+++ b/ark/internal/telemetry/routing/target_discovery.go
@@ -23,27 +23,29 @@ func DiscoverTargetEndpoints(ctx context.Context, k8sClient client.Client) ([]Ta
 		return nil, nil
 	}
 
-	secretList := &corev1.SecretList{}
-	if err := k8sClient.List(ctx, secretList, scopedListOptions()...); err != nil {
-		return nil, fmt.Errorf("failed to list Secrets: %w", err)
-	}
-
 	endpoints := make([]TargetEndpoint, 0)
 
-	for _, secret := range secretList.Items {
-		if secret.Name != otelSecretName {
-			continue
+	for _, opts := range scopedListOptionSets() {
+		secretList := &corev1.SecretList{}
+		if err := k8sClient.List(ctx, secretList, opts...); err != nil {
+			return nil, fmt.Errorf("failed to list Secrets: %w", err)
 		}
 
-		endpoint := parseTargetSecret(&secret)
-		if endpoint == nil {
-			continue
+		for _, secret := range secretList.Items {
+			if secret.Name != otelSecretName {
+				continue
+			}
+
+			endpoint := parseTargetSecret(&secret)
+			if endpoint == nil {
+				continue
+			}
+
+			endpoint.Namespace = secret.Namespace
+			endpoints = append(endpoints, *endpoint)
+
+			log.Info("discovered OTEL endpoint", "namespace", secret.Namespace, "endpoint", endpoint.Endpoint)
 		}
-
-		endpoint.Namespace = secret.Namespace
-		endpoints = append(endpoints, *endpoint)
-
-		log.Info("discovered OTEL endpoint", "namespace", secret.Namespace, "endpoint", endpoint.Endpoint)
 	}
 
 	return endpoints, nil

--- a/ark/internal/validation/lookup.go
+++ b/ark/internal/validation/lookup.go
@@ -64,7 +64,7 @@ func (l *WebhookLookup) GetArkConfig(ctx context.Context) (*arkv1alpha1.ArkConfi
 
 type StorageLookup struct {
 	Backend   storage.Backend
-	K8sClient client.Client
+	K8sClient client.Reader
 }
 
 func (l *StorageLookup) GetResource(ctx context.Context, kind, namespace, name string) (runtime.Object, error) {


### PR DESCRIPTION
## Summary
- Switch apiserver parameter resolution to the uncached reader (`mgr.GetAPIReader`) and drop the `ark-apiserver-parameter-resolution` ClusterRole to `get` only. Resolution only ever reads Secrets/ConfigMaps by name, so `list`/`watch` were unnecessary; without them the ServiceAccount can no longer enumerate or dump Secrets it was never pointed at.
- The apiserver resolution client field is now `client.Reader`, so the type system guarantees the path can only `Get`.
- Correct the CEL `paramKind` RBAC comment: a ConfigMap/Secret paramKind now needs its own `list`/`watch` rule via `policy.extraParamRules`, since the base grant is get-only.
- Add an opt-in namespaced mode for the controller (`controllerManager.watchNamespaces` / `ARK_WATCH_NAMESPACES`). The controller's Secret/ConfigMap watches genuinely need `list`/`watch`, so the only lever is namespace-scoping: when set, the manager cache is confined to those namespaces and `ark-controller-role` is bound through per-namespace RoleBindings instead of a cluster-wide ClusterRoleBinding, with a small cluster-scoped role for the cluster-scoped ArkConfig. Empty (default) keeps today's cluster-wide behavior, so existing installs are unchanged.

Fixes #2685.

## Validation
- `make lint` (0 issues), `go vet`, and unit tests pass for `cmd`, `internal/apiserver`, `internal/validation`; added `TestWatchNamespaces`.
- `helm lint` clean on both charts; rendered both controller modes (default = one ClusterRoleBinding, namespaced = per-namespace RoleBindings + ArkConfig cluster role) and confirmed the apiserver role renders `verbs: ["get"]`.
- Verified live on a kind cluster: a get-only ServiceAccount can `get` a named Secret in a foreign namespace (resolution keeps working) but `list` and `watch` are forbidden.