### PR TITLE
fix: persist MemoryUnavailable and MemoryDegraded conditions on Query status

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -1035,10 +1035,30 @@ func (r *QueryReconciler) setConditionForPhase(query *arkv1alpha1.Query, status 
 	}
 }
 
+// memoryConditionTypes are set on the in-memory Query by the dispatch path and
+// must survive the refetch inside mutateStatus. They are the only conditions
+// this reconcile knows more about than the API server does; every other
+// condition is authored inside the mutator against the refetched object.
+var memoryConditionTypes = []arkv1alpha1.QueryConditionType{
+	arkv1alpha1.QueryMemoryUnavailable,
+	arkv1alpha1.QueryMemoryDegraded,
+}
+
+func memoryConditionsFrom(query *arkv1alpha1.Query) []metav1.Condition {
+	var conditions []metav1.Condition
+	for _, condType := range memoryConditionTypes {
+		if cond := meta.FindStatusCondition(query.Status.Conditions, string(condType)); cond != nil {
+			conditions = append(conditions, *cond)
+		}
+	}
+	return conditions
+}
+
 type savedQueryStatus struct {
-	response       *arkv1alpha1.Response
-	tokenUsage     arkv1alpha1.TokenUsage
-	conversationId string
+	response         *arkv1alpha1.Response
+	tokenUsage       arkv1alpha1.TokenUsage
+	conversationId   string
+	memoryConditions []metav1.Condition
 }
 
 func (s *savedQueryStatus) restoreOnto(query *arkv1alpha1.Query) {
@@ -1049,16 +1069,20 @@ func (s *savedQueryStatus) restoreOnto(query *arkv1alpha1.Query) {
 	if s.conversationId != "" {
 		query.Status.ConversationId = s.conversationId
 	}
+	for _, cond := range s.memoryConditions {
+		meta.SetStatusCondition(&query.Status.Conditions, cond)
+	}
 }
 
 func (r *QueryReconciler) updateStatusWithDuration(ctx context.Context, query *arkv1alpha1.Query, status string, duration *metav1.Duration) error {
-	// This reconcile holds the freshest Response/TokenUsage/ConversationId in
-	// memory; the refetch inside mutateStatus would drop them, so re-apply the
-	// snapshot onto the refetched object before writing.
+	// This reconcile holds the freshest Response/TokenUsage/ConversationId and
+	// memory conditions in memory; the refetch inside mutateStatus would drop
+	// them, so re-apply the snapshot onto the refetched object before writing.
 	saved := savedQueryStatus{
-		response:       query.Status.Response,
-		tokenUsage:     query.Status.TokenUsage,
-		conversationId: query.Status.ConversationId,
+		response:         query.Status.Response,
+		tokenUsage:       query.Status.TokenUsage,
+		conversationId:   query.Status.ConversationId,
+		memoryConditions: memoryConditionsFrom(query),
 	}
 	// Do NOT clear A2A taskID when transitioning from input-required to running.
 	// The executor needs the taskID to detect this is a resumption after approval

--- a/ark/internal/controller/query_controller_dispatch_test.go
+++ b/ark/internal/controller/query_controller_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 
@@ -503,6 +505,97 @@ func TestSetConditionMemoryDegraded(t *testing.T) {
 		cond := findCondition(query.Status.Conditions, condType)
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	})
+}
+
+// The setters above run against an in-memory Query, but the terminal write
+// refetches the object inside mutateStatus. Without the snapshot in
+// savedQueryStatus, both conditions are dropped before they are ever persisted
+// and a completed query carries only Completed.
+func TestUpdateStatusWithDuration_PersistsMemoryConditions(t *testing.T) {
+	ctx := context.Background()
+	unavailableType := string(arkv1alpha1.QueryMemoryUnavailable)
+	degradedType := string(arkv1alpha1.QueryMemoryDegraded)
+
+	newPersistedQuery := func(name string) (*arkv1alpha1.Query, *QueryReconciler, client.Client) {
+		q := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: targetTypeAgent, Name: "test-agent"},
+			},
+			Status: arkv1alpha1.QueryStatus{Phase: statusRunning},
+		}
+		c := fake.NewClientBuilder().WithScheme(newTestScheme()).
+			WithObjects(q).
+			WithStatusSubresource(&arkv1alpha1.Query{}).
+			Build()
+		return q, &QueryReconciler{Client: c, Scheme: c.Scheme()}, c
+	}
+
+	fetch := func(t *testing.T, c client.Client, q *arkv1alpha1.Query) *arkv1alpha1.Query {
+		t.Helper()
+		after := &arkv1alpha1.Query{}
+		require.NoError(t, c.Get(ctx, apimachinerytypes.NamespacedName{Name: q.Name, Namespace: q.Namespace}, after))
+		return after
+	}
+
+	t.Run("persists the False form when memory was healthy", func(t *testing.T) {
+		q, r, c := newPersistedQuery("memory-conditions-false")
+		r.setConditionMemoryUnavailable(q, false)
+		r.setConditionMemoryDegraded(q, false)
+
+		require.NoError(t, r.updateStatusWithDuration(ctx, q, statusDone, &metav1.Duration{Duration: time.Second}))
+
+		after := fetch(t, c, q)
+		unavailable := findCondition(after.Status.Conditions, unavailableType)
+		require.NotNil(t, unavailable, "MemoryUnavailable must be persisted in its False form so consumers can tell 'memory was fine' from 'never evaluated'")
+		assert.Equal(t, metav1.ConditionFalse, unavailable.Status)
+		assert.Equal(t, "MemoryReachable", unavailable.Reason)
+
+		degraded := findCondition(after.Status.Conditions, degradedType)
+		require.NotNil(t, degraded, "MemoryDegraded must be persisted in its False form")
+		assert.Equal(t, metav1.ConditionFalse, degraded.Status)
+		assert.Equal(t, "MemoryHealthy", degraded.Reason)
+
+		require.NotNil(t, findCondition(after.Status.Conditions, string(arkv1alpha1.QueryCompleted)), "the phase condition must still be written alongside the restored memory conditions")
+	})
+
+	t.Run("persists the True form when memory was unavailable", func(t *testing.T) {
+		q, r, c := newPersistedQuery("memory-conditions-unavailable")
+		r.setConditionMemoryUnavailable(q, true)
+		r.setConditionMemoryDegraded(q, false)
+
+		require.NoError(t, r.updateStatusWithDuration(ctx, q, statusDone, &metav1.Duration{Duration: time.Second}))
+
+		after := fetch(t, c, q)
+		unavailable := findCondition(after.Status.Conditions, unavailableType)
+		require.NotNil(t, unavailable)
+		assert.Equal(t, metav1.ConditionTrue, unavailable.Status)
+		assert.Equal(t, "NoMemoryBackend", unavailable.Reason)
+	})
+
+	t.Run("persists the True form when memory was degraded", func(t *testing.T) {
+		q, r, c := newPersistedQuery("memory-conditions-degraded")
+		r.setConditionMemoryUnavailable(q, false)
+		r.setConditionMemoryDegraded(q, true)
+
+		require.NoError(t, r.updateStatusWithDuration(ctx, q, statusDone, &metav1.Duration{Duration: time.Second}))
+
+		after := fetch(t, c, q)
+		degraded := findCondition(after.Status.Conditions, degradedType)
+		require.NotNil(t, degraded)
+		assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+		assert.Equal(t, "GetMessagesFailed", degraded.Reason)
+	})
+
+	t.Run("leaves conditions absent when dispatch never evaluated memory", func(t *testing.T) {
+		q, r, c := newPersistedQuery("memory-conditions-untouched")
+
+		require.NoError(t, r.updateStatusWithDuration(ctx, q, statusRunning, nil))
+
+		after := fetch(t, c, q)
+		assert.Nil(t, findCondition(after.Status.Conditions, unavailableType), "a non-dispatch status write must not invent a memory condition")
+		assert.Nil(t, findCondition(after.Status.Conditions, degradedType))
 	})
 }
 


### PR DESCRIPTION
## Checklist

[Problem](https://github.com/mckinsey/agents-at-scale-ark/issues/3166) 
- Persist the `MemoryUnavailable` and `MemoryDegraded` conditions on Query status. Both were computed and set, but never reached the API server, so a completed Query carried only `Completed`.
- Root cause: `mutateStatus` refetches the Query into the caller's own pointer (`query_controller.go:1135`), replacing `Status.Conditions` with server state. The memory conditions are set on the in-memory object at `query_controller.go:1603-1604`, before that refetch, so they were discarded prior to every write — in both their `True` and `False` forms.
- `savedQueryStatus` already exists to carry in-memory fields across this refetch (`Response`, `TokenUsage`, `ConversationId`). This adds the two condition types to that snapshot, re-applied via `meta.SetStatusCondition`.
- Add `TestUpdateStatusWithDuration_PersistsMemoryConditions`, which drives the real persist path. Existing tests asserted on the in-memory slice only and never crossed it, so both features shipped green and inert.

Repairs #2899 (`MemoryUnavailable`) and #3020 (`MemoryDegraded`). Fixes #<issue>.

Verified on kind with the same agent, input, and cluster, changing only the controller image:

| | Conditions on completed Query |
|---|---|
| Stock `0.1.68` | `Completed=True` |
| This change | `Completed=True`, `MemoryUnavailable=False (MemoryReachable)`, `MemoryDegraded=False (MemoryHealthy)` |
| This change, no Memory backend | `Completed=True`, `MemoryUnavailable=True (NoMemoryBackend)`, `MemoryDegraded=False` |



<img width="1441" height="322" alt="Screenshot 2026-08-24 at 10 44 56 PM" src="https://github.com/user-attachments/assets/06ab291e-7d43-4c3f-bcce-206b5ad1f811" />

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 