### PR TITLE
fix(ark-broker): cascade Query deletion to the sessions read model

### DIFF
--- a/ark/internal/common/transport.go
+++ b/ark/internal/common/transport.go
@@ -17,6 +17,7 @@ import (
 const (
 	QueryMessagesEndpointFmt = "/queries/%s/messages"
 	QueryEventsEndpointFmt   = "/events/%s"
+	QuerySessionsEndpointFmt = "/sessions/queries/%s"
 )
 
 // LoggingTransport wraps an http.RoundTripper to provide optional HTTP request/response logging.

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -1299,12 +1299,13 @@ func (r *QueryReconciler) resolveBrokerEndpoint(ctx context.Context, namespace s
 	return routing.ResolveBrokerEndpoint(ctx, r.Client, namespace)
 }
 
-// deleteBrokerEvents removes the broker's operation events for query. Unlike
-// deleteBrokerMessages, this does not go through the Memory contract: events
-// are emitted directly to the broker endpoint discovered via the
-// ark-config-broker ConfigMap (see internal/eventing/broker), keyed by the
-// Query's UID rather than its name (see operation_tracker.go).
-func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1alpha1.Query) error {
+// deleteBrokerQueryResource removes one query-scoped resource from the broker
+// serving query's namespace. Unlike deleteBrokerMessages this does not go
+// through the Memory contract: events and sessions are broker concerns, reached
+// at the endpoint discovered via the ark-config-broker ConfigMap (see
+// internal/eventing/broker). key is what the broker files the resource under,
+// and it is the one thing that differs between the callers.
+func (r *QueryReconciler) deleteBrokerQueryResource(ctx context.Context, query *arkv1alpha1.Query, pathFmt, resource, key string) error {
 	log := logf.FromContext(ctx)
 
 	endpoint, err := r.resolveBrokerEndpoint(ctx, query.Namespace)
@@ -1312,34 +1313,27 @@ func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1al
 		return fmt.Errorf("failed to resolve broker endpoint: %w", err)
 	}
 	if endpoint == "" {
-		log.Info("no broker configured for namespace, skipping broker event cleanup", "namespace", query.Namespace, "query", query.Name)
+		log.Info("no broker configured for namespace, skipping broker cleanup", "namespace", query.Namespace, "resource", resource, "query", query.Name)
 		return nil
 	}
 
-	path := fmt.Sprintf(common.QueryEventsEndpointFmt, url.PathEscape(string(query.UID)))
-	return deleteBrokerResource(ctx, endpoint, path, "events", query.Name)
+	path := fmt.Sprintf(pathFmt, url.PathEscape(key))
+	return deleteBrokerResource(ctx, endpoint, path, resource, query.Name)
+}
+
+// deleteBrokerEvents removes the broker's operation events for query, keyed by
+// the Query UID rather than its name (see operation_tracker.go).
+func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1alpha1.Query) error {
+	return r.deleteBrokerQueryResource(ctx, query, common.QueryEventsEndpointFmt, "events", string(query.UID))
 }
 
 // deleteBrokerSessionQuery removes query's row from the broker's sessions read
-// model. Like deleteBrokerEvents this talks to the broker endpoint rather than
-// the Memory contract, since sessions are not part of that contract - but the
-// key is the Query NAME, not the UID. session_queries.query_id is written from
-// the event's queryName field, and the sessions payload carries no UID at all,
-// so keying this on query.UID would match no rows and still get a 200 back.
+// model, keyed by the Query NAME and not the UID: session_queries.query_id is
+// written from the event's queryName field, and the sessions payload carries no
+// UID at all, so keying this on query.UID would match no rows and still get a
+// 200 back - the cleanup would silently do nothing.
 func (r *QueryReconciler) deleteBrokerSessionQuery(ctx context.Context, query *arkv1alpha1.Query) error {
-	log := logf.FromContext(ctx)
-
-	endpoint, err := r.resolveBrokerEndpoint(ctx, query.Namespace)
-	if err != nil {
-		return fmt.Errorf("failed to resolve broker endpoint: %w", err)
-	}
-	if endpoint == "" {
-		log.Info("no broker configured for namespace, skipping broker session cleanup", "namespace", query.Namespace, "query", query.Name)
-		return nil
-	}
-
-	path := fmt.Sprintf(common.QuerySessionsEndpointFmt, url.PathEscape(query.Name))
-	return deleteBrokerResource(ctx, endpoint, path, "session query", query.Name)
+	return r.deleteBrokerQueryResource(ctx, query, common.QuerySessionsEndpointFmt, "session query", query.Name)
 }
 
 func (r *QueryReconciler) getClientForQuery(query arkv1alpha1.Query) (client.Client, error) {

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -119,10 +119,10 @@ type QueryReconciler struct {
 	sem        *semaphore.Weighted
 	operations sync.Map
 
-	// brokerEventsEndpoint resolves the broker endpoint for a namespace, used
-	// by deleteBrokerEvents. Defaults to routing.ResolveBrokerEndpoint when
-	// nil; tests override it to avoid depending on real cluster DNS.
-	brokerEventsEndpoint func(ctx context.Context, namespace string) (string, error)
+	// brokerEndpoint resolves the broker endpoint for a namespace, used by the
+	// finalizer's broker cleanups. Defaults to routing.ResolveBrokerEndpoint
+	// when nil; tests override it to avoid depending on real cluster DNS.
+	brokerEndpoint func(ctx context.Context, namespace string) (string, error)
 }
 
 // +kubebuilder:rbac:groups=ark.mckinsey.com,resources=queries,verbs=get;list;watch;create;update;patch;delete
@@ -1286,11 +1286,11 @@ func deleteBrokerResource(ctx context.Context, baseURL, path, resource, queryNam
 	return nil
 }
 
-// resolveBrokerEventsEndpoint resolves the broker endpoint for namespace,
-// returning "" when no broker is configured there.
-func (r *QueryReconciler) resolveBrokerEventsEndpoint(ctx context.Context, namespace string) (string, error) {
-	if r.brokerEventsEndpoint != nil {
-		return r.brokerEventsEndpoint(ctx, namespace)
+// resolveBrokerEndpoint resolves the broker endpoint for namespace, returning
+// "" when no broker is configured there.
+func (r *QueryReconciler) resolveBrokerEndpoint(ctx context.Context, namespace string) (string, error) {
+	if r.brokerEndpoint != nil {
+		return r.brokerEndpoint(ctx, namespace)
 	}
 	return routing.ResolveBrokerEndpoint(ctx, r.Client, namespace)
 }
@@ -1303,7 +1303,7 @@ func (r *QueryReconciler) resolveBrokerEventsEndpoint(ctx context.Context, names
 func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1alpha1.Query) error {
 	log := logf.FromContext(ctx)
 
-	endpoint, err := r.resolveBrokerEventsEndpoint(ctx, query.Namespace)
+	endpoint, err := r.resolveBrokerEndpoint(ctx, query.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to resolve broker endpoint: %w", err)
 	}

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -1208,7 +1208,11 @@ func (r *QueryReconciler) finalize(ctx context.Context, query *arkv1alpha1.Query
 		log.Info("cancelled running operation for query", "name", query.Name, "namespace", query.Namespace)
 	}
 
-	return stderrors.Join(r.deleteBrokerMessages(ctx, query), r.deleteBrokerEvents(ctx, query))
+	return stderrors.Join(
+		r.deleteBrokerMessages(ctx, query),
+		r.deleteBrokerEvents(ctx, query),
+		r.deleteBrokerSessionQuery(ctx, query),
+	)
 }
 
 func (r *QueryReconciler) deleteBrokerMessages(ctx context.Context, query *arkv1alpha1.Query) error {
@@ -1314,6 +1318,28 @@ func (r *QueryReconciler) deleteBrokerEvents(ctx context.Context, query *arkv1al
 
 	path := fmt.Sprintf(common.QueryEventsEndpointFmt, url.PathEscape(string(query.UID)))
 	return deleteBrokerResource(ctx, endpoint, path, "events", query.Name)
+}
+
+// deleteBrokerSessionQuery removes query's row from the broker's sessions read
+// model. Like deleteBrokerEvents this talks to the broker endpoint rather than
+// the Memory contract, since sessions are not part of that contract - but the
+// key is the Query NAME, not the UID. session_queries.query_id is written from
+// the event's queryName field, and the sessions payload carries no UID at all,
+// so keying this on query.UID would match no rows and still get a 200 back.
+func (r *QueryReconciler) deleteBrokerSessionQuery(ctx context.Context, query *arkv1alpha1.Query) error {
+	log := logf.FromContext(ctx)
+
+	endpoint, err := r.resolveBrokerEndpoint(ctx, query.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to resolve broker endpoint: %w", err)
+	}
+	if endpoint == "" {
+		log.Info("no broker configured for namespace, skipping broker session cleanup", "namespace", query.Namespace, "query", query.Name)
+		return nil
+	}
+
+	path := fmt.Sprintf(common.QuerySessionsEndpointFmt, url.PathEscape(query.Name))
+	return deleteBrokerResource(ctx, endpoint, path, "session query", query.Name)
 }
 
 func (r *QueryReconciler) getClientForQuery(query arkv1alpha1.Query) (client.Client, error) {

--- a/ark/internal/controller/query_delete_broker_test.go
+++ b/ark/internal/controller/query_delete_broker_test.go
@@ -251,7 +251,7 @@ func TestDeleteBrokerEvents_EndpointResolved(t *testing.T) {
 	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
 
 	r := &QueryReconciler{
-		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
 			return srv.URL, nil
 		},
 	}
@@ -274,7 +274,7 @@ func TestDeleteBrokerEvents_NoBrokerConfigured(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	r := &QueryReconciler{
-		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
 			return "", nil
 		},
 	}
@@ -291,7 +291,7 @@ func TestDeleteBrokerEvents_Broker500ReturnsError(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
 
 	r := &QueryReconciler{
-		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
 			return srv.URL, nil
 		},
 	}
@@ -308,7 +308,7 @@ func TestDeleteBrokerEvents_Broker404IsSkipped(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
 
 	r := &QueryReconciler{
-		brokerEventsEndpoint: func(_ context.Context, _ string) (string, error) {
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
 			return srv.URL, nil
 		},
 	}
@@ -320,14 +320,14 @@ func TestDeleteBrokerEvents_Broker404IsSkipped(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestResolveBrokerEventsEndpoint_DefaultUsesRoutingDiscovery(t *testing.T) {
+func TestResolveBrokerEndpoint_DefaultUsesRoutingDiscovery(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	r := &QueryReconciler{Client: fc}
 
-	endpoint, err := r.resolveBrokerEventsEndpoint(context.Background(), "default")
+	endpoint, err := r.resolveBrokerEndpoint(context.Background(), "default")
 	require.NoError(t, err)
 	assert.Empty(t, endpoint, "no ark-config-broker ConfigMap exists, so no endpoint should resolve")
 }

--- a/ark/internal/controller/query_delete_broker_test.go
+++ b/ark/internal/controller/query_delete_broker_test.go
@@ -320,6 +320,122 @@ func TestDeleteBrokerEvents_Broker404IsSkipped(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeleteBrokerSessionQuery_KeyedOnQueryName(t *testing.T) {
+	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
+
+	r := &QueryReconciler{
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.deleteBrokerSessionQuery(context.Background(), query)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, *capturedMethod)
+	// The name, not the UID: session_queries.query_id holds the Query name, so
+	// the UID would match no rows and the broker would still answer 200.
+	assert.Equal(t, "/sessions/queries/my-query", *capturedPath)
+}
+
+func TestDeleteBrokerSessionQuery_NoBrokerConfigured(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := &QueryReconciler{
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
+			return "", nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+	}
+
+	err := r.deleteBrokerSessionQuery(context.Background(), query)
+	require.NoError(t, err)
+	assert.False(t, called, "should not call broker when no broker is configured for the namespace")
+}
+
+func TestDeleteBrokerSessionQuery_Broker500ReturnsError(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
+
+	r := &QueryReconciler{
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+	}
+
+	err := r.deleteBrokerSessionQuery(context.Background(), query)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestDeleteBrokerSessionQuery_Broker404IsSkipped(t *testing.T) {
+	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
+
+	r := &QueryReconciler{
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
+			return srv.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
+	}
+
+	err := r.deleteBrokerSessionQuery(context.Background(), query)
+	require.NoError(t, err)
+}
+
+// A failing cleanup must not stop the others: finalize joins all three so one
+// broker being unreachable cannot leave the other two leftovers behind.
+func TestFinalize_RunsEverySessionCleanupDespiteAFailure(t *testing.T) {
+	brokerPaths := make(chan string, 4)
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokerPaths <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(broker.Close)
+
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(failing.Close)
+
+	memory := memoryWithAddress("default", failing.URL)
+	scheme := runtime.NewScheme()
+	_ = arkv1alpha1.AddToScheme(scheme)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(memory).Build()
+
+	r := &QueryReconciler{
+		Client: fc,
+		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
+			return broker.URL, nil
+		},
+	}
+	query := &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+
+	err := r.finalize(context.Background(), query)
+	require.Error(t, err, "the failing memory cleanup should surface")
+
+	close(brokerPaths)
+	paths := make([]string, 0, len(brokerPaths))
+	for p := range brokerPaths {
+		paths = append(paths, p)
+	}
+	assert.ElementsMatch(t, []string{"/events/query-uid-123", "/sessions/queries/my-query"}, paths)
+}
+
 func TestResolveBrokerEndpoint_DefaultUsesRoutingDiscovery(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/ark/internal/controller/query_delete_broker_test.go
+++ b/ark/internal/controller/query_delete_broker_test.go
@@ -44,6 +44,31 @@ func makeBrokerServer(t *testing.T, status int) (*httptest.Server, *string, *str
 	return srv, &capturedMethod, &capturedPath
 }
 
+// brokerAt builds the endpoint resolver the finalizer's broker cleanups use, so
+// a test states which broker answers and nothing else.
+func brokerAt(url string) func(context.Context, string) (string, error) {
+	return func(context.Context, string) (string, error) { return url, nil }
+}
+
+// recordingBrokerServer answers 200 and reports whether it was called at all,
+// which is the assertion for "no broker configured means no request".
+func recordingBrokerServer(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return &called
+}
+
+func testQuery() *arkv1alpha1.Query {
+	return &arkv1alpha1.Query{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
+	}
+}
+
 func TestDeleteBrokerMessages_ExplicitMemory(t *testing.T) {
 	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
 
@@ -89,12 +114,7 @@ func TestDeleteBrokerMessages_DefaultMemoryFallback(t *testing.T) {
 }
 
 func TestDeleteBrokerMessages_NoMemory(t *testing.T) {
-	called := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
+	called := recordingBrokerServer(t)
 
 	fc := fake.NewClientBuilder().
 		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
@@ -108,16 +128,11 @@ func TestDeleteBrokerMessages_NoMemory(t *testing.T) {
 
 	err := r.deleteBrokerMessages(context.Background(), query)
 	require.NoError(t, err)
-	assert.False(t, called, "should not call broker when no memory exists")
+	assert.False(t, *called, "should not call broker when no memory exists")
 }
 
 func TestDeleteBrokerMessages_MemoryNotFound(t *testing.T) {
-	called := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
+	called := recordingBrokerServer(t)
 
 	fc := fake.NewClientBuilder().
 		WithScheme(func() *runtime.Scheme { s := runtime.NewScheme(); _ = arkv1alpha1.AddToScheme(s); return s }()).
@@ -133,7 +148,7 @@ func TestDeleteBrokerMessages_MemoryNotFound(t *testing.T) {
 
 	err := r.deleteBrokerMessages(context.Background(), query)
 	require.NoError(t, err)
-	assert.False(t, called, "should not call broker when referenced memory is not found")
+	assert.False(t, *called, "should not call broker when referenced memory is not found")
 }
 
 func TestDeleteBrokerMessages_Broker500ReturnsError(t *testing.T) {
@@ -251,13 +266,9 @@ func TestDeleteBrokerEvents_EndpointResolved(t *testing.T) {
 	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerEvents(context.Background(), query)
 	require.NoError(t, err)
@@ -266,38 +277,25 @@ func TestDeleteBrokerEvents_EndpointResolved(t *testing.T) {
 }
 
 func TestDeleteBrokerEvents_NoBrokerConfigured(t *testing.T) {
-	called := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
+	called := recordingBrokerServer(t)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return "", nil
-		},
+		brokerEndpoint: brokerAt(""),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerEvents(context.Background(), query)
 	require.NoError(t, err)
-	assert.False(t, called, "should not call broker when no broker is configured for the namespace")
+	assert.False(t, *called, "should not call broker when no broker is configured for the namespace")
 }
 
 func TestDeleteBrokerEvents_Broker500ReturnsError(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerEvents(context.Background(), query)
 	require.Error(t, err)
@@ -308,13 +306,9 @@ func TestDeleteBrokerEvents_Broker404IsSkipped(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerEvents(context.Background(), query)
 	require.NoError(t, err)
@@ -324,13 +318,9 @@ func TestDeleteBrokerSessionQuery_KeyedOnQueryName(t *testing.T) {
 	srv, capturedMethod, capturedPath := makeBrokerServer(t, http.StatusOK)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerSessionQuery(context.Background(), query)
 	require.NoError(t, err)
@@ -341,38 +331,25 @@ func TestDeleteBrokerSessionQuery_KeyedOnQueryName(t *testing.T) {
 }
 
 func TestDeleteBrokerSessionQuery_NoBrokerConfigured(t *testing.T) {
-	called := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
+	called := recordingBrokerServer(t)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return "", nil
-		},
+		brokerEndpoint: brokerAt(""),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerSessionQuery(context.Background(), query)
 	require.NoError(t, err)
-	assert.False(t, called, "should not call broker when no broker is configured for the namespace")
+	assert.False(t, *called, "should not call broker when no broker is configured for the namespace")
 }
 
 func TestDeleteBrokerSessionQuery_Broker500ReturnsError(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusInternalServerError)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerSessionQuery(context.Background(), query)
 	require.Error(t, err)
@@ -383,13 +360,9 @@ func TestDeleteBrokerSessionQuery_Broker404IsSkipped(t *testing.T) {
 	srv, _, _ := makeBrokerServer(t, http.StatusNotFound)
 
 	r := &QueryReconciler{
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return srv.URL, nil
-		},
+		brokerEndpoint: brokerAt(srv.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default"},
-	}
+	query := testQuery()
 
 	err := r.deleteBrokerSessionQuery(context.Background(), query)
 	require.NoError(t, err)
@@ -416,14 +389,10 @@ func TestFinalize_RunsEverySessionCleanupDespiteAFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(memory).Build()
 
 	r := &QueryReconciler{
-		Client: fc,
-		brokerEndpoint: func(_ context.Context, _ string) (string, error) {
-			return broker.URL, nil
-		},
+		Client:         fc,
+		brokerEndpoint: brokerAt(broker.URL),
 	}
-	query := &arkv1alpha1.Query{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-query", Namespace: "default", UID: "query-uid-123"},
-	}
+	query := testQuery()
 
 	err := r.finalize(context.Background(), query)
 	require.Error(t, err, "the failing memory cleanup should surface")

--- a/services/ark-broker/ark-broker/src/brokers/sessions-broker.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions-broker.ts
@@ -158,6 +158,14 @@ export interface SessionsStorage {
   ): Promise<(QueryEntry & {sessionId: string}) | undefined>;
   save(): Promise<void>;
   delete(): Promise<void>;
+  /**
+   * Removes a query from every session holding it, returning how many rows went.
+   * `queryId` is the Query resource NAME: applyEvent writes the event's
+   * queryName into session_queries.query_id and applyMessage looks it up by the
+   * messages payload's query_id, both of which carry query.Name. The UID
+   * matches nothing.
+   */
+  deleteQuery(queryId: string): Promise<number>;
   subscribe(
     callback: (data: {sessionId: string; queryName: string}) => void
   ): () => void;
@@ -218,6 +226,10 @@ export class SessionsBroker {
 
   async delete(): Promise<void> {
     return this.storage.delete();
+  }
+
+  async deleteQuery(queryId: string): Promise<number> {
+    return this.storage.deleteQuery(queryId);
   }
 
   subscribe(

--- a/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/in-memory-sessions-storage.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/in-memory-sessions-storage.test.ts
@@ -419,6 +419,54 @@ describe('InMemorySessionsStorage', () => {
     });
   });
 
+  describe('deleteQuery', () => {
+    const indexOf = (): Map<string, string> =>
+      (storage as unknown as {queryToSession: Map<string, string>})
+        .queryToSession;
+
+    test('removes the query and leaves the session header where it was', async () => {
+      await storage.applyEvent({
+        sessionId: 's1',
+        queryName: 'q1',
+        _reason: 'QueryExecutionError',
+        error: 'boom',
+      });
+      await storage.applyEvent({sessionId: 's1', queryName: 'q2'});
+      const before = (await storage.getSession('s1'))!.lastActivity;
+
+      expect(await storage.deleteQuery('q1')).toBe(1);
+
+      const session = (await storage.getSession('s1'))!;
+      expect(Object.keys(session.queries)).toEqual(['q2']);
+      expect(session.errorCount).toBe(0);
+      expect(session.lastActivity).toBe(before);
+    });
+
+    test('does not orphan the index when the same name lives under two sessions', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'shared'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'keeper'});
+      await storage.applyEvent({sessionId: 's2', queryName: 'shared'});
+      await storage.applyEvent({sessionId: 's2', queryName: 'keeper'});
+
+      expect(await storage.deleteQuery('shared')).toBe(2);
+
+      expect(indexOf().has('shared')).toBe(false);
+      // The surviving queries still route, so the index was not over-pruned.
+      await storage.applyMessage('conv-1', 'keeper');
+      expect(indexOf().get('keeper')).toBe('s2');
+    });
+
+    test('drops the session once its last query goes', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+
+      await storage.deleteQuery('q1');
+
+      const store = await storage.getAll();
+      expect(Object.keys(store.sessions)).toHaveLength(0);
+      expect(indexOf().size).toBe(0);
+    });
+  });
+
   describe('subscribe', () => {
     test('emits on applyEvent', async () => {
       const received: Array<{sessionId: string; queryName: string}> = [];

--- a/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/in-memory-sessions-storage.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/in-memory-sessions-storage.test.ts
@@ -442,7 +442,7 @@ describe('InMemorySessionsStorage', () => {
       expect(session.lastActivity).toBe(before);
     });
 
-    test('does not orphan the index when the same name lives under two sessions', async () => {
+    test('clears the index for the deleted name only, across every session', async () => {
       await storage.applyEvent({sessionId: 's1', queryName: 'shared'});
       await storage.applyEvent({sessionId: 's1', queryName: 'keeper'});
       await storage.applyEvent({sessionId: 's2', queryName: 'shared'});
@@ -451,9 +451,12 @@ describe('InMemorySessionsStorage', () => {
       expect(await storage.deleteQuery('shared')).toBe(2);
 
       expect(indexOf().has('shared')).toBe(false);
-      // The surviving queries still route, so the index was not over-pruned.
-      await storage.applyMessage('conv-1', 'keeper');
+      // Fails if the delete reaches for the whole index rather than one key.
       expect(indexOf().get('keeper')).toBe('s2');
+      await storage.applyMessage('conv-1', 'keeper');
+      expect(
+        (await storage.getSession('s2'))!.queries['keeper']!.conversationId
+      ).toBe('conv-1');
     });
 
     test('drops the session once its last query goes', async () => {

--- a/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
@@ -1410,10 +1410,12 @@ describe('PostgresSessionsStorage', () => {
       await storage.applyEvent({sessionId: 'sess-1', queryName: 'q1'});
       await storage.deleteQuery('q1');
 
-      // Characterises the window, it does not endorse it: the finalizer cancels
-      // the in-flight operation before deleting, so this only covers events the
-      // broker had already accepted. Closing it needs a tombstone table, which
-      // trades a bounded orphan for an unbounded one (#2622 has no reaper).
+      // Characterises the window, it does not endorse it. Cancelling the query
+      // does not narrow this: the finalizer's cancel makes the executor emit
+      // QueryExecutionCanceled, and the emitter dispatches it under
+      // context.WithoutCancel, so deleting a running query is the case most
+      // likely to hit it. Closing it needs a tombstone table, which trades a
+      // bounded orphan for an unbounded one (#2622 has no reaper).
       await storage.applyEvent({sessionId: 'sess-1', queryName: 'q1'});
 
       const session = (await storage.getSession('sess-1'))!;

--- a/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts
@@ -18,6 +18,16 @@ describe('PostgresSessionsStorage', () => {
     storage = new PostgresSessionsStorage(silentLogger, db(), 3600);
   });
 
+  async function headerTimes(
+    sessionId: string
+  ): Promise<{last_activity: Date; expires_at: Date}> {
+    const [row] = await db()<{last_activity: Date; expires_at: Date}[]>`
+      SELECT last_activity, expires_at FROM sessions
+      WHERE session_id = ${sessionId}
+    `;
+    return row!;
+  }
+
   describe('applyEvent', () => {
     test('creates session and query on first event', async () => {
       await storage.applyEvent({
@@ -686,6 +696,156 @@ describe('PostgresSessionsStorage', () => {
     });
   });
 
+  describe('deleteQuery', () => {
+    test('removes the named query row', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'q2'});
+
+      expect(await storage.deleteQuery('q1')).toBe(1);
+
+      const rows = await db()`
+        SELECT query_id FROM session_queries WHERE session_id = 's1'
+      `;
+      expect(rows.map((r) => r['query_id'])).toEqual(['q2']);
+    });
+
+    // SessionEventData carries no queryId at all, so a UID can never reach
+    // session_queries - keying the cleanup on query.UID would delete nothing
+    // and still answer 200.
+    test('is keyed on the query name, so an id-shaped key matches nothing', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+
+      expect(
+        await storage.deleteQuery('e5f6a7b8-1234-4321-9876-abcdefabcdef')
+      ).toBe(0);
+      expect(await storage.deleteQuery('q1')).toBe(1);
+    });
+
+    test('recomputes errorCount, status and conversations from what remains', async () => {
+      await storage.applyEvent({
+        sessionId: 's1',
+        queryName: 'q1',
+        conversationId: 'c1',
+        agent: 'agent-a',
+        _reason: 'QueryExecutionError',
+        error: 'boom',
+      });
+      await storage.applyEvent({
+        sessionId: 's1',
+        queryName: 'q2',
+        conversationId: 'c2',
+        agent: 'agent-b',
+        _reason: 'QueryExecutionComplete',
+      });
+
+      await storage.deleteQuery('q1');
+
+      const session = (await storage.getSession('s1'))!;
+      expect(session.errorCount).toBe(0);
+      expect(session.status).toBe('idle');
+      expect(session.conversations!.map((c) => c.name)).toEqual(['agent-b']);
+      expect(session.participants!.map((p) => p.name)).toEqual(['agent-b']);
+    });
+
+    test('does not move last_activity or expires_at', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'q2'});
+
+      const before = await headerTimes('s1');
+      await sleep(20);
+      await storage.deleteQuery('q1');
+
+      expect(await headerTimes('s1')).toEqual(before);
+    });
+
+    test('does not revive an expired session', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'q2'});
+      await db()`
+        UPDATE sessions SET expires_at = now() - interval '1 hour'
+        WHERE session_id = 's1'
+      `;
+
+      await storage.deleteQuery('q1');
+
+      expect(await storage.getSession('s1')).toBeUndefined();
+    });
+
+    test('drops the header once its last query goes', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+
+      await storage.deleteQuery('q1');
+
+      const headers = await db()`
+        SELECT session_id FROM sessions WHERE session_id = 's1'
+      `;
+      expect(headers).toHaveLength(0);
+    });
+
+    test('keeps the header while another query remains', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'q2'});
+
+      await storage.deleteQuery('q1');
+
+      expect(await storage.getSession('s1')).toBeDefined();
+    });
+
+    test('cleans every session holding the name', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'shared'});
+      await storage.applyEvent({sessionId: 's1', queryName: 'keeper'});
+      await storage.applyEvent({sessionId: 's2', queryName: 'shared'});
+      await storage.applyEvent({sessionId: 's2', queryName: 'keeper'});
+
+      expect(await storage.deleteQuery('shared')).toBe(2);
+
+      const rows = await db()`
+        SELECT session_id FROM session_queries WHERE query_id = 'shared'
+      `;
+      expect(rows).toHaveLength(0);
+    });
+
+    test('leaves a reused query name with exactly one owning session', async () => {
+      await storage.applyEvent({sessionId: 's-old', queryName: 'q1'});
+      await storage.deleteQuery('q1');
+      await storage.applyEvent({sessionId: 's-new', queryName: 'q1'});
+
+      // The probe applyMessage uses to find a query's owner.
+      const owners = await db()`
+        SELECT session_id FROM session_queries WHERE query_id = 'q1'
+      `;
+      expect(owners.map((r) => r['session_id'])).toEqual(['s-new']);
+
+      await storage.applyMessage('conv-1', 'q1');
+      const session = (await storage.getSession('s-new'))!;
+      expect(session.queries['q1']!.conversationId).toBe('conv-1');
+    });
+
+    test('an unknown query is a no-op', async () => {
+      await storage.applyEvent({sessionId: 's1', queryName: 'q1'});
+
+      expect(await storage.deleteQuery('nope')).toBe(0);
+      expect(await storage.getSession('s1')).toBeDefined();
+    });
+
+    test('notifies surviving sessions and not dropped ones', async () => {
+      await storage.whenListening();
+      await storage.applyEvent({sessionId: 's-lives', queryName: 'shared'});
+      await storage.applyEvent({sessionId: 's-lives', queryName: 'keeper'});
+      await storage.applyEvent({sessionId: 's-dies', queryName: 'shared'});
+      // The setup's own notifications are still in flight; subscribing before
+      // they drain attributes them to the delete.
+      await sleep(200);
+
+      const received: string[] = [];
+      storage.subscribe(({sessionId}) => received.push(sessionId));
+      await storage.deleteQuery('shared');
+      await sleep(200);
+
+      expect(received).toEqual(['s-lives']);
+    });
+  });
+
   describe('subscribe', () => {
     test('emits on applyEvent, delivered via LISTEN/NOTIFY', async () => {
       await storage.whenListening();
@@ -1218,6 +1378,46 @@ describe('PostgresSessionsStorage', () => {
       const session = (await storage.getSession('shared-conv'))!;
       expect(session.conversations).toHaveLength(1);
       expect(session.conversations![0]!.messageCount).toBe(N);
+    });
+
+    test('a delete taking the header before the query row cannot deadlock an event for that same query', async () => {
+      await storage.applyEvent({sessionId: 'sess-1', queryName: 'q1'});
+      await storage.applyEvent({sessionId: 'sess-1', queryName: 'keeper'});
+
+      // Both writers must want the same query row, or there is no cycle to
+      // form. Queued behind the header, an event that reaches the header first
+      // would deadlock against a delete already holding that row - which is
+      // what taking the header before the DELETE prevents.
+      const gate = holdSessionHeader('sess-1');
+      await gate.locked;
+
+      const eventing = storage.applyEvent({
+        sessionId: 'sess-1',
+        queryName: 'q1',
+        _reason: 'QueryExecutionComplete',
+      });
+      await waitForLockWaiters(1);
+      const deleting = storage.deleteQuery('q1');
+      await waitForLockWaiters(2);
+      gate.release();
+      await gate.done;
+
+      await Promise.all([eventing, deleting]);
+      expect(await storage.getSession('sess-1')).toBeDefined();
+    });
+
+    test('a late event for a deleted query recreates it', async () => {
+      await storage.applyEvent({sessionId: 'sess-1', queryName: 'q1'});
+      await storage.deleteQuery('q1');
+
+      // Characterises the window, it does not endorse it: the finalizer cancels
+      // the in-flight operation before deleting, so this only covers events the
+      // broker had already accepted. Closing it needs a tombstone table, which
+      // trades a bounded orphan for an unbounded one (#2622 has no reaper).
+      await storage.applyEvent({sessionId: 'sess-1', queryName: 'q1'});
+
+      const session = (await storage.getSession('sess-1'))!;
+      expect(Object.keys(session.queries)).toEqual(['q1']);
     });
   });
 

--- a/services/ark-broker/ark-broker/src/brokers/sessions/in-memory-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/in-memory-sessions-storage.ts
@@ -324,6 +324,37 @@ export class InMemorySessionsStorage implements SessionsStorage {
     return this.save();
   }
 
+  async deleteQuery(queryId: string): Promise<number> {
+    let removed = 0;
+
+    // Object.entries snapshots, so dropping sessions while iterating is safe.
+    for (const [sessionId, session] of Object.entries(this.store.sessions)) {
+      if (!session.queries[queryId]) continue;
+
+      delete session.queries[queryId];
+      removed++;
+
+      // The index is keyed by name alone, so with the same name under two
+      // sessions it points at only one. Clearing it unconditionally would break
+      // applyMessage for the session that still holds that name.
+      if (this.queryToSession.get(queryId) === sessionId) {
+        this.queryToSession.delete(queryId);
+      }
+
+      if (Object.keys(session.queries).length === 0) {
+        delete this.store.sessions[sessionId];
+        continue;
+      }
+
+      // lastActivity stays put: a delete is not activity.
+      recalculateSessionStatus(session);
+      this.emitter.emit('upsert', {sessionId, queryName: queryId});
+    }
+
+    if (removed > 0) this.deferredSave();
+    return removed;
+  }
+
   subscribe(
     callback: (data: {sessionId: string; queryName: string}) => void
   ): () => void {

--- a/services/ark-broker/ark-broker/src/brokers/sessions/in-memory-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/in-memory-sessions-storage.ts
@@ -334,12 +334,7 @@ export class InMemorySessionsStorage implements SessionsStorage {
       delete session.queries[queryId];
       removed++;
 
-      // The index is keyed by name alone, so with the same name under two
-      // sessions it points at only one. Clearing it unconditionally would break
-      // applyMessage for the session that still holds that name.
-      if (this.queryToSession.get(queryId) === sessionId) {
-        this.queryToSession.delete(queryId);
-      }
+      this.queryToSession.delete(queryId);
 
       if (Object.keys(session.queries).length === 0) {
         delete this.store.sessions[sessionId];

--- a/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
@@ -224,22 +224,31 @@ export class PostgresSessionsStorage implements SessionsStorage {
    * cannot drift apart and a wrong aggregate repairs itself on the next write.
    * Runs after the session_queries write, with the header already locked, so
    * it sees this transaction's own row and no concurrent writer's half-state.
-   * Ordered by created_at because conversation startTime and duration are
-   * taken from the first and last query of each conversation.
    */
+  /**
+   * Ordered by created_at because conversation startTime and duration come from
+   * the first and last query of each conversation, and because the tie-break in
+   * the status election depends on this order.
+   */
+  private async readSession(
+    sql: postgres.TransactionSql,
+    header: SessionRow
+  ): Promise<SessionEntry> {
+    const rows = await sql<SessionQueryRow[]>`
+      SELECT * FROM session_queries
+      WHERE session_id = ${header.session_id}
+      ORDER BY created_at, query_id
+    `;
+    return rowsToSessionEntry(header, rows);
+  }
+
   private async refreshHeader(
     sql: postgres.TransactionSql,
     header: SessionRow,
     now: string,
     conversationsOnly = false
   ): Promise<void> {
-    const rows = await sql<SessionQueryRow[]>`
-      SELECT * FROM session_queries
-      WHERE session_id = ${header.session_id}
-      ORDER BY created_at, query_id
-    `;
-
-    const session = rowsToSessionEntry(header, rows);
+    const session = await this.readSession(sql, header);
     if (conversationsOnly) {
       recalculateSessionConversations(session);
     } else {
@@ -267,13 +276,7 @@ export class PostgresSessionsStorage implements SessionsStorage {
     sql: postgres.TransactionSql,
     header: SessionRow
   ): Promise<void> {
-    const rows = await sql<SessionQueryRow[]>`
-      SELECT * FROM session_queries
-      WHERE session_id = ${header.session_id}
-      ORDER BY created_at, query_id
-    `;
-
-    const session = rowsToSessionEntry(header, rows);
+    const session = await this.readSession(sql, header);
     recalculateSessionStatus(session);
 
     await sql`

--- a/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
@@ -257,6 +257,34 @@ export class PostgresSessionsStorage implements SessionsStorage {
     `;
   }
 
+  /**
+   * Recomputes the aggregates from the remaining query rows without touching
+   * last_activity or expires_at. refreshHeader cannot serve this: it moves both
+   * on every call, so a delete would register as activity and would revive an
+   * expired session back into the list.
+   */
+  private async refreshHeaderAggregates(
+    sql: postgres.TransactionSql,
+    header: SessionRow
+  ): Promise<void> {
+    const rows = await sql<SessionQueryRow[]>`
+      SELECT * FROM session_queries
+      WHERE session_id = ${header.session_id}
+      ORDER BY created_at, query_id
+    `;
+
+    const session = rowsToSessionEntry(header, rows);
+    recalculateSessionStatus(session);
+
+    await sql`
+      UPDATE sessions SET
+        error_count = ${session.errorCount ?? 0},
+        status = ${session.status ?? 'idle'},
+        conversations = ${sql.json((session.conversations ?? []) as unknown as postgres.JSONValue)}
+      WHERE session_id = ${header.session_id}
+    `;
+  }
+
   async applyEvent(
     eventData: Partial<SessionEventData>,
     sequence?: number
@@ -623,6 +651,70 @@ export class PostgresSessionsStorage implements SessionsStorage {
 
   async delete(): Promise<void> {
     await this.db`DELETE FROM sessions`;
+  }
+
+  async deleteQuery(queryId: string): Promise<number> {
+    // Unlocked probe. No expires_at filter: an expired-but-present row is
+    // exactly the durable leftover this exists to remove.
+    const owners = await this.db<{session_id: string}[]>`
+      SELECT DISTINCT session_id FROM session_queries
+      WHERE query_id = ${queryId}
+      ORDER BY session_id
+    `;
+
+    let removed = 0;
+    const survivors: string[] = [];
+
+    // One transaction per owning session, each locking a single header. A
+    // transaction spanning several would be the only thing here that could
+    // deadlock against the write paths, which lock one. Idempotent, so the
+    // finalizer's retry after a partial failure is safe.
+    for (const {session_id: sessionId} of owners) {
+      const outcome = await this.db.begin(async (sql) => {
+        // Header before the query row, the order both write paths take.
+        const header = await this.lockHeader(sql, sessionId);
+        if (!header) return undefined;
+
+        const deleted = await sql<{query_id: string}[]>`
+          DELETE FROM session_queries
+          WHERE session_id = ${sessionId} AND query_id = ${queryId}
+          RETURNING query_id
+        `;
+        if (deleted.length === 0) return undefined;
+
+        // In this transaction, so it sees this transaction's own DELETE: read on
+        // the pool it would still count the row just removed and the header
+        // would never be dropped. Concurrent inserts are not the concern here -
+        // the header lock above already excludes them.
+        const [remaining] = await sql<[{n: string}]>`
+          SELECT count(*)::text AS n FROM session_queries
+          WHERE session_id = ${sessionId}
+        `;
+        if (Number(remaining!.n) === 0) {
+          await sql`DELETE FROM sessions WHERE session_id = ${sessionId}`;
+          return {count: deleted.length, survived: false};
+        }
+
+        await this.refreshHeaderAggregates(sql, header);
+        return {count: deleted.length, survived: true};
+      });
+
+      if (!outcome) continue;
+      removed += outcome.count;
+      if (outcome.survived) survivors.push(sessionId);
+    }
+
+    // After commit, on the pool: notifying inside db.begin() deadlocks
+    // postgres.js's own pool. Only survivors, since a session that is gone
+    // yields no SSE frame anyway - the stream drops a getSession that misses.
+    for (const sessionId of survivors) {
+      await this.db.notify(
+        NOTIFY_CHANNEL,
+        JSON.stringify({sessionId, queryName: queryId})
+      );
+    }
+
+    return removed;
   }
 
   subscribe(

--- a/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
+++ b/services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts
@@ -219,13 +219,6 @@ export class PostgresSessionsStorage implements SessionsStorage {
   }
 
   /**
-   * Recomputes the header's aggregates from the session's own query rows, via
-   * the same pure function the in-memory backend uses, so the two backends
-   * cannot drift apart and a wrong aggregate repairs itself on the next write.
-   * Runs after the session_queries write, with the header already locked, so
-   * it sees this transaction's own row and no concurrent writer's half-state.
-   */
-  /**
    * Ordered by created_at because conversation startTime and duration come from
    * the first and last query of each conversation, and because the tie-break in
    * the status election depends on this order.
@@ -242,6 +235,13 @@ export class PostgresSessionsStorage implements SessionsStorage {
     return rowsToSessionEntry(header, rows);
   }
 
+  /**
+   * Recomputes the header's aggregates from the session's own query rows, via
+   * the same pure function the in-memory backend uses, so the two backends
+   * cannot drift apart and a wrong aggregate repairs itself on the next write.
+   * Runs after the session_queries write, with the header already locked, so
+   * it sees this transaction's own row and no concurrent writer's half-state.
+   */
   private async refreshHeader(
     sql: postgres.TransactionSql,
     header: SessionRow,

--- a/services/ark-broker/ark-broker/src/http/routes/sessions/handlers.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/sessions/handlers.ts
@@ -2,6 +2,7 @@ import type {Request, Response} from 'express';
 import {SessionsBroker} from '@ark-broker/brokers/sessions-broker.js';
 import {streamSSE} from '@ark-broker/http/sse.js';
 import {parsePaginationParams} from '@ark-broker/brokers/pagination.js';
+import {sendInternalError} from '@ark-broker/http/routes/errors.js';
 import {GetSessionsQuery} from './schemas.js';
 
 export function handleStreamingSessions(
@@ -68,4 +69,31 @@ export async function handlePaginatedSessions(
 
   const result = await sessionsBroker.paginate(params, filters, sort);
   res.json(result);
+}
+
+export async function handleDeleteSessionQuery(
+  req: Request<{query_id: string}>,
+  res: Response,
+  sessionsBroker: SessionsBroker
+): Promise<void> {
+  const queryId = req.params.query_id;
+  try {
+    req.log.info({queryId}, 'deleting query from sessions');
+    const removed = await sessionsBroker.deleteQuery(queryId);
+    // The in-memory backend only arms a debounced write; every other mutating
+    // sessions route flushes, and without it a kill inside that window reloads
+    // the query this call removed.
+    await sessionsBroker.save();
+    // 200 even when nothing matched: the controller reads 404 as "this broker
+    // does not implement the route" and skips, which would hide a real failure.
+    // A query that never emitted an event legitimately has no row.
+    res.json({
+      status: 'success',
+      message: `Query ${queryId} removed from ${removed} session(s)`,
+      removed,
+    });
+  } catch (error) {
+    req.log.error({err: error}, 'failed to delete query from sessions');
+    sendInternalError(res, req.id);
+  }
 }

--- a/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
@@ -5,6 +5,7 @@ import {
   sendValidationError,
   sendPaginationError,
   sendInternalError,
+  sendMissingQueryIdError,
 } from '@ark-broker/http/routes/errors.js';
 import {PaginationError} from '@ark-broker/brokers/pagination.js';
 import {
@@ -102,6 +103,31 @@ export function createSessionsRouter(sessionsBroker: SessionsBroker): Router {
       res.json({status: 'success', message: 'Sessions purged'});
     } catch (error) {
       req.log.error({err: error}, 'purge failed');
+      sendInternalError(res, req.id);
+    }
+  });
+
+  router.delete<{query_id: string}>('/queries/:query_id', async (req, res) => {
+    const {query_id: queryId} = req.params;
+
+    if (!queryId) {
+      sendMissingQueryIdError(res, req.id);
+      return;
+    }
+
+    try {
+      req.log.info({queryId}, 'deleting query from sessions');
+      const removed = await sessionsBroker.deleteQuery(queryId);
+      // 200 even when nothing matched: the controller reads 404 as "this broker
+      // does not implement the route" and skips, which would hide a real
+      // failure. A query that never emitted an event legitimately has no row.
+      res.json({
+        status: 'success',
+        message: `Query ${queryId} removed from ${removed} session(s)`,
+        removed,
+      });
+    } catch (error) {
+      req.log.error({err: error}, 'failed to delete query from sessions');
       sendInternalError(res, req.id);
     }
   });

--- a/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
@@ -118,6 +118,10 @@ export function createSessionsRouter(sessionsBroker: SessionsBroker): Router {
     try {
       req.log.info({queryId}, 'deleting query from sessions');
       const removed = await sessionsBroker.deleteQuery(queryId);
+      // The in-memory backend only arms a debounced write; every other mutating
+      // route on this router flushes, and without it a kill inside that window
+      // reloads the query this call removed.
+      await sessionsBroker.save();
       // 200 even when nothing matched: the controller reads 404 as "this broker
       // does not implement the route" and skips, which would hide a real
       // failure. A query that never emitted an event legitimately has no row.

--- a/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
+++ b/services/ark-broker/ark-broker/src/http/routes/sessions/index.ts
@@ -5,7 +5,6 @@ import {
   sendValidationError,
   sendPaginationError,
   sendInternalError,
-  sendMissingQueryIdError,
 } from '@ark-broker/http/routes/errors.js';
 import {PaginationError} from '@ark-broker/brokers/pagination.js';
 import {
@@ -15,7 +14,11 @@ import {
   postSessionEventBodySchema,
   PostSessionEventBody,
 } from './schemas.js';
-import {handleStreamingSessions, handlePaginatedSessions} from './handlers.js';
+import {
+  handleStreamingSessions,
+  handlePaginatedSessions,
+  handleDeleteSessionQuery,
+} from './handlers.js';
 
 export function createSessionsRouter(sessionsBroker: SessionsBroker): Router {
   const router = Router();
@@ -107,34 +110,9 @@ export function createSessionsRouter(sessionsBroker: SessionsBroker): Router {
     }
   });
 
-  router.delete<{query_id: string}>('/queries/:query_id', async (req, res) => {
-    const {query_id: queryId} = req.params;
-
-    if (!queryId) {
-      sendMissingQueryIdError(res, req.id);
-      return;
-    }
-
-    try {
-      req.log.info({queryId}, 'deleting query from sessions');
-      const removed = await sessionsBroker.deleteQuery(queryId);
-      // The in-memory backend only arms a debounced write; every other mutating
-      // route on this router flushes, and without it a kill inside that window
-      // reloads the query this call removed.
-      await sessionsBroker.save();
-      // 200 even when nothing matched: the controller reads 404 as "this broker
-      // does not implement the route" and skips, which would hide a real
-      // failure. A query that never emitted an event legitimately has no row.
-      res.json({
-        status: 'success',
-        message: `Query ${queryId} removed from ${removed} session(s)`,
-        removed,
-      });
-    } catch (error) {
-      req.log.error({err: error}, 'failed to delete query from sessions');
-      sendInternalError(res, req.id);
-    }
-  });
+  router.delete<{query_id: string}>('/queries/:query_id', async (req, res) =>
+    handleDeleteSessionQuery(req, res, sessionsBroker)
+  );
 
   return router;
 }

--- a/services/ark-broker/ark-broker/test/sessions-broker.test.ts
+++ b/services/ark-broker/ark-broker/test/sessions-broker.test.ts
@@ -61,6 +61,13 @@ describe('SessionsBroker', () => {
     expect(Object.keys(store.sessions)).toHaveLength(0);
   });
 
+  test('delegates deleteQuery', async () => {
+    await broker.applyEvent({sessionId: 'sess-1', queryName: 'query-1'});
+
+    expect(await broker.deleteQuery('query-1')).toBe(1);
+    expect(await broker.getSession('sess-1')).toBeUndefined();
+  });
+
   test('delegates subscribe', async () => {
     const received: Array<{sessionId: string; queryName: string}> = [];
     broker.subscribe((data) => received.push(data));

--- a/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
+++ b/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
@@ -1,3 +1,6 @@
+import {mkdtempSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
 import request from 'supertest';
 import {loadConfig} from '../src/config/index.js';
 import {createLogger} from '../src/logging/logger.js';
@@ -48,5 +51,41 @@ describe('DELETE /sessions/queries/:query_id', () => {
       .expect(200);
 
     expect(res.body.removed).toBe(0);
+  });
+});
+
+// The flush matters only when the in-memory backend is persisting: without it
+// the route leaves the removal in a 2s debounce, and a kill inside that window
+// reloads a query the cluster has already deleted.
+describe('DELETE /sessions/queries/:query_id with persistence enabled', () => {
+  test('the removal is on disk before the response returns', async () => {
+    const path = join(
+      mkdtempSync(join(tmpdir(), 'ark-sessions-')),
+      'store.json'
+    );
+    const persistedConfig = loadConfig({SESSIONS_FILE_PATH: path});
+    const {app: persistedApp} = buildApp({
+      config: persistedConfig,
+      logger,
+      version: 'test',
+      messageStream: createMessageStream(persistedConfig, logger),
+      chunkStream: createChunkStream(persistedConfig, logger),
+      eventStream: createEventStream(persistedConfig, logger),
+      sessionsStorage: createSessionsStorage(persistedConfig, logger),
+    });
+
+    await request(persistedApp)
+      .post('/sessions')
+      .send({sessionId: 'sess-1', queryName: 'query-1'})
+      .expect(201);
+    await request(persistedApp)
+      .post('/sessions')
+      .send({sessionId: 'sess-1', queryName: 'query-2'})
+      .expect(201);
+
+    await request(persistedApp).delete('/sessions/queries/query-1').expect(200);
+
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(Object.keys(onDisk.sessions['sess-1'].queries)).toEqual(['query-2']);
   });
 });

--- a/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
+++ b/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import {loadConfig} from '../src/config/index.js';
+import {createLogger} from '../src/logging/logger.js';
+import {buildApp} from '../src/server.js';
+import {createMessageStream} from '../src/brokers/stream/message-stream-factory.js';
+import {createChunkStream} from '../src/brokers/stream/chunk-stream-factory.js';
+import {createEventStream} from '../src/brokers/stream/event-stream-factory.js';
+import {createSessionsStorage} from '../src/brokers/sessions/sessions-storage-factory.js';
+
+const config = loadConfig({});
+const logger = createLogger({level: 'silent', pretty: false});
+const {
+  app,
+  brokers: {sessions},
+} = buildApp({
+  config,
+  logger,
+  version: 'test',
+  messageStream: createMessageStream(config, logger),
+  chunkStream: createChunkStream(config, logger),
+  eventStream: createEventStream(config, logger),
+  sessionsStorage: createSessionsStorage(config, logger),
+});
+
+describe('DELETE /sessions/queries/:query_id', () => {
+  afterEach(async () => {
+    await sessions.delete();
+  });
+
+  test('removes the query and reports how many sessions it came from', async () => {
+    await sessions.applyEvent({sessionId: 'sess-1', queryName: 'query-1'});
+    await sessions.applyEvent({sessionId: 'sess-1', queryName: 'query-2'});
+
+    const res = await request(app)
+      .delete('/sessions/queries/query-1')
+      .expect(200);
+
+    expect(res.body.removed).toBe(1);
+    const session = await sessions.getSession('sess-1');
+    expect(Object.keys(session!.queries)).toEqual(['query-2']);
+  });
+
+  // A 404 here would be read by the controller's finalizer as "this broker does
+  // not implement the route" and skipped, hiding a genuine cleanup failure.
+  test('answers 200, not 404, for a query it has never seen', async () => {
+    const res = await request(app)
+      .delete('/sessions/queries/never-existed')
+      .expect(200);
+
+    expect(res.body.removed).toBe(0);
+  });
+});

--- a/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
+++ b/services/ark-broker/ark-broker/test/sessions-query-delete.test.ts
@@ -43,8 +43,15 @@ describe('DELETE /sessions/queries/:query_id', () => {
     expect(Object.keys(session!.queries)).toEqual(['query-2']);
   });
 
-  // A 404 here would be read by the controller's finalizer as "this broker does
-  // not implement the route" and skipped, hiding a genuine cleanup failure.
+  // Express does not match /queries/ against /queries/:query_id, so the handler
+  // never sees an empty id and needs no guard for one - this pins that.
+  test('an empty query id does not reach the handler at all', async () => {
+    await request(app).delete('/sessions/queries/').expect(404);
+  });
+
+  // A 404 for a *named* query would be read by the controller's finalizer as
+  // "this broker does not implement the route" and skipped, hiding a genuine
+  // cleanup failure.
   test('answers 200, not 404, for a query it has never seen', async () => {
     const res = await request(app)
       .delete('/sessions/queries/never-existed')

--- a/tests/sessions-broker-postgres/README.md
+++ b/tests/sessions-broker-postgres/README.md
@@ -8,6 +8,7 @@ Verifies that two queries sharing a `sessionId` are recorded as two rows in the 
 - The broker's `session_queries` table has one row per query, both `phase='done'`
 - The `sessions` header row shows `status=idle`, `error_count=0`, two conversations
 - `GET /sessions/:id` returns the same shape over the broker HTTP API, including the two participants derived from those conversations
+- Deleting one of the two queries removes its `session_queries` row, and the header is left aggregated over the one that remains (`status=idle`, `error_count=0`, one conversation, named after the surviving agent)
 - Requires the broker running with postgres sessions backend (`postgresql: "true"` label)
 
 ## Running

--- a/tests/sessions-broker-postgres/chainsaw-test.yaml
+++ b/tests/sessions-broker-postgres/chainsaw-test.yaml
@@ -225,8 +225,6 @@ spec:
           echo "conversation names after delete: ${CONV_NAMES}"
           [ "${CONV_NAMES}" = "sessions-postgres-agent-a" ] || { echo "expected 'sessions-postgres-agent-a', got '${CONV_NAMES}'"; exit 1; }
         env:
-        - name: NAMESPACE
-          value: ($namespace)
         - name: SESSION_ID
           value: ($namespace)
     catch:

--- a/tests/sessions-broker-postgres/chainsaw-test.yaml
+++ b/tests/sessions-broker-postgres/chainsaw-test.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     postgresql: "true"
 spec:
-  description: Two queries sharing a sessionId land as two rows in the Postgres session_queries table under one sessions header row, with conversations and errorCount aggregated on it; GET /sessions/:id returns the same shape over HTTP, participants included
+  description: Two queries sharing a sessionId land as two rows in the Postgres session_queries table under one sessions header row, with conversations and errorCount aggregated on it; GET /sessions/:id returns the same shape over HTTP, participants included; deleting one Query removes its row and leaves the header aggregated over what remains
   steps:
   - name: setup-mock-llm
     try:
@@ -173,6 +173,57 @@ spec:
             ")
           echo "HTTP session (queries,conversations,participants,errorCount): ${RESULT}"
           [ "${RESULT}" = "2,2,sessions-postgres-agent-a+sessions-postgres-agent-b,0" ] || { echo "expected '2,2,sessions-postgres-agent-a+sessions-postgres-agent-b,0', got '${RESULT}'"; exit 1; }
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        - name: SESSION_ID
+          value: ($namespace)
+    catch:
+    - events: {}
+    - script:
+        content: |
+          bash ../shared/dump-broker-logs.sh
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+
+  - name: delete-query-cascades-to-sessions
+    try:
+    # This blocks until the object is gone, and the finalizer only completes if
+    # every broker cleanup returned - so reaching the next step is already an
+    # assertion that the sessions delete did not fail.
+    - delete:
+        ref:
+          apiVersion: ark.mckinsey.com/v1alpha1
+          kind: Query
+          name: sessions-postgres-query-2
+    - script:
+        timeout: 120s
+        content: |
+          ROWS=$(bash ../shared/psql-poll.sh \
+            "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}';" \
+            "1" 120 0.5) || { echo "expected 1 remaining session_queries row, got '${ROWS}'"; exit 1; }
+          echo "session_queries rows after delete: ${ROWS}"
+
+          GONE=$(bash ../shared/psql-query.sh \
+            "SELECT count(*) FROM session_queries WHERE session_id='${SESSION_ID}' AND query_id='sessions-postgres-query-2';" \
+            | tr -d ' \n')
+          echo "rows for the deleted query: ${GONE}"
+          [ "${GONE}" = "0" ] || { echo "expected 0, got '${GONE}'"; exit 1; }
+
+          HEADER=$(bash ../shared/psql-query.sh \
+            "SELECT status || ',' || error_count || ',' || jsonb_array_length(conversations) FROM sessions WHERE session_id='${SESSION_ID}';" \
+            | tr -d ' \n')
+          echo "sessions header after delete (status,error_count,conversations): ${HEADER}"
+          [ "${HEADER}" = "idle,0,1" ] || { echo "expected 'idle,0,1', got '${HEADER}'"; exit 1; }
+
+          # The count alone would pass on a regression that kept the wrong
+          # conversation, so the surviving name is what pins agent-a.
+          CONV_NAMES=$(bash ../shared/psql-query.sh \
+            "SELECT string_agg(c->>'name', ',' ORDER BY c->>'name') FROM sessions s, jsonb_array_elements(s.conversations) c WHERE s.session_id='${SESSION_ID}';" \
+            | tr -d ' \n')
+          echo "conversation names after delete: ${CONV_NAMES}"
+          [ "${CONV_NAMES}" = "sessions-postgres-agent-a" ] || { echo "expected 'sessions-postgres-agent-a', got '${CONV_NAMES}'"; exit 1; }
         env:
         - name: NAMESPACE
           value: ($namespace)


### PR DESCRIPTION
## Context

Deleting a `Query` already cleans up its broker messages (#2557) and its operation events (#2806), both driven from the `Query` finalizer. Nothing removed the corresponding row from the **sessions read model**, so the session aggregate kept describing work that no longer exists.

Until Phase 4 (#3004) that leftover was transient: on the in-memory sessions backend it disappeared at the next broker restart, and the purge-all `DELETE /sessions` cleared it. On the Postgres backend the row in `session_queries` survives both. A cluster that creates and deletes queries continuously accumulates rows for queries that are gone, and the derived numbers a user sees — `messageCount` on a conversation, `errorCount` on the session header, the participant list — keep counting them.

Closes #3114. This is the last open item before Phase 4 can be marked delivered in #2153.

## Problem

The gap is not hypothetical, and #3004 already pays for it. `applyMessage` cannot simply look up a query's owning session, because the same `query_id` can legitimately exist under two different sessions — which is only possible *because* deleting a `Query` leaves its `session_queries` row behind for a later query of the same name to collide with. That is why the owner probe has to rank candidates (`ORDER BY (s.expires_at > now()) DESC, sq.session_id`) rather than pick one. Closing this gap removes the condition that ranking defends against.

## The one thing that would have made this silently do nothing

`session_queries.query_id` holds the Query **name**, not its UID. The column name suggests otherwise, and the adjacent events cleanup keys on `query.UID`, so copying that path is the natural mistake — it would match zero rows, the endpoint would still answer `200`, and `deleteBrokerResource` would report success while the finalizer moved on.

The name is what every writer puts there:

- `operations.OperationTracker` carries `QueryID` (the UID) and `QueryName` (the resource name) as two distinct fields and emits both (`ark/internal/eventing/recorder/operations/operation_tracker.go:58`, `:111`). `applyEvent` reads `queryName` and writes it as `query_id`.
- The messages side agrees: the completions executor passes `state.query.Name` as `query_id`, and the Python SDK sends `query_name`.
- `SessionEventData` has no query-UID field at all, so a UID cannot reach this table by any route.

The Go test asserts the request path verbatim, so a future change back to the UID fails rather than silently no-ops.

## What this does, and why each choice

**A per-query route on the sessions router — `DELETE /sessions/queries/:query_id`.** Two path segments, so it does not collide with `GET /sessions/:session_id`; a single-segment `DELETE /sessions/:x` should mean "delete the session".

**It answers `200` even when nothing matched, never `404`.** The shared helper in the controller treats `404`/`405` as "this broker does not implement this delete, skip it", which is what keeps a new controller working against an older broker image. Returning `404` for an unknown query would make a genuine cleanup failure indistinguishable from that case. A query that never emitted an event legitimately has no row, so the count goes in the response body where a caller can inspect it instead.

**One transaction per owning session, each locking exactly one header before touching the query row.** The write paths lock the header first and the query row second; a transaction that took the query row first would form an ABBA cycle with an event for that same query. A single transaction spanning several headers would be the only thing here capable of deadlocking against writers that lock one, and it would buy nothing: no invariant spans sessions. Per-session transactions are idempotent, so the finalizer's retry after a partial failure is safe.

**The count of remaining rows happens inside that transaction** so it sees the transaction's own `DELETE`. Read on the pool it would still count the row just removed and the header would never be dropped.

**The header row is deleted once no query rows remain.** Keeping empty headers would only move the leak from one row per query to one row per session, and nothing reaps either (#2622). Nothing creates a header without a query — both `INSERT`s into `sessions` require a session id and a query name — so an empty header has no other origin. A writer queued behind the delete recreates the header through the existing `lockHeaderOrRecreate` recovery path, the same one that already handles a purge landing mid-write.

**Aggregates are recomputed through a new `refreshHeaderAggregates` that leaves `last_activity` and `expires_at` alone.** The existing `refreshHeader` moves both on every call; reusing it would register a delete as activity and pull an expired — that is, hidden — session back into the list. It is a separate method rather than a third flag on `refreshHeader`, which sits on both write paths. The recomputation itself goes through the same pure aggregate function the in-memory backend uses, so `errorCount`, `conversations` and the derived `participants` cannot drift between backends.

**Notifications fire after commit, on the pool, and only for sessions that survived.** Notifying inside `db.begin()` deadlocks postgres.js's own pool under load. A session that is gone produces no SSE frame either way: the stream handler re-reads the session and drops a miss. Deletions are invisible to watchers today — the purge-all does not notify at all — and this PR does not change that.

**The in-memory backend gets a correctness floor rather than semantic parity.** `SESSIONS_BACKEND` defaults to `memory`, so it cannot be a stub: it removes the query from every session holding it, clears the index entry, drops the session when it empties, and leaves `lastActivity` where it was. Where the two backends could diverge in some corner, Postgres is the one held to the contract.

## Deliberately not in this PR

**A late event can resurrect a deleted query.** After the delete commits, an event that was already in flight for that name recreates the header and the row through the normal upsert path. Cancelling does not narrow this window — it widens it: the finalizer's cancel is what makes the executor emit `QueryExecutionCanceled`, and the emitter dispatches it under `context.WithoutCancel`, so deleting a *running* query is the case most likely to reach it. The same window already exists for messages (#2557) and events (#2806), where a late `POST` re-inserts after the delete. Closing it needs a tombstone of deleted names, which trades a bounded orphan for an unbounded set of tombstones with no reaper. There is a test that characterises the behaviour so it is pinned rather than discovered later.

**Authorisation.** This adds one more unauthenticated delete route to the broker, which trusts the network; gating them is #3115.

## Review guide

- `services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts:656` — `deleteQuery`: the probe, the per-session transaction, the lock order, and the header drop.
- `services/ark-broker/ark-broker/src/brokers/sessions/postgres-sessions-storage.ts:266` — `refreshHeaderAggregates`, next to the `refreshHeader` it deliberately does not reuse.
- `services/ark-broker/ark-broker/src/brokers/sessions/in-memory-sessions-storage.ts:327` — the in-memory equivalent.
- `services/ark-broker/ark-broker/src/http/routes/sessions/index.ts:110` — the route, the always-`200` contract, and the flush.
- `ark/internal/controller/query_controller.go:1329` — `deleteBrokerSessionQuery`, and `:1211` where `finalize` joins it with the other two cleanups so one failure cannot skip the others.
- `services/ark-broker/ark-broker/src/brokers/sessions/__tests__/postgres-sessions-storage.test.ts:699` — the `deleteQuery` cases; `:1383` is the deadlock test and `:1409` characterises the late-event window.
- `tests/sessions-broker-postgres/chainsaw-test.yaml:190` — the e2e step. It extends the existing fixture rather than standing up a second one, because two queries in one session with two conversations is already the shape this needs and repeating the mock-llm install plus two four-minute queries would add that cost to the slowest matrix. The `delete` blocks until the object is gone and the finalizer only completes once every broker cleanup returned, so reaching the assertions is itself evidence the sessions delete did not fail.

## Verification

Locally: `eslint`, `prettier --check` and `tsc --noEmit` clean, 529 broker tests across 33 suites green; `golangci-lint` reports no issues and the Go suite passes.

Every new test was mutation-checked — the production line it protects was changed, the mutation's diff printed to prove it landed, and the test rerun to confirm it fails. Two of those checks found real defects rather than confirming the work. The first deadlock test contended on different query rows, so moving the header lock after the `DELETE` passed all ten concurrency tests; it now contends on the same row and catches the inversion with a real Postgres deadlock. A comment justifying the in-transaction count described a hazard the header lock already excludes, and the mutation landed on a different test than that reasoning predicted, which is how the wrong explanation surfaced.

Because `chainsaw lint` validates document structure but not SQL, the four statements in the new e2e step were run against the real schema — a Postgres container with all five migrations applied — and return exactly the values the step asserts.
