### PR TITLE
fix(deps): bump fast-uri to 3.1.6 for CVE-2026-75899/75931/75975/76172

### DIFF
--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ark-broker",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ark-broker",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
@@ -5494,9 +5494,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -93,6 +93,7 @@
     "ws": "^8.21.0",
     "form-data": "^4.0.6",
     "undici": "^7.28.0",
+    "fast-uri": "^3.1.6",
     "dockerode": {
       "protobufjs": "^7.6.5"
     }

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agents-at-scale/ark",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agents-at-scale/ark",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3807,9 +3807,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -95,7 +95,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "ws": "^8.21.0",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",


### PR DESCRIPTION
## Summary
- Bumps `fast-uri` (transitive via `ajv`) to `>=3.1.6` in `tools/ark-cli` and `services/ark-broker`, remediating four High-severity advisories flagged by JFrog Xray in #3269 (all fixed in the same upstream release):
  - CVE-2026-75899 — SSRF via repeated hostname percent-decoding
  - CVE-2026-75931 — host confusion via skipped IDN canonicalization on scheme-relative refs
  - CVE-2026-75975 — SSRF via malformed IPv6 normalization
  - CVE-2026-76172 — host confusion via percent-encoded scheme normalization
- `ark-cli`: existing override bumped `^3.1.5` → `^3.1.6`; lockfile resolves to 3.1.6.
- `ark-broker`: new `fast-uri` override added; lockfile resolves to 3.1.6.
- No Go/Python/Docker components reference `fast-uri` (npm-only).

Closes #3269