### PR TITLE
feat: make ark-broker mandatory and drop its experimental feature flag

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/constants/dashboard-icons.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/constants/dashboard-icons.test.ts
@@ -78,9 +78,5 @@ describe('dashboard-icons', () => {
     it('should have enabler feature for files section', () => {
       expect(DASHBOARD_SECTIONS.files.enablerFeature).toBeDefined();
     });
-
-    it('should have enabler feature for broker section', () => {
-      expect(DASHBOARD_SECTIONS.broker.enablerFeature).toBeDefined();
-    });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
+++ b/services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts
@@ -41,18 +41,6 @@ export const isChatStreamingEnabledAtom = atom(get => {
   return get(storedIsChatStreamingEnabledAtom);
 });
 
-export const BROKER_FEATURE_KEY = 'experimental-broker';
-export const storedIsBrokerEnabledAtom = atomWithStorage<boolean>(
-  BROKER_FEATURE_KEY,
-  false,
-  undefined,
-  { getOnInit: true },
-);
-
-export const isBrokerEnabledAtom = atom(get => {
-  return get(storedIsBrokerEnabledAtom);
-});
-
 export const MARKETPLACE_FEATURE_KEY = 'experimental-marketplace';
 export const storedIsMarketplaceEnabledAtom = atomWithStorage<boolean>(
   MARKETPLACE_FEATURE_KEY,

--- a/services/ark-dashboard/ark-dashboard/components/experimental-features-dialog/experimental-features.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/experimental-features-dialog/experimental-features.tsx
@@ -1,5 +1,4 @@
 import {
-  storedIsBrokerEnabledAtom,
   storedIsChatStreamingEnabledAtom,
   storedIsExperimentalDarkModeEnabledAtom,
   storedIsExperimentalExecutionEngineEnabledAtom,
@@ -42,24 +41,6 @@ export const experimentalFeatureGroups: ExperimentalFeatureGroup[] = [
           </span>
         ),
         atom: storedIsExperimentalExecutionEngineEnabledAtom,
-      },
-    ],
-  },
-  {
-    groupKey: 'observability',
-    groupLabel: 'Observability',
-    features: [
-      {
-        type: 'boolean',
-        feature: 'Broker',
-        description: (
-          <span>
-            Enables the experimental <span className="font-bold">Broker</span>{' '}
-            diagnostic page for viewing real-time OTEL traces, messages, and LLM
-            chunks
-          </span>
-        ),
-        atom: storedIsBrokerEnabledAtom,
       },
     ],
   },

--- a/services/ark-dashboard/ark-dashboard/lib/constants/dashboard-icons.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/constants/dashboard-icons.ts
@@ -21,10 +21,7 @@ import {
   Zap,
 } from 'lucide-react';
 
-import {
-  BROKER_FEATURE_KEY,
-  FILES_BROWSER_FEATURE_KEY,
-} from '@/atoms/experimental-features';
+import { FILES_BROWSER_FEATURE_KEY } from '@/atoms/experimental-features';
 
 export interface DashboardSection {
   key: string;
@@ -104,7 +101,6 @@ export const DASHBOARD_SECTIONS: Record<string, DashboardSection> = {
     title: 'Broker',
     icon: Activity,
     group: 'monitoring',
-    enablerFeature: BROKER_FEATURE_KEY,
   },
   events: {
     key: 'events',

--- a/tools/ark-cli/src/arkServices.ts
+++ b/tools/ark-cli/src/arkServices.ts
@@ -188,6 +188,7 @@ const defaultArkServices: ServiceCollection = {
     description:
       'In-memory storage service with streaming support for Ark queries',
     enabled: true,
+    mandatory: true,
     category: 'service',
     chartPath: `${REGISTRY_BASE}/ark-broker:${CHART_VERSION}`,
     installArgs: [],


### PR DESCRIPTION
## Context

Sub-issue of #2153 (the ark-broker backend refactoring umbrella), part of the Phase 5 cleanup. The umbrella's premise is that the broker has grown from a dev-time diagnostic aid into a core piece of the platform — it now backs conversation memory, streaming chunks, operation events and the sessions read model, with Postgres and Redis backends behind it. Two places in the codebase still describe it as something the user opts into. This PR closes that gap.

## Problem

**The dashboard offers a toggle that controls nothing.** When the Broker page was introduced in #634 the sidebar gated it on a feature flag:

```ts
switch (item.enablerFeature) {
  case BROKER_FEATURE_KEY: return isBrokerEnabled;
  default: return true;
}
```

That switch was removed in #1088 (`feat: navigation`, 2026-02-23) when the sidebar was rewritten around `CollapsibleSection`. Since then `app-sidebar.tsx` renders `MONITORING_SECTIONS` unfiltered, and `__tests__/unit/lib/dashboard-sections.test.ts` actively asserts that `broker` is present in that list. `isBrokerEnabledAtom` has had no consumers for six months.

So the current behaviour is: the Broker page is always visible under Monitoring, and the "Broker" switch in the Experimental Features dialog does nothing at all. Flipping it off does not hide the page. This is worse than a stale flag — it is a control that visibly lies about what it does.

**The installer lets you deselect a service the platform depends on.** In `arkServices.ts`, `ark-broker` is `enabled: true` but not `mandatory`. In the interactive `ark install` checklist (`commands/install/index.ts:447-468`) mandatory services render as a non-toggleable `inquirer.Separator` and are always appended to `selectedComponents`; everything else is a deselectable checkbox. Today the broker is a checkbox.

Unchecking it yields a cluster that looks installed but is not functional: the broker chart is what creates the `default` Memory resource (`chart/values.yaml:135-139`, `createMemoryCRD: true` + `setAsDefault: true`) and the `ark-config-streaming` ConfigMap that the controller and SDK clients discover to stream completions. Without it there is no default memory and no streaming, with no error at install time to explain why.

## Fix

Two independent changes, one commit each.

The dashboard side removes the flag entirely rather than reconnecting it. Reconnecting would be a regression: the page has been unconditionally available for six months and nothing suggests hiding it is wanted. This follows the shape of #497, which did the same for the A2A Tasks flag. The `observability` group disappears from the dialog along with it, since Broker was its only member.

The CLI side adds `mandatory: true` to the `ark-broker` entry. `category` deliberately stays `'service'` rather than moving to `'core'`: every `core` service is pinned to the `ark-system` namespace, while the broker is deployed per-namespace — a decision already settled in the Phase 4 sessions work. The `mandatoryServiceNames` filter spans both core and service categories, so the flag takes effect regardless of grouping.

Worth being explicit about the limit of this change: `mandatory` governs the interactive checklist only. `getInstallableServices` still filters on `service.enabled`, so an operator who sets `'ark-broker': {enabled: false}` in CLI config continues to skip it. That is exactly how `ark-controller` and the other mandatory services already behave, so the semantics stay consistent — "mandatory" means "not deselectable at the prompt", not "impossible to disable".

Intentionally unchanged: the chart's `streaming.enabled`, `otelEndpoint.enabled`, `memory.createMemoryCRD` and `persistence.enabled` values. Those configure how the broker behaves, not whether it exists, and the Postgres/Redis backends stay opt-in per the umbrella's migration plan. No documentation changes either — no doc describes the broker as experimental; the "optional" wording in the docs refers to the storage backends, which remains accurate.

## Review guide

`tools/ark-cli/src/arkServices.ts:191` — the one functional line. Worth confirming against `commands/install/index.ts:459` that a `mandatory` service in the `service` category renders correctly as a separator under "Ark Services", not just under "Ark Core".

`services/ark-dashboard/ark-dashboard/lib/constants/dashboard-icons.ts:103-107` — the broker section keeps its key, title, icon and group; only `enablerFeature` is gone. After this, `files` is the sole remaining `enablerFeature` consumer, and it is inert too: the Files nav item is hardcoded at `app-sidebar.tsx:426` and the availability check lives in the page, not the nav. The mechanism is effectively dead in full — removing it entirely felt like scope creep here, but it is a fair follow-up.

`services/ark-dashboard/ark-dashboard/atoms/experimental-features.ts` — note that `atomWithStorage` means the `experimental-broker` key may still sit in users' `localStorage`. It is harmless: nothing reads it any more, and it was already inert.

`services/ark-dashboard/ark-dashboard/components/experimental-features-dialog/experimental-features.tsx` — the whole `observability` group is removed, not just the feature entry, so the dialog does not render an empty section.

## Notes on verification

The dashboard suite passes (233 of 234 files, 2421 tests). The one failing file, `__tests__/unit/components/sessions-conversations/filter-combinations.test.tsx`, fails identically on `main` — verified by stashing this branch's changes and re-running. It is a `pointer-events: none` issue in a combobox interaction, unrelated to anything here.

The ark-cli suite passes in full (58 files, 660 tests), and `arkServices.ts` is clean under both eslint and prettier. `npm run lint:check` for ark-cli does report 4 errors, all pre-existing and in untouched files (`install/index.ts:95`, `arkApiClient.spec.ts:4`, `chatClient.spec.ts:370`, `chatClient.ts:195`) — left alone to keep this diff scoped.

One thing to flag for the team separately: the dashboard's `npm run lint` script is broken. It invokes `next lint`, which current Next versions interpret as a request to lint a directory named `lint`, so it exits with "Invalid project directory". Nothing catches it because CI only runs `make services-test-all` for the dashboard, which is `npm audit` plus vitest — no lint step. That is why formatting drift has accumulated on `main`; running prettier over the test file touched here reformatted two unrelated lines, which I reverted to keep the commit atomic.

Closes #2730
