### PR TITLE
fix(postgresql): emit resume-overlap rows as Modified, not Added

### DIFF
--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -1169,15 +1169,7 @@ func (w *postgresWatcher) forwardRow(row *changeRow) bool {
 	if w.markSeen(row.uid, row.rv) {
 		return true
 	}
-	var eventType watch.EventType
-	switch {
-	case row.deleted:
-		eventType = watch.Deleted
-	case uidNew:
-		eventType = watch.Added
-	default:
-		eventType = watch.Modified
-	}
+	eventType := w.resumeEventType(row.rv, row.deleted, uidNew)
 	w.advanceRV(row.rv)
 	select {
 	case w.outCh <- watch.Event{Type: eventType, Object: row.obj.DeepCopyObject()}:
@@ -1243,6 +1235,24 @@ func (w *postgresWatcher) hasSeenUID(uid string) bool {
 	defer w.seenMu.Unlock()
 	_, ok := w.seenRVs[uid]
 	return ok
+}
+
+// resumeEventType picks the event type for a forwarded row. Rows in the resume
+// overlap (rv <= startRV) are emitted as Modified, not Added, so a resuming client
+// resyncs state it already holds instead of seeing phantom creations; a genuinely
+// missed row here is still delivered (an informer applies Modified as an add), so
+// nothing is lost. startRV is 0 when replaying all state. See #3246.
+func (w *postgresWatcher) resumeEventType(rv int64, deleted, uidNew bool) watch.EventType {
+	switch {
+	case deleted:
+		return watch.Deleted
+	case rv <= w.startRV:
+		return watch.Modified
+	case uidNew:
+		return watch.Added
+	default:
+		return watch.Modified
+	}
 }
 
 // resumeFloor is the lowest resource_version this watcher will (re-)emit: a full
@@ -1317,15 +1327,7 @@ func (w *postgresWatcher) emitRow(rv, generation int64, ns, name, uid string, sp
 	if err != nil {
 		return true
 	}
-	var eventType watch.EventType
-	switch {
-	case deletedAt.Valid:
-		eventType = watch.Deleted
-	case uidNew:
-		eventType = watch.Added
-	default:
-		eventType = watch.Modified
-	}
+	eventType := w.resumeEventType(rv, deletedAt.Valid, uidNew)
 	w.advanceRV(rv)
 	select {
 	case w.outCh <- watch.Event{Type: eventType, Object: obj}:

--- a/ark/internal/storage/postgresql/postgresql_integration_test.go
+++ b/ark/internal/storage/postgresql/postgresql_integration_test.go
@@ -915,6 +915,106 @@ func TestWatchResumeFromResourceVersion_Integration(t *testing.T) {
 	_, _ = backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1 AND namespace = $2", testKind, testNS)
 }
 
+// TestWatchResumeOverlapEmitsModifiedNotAdded_Integration pins the #3246 interim
+// fix: rows within the lookback window at or below the resume point that the client
+// already holds are re-delivered as Modified, not Added, so a resuming informer
+// treats them as a no-op resync rather than 500 phantom creations. A genuine change
+// above the resume point is still Added.
+func TestWatchResumeOverlapEmitsModifiedNotAdded_Integration(t *testing.T) {
+	cfg := testConfig(t)
+
+	backend, err := New(cfg, &integrationMockConverter{})
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+	backend.StartWALConsumer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testNS := "integration-test"
+	testKind := "ResumeOverlapResource"
+
+	_, _ = backend.db.ExecContext(ctx, "DELETE FROM resources WHERE kind = $1 AND namespace = $2", testKind, testNS)
+	defer func() {
+		_, _ = backend.db.ExecContext(context.Background(), "DELETE FROM resources WHERE kind = $1 AND namespace = $2", testKind, testNS)
+	}()
+
+	mkObj := func(name, uid string) *integrationTestObject {
+		obj := &integrationTestObject{APIVersion: "ark.mckinsey.com/v1alpha1", Kind: testKind}
+		obj.Metadata.Name = name
+		obj.Metadata.Namespace = testNS
+		obj.Metadata.UID = uid
+		obj.Spec = map[string]interface{}{"k": "v"}
+		return obj
+	}
+
+	// overlap-1 exists before the watch; the client already holds it. Resuming from
+	// its own rv puts it inside the lookback window at rv == startRV.
+	const overlapName = "overlap-1"
+	if err := backend.Create(ctx, testKind, testNS, overlapName, mkObj(overlapName, "uid-overlap")); err != nil {
+		t.Fatalf("Create %s failed: %v", overlapName, err)
+	}
+	var baselineRV int64
+	if err := backend.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(resource_version), 0) FROM resources WHERE kind = $1 AND namespace = $2",
+		testKind, testNS).Scan(&baselineRV); err != nil {
+		t.Fatalf("read baseline resourceVersion: %v", err)
+	}
+
+	w, err := backend.Watch(ctx, testKind, testNS, storage.WatchOptions{
+		ResourceVersion: strconv.FormatInt(baselineRV, 10),
+	})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+	defer w.Stop()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// A genuine change above the resume point. Relist/stream emit ascending by rv, so
+	// overlap-1 (rv == baselineRV) arrives no later than this sentinel — making the
+	// sentinel a deterministic stop condition.
+	const sentinelName = "sentinel-1"
+	if err := backend.Create(ctx, testKind, testNS, sentinelName, mkObj(sentinelName, "uid-sentinel")); err != nil {
+		t.Fatalf("Create %s failed: %v", sentinelName, err)
+	}
+
+	deadline := time.After(15 * time.Second)
+	overlapType, sentinelType := watch.EventType(""), watch.EventType("")
+	for sentinelType == "" {
+		select {
+		case ev, ok := <-w.ResultChan():
+			if !ok {
+				t.Fatal("watch channel closed before sentinel arrived")
+			}
+			if ev.Type == watch.Bookmark {
+				continue
+			}
+			obj, _ := ev.Object.(*integrationTestObject)
+			if obj == nil {
+				continue
+			}
+			switch obj.Metadata.Name {
+			case overlapName:
+				overlapType = ev.Type
+			case sentinelName:
+				sentinelType = ev.Type
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for sentinel; overlapType=%q", overlapType)
+		}
+	}
+
+	if overlapType != watch.Modified {
+		t.Errorf("resume overlap object %q (rv=%d, <= startRV) emitted as %q; want Modified so a resuming informer resyncs rather than sees a phantom creation",
+			overlapName, baselineRV, overlapType)
+	}
+	if sentinelType != watch.Added {
+		t.Errorf("genuine change %q above the resume point emitted as %q; want Added", sentinelName, sentinelType)
+	}
+}
+
 // TestWatchResumeDoesNotDropOutOfOrderCommit_Integration guards the resume boundary
 // against the out-of-order-commit race that the relist() lookback exists to defend
 // against. BIGSERIAL assigns resource_version at INSERT statement time but a row is
@@ -1050,6 +1150,7 @@ func TestWatchResumeDoesNotDropOutOfOrderCommit_Integration(t *testing.T) {
 
 	deadline := time.After(15 * time.Second)
 	sawLost := false
+	lostType := watch.EventType("")
 	for {
 		select {
 		case ev, ok := <-w.ResultChan():
@@ -1066,10 +1167,17 @@ func TestWatchResumeDoesNotDropOutOfOrderCommit_Integration(t *testing.T) {
 			switch obj.Metadata.Name {
 			case lostName:
 				sawLost = true
+				lostType = ev.Type
 			case sentinelName:
 				if !sawLost {
 					t.Fatalf("resume from resourceVersion=%d silently dropped out-of-order commit %q (rv=%d, below resume point); "+
 						"the lookback window must floor at startRV-relistLookbackRVs, not at startRV", rvSeen, lostName, rvLost)
+				}
+				// The recovered row sits at rv <= startRV, so it arrives as Modified
+				// (an informer applies it as an add since it lacks the object) — the
+				// #3246 interim relabel must not turn no-drop recovery into a drop.
+				if lostType != watch.Modified {
+					t.Errorf("recovered out-of-order commit %q emitted as %q; want Modified", lostName, lostType)
 				}
 				return
 			}


### PR DESCRIPTION
## Summary
- A watch resumed from a concrete `resourceVersion` reaches a lookback window below the resume point to recover out-of-order commits (#3120). On a fresh resuming watcher `seenRVs` is empty, so every row in `[startRV-500, startRV]` the client already holds was re-emitted as `Added` — up to 500 phantom creations per kind per reconnect (#3246).
- Relabel rows at `rv <= startRV` as `Modified`. A resuming informer treats these as a no-op resync of state it already has rather than spurious creates, so create-only side effects no longer fire incorrectly.
- No-drop guarantee from #3120 is preserved: a genuinely-missed out-of-order commit in the window is still delivered, and client-go applies a `Modified` for an object absent from its store as an add, so nothing is lost. Rows above `startRV` keep normal `Added`/`Modified`/`Deleted` semantics; replay-all (`startRV=0`) is unchanged.
- Interim mitigation only. The durable fix (resume from the list's MVCC snapshot, eliminating the lookback over-delivery entirely) is tracked in #3248.

Closes #3246