### PR TITLE
feat(controller): instrument broker event-emitter drops and latency

### DIFF
--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -99,7 +99,7 @@ func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Obj
 			e.sendEvent(context.WithoutCancel(ctx), query.Namespace, event)
 		}()
 	} else {
-		emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, query.Namespace).Inc()
+		emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull).Inc()
 		log.V(1).Info("semaphore full, dropping event", "namespace", query.Namespace, "reason", reason)
 	}
 }
@@ -114,7 +114,7 @@ func (e *BrokerEventEmitter) getEndpointForNamespace(ctx context.Context, namesp
 func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, event Event) {
 	baseURL, err := e.getEndpointForNamespace(ctx, namespace)
 	if err != nil {
-		emitDroppedTotal.WithLabelValues(dropReasonEndpointError, namespace).Inc()
+		emitDroppedTotal.WithLabelValues(dropReasonEndpointError).Inc()
 		log.Error(err, "failed to resolve broker endpoint", "namespace", namespace, "reason", event.Reason)
 		return
 	}
@@ -126,14 +126,14 @@ func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, ev
 
 	body, err := json.Marshal(event)
 	if err != nil {
-		emitDroppedTotal.WithLabelValues(dropReasonMarshalError, namespace).Inc()
+		emitDroppedTotal.WithLabelValues(dropReasonMarshalError).Inc()
 		log.Error(err, "failed to marshal event")
 		return
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		emitDroppedTotal.WithLabelValues(dropReasonRequestError, namespace).Inc()
+		emitDroppedTotal.WithLabelValues(dropReasonRequestError).Inc()
 		log.Error(err, "failed to create request", "endpoint", endpoint)
 		return
 	}
@@ -149,7 +149,7 @@ func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, ev
 			reason = dropReasonTimeout
 		}
 		emitLatencySeconds.WithLabelValues(reason).Observe(time.Since(start).Seconds())
-		emitDroppedTotal.WithLabelValues(reason, namespace).Inc()
+		emitDroppedTotal.WithLabelValues(reason).Inc()
 		log.Error(err, "failed to send event to broker", "endpoint", endpoint)
 		return
 	}
@@ -161,7 +161,7 @@ func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, ev
 
 	if resp.StatusCode != http.StatusCreated {
 		emitLatencySeconds.WithLabelValues(dropReasonBadStatus).Observe(time.Since(start).Seconds())
-		emitDroppedTotal.WithLabelValues(dropReasonBadStatus, namespace).Inc()
+		emitDroppedTotal.WithLabelValues(dropReasonBadStatus).Inc()
 		log.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "failed to send event to broker", "endpoint", endpoint)
 		return
 	}

--- a/ark/internal/eventing/broker/emitter.go
+++ b/ark/internal/eventing/broker/emitter.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -97,6 +99,7 @@ func (e *BrokerEventEmitter) EmitStructured(ctx context.Context, obj runtime.Obj
 			e.sendEvent(context.WithoutCancel(ctx), query.Namespace, event)
 		}()
 	} else {
+		emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, query.Namespace).Inc()
 		log.V(1).Info("semaphore full, dropping event", "namespace", query.Namespace, "reason", reason)
 	}
 }
@@ -111,6 +114,7 @@ func (e *BrokerEventEmitter) getEndpointForNamespace(ctx context.Context, namesp
 func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, event Event) {
 	baseURL, err := e.getEndpointForNamespace(ctx, namespace)
 	if err != nil {
+		emitDroppedTotal.WithLabelValues(dropReasonEndpointError, namespace).Inc()
 		log.Error(err, "failed to resolve broker endpoint", "namespace", namespace, "reason", event.Reason)
 		return
 	}
@@ -122,20 +126,30 @@ func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, ev
 
 	body, err := json.Marshal(event)
 	if err != nil {
+		emitDroppedTotal.WithLabelValues(dropReasonMarshalError, namespace).Inc()
 		log.Error(err, "failed to marshal event")
 		return
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
+		emitDroppedTotal.WithLabelValues(dropReasonRequestError, namespace).Inc()
 		log.Error(err, "failed to create request", "endpoint", endpoint)
 		return
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
+	start := time.Now()
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
+		reason := dropReasonHTTPError
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			reason = dropReasonTimeout
+		}
+		emitLatencySeconds.WithLabelValues(reason).Observe(time.Since(start).Seconds())
+		emitDroppedTotal.WithLabelValues(reason, namespace).Inc()
 		log.Error(err, "failed to send event to broker", "endpoint", endpoint)
 		return
 	}
@@ -146,6 +160,11 @@ func (e *BrokerEventEmitter) sendEvent(ctx context.Context, namespace string, ev
 	}()
 
 	if resp.StatusCode != http.StatusCreated {
+		emitLatencySeconds.WithLabelValues(dropReasonBadStatus).Observe(time.Since(start).Seconds())
+		emitDroppedTotal.WithLabelValues(dropReasonBadStatus, namespace).Inc()
 		log.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "failed to send event to broker", "endpoint", endpoint)
+		return
 	}
+
+	emitLatencySeconds.WithLabelValues("ok").Observe(time.Since(start).Seconds())
 }

--- a/ark/internal/eventing/broker/emitter_test.go
+++ b/ark/internal/eventing/broker/emitter_test.go
@@ -261,9 +261,9 @@ func TestEmitStructured_IncrementsDroppedCounterWhenSemaphoreFull(t *testing.T) 
 	e.sem = semaphore.NewWeighted(0)
 	query := newTestQuery("sem-full-ns")
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, "sem-full-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull))
 	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", nil)
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, "sem-full-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull))
 
 	assert.Equal(t, float64(1), after-before)
 }
@@ -276,9 +276,9 @@ func TestSendEvent_IncrementsDroppedCounterOnBadStatus(t *testing.T) {
 
 	e := newTestEmitter(map[string]string{"bad-status-ns": srv.URL})
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus, "bad-status-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus))
 	e.sendEvent(context.Background(), "bad-status-ns", Event{Reason: "QueryExecutionStart"})
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus, "bad-status-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus))
 
 	assert.Equal(t, float64(1), after-before)
 }
@@ -286,9 +286,9 @@ func TestSendEvent_IncrementsDroppedCounterOnBadStatus(t *testing.T) {
 func TestSendEvent_IncrementsDroppedCounterOnHTTPError(t *testing.T) {
 	e := newTestEmitter(map[string]string{"http-err-ns": "http://127.0.0.1:1"})
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError))
 	e.sendEvent(context.Background(), "http-err-ns", Event{Reason: "QueryExecutionStart"})
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError))
 
 	assert.Equal(t, float64(1), after-before)
 }
@@ -302,9 +302,9 @@ func TestSendEvent_IncrementsDroppedCounterOnEndpointError(t *testing.T) {
 		},
 	}
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError, "endpoint-err-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError))
 	e.sendEvent(context.Background(), "endpoint-err-ns", Event{Reason: "QueryExecutionStart"})
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError, "endpoint-err-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError))
 
 	assert.Equal(t, float64(1), after-before)
 }
@@ -313,9 +313,9 @@ func TestSendEvent_IncrementsDroppedCounterOnMarshalError(t *testing.T) {
 	e := newTestEmitter(map[string]string{"marshal-err-ns": "http://broker.local"})
 	badEvent := Event{Reason: "QueryExecutionStart", Data: map[string]interface{}{"bad": make(chan int)}}
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError, "marshal-err-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError))
 	e.sendEvent(context.Background(), "marshal-err-ns", badEvent)
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError, "marshal-err-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError))
 
 	assert.Equal(t, float64(1), after-before)
 }
@@ -323,9 +323,9 @@ func TestSendEvent_IncrementsDroppedCounterOnMarshalError(t *testing.T) {
 func TestSendEvent_IncrementsDroppedCounterOnRequestError(t *testing.T) {
 	e := newTestEmitter(map[string]string{"request-err-ns": "http://\x7f"})
 
-	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError, "request-err-ns"))
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError))
 	e.sendEvent(context.Background(), "request-err-ns", Event{Reason: "QueryExecutionStart"})
-	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError, "request-err-ns"))
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError))
 
 	assert.Equal(t, float64(1), after-before)
 }

--- a/ark/internal/eventing/broker/emitter_test.go
+++ b/ark/internal/eventing/broker/emitter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
@@ -252,6 +253,43 @@ func TestEmitStructured_DropsEventWhenSemaphoreFull(t *testing.T) {
 	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", nil)
 
 	assert.False(t, called, "event should be dropped when semaphore is full")
+}
+
+func TestEmitStructured_IncrementsDroppedCounterWhenSemaphoreFull(t *testing.T) {
+	e := newTestEmitter(map[string]string{"sem-full-ns": "http://unused"})
+	e.sem = semaphore.NewWeighted(0)
+	query := newTestQuery("sem-full-ns")
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, "sem-full-ns"))
+	e.EmitStructured(context.Background(), query, corev1.EventTypeNormal, "QueryExecutionStart", "msg", nil)
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonSemaphoreFull, "sem-full-ns"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+func TestSendEvent_IncrementsDroppedCounterOnBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	e := newTestEmitter(map[string]string{"bad-status-ns": srv.URL})
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus, "bad-status-ns"))
+	e.sendEvent(context.Background(), "bad-status-ns", Event{Reason: "QueryExecutionStart"})
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonBadStatus, "bad-status-ns"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+func TestSendEvent_IncrementsDroppedCounterOnHTTPError(t *testing.T) {
+	e := newTestEmitter(map[string]string{"http-err-ns": "http://127.0.0.1:1"})
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
+	e.sendEvent(context.Background(), "http-err-ns", Event{Reason: "QueryExecutionStart"})
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
+
+	assert.Equal(t, float64(1), after-before)
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/ark/internal/eventing/broker/emitter_test.go
+++ b/ark/internal/eventing/broker/emitter_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -288,6 +289,43 @@ func TestSendEvent_IncrementsDroppedCounterOnHTTPError(t *testing.T) {
 	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
 	e.sendEvent(context.Background(), "http-err-ns", Event{Reason: "QueryExecutionStart"})
 	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonHTTPError, "http-err-ns"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+func TestSendEvent_IncrementsDroppedCounterOnEndpointError(t *testing.T) {
+	e := &BrokerEventEmitter{
+		httpClient: &http.Client{},
+		sem:        semaphore.NewWeighted(64),
+		resolveEndpoint: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("resolve failed")
+		},
+	}
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError, "endpoint-err-ns"))
+	e.sendEvent(context.Background(), "endpoint-err-ns", Event{Reason: "QueryExecutionStart"})
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonEndpointError, "endpoint-err-ns"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+func TestSendEvent_IncrementsDroppedCounterOnMarshalError(t *testing.T) {
+	e := newTestEmitter(map[string]string{"marshal-err-ns": "http://broker.local"})
+	badEvent := Event{Reason: "QueryExecutionStart", Data: map[string]interface{}{"bad": make(chan int)}}
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError, "marshal-err-ns"))
+	e.sendEvent(context.Background(), "marshal-err-ns", badEvent)
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonMarshalError, "marshal-err-ns"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+func TestSendEvent_IncrementsDroppedCounterOnRequestError(t *testing.T) {
+	e := newTestEmitter(map[string]string{"request-err-ns": "http://\x7f"})
+
+	before := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError, "request-err-ns"))
+	e.sendEvent(context.Background(), "request-err-ns", Event{Reason: "QueryExecutionStart"})
+	after := testutil.ToFloat64(emitDroppedTotal.WithLabelValues(dropReasonRequestError, "request-err-ns"))
 
 	assert.Equal(t, float64(1), after-before)
 }

--- a/ark/internal/eventing/broker/metrics.go
+++ b/ark/internal/eventing/broker/metrics.go
@@ -1,0 +1,44 @@
+/* Copyright 2025. McKinsey & Company */
+
+package broker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	dropReasonSemaphoreFull = "semaphore_full"
+	dropReasonTimeout       = "timeout"
+	dropReasonHTTPError     = "http_error"
+	dropReasonMarshalError  = "marshal_error"
+	dropReasonRequestError  = "request_error"
+	dropReasonEndpointError = "endpoint_error"
+	dropReasonBadStatus     = "bad_status"
+)
+
+// Registered on controller-runtime's metrics.Registry, not the default
+// prometheus registry — the controller's metrics endpoint only serves the
+// former.
+var (
+	emitDroppedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ark_broker_emit_dropped_total",
+			Help: "Structured events dropped by the broker event emitter before delivery, by drop reason and namespace.",
+		},
+		[]string{"reason", "namespace"},
+	)
+
+	emitLatencySeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ark_broker_emit_latency_seconds",
+			Help:    "Latency of a broker /events POST from the emitter, by outcome.",
+			Buckets: []float64{0.005, 0.01, 0.05, 0.2, 0.5, 1, 5, 10},
+		},
+		[]string{"outcome"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(emitDroppedTotal, emitLatencySeconds)
+}

--- a/ark/internal/eventing/broker/metrics.go
+++ b/ark/internal/eventing/broker/metrics.go
@@ -26,9 +26,9 @@ var (
 	emitDroppedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ark_broker_emit_dropped_total",
-			Help: "Structured events dropped by the broker event emitter before delivery, by drop reason and namespace.",
+			Help: "Structured events dropped by the broker event emitter before delivery, by drop reason.",
 		},
-		[]string{"reason", "namespace"},
+		[]string{"reason"},
 	)
 
 	emitLatencySeconds = prometheus.NewHistogramVec(

--- a/ark/internal/eventing/broker/metrics.go
+++ b/ark/internal/eventing/broker/metrics.go
@@ -17,9 +17,11 @@ const (
 	dropReasonBadStatus     = "bad_status"
 )
 
-// Registered on controller-runtime's metrics.Registry, not the default
-// prometheus registry — the controller's metrics endpoint only serves the
-// former.
+// The broker emitter runs in both the controller and the completions
+// executor. The controller's metrics endpoint serves controller-runtime's
+// metrics.Registry, while the executor serves the default prometheus registry
+// via promhttp.Handler(). Register on both so drops surface regardless of the
+// hosting process.
 var (
 	emitDroppedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -41,4 +43,5 @@ var (
 
 func init() {
 	ctrlmetrics.Registry.MustRegister(emitDroppedTotal, emitLatencySeconds)
+	prometheus.MustRegister(emitDroppedTotal, emitLatencySeconds)
 }

--- a/ark/internal/eventing/broker/metrics_test.go
+++ b/ark/internal/eventing/broker/metrics_test.go
@@ -28,7 +28,7 @@ func gatheredMetricNames(t *testing.T, g prometheus.Gatherer) map[string]bool {
 func TestEmitMetricsRegisteredOnBothRegistries(t *testing.T) {
 	// Materialize a child so the vec collectors emit their metric family; an
 	// untouched vec gathers nothing and the family name would be absent.
-	emitDroppedTotal.WithLabelValues("registration_probe", "registration-probe-ns").Inc()
+	emitDroppedTotal.WithLabelValues("registration_probe").Inc()
 	emitLatencySeconds.WithLabelValues("registration_probe").Observe(0)
 
 	for _, tc := range []struct {

--- a/ark/internal/eventing/broker/metrics_test.go
+++ b/ark/internal/eventing/broker/metrics_test.go
@@ -1,0 +1,47 @@
+/* Copyright 2025. McKinsey & Company */
+
+package broker
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func gatheredMetricNames(t *testing.T, g prometheus.Gatherer) map[string]bool {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	names := make(map[string]bool, len(families))
+	for _, mf := range families {
+		names[mf.GetName()] = true
+	}
+	return names
+}
+
+// The emitter runs in both the controller (serves controller-runtime's
+// registry) and the completions executor (serves the default registry via
+// promhttp). Both must expose the metrics, or drops in one process go nowhere.
+func TestEmitMetricsRegisteredOnBothRegistries(t *testing.T) {
+	// Materialize a child so the vec collectors emit their metric family; an
+	// untouched vec gathers nothing and the family name would be absent.
+	emitDroppedTotal.WithLabelValues("registration_probe", "registration-probe-ns").Inc()
+	emitLatencySeconds.WithLabelValues("registration_probe").Observe(0)
+
+	for _, tc := range []struct {
+		name     string
+		gatherer prometheus.Gatherer
+	}{
+		{"controller-runtime", ctrlmetrics.Registry},
+		{"default", prometheus.DefaultGatherer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			names := gatheredMetricNames(t, tc.gatherer)
+			assert.True(t, names["ark_broker_emit_dropped_total"], "ark_broker_emit_dropped_total missing from %s registry", tc.name)
+			assert.True(t, names["ark_broker_emit_latency_seconds"], "ark_broker_emit_latency_seconds missing from %s registry", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ark_broker_emit_dropped_total{reason,namespace}` and `ark_broker_emit_latency_seconds{outcome}` to the broker event emitter, which previously dropped events silently (semaphore full, HTTP timeout, connection error, non-201) with only logs to go on.
- Registered on controller-runtime's `metrics.Registry` (the controller's metrics endpoint serves only that registry, not the default global one).
- This is fix-candidate #1 from #2863. A re-benchmark on 0.1.68-rc using these metrics is posted on the issue: in-memory broker ~12.5% emit drops (http_error-dominated) vs Postgres event backend ~0.33%.

Refs #2863