### PR TITLE
fix: don't misclassify completed external A2A tasks as HITL resumptions

### DIFF
--- a/ark/executors/completions/handler.go
+++ b/ark/executors/completions/handler.go
@@ -866,6 +866,15 @@ func (h *Handler) checkResumption(ctx context.Context, query *arkv1alpha1.Query)
 
 	log.Info("A2ATask status", "taskId", taskID, "phase", a2aTask.Status.Phase)
 
+	// Only HITL approval tasks are resumable. External A2A agent tasks (blocking or
+	// streaming) also reach PhaseCompleted and record their TaskID in query status, but
+	// they carry no approval metadata; resuming them fails with "no toolCalls in
+	// protocolMetadata". Distinguish by A2AServerRef, which approval tasks never set.
+	if !arka2a.IsHITLApprovalTask(&a2aTask) {
+		log.Info("A2ATask is an external A2A agent task, not a HITL resumption", "taskId", taskID)
+		return false, nil
+	}
+
 	// Check if task is completed (approval) or denied in a way the agent can react to
 	if a2aTask.Status.Phase == arka2a.PhaseCompleted {
 		log.Info("A2ATask completed, resuming", "taskId", taskID)

--- a/ark/executors/completions/handler_test.go
+++ b/ark/executors/completions/handler_test.go
@@ -1038,6 +1038,25 @@ func TestCheckResumption(t *testing.T) {
 			expectPhase:      arka2a.PhaseFailed,
 		},
 		{
+			name: "no resumption - completed external agent task",
+			a2aTask: &arkv1alpha1.A2ATask{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a2a-task-test-123",
+					Namespace: "default",
+				},
+				Spec: arkv1alpha1.A2ATaskSpec{
+					A2AServerRef: &arkv1alpha1.A2AServerRef{
+						Name:      "external-agent-server",
+						Namespace: "default",
+					},
+				},
+				Status: arkv1alpha1.A2ATaskStatus{
+					Phase: arka2a.PhaseCompleted,
+				},
+			},
+			expectResumption: false,
+		},
+		{
 			name:             "no resumption - no task",
 			a2aTask:          nil,
 			expectResumption: false,

--- a/ark/internal/a2a/a2a_protocol.go
+++ b/ark/internal/a2a/a2a_protocol.go
@@ -298,6 +298,14 @@ func IsUserRejection(task *arkv1alpha1.A2ATask) bool {
 	return cond != nil && cond.Reason == ConditionReasonApprovalRejected
 }
 
+// IsHITLApprovalTask reports whether the A2ATask originated from a human-in-the-loop
+// approval flow. Approval tasks are created directly by the executor and carry no
+// A2AServerRef; external A2A agent tasks (blocking or streaming) always reference the
+// A2AServer they poll. Only approval tasks are resumable by the completions executor.
+func IsHITLApprovalTask(task *arkv1alpha1.A2ATask) bool {
+	return task.Spec.A2AServerRef == nil
+}
+
 // IsResumableDenial reports whether the agent should resume to handle the denial
 // gracefully. Covers both explicit user rejection and timeout-driven rejection so
 // that the agent can respond to the user in either case.

--- a/ark/internal/a2a/a2a_protocol_test.go
+++ b/ark/internal/a2a/a2a_protocol_test.go
@@ -1009,6 +1009,26 @@ func TestIsUserRejection(t *testing.T) {
 	})
 }
 
+func TestIsHITLApprovalTask(t *testing.T) {
+	t.Run("returns true when A2AServerRef is nil", func(t *testing.T) {
+		task := &arkv1alpha1.A2ATask{}
+		if !IsHITLApprovalTask(task) {
+			t.Error("expected true when A2AServerRef is nil")
+		}
+	})
+
+	t.Run("returns false when A2AServerRef is set", func(t *testing.T) {
+		task := &arkv1alpha1.A2ATask{
+			Spec: arkv1alpha1.A2ATaskSpec{
+				A2AServerRef: &arkv1alpha1.A2AServerRef{Name: "server"},
+			},
+		}
+		if IsHITLApprovalTask(task) {
+			t.Error("expected false when A2AServerRef references an A2AServer")
+		}
+	})
+}
+
 func TestIsResumableDenial(t *testing.T) {
 	completedType := string(arkv1alpha1.A2ATaskCompleted)
 


### PR DESCRIPTION
## Summary
- `checkResumption` treated any completed `A2ATask` referenced by a query as a HITL approval resumption, so a normally-completed external A2A agent task (blocking or streaming) was indistinguishable from an approval-completed one. On re-dispatch, `handleResumption` failed with `A2ATask has no toolCalls in protocolMetadata` and the query was marked `phase: error` even though the agent task succeeded.
- Distinguish the flows by `A2AServerRef`, the one field that already separates them: HITL approval tasks are created directly by the executor with no `A2AServerRef`, while external A2A agent tasks always set it. Added `IsHITLApprovalTask` in `internal/a2a` and gated `checkResumption` on it — external-agent tasks are no longer treated as resumptions.
- Added a `TestCheckResumption` regression case for a completed external-agent task (no `toolCalls`/approval metadata) asserting `expectResumption: false`. Existing HITL approve/reject resumption cases still resume.

Fixes #3204