### PR TITLE
feat(memory): surface dropped conversation history in chat and ark status

### DIFF
--- a/docs/content/reference/resources/memory.mdx
+++ b/docs/content/reference/resources/memory.mdx
@@ -134,7 +134,32 @@ ark query agent/my-agent "What was the last message?" --conversation-id "my-conv
 - **sessionId**: Groups related queries for tracking and telemetry purposes.
 - **conversationId**: Conversation threading identifier sent to all execution engines as A2A `contextId`. The completions engine uses it for memory continuity; named engines can use it for their own session management.
 
-When creating a query in the dashboard it is also possible to specify the memory resource. Note that in the dashboard 'chat' window, no memory is used — messages are simply stored client-side as is common for chat applications.
+When creating a query in the dashboard it is also possible to specify the memory resource. The dashboard chat window keeps its transcript client-side. It also threads a `conversationId` once it has one — but it only ever gets one because a memory backend minted it, so in a namespace with no working memory the chat has no `conversationId` at all and each turn starts from nothing.
+
+## Telling when memory is not working
+
+A namespace with **no** `Memory` degrades rather than failing: resolution falls back to a no-op and queries run without conversation history. A namespace with a `Memory` that never resolved an address is the harsher case — `NewHTTPMemory` errors, so those queries **fail**. The two are worth telling apart, because only the first one is reported on the `Query`:
+
+| Condition | `status: "True"` means |
+| --- | --- |
+| `MemoryUnavailable` | The query carried a `conversationId` but no memory backend was reachable, so history was dropped. |
+| `MemoryDegraded` | A backend was reachable but reading the history from it failed, so the query ran without prior context. |
+
+Both conditions are written on every query whose dispatch completes, carrying `status: "False"` and a reassuring message on the healthy path. Read the `status` field — the presence of the condition says nothing.
+
+```bash
+kubectl get query <name> -o jsonpath='{.status.conditions[?(@.type=="MemoryUnavailable")]}'
+```
+
+Two limits on that signal, both of which the `ark status` check below exists to cover:
+
+- A query that **failed to dispatch** carries neither condition. An unresolved `Memory` is exactly that case: the query errors with `failed to create memory client`, and no memory condition is written.
+- `MemoryUnavailable` requires a `conversationId` on the query, since it means "continuity was expected and not delivered". A dashboard chat in a namespace that never had a working memory never obtains one, so the notice below does not appear there — it appears when a chat that *had* continuity loses the backend.
+
+Two surfaces read this for you:
+
+- **Dashboard chat** shows a notice at the top of the conversation when the last turn reported either condition as `True`, quoting the condition's own message.
+- **`ark status`** prints a `default memory` line for the kubeconfig's current namespace, and it asks the namespace directly rather than reading conditions. It reports the namespace as broken when it has a broker but no `Memory`, and when a `Memory` exists but never resolved an address. A broker counts when it has published an enabled `ark-config-broker` / `ark-config-streaming` ConfigMap, or failing that when a Service carrying the broker chart's label is present — those ConfigMaps are optional, so their absence alone is not proof there is no broker. A namespace with no broker is reported as unconfigured rather than broken. What it cannot read, it does not guess at: an unlistable ConfigMap is always undetermined, and a forbidden cluster-scoped `ArkConfig` downgrades a *broken* verdict to undetermined rather than accusing the namespace of a fault that a default it cannot see may already rule out. The line is informational: it does not change the command's exit code.
 
 ## Memory HTTP API
 

--- a/docs/content/reference/resources/query.mdx
+++ b/docs/content/reference/resources/query.mdx
@@ -281,7 +281,7 @@ status:
 | Field | Description |
 | --- | --- |
 | `status.phase` | One of `pending`, `provisioning`, `running`, `done`, `error`, `canceled`. |
-| `status.conditions[]` | Standard Kubernetes conditions. The `Completed` condition flips to `True` on success or failure. |
+| `status.conditions[]` | Standard Kubernetes conditions. The `Completed` condition flips to `True` on success or failure. `MemoryUnavailable` and `MemoryDegraded` report conversation history that was dropped — both are written on every query whose dispatch completes, so read `status`, not presence. See [telling when memory is not working](/reference/resources/memory#telling-when-memory-is-not-working). |
 | `status.response` | Single response object (singular — there is no `responses[]` array). A selector resolves to one target, so there is always exactly one response. |
 | `status.response.content` | The final assistant message. |
 | `status.response.raw` | The full conversation as a JSON-encoded array of messages — what the dashboard's Debug tab renders. |

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/memory-chat-notice.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/memory-chat-notice.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MemoryChatNotice } from '@/components/chat/memory-chat-notice';
+
+describe('MemoryChatNotice', () => {
+  it('leads the unavailable case and keeps the condition message verbatim', () => {
+    render(
+      <MemoryChatNotice
+        notice={{
+          type: 'MemoryUnavailable',
+          message:
+            'conversationId was set but no Memory backend was reachable; conversation history was disabled for this query',
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/This chat is not keeping conversation history\./),
+    ).toHaveTextContent(
+      'This chat is not keeping conversation history. conversationId was set but no Memory backend was reachable; conversation history was disabled for this query',
+    );
+  });
+
+  it('leads the degraded case differently', () => {
+    render(
+      <MemoryChatNotice
+        notice={{
+          type: 'MemoryDegraded',
+          message: 'failed to read conversation history from the backend',
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Conversation history could not be read\./),
+    ).toHaveTextContent(
+      'Conversation history could not be read. failed to read conversation history from the backend',
+    );
+    expect(screen.queryByText(/is not keeping/)).not.toBeInTheDocument();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/floating-chat.test.tsx
@@ -35,6 +35,9 @@ vi.mock('@/lib/services', () => ({
     submitChatQuery: vi.fn(),
     getQueryResult: vi.fn(),
     getQuery: vi.fn().mockResolvedValue({ status: { conversationId: '' } }),
+    resolveMemoryNotice: vi
+      .fn()
+      .mockResolvedValue({ settled: true, notice: null }),
   },
   agentsService: {
     getByName: vi.fn().mockResolvedValue({ parameters: [] }),

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/hooks/use-chat-session.test.ts
@@ -26,9 +26,11 @@ const mockStartStreamChatResponse = vi.fn();
 const mockStreamQueryStatus = vi.fn();
 const mockSubmitChatQuery = vi.fn();
 const mockGetQueryResult = vi.fn();
+const mockGetQuery = vi.fn();
 const mockCancelQuery = vi.fn();
 const mockGetByName = vi.fn();
 const mockTeamGetByName = vi.fn();
+const mockResolveMemoryNotice = vi.fn();
 
 vi.mock('@/lib/services', () => ({
   chatService: {
@@ -38,7 +40,10 @@ vi.mock('@/lib/services', () => ({
     streamQueryStatus: (...args: unknown[]) => mockStreamQueryStatus(...args),
     submitChatQuery: (...args: unknown[]) => mockSubmitChatQuery(...args),
     getQueryResult: (...args: unknown[]) => mockGetQueryResult(...args),
+    getQuery: (...args: unknown[]) => mockGetQuery(...args),
     cancelQuery: (...args: unknown[]) => mockCancelQuery(...args),
+    resolveMemoryNotice: (...args: unknown[]) =>
+      mockResolveMemoryNotice(...args),
   },
   agentsService: {
     getByName: (...args: unknown[]) => mockGetByName(...args),
@@ -128,6 +133,8 @@ describe('useChatSession', () => {
       return Promise.resolve({ queryName: 'test-query', chunks });
     });
     mockStreamQueryStatus.mockResolvedValue(() => {});
+    mockResolveMemoryNotice.mockResolvedValue({settled: true, notice: null});
+    mockGetQuery.mockResolvedValue({ status: { phase: 'done' } });
   });
 
   afterEach(() => {
@@ -831,6 +838,335 @@ describe('useChatSession', () => {
         expect(result.current.isProcessing).toBe(false);
         expect(result.current.error).toBeNull();
       });
+    });
+  });
+
+  describe('memory notice', () => {
+    const unavailable = {
+      type: 'MemoryUnavailable' as const,
+      message:
+        'conversationId was set but no Memory backend was reachable; conversation history was disabled for this query',
+    };
+    const settled = (notice: typeof unavailable | null) => ({
+      settled: true,
+      notice,
+    });
+    const unsettled = {settled: false, notice: null};
+
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>(r => {
+        resolve = r;
+      });
+      return {promise, resolve};
+    }
+
+    // The streaming path cannot read the verdict off the stream: the executor
+    // closes it before the controller writes the terminal status. It polls,
+    // unawaited, so the lookup outlives the turn.
+    function streamedTurn() {
+      mockStreamChatResponse.mockReturnValue(
+        asyncIterableFrom([
+          createContentChunk('Hello'),
+          createStopChunk(),
+          createArkFinalChunk({}),
+        ]),
+      );
+    }
+
+    // The polling path already holds a terminal response, so it reads the
+    // verdict straight off it.
+    function polledTurn(lookup?: {
+      settled: boolean;
+      notice: typeof unavailable | null;
+    }) {
+      store.set(storedIsChatStreamingEnabledAtom, false);
+      mockGetQueryResult.mockResolvedValue({
+        status: 'done',
+        terminal: true,
+        response: 'Hi',
+        ...(lookup ? {memoryLookup: lookup} : {}),
+      });
+    }
+
+    function renderChat(name = 'test-agent') {
+      return renderHook(
+        ({ name: n }: { name: string }) => useChatSession({ name: n, type: 'agent' }),
+        { wrapper, initialProps: { name } },
+      );
+    }
+
+    it('starts with no notice', () => {
+      const { result } = renderChat();
+
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    it('surfaces the notice after a streamed turn', async () => {
+      streamedTurn();
+      mockResolveMemoryNotice.mockResolvedValue(settled(unavailable));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+      expect(mockResolveMemoryNotice).toHaveBeenCalledWith('test-query');
+    });
+
+    it('leaves the notice null when a streamed turn reports no problem', async () => {
+      streamedTurn();
+      mockResolveMemoryNotice.mockResolvedValue(settled(null));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+
+      await waitFor(() => {
+        expect(mockResolveMemoryNotice).toHaveBeenCalled();
+      });
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    it('takes the notice off the polled response, without a second lookup', async () => {
+      polledTurn(settled(unavailable));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+      expect(mockResolveMemoryNotice).not.toHaveBeenCalled();
+    });
+
+    it('drops the notice once a later turn is healthy again', async () => {
+      polledTurn(settled(unavailable));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+
+      polledTurn(settled(null));
+
+      await act(async () => {
+        await result.current.sendMessage('Hello again');
+      });
+
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toBeNull();
+      });
+    });
+
+    // A lookup that timed out, or a query that ended without the controller's
+    // verdict on it, says nothing about memory. Treating either as healthy made
+    // the banner flap off between turns of a chat that was still broken.
+    it('keeps a standing notice when the next turn carries no verdict', async () => {
+      polledTurn(settled(unavailable));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+
+      polledTurn();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello again');
+      });
+
+      await waitFor(() => {
+        expect(mockGetQueryResult).toHaveBeenCalledTimes(2);
+      });
+      expect(result.current.memoryNotice).toEqual(unavailable);
+    });
+
+    it('keeps a standing notice when a streamed lookup cannot settle', async () => {
+      streamedTurn();
+      mockResolveMemoryNotice
+        .mockResolvedValueOnce(settled(unavailable))
+        .mockResolvedValue(unsettled);
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+
+      streamedTurn();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello again');
+      });
+
+      await waitFor(() => {
+        expect(mockResolveMemoryNotice).toHaveBeenCalledTimes(2);
+      });
+      expect(result.current.memoryNotice).toEqual(unavailable);
+    });
+
+    // The lookup is fired unawaited and isProcessing goes false immediately, so
+    // the switcher and New chat are live while it is still running.
+    it('does not write a pending notice into the next target', async () => {
+      streamedTurn();
+      const pending = deferred<ReturnType<typeof settled>>();
+      mockResolveMemoryNotice.mockReturnValue(pending.promise);
+
+      const { result, rerender } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+
+      rerender({ name: 'other-agent' });
+
+      await act(async () => {
+        pending.resolve(settled(unavailable));
+        await pending.promise;
+      });
+
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    // The turn's epoch is snapshotted when the turn starts, not when the lookup
+    // is fired, so a switch part-way through the turn is caught too.
+    it('does not write a notice for a turn the user switched away from mid-flight', async () => {
+      const pendingStream = deferred<void>();
+      mockStreamChatResponse.mockImplementation(async function* () {
+        yield createContentChunk('Hello');
+        yield createStopChunk();
+        await pendingStream.promise;
+        yield createArkFinalChunk({});
+      });
+      mockResolveMemoryNotice.mockResolvedValue(settled(unavailable));
+
+      const { result, rerender } = renderChat();
+
+      let turn: Promise<void>;
+      await act(async () => {
+        turn = result.current.sendMessage('Hello');
+        await Promise.resolve();
+      });
+
+      rerender({ name: 'other-agent' });
+
+      await act(async () => {
+        pendingStream.resolve();
+        await turn!;
+      });
+
+      await waitFor(() => {
+        expect(mockResolveMemoryNotice).toHaveBeenCalled();
+      });
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    it('does not write a pending notice back after the chat is cleared', async () => {
+      streamedTurn();
+      const pending = deferred<ReturnType<typeof settled>>();
+      mockResolveMemoryNotice.mockReturnValue(pending.promise);
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+
+      act(() => {
+        result.current.clearChat();
+      });
+
+      await act(async () => {
+        pending.resolve(settled(unavailable));
+        await pending.promise;
+      });
+
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    // Two turns in flight at once: the older lookup must not overwrite what the
+    // newer one already decided.
+    it('ignores a lookup for a query that is no longer the current turn', async () => {
+      streamedTurn();
+      mockSubmitChatQuery
+        .mockResolvedValueOnce({ name: 'query-1' })
+        .mockResolvedValueOnce({ name: 'query-2' });
+      mockStartStreamChatResponse
+        .mockImplementationOnce((...args: unknown[]) =>
+          Promise.resolve({
+            queryName: 'query-1',
+            chunks: mockStreamChatResponse(...args),
+          }),
+        )
+        .mockImplementationOnce((...args: unknown[]) =>
+          Promise.resolve({
+            queryName: 'query-2',
+            chunks: mockStreamChatResponse(...args),
+          }),
+        );
+      const first = deferred<ReturnType<typeof settled>>();
+      mockResolveMemoryNotice
+        .mockReturnValueOnce(first.promise)
+        .mockResolvedValue(settled(null));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+      streamedTurn();
+      await act(async () => {
+        await result.current.sendMessage('Hello again');
+      });
+
+      await act(async () => {
+        first.resolve(settled(unavailable));
+        await first.promise;
+      });
+
+      expect(mockResolveMemoryNotice).toHaveBeenCalledWith('query-1');
+      expect(mockResolveMemoryNotice).toHaveBeenCalledWith('query-2');
+      expect(result.current.memoryNotice).toBeNull();
+    });
+
+    it('clears the notice when the chat is cleared', async () => {
+      polledTurn(settled(unavailable));
+
+      const { result } = renderChat();
+
+      await act(async () => {
+        await result.current.sendMessage('Hello');
+      });
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
+      });
+
+      act(() => {
+        result.current.clearChat();
+      });
+
+      expect(result.current.memoryNotice).toBeNull();
     });
   });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat-memory-notice.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/chat-memory-notice.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  chatService,
+  extractMemoryNotice,
+  hasMemoryCondition,
+  type QueryDetailResponse,
+} from '@/lib/services/chat';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api/config', () => ({
+  apiUrl: vi.fn((path: string) => path),
+}));
+
+vi.mock('@/lib/analytics/singleton', () => ({
+  trackEvent: vi.fn(),
+}));
+
+const HEALTHY_CONDITIONS = [
+  {
+    type: 'MemoryUnavailable',
+    status: 'False',
+    reason: 'MemoryReachable',
+    message: 'Conversation history was available for this query',
+  },
+  {
+    type: 'MemoryDegraded',
+    status: 'False',
+    reason: 'MemoryHealthy',
+    message: 'Conversation history was read from memory for this query',
+  },
+];
+
+const UNAVAILABLE_MESSAGE =
+  'conversationId was set but no Memory backend was reachable; conversation history was disabled for this query';
+
+const DEGRADED_MESSAGE =
+  'failed to read conversation history from the memory backend; the query ran without prior context.';
+
+function query(
+  status: Record<string, unknown> | undefined,
+): QueryDetailResponse {
+  return {
+    name: 'chat-query-1',
+    input: 'hello',
+    status,
+  } as QueryDetailResponse;
+}
+
+describe('extractMemoryNotice', () => {
+  it('returns null when both conditions are present but False', () => {
+    expect(
+      extractMemoryNotice({ phase: 'done', conditions: HEALTHY_CONDITIONS }),
+    ).toBeNull();
+  });
+
+  it('returns the notice when MemoryUnavailable is True', () => {
+    expect(
+      extractMemoryNotice({
+        phase: 'done',
+        conditions: [
+          {
+            type: 'MemoryUnavailable',
+            status: 'True',
+            message: UNAVAILABLE_MESSAGE,
+          },
+          HEALTHY_CONDITIONS[1],
+        ],
+      }),
+    ).toEqual({ type: 'MemoryUnavailable', message: UNAVAILABLE_MESSAGE });
+  });
+
+  it('returns the notice when MemoryDegraded is True', () => {
+    expect(
+      extractMemoryNotice({
+        phase: 'done',
+        conditions: [
+          HEALTHY_CONDITIONS[0],
+          {
+            type: 'MemoryDegraded',
+            status: 'True',
+            message: DEGRADED_MESSAGE,
+          },
+        ],
+      }),
+    ).toEqual({ type: 'MemoryDegraded', message: DEGRADED_MESSAGE });
+  });
+
+  it('prefers MemoryUnavailable when both are True', () => {
+    expect(
+      extractMemoryNotice({
+        phase: 'done',
+        conditions: [
+          {
+            type: 'MemoryDegraded',
+            status: 'True',
+            message: DEGRADED_MESSAGE,
+          },
+          {
+            type: 'MemoryUnavailable',
+            status: 'True',
+            message: UNAVAILABLE_MESSAGE,
+          },
+        ],
+      }),
+    ).toEqual({ type: 'MemoryUnavailable', message: UNAVAILABLE_MESSAGE });
+  });
+
+  it('falls back to a built-in message when the condition carries none', () => {
+    const notice = extractMemoryNotice({
+      phase: 'done',
+      conditions: [
+        { type: 'MemoryUnavailable', status: 'True', message: '   ' },
+      ],
+    });
+
+    expect(notice?.type).toBe('MemoryUnavailable');
+    expect(notice?.message).toBe(
+      'No memory backend was reachable, so this query ran without conversation history.',
+    );
+  });
+
+  it('ignores unrelated conditions that are True', () => {
+    expect(
+      extractMemoryNotice({
+        phase: 'done',
+        conditions: [
+          { type: 'Completed', status: 'True', message: 'Query succeeded' },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for a status with no conditions at all', () => {
+    expect(extractMemoryNotice({ phase: 'done' })).toBeNull();
+    expect(extractMemoryNotice(undefined)).toBeNull();
+    expect(extractMemoryNotice(null)).toBeNull();
+  });
+});
+
+describe('extractMemoryNotice edge shapes', () => {
+  it('returns null for a status that is not an object', () => {
+    expect(extractMemoryNotice('done')).toBeNull();
+    expect(extractMemoryNotice(42)).toBeNull();
+  });
+
+  it('returns null when conditions is present but not an array', () => {
+    expect(
+      extractMemoryNotice({ phase: 'done', conditions: {} }),
+    ).toBeNull();
+  });
+
+  it('tolerates a null entry inside conditions', () => {
+    expect(
+      extractMemoryNotice({
+        phase: 'done',
+        conditions: [
+          null,
+          {
+            type: 'MemoryUnavailable',
+            status: 'True',
+            message: UNAVAILABLE_MESSAGE,
+          },
+        ],
+      }),
+    ).toEqual({ type: 'MemoryUnavailable', message: UNAVAILABLE_MESSAGE });
+  });
+});
+
+describe('hasMemoryCondition', () => {
+  it('is true for either memory condition, whatever its status', () => {
+    expect(
+      hasMemoryCondition({phase: 'done', conditions: HEALTHY_CONDITIONS}),
+    ).toBe(true);
+    expect(
+      hasMemoryCondition({
+        phase: 'done',
+        conditions: [{type: 'MemoryDegraded', status: 'True'}],
+      }),
+    ).toBe(true);
+  });
+
+  // A query that failed before dispatch is terminal and carries neither
+  // condition. That says nothing about memory, so it must not read as healthy.
+  it('is false for a terminal query that carries no memory condition', () => {
+    expect(
+      hasMemoryCondition({
+        phase: 'error',
+        conditions: [{type: 'Completed', status: 'True'}],
+      }),
+    ).toBe(false);
+    expect(hasMemoryCondition({phase: 'done'})).toBe(false);
+    expect(hasMemoryCondition({phase: 'done', conditions: []})).toBe(false);
+    expect(hasMemoryCondition(undefined)).toBe(false);
+  });
+});
+
+describe('chatService.getQueryResult memory lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('carries a settled lookup when the query holds the verdict', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(
+      query({
+        phase: 'done',
+        response: {content: 'hi'},
+        conditions: [
+          {
+            type: 'MemoryUnavailable',
+            status: 'True',
+            message: UNAVAILABLE_MESSAGE,
+          },
+        ],
+      }),
+    );
+
+    const result = await chatService.getQueryResult('chat-query-1');
+
+    expect(result.memoryLookup).toEqual({
+      settled: true,
+      notice: {type: 'MemoryUnavailable', message: UNAVAILABLE_MESSAGE},
+    });
+  });
+
+  it('carries a settled healthy lookup when the verdict says so', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(
+      query({phase: 'done', conditions: HEALTHY_CONDITIONS}),
+    );
+
+    const result = await chatService.getQueryResult('chat-query-1');
+
+    expect(result.memoryLookup).toEqual({settled: true, notice: null});
+  });
+
+  it('carries no lookup when the query holds no verdict', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(
+      query({phase: 'error', response: {content: 'target unresolvable'}}),
+    );
+
+    const result = await chatService.getQueryResult('chat-query-1');
+
+    expect(result.memoryLookup).toBeUndefined();
+  });
+
+  it('carries no lookup when the query could not be read', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(new Error('network error'));
+
+    const result = await chatService.getQueryResult('chat-query-1');
+
+    expect(result).toEqual({status: 'error', terminal: true});
+  });
+});
+
+describe('chatService.resolveMemoryNotice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps polling until the verdict lands on the query', async () => {
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce(query({ phase: 'running' }))
+      .mockResolvedValueOnce(query({ phase: 'running' }))
+      .mockResolvedValueOnce(
+        query({
+          phase: 'done',
+          conditions: [
+            {
+              type: 'MemoryUnavailable',
+              status: 'True',
+              message: UNAVAILABLE_MESSAGE,
+            },
+          ],
+        }),
+      );
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 6, 0);
+
+    expect(lookup).toEqual({
+      settled: true,
+      notice: { type: 'MemoryUnavailable', message: UNAVAILABLE_MESSAGE },
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('settles on a healthy verdict at the first read', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(
+      query({ phase: 'done', conditions: HEALTHY_CONDITIONS }),
+    );
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 6, 0);
+
+    expect(lookup).toEqual({ settled: true, notice: null });
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  // "Could not tell" must never be reported as "nothing wrong": the caller
+  // clears its banner on a settled lookup.
+  it('stays unsettled when the verdict never lands', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(query({ phase: 'running' }));
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 3, 0);
+
+    expect(lookup).toEqual({ settled: false, notice: null });
+    expect(apiClient.get).toHaveBeenCalledTimes(3);
+  });
+
+  // The banner used to be cleared here: the query is terminal, so the old
+  // phase-based gate settled, and no conditions read as "no problem".
+  it('stays unsettled for a query that ended without a verdict', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(
+      query({ phase: 'error', response: { content: 'target unresolvable' } }),
+    );
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 3, 0);
+
+    expect(lookup).toEqual({ settled: false, notice: null });
+  });
+
+  it('stays unsettled when every lookup fails', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('network error'));
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 3, 0);
+
+    expect(lookup).toEqual({ settled: false, notice: null });
+  });
+
+  // A 502 from the gateway inside the poll window used to abandon the budget
+  // and report health.
+  it('keeps polling past a transient failure', async () => {
+    vi.mocked(apiClient.get)
+      .mockRejectedValueOnce(new Error('bad gateway'))
+      .mockResolvedValueOnce(
+        query({
+          phase: 'done',
+          conditions: [
+            {
+              type: 'MemoryDegraded',
+              status: 'True',
+              message: DEGRADED_MESSAGE,
+            },
+          ],
+        }),
+      );
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 3, 0);
+
+    expect(lookup).toEqual({
+      settled: true,
+      notice: { type: 'MemoryDegraded', message: DEGRADED_MESSAGE },
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps polling when the query is not found yet', async () => {
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(query({ phase: 'done', conditions: HEALTHY_CONDITIONS }));
+
+    const lookup = await chatService.resolveMemoryNotice('chat-query-1', 3, 0);
+
+    expect(lookup).toEqual({ settled: true, notice: null });
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('makes exactly as many reads as the attempt budget allows', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(query(undefined));
+
+    await chatService.resolveMemoryNotice('chat-query-1', 4, 0);
+
+    expect(apiClient.get).toHaveBeenCalledTimes(4);
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { ChatMessageList } from '@/components/chat/chat-message-list';
 import { ChatNotice } from '@/components/chat/chat-notice';
+import { MemoryChatNotice } from '@/components/chat/memory-chat-notice';
 import { Autorenew, Build, Info, Send, Stop, Warning } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { ChatParameterFields } from '@/components/ui/chat-parameter-fields';
@@ -47,6 +48,7 @@ export function ChatPanel({
     statusText,
     isWaitingForApprovalResponse,
     error,
+    memoryNotice,
     sendMessage,
     clearChat,
     messagesEndRef,
@@ -145,6 +147,16 @@ export function ChatPanel({
       </ScrollArea>
 
       <div className="border-stroke-divider flex-shrink-0 border-t">
+        {/* Pinned above the composer rather than sitting with the other
+            notices in the scroll area. Those are set at mount and read before
+            the first send; this one is set after the newest turn, and the
+            viewport is pinned to the bottom by then, so in the scroll area it
+            would be painted screens above where the user is looking. */}
+        {memoryNotice && (
+          <div className="px-4 pt-4">
+            <MemoryChatNotice notice={memoryNotice} />
+          </div>
+        )}
         {hasParameters && (
           <div className="px-4 pt-4">
             {parameterVariant === 'team' ? (

--- a/services/ark-dashboard/ark-dashboard/components/chat/memory-chat-notice.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/memory-chat-notice.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ChatNotice } from '@/components/chat/chat-notice';
+import { Warning } from '@/components/icons';
+import type { MemoryNotice } from '@/lib/services/chat';
+
+// The condition's own message describes what happened to this query in the
+// executor's words. It says nothing about what that means for the conversation
+// the user is looking at, which is what the lead-in is for.
+const MEMORY_NOTICE_LEAD: Record<MemoryNotice['type'], string> = {
+  MemoryUnavailable: 'This chat is not keeping conversation history.',
+  MemoryDegraded: 'Conversation history could not be read.',
+};
+
+interface MemoryChatNoticeProps {
+  notice: MemoryNotice;
+}
+
+export function MemoryChatNotice({
+  notice,
+}: Readonly<MemoryChatNoticeProps>) {
+  return (
+    <ChatNotice icon={<Warning />} iconClassName="text-status-warning">
+      {MEMORY_NOTICE_LEAD[notice.type]} {notice.message}
+    </ChatNotice>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.test.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.test.ts
@@ -13,6 +13,9 @@ vi.mock('@/lib/services', () => ({
     streamQueryStatus: vi.fn(),
     getQueryResult: vi.fn(),
     getQuery: vi.fn(),
+    resolveMemoryNotice: vi
+      .fn()
+      .mockResolvedValue({ settled: true, notice: null }),
     submitChatQuery: vi.fn(),
     cancelQuery: vi.fn(),
   },
@@ -39,6 +42,10 @@ describe('useChatSession - Approval Handling', () => {
     vi.clearAllMocks();
     vi.resetAllMocks();
     vi.mocked(agentsService.getByName).mockResolvedValue(null);
+    vi.mocked(chatService.resolveMemoryNotice).mockResolvedValue({
+      settled: true,
+      notice: null,
+    });
   });
 
   describe('Tool Approval Detection', () => {
@@ -221,6 +228,61 @@ describe('useChatSession - Approval Handling', () => {
         expect(chatService.getQueryResult).toHaveBeenCalledWith(
           'test-query-poll',
         );
+      });
+    });
+
+    // applyTerminalResult is the third and least-travelled place the banner is
+    // written from; nothing else exercises it.
+    it('surfaces a memory notice carried by the post-approval result', async () => {
+      const unavailable = {
+        type: 'MemoryUnavailable' as const,
+        message: 'no Memory backend was reachable',
+      };
+      async function* approvalChunks(): AsyncGenerator<
+        Record<string, unknown>,
+        void,
+        unknown
+      > {
+        yield {
+          type: 'tool_approval_request',
+          taskId: 'task-notice',
+          toolCalls: [
+            {
+              id: 'call-1',
+              type: 'function',
+              function: { name: 'test-tool', arguments: '{}' },
+            },
+          ],
+        };
+      }
+
+      vi.mocked(chatService.startStreamChatResponse).mockResolvedValueOnce({
+        queryName: 'test-query-notice',
+        chunks: approvalChunks(),
+      });
+      vi.mocked(chatService.streamQueryStatus).mockResolvedValue(vi.fn());
+      vi.mocked(chatService.getQueryResult).mockResolvedValue({
+        terminal: true,
+        status: 'done',
+        messages: [{ role: 'assistant', content: 'Tool executed' }],
+        memoryLookup: { settled: true, notice: unavailable },
+      });
+
+      const { result } = renderHook(
+        () => useChatSession({ name: 'test-agent', type: 'agent' }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.sendMessage('test message');
+      });
+
+      await act(async () => {
+        await result.current.pollAfterApproval();
+      });
+
+      await waitFor(() => {
+        expect(result.current.memoryNotice).toEqual(unavailable);
       });
     });
 
@@ -415,6 +477,10 @@ describe('useChatSession - Conversation ID Continuity', () => {
     vi.clearAllMocks();
     vi.resetAllMocks();
     vi.mocked(agentsService.getByName).mockResolvedValue(null);
+    vi.mocked(chatService.resolveMemoryNotice).mockResolvedValue({
+      settled: true,
+      notice: null,
+    });
     globalThis.sessionStorage?.clear();
   });
 

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
@@ -25,7 +25,11 @@ import {
 } from '@/lib/hooks/use-agent-query-parameters';
 import { useStickyScroll } from '@/lib/hooks/use-sticky-scroll';
 import { chatService } from '@/lib/services';
-import type { ChatResponse } from '@/lib/services/chat';
+import type {
+  ChatResponse,
+  MemoryNotice,
+  MemoryNoticeLookup,
+} from '@/lib/services/chat';
 import type {
   ArkExtendedChunk,
   ExtendedChatMessage,
@@ -125,6 +129,7 @@ interface UseChatSessionReturn {
   isWaitingForApprovalResponse: boolean;
 
   error: string | null;
+  memoryNotice: MemoryNotice | null;
   sendMessage: (message: string) => Promise<void>;
   clearChat: () => void;
   messagesEndRef: RefObject<HTMLDivElement | null>;
@@ -289,6 +294,7 @@ export function useChatSession({
     useState(false);
 
   const [error, setError] = useState<string | null>(null);
+  const [memoryNotice, setMemoryNotice] = useState<MemoryNotice | null>(null);
   const isChatStreamingEnabled = useAtomValue(isChatStreamingEnabledAtom);
   const queryTimeout = useAtomValue(queryTimeoutSettingAtom);
   const stopPollingRef = useRef<(() => void) | null>(null);
@@ -325,6 +331,70 @@ export function useChatSession({
       }
     };
   }, []);
+
+  // Bumped by anything that makes an outstanding notice irrelevant, and
+  // snapshotted at the start of each turn. `lastQueryName` alone is not enough:
+  // it still holds the finished query's name after a target switch or a New
+  // chat, and a late result would write the notice straight back. Snapshotting
+  // at the start of the turn rather than at the lookup covers a switch that
+  // happens while the turn is still running, which is most of the window.
+  const noticeEpochRef = useRef(0);
+  const turnEpochRef = useRef(0);
+
+  const discardMemoryNotice = useCallback(() => {
+    noticeEpochRef.current += 1;
+    setMemoryNotice(null);
+  }, []);
+
+  const beginMemoryNoticeTurn = useCallback(() => {
+    turnEpochRef.current = noticeEpochRef.current;
+  }, []);
+
+  const applyMemoryLookup = useCallback(
+    (lookup: MemoryNoticeLookup | undefined, queryName: string) => {
+      // No unmount guard: React 19 makes a state update on an unmounted
+      // component a no-op, and a guard nothing can observe is a guard nothing
+      // can test.
+      if (
+        !lookup?.settled ||
+        noticeEpochRef.current !== turnEpochRef.current ||
+        lastQueryName.current !== queryName
+      ) {
+        return;
+      }
+      setMemoryNotice(lookup.notice);
+    },
+    [],
+  );
+
+  // The notice describes the last turn of one conversation; switching target
+  // must not carry it over to the next one.
+  useEffect(() => {
+    discardMemoryNotice();
+  }, [chatKey, discardMemoryNotice]);
+
+  // Deliberately not awaited: the stream has already delivered the answer, and
+  // the controller writes the memory conditions a beat later, so blocking the
+  // turn on that write would only keep the composer disabled for no reason.
+  const refreshMemoryNotice = useCallback(
+    (queryName: string) => {
+      if (!queryName) {
+        return;
+      }
+      void (async () => {
+        try {
+          applyMemoryLookup(
+            await chatService.resolveMemoryNotice(queryName),
+            queryName,
+          );
+        } catch {
+          // Best effort. The turn already produced an answer, so a failed
+          // lookup must not turn it into a chat error.
+        }
+      })();
+    },
+    [applyMemoryLookup],
+  );
 
   useEffect(() => {
     const id = setTimeout(scrollToBottom, 100);
@@ -839,6 +909,7 @@ export function useChatSession({
           setProcessingPhase(result.status);
 
           if (result.terminal) {
+            applyMemoryLookup(result.memoryLookup, query.name);
             const fullQuery = await chatService.getQuery(query.name);
             const queryConversationId = (
               fullQuery?.status as { conversationId?: string } | undefined
@@ -963,6 +1034,7 @@ export function useChatSession({
       }
     },
     [
+      applyMemoryLookup,
       buildChatMessages,
       chatMessages,
       name,
@@ -1000,11 +1072,13 @@ export function useChatSession({
       ]);
 
       setIsProcessing(true);
+      beginMemoryNoticeTurn();
 
       try {
         if (isChatStreamingEnabled) {
           await handleStreamChatResponse(userMessage, apiParameters);
           await ensureConversationId();
+          refreshMemoryNotice(lastQueryName.current);
         } else {
           await handlePollChatResponse(userMessage, apiParameters);
         }
@@ -1042,12 +1116,14 @@ export function useChatSession({
       }
     },
     [
+      beginMemoryNoticeTurn,
       ensureConversationId,
       handlePollChatResponse,
       handleStreamChatResponse,
       isChatStreamingEnabled,
       missingParameters,
       name,
+      refreshMemoryNotice,
       resumeAutoScroll,
       toApiParameters,
       type,
@@ -1074,7 +1150,14 @@ export function useChatSession({
       },
     }));
     setError(null);
-  }, [chatKey, name, setChatHistory, setLastConversationId]);
+    discardMemoryNotice();
+  }, [
+    chatKey,
+    discardMemoryNotice,
+    name,
+    setChatHistory,
+    setLastConversationId,
+  ]);
 
   const cancelQuery = useCallback(async () => {
     chatStreamAbortControllerRef.current.abort();
@@ -1131,6 +1214,7 @@ export function useChatSession({
   const applyTerminalResult = useCallback(
     (result: ChatResponse, messageIndex: number, queryName: string): void => {
       stopPollingRef.current = null;
+      applyMemoryLookup(result.memoryLookup, queryName);
 
       if (result.status === 'done') {
         if (result.messages && result.messages.length > 0) {
@@ -1155,7 +1239,7 @@ export function useChatSession({
 
       setIsProcessing(false);
     },
-    [updateChatMessages, setIsProcessing],
+    [updateChatMessages, setIsProcessing, applyMemoryLookup],
   );
 
   const pollAfterApproval = useCallback(async () => {
@@ -1222,6 +1306,7 @@ export function useChatSession({
     processingPhase,
     statusText,
     error,
+    memoryNotice,
     sendMessage,
     clearChat,
     messagesEndRef,

--- a/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
@@ -58,6 +58,9 @@ const QUERY_STATUS_PHASES: readonly QueryStatusPhase[] = [
   ...NON_TERMINAL_QUERY_STATUS_PHASES,
 ] as const;
 
+const MEMORY_NOTICE_POLL_ATTEMPTS = 6;
+const MEMORY_NOTICE_POLL_INTERVAL_MS = 500;
+
 type QueryStatusWithPhase = {
   phase: string;
   response?: {
@@ -66,9 +69,101 @@ type QueryStatusWithPhase = {
   };
   conditions?: Array<{
     type?: string;
+    status?: string;
     message?: string;
   }>;
 };
+
+// The controller writes both memory conditions on every query whose dispatch
+// completes, carrying Status "False" and a reassuring message on the healthy
+// path. Their presence therefore says nothing; only Status "True" reports a
+// problem. A query that failed before dispatch carries neither.
+export const MEMORY_CONDITION_TYPES = [
+  'MemoryUnavailable',
+  'MemoryDegraded',
+] as const;
+
+export type MemoryConditionType = (typeof MEMORY_CONDITION_TYPES)[number];
+
+export type MemoryNotice = {
+  type: MemoryConditionType;
+  message: string;
+};
+
+/**
+ * The outcome of asking a query what it recorded about memory. `settled` false
+ * means the question could not be answered — never that the answer was "no
+ * problem". Callers must leave what they are showing untouched in that case,
+ * or a slow status write silently clears a notice that is still true.
+ */
+export type MemoryNoticeLookup = {
+  settled: boolean;
+  notice: MemoryNotice | null;
+};
+
+const MEMORY_LOOKUP_UNSETTLED: MemoryNoticeLookup = {
+  settled: false,
+  notice: null,
+};
+
+const MEMORY_NOTICE_FALLBACK_MESSAGE: Record<MemoryConditionType, string> = {
+  MemoryUnavailable:
+    'No memory backend was reachable, so this query ran without conversation history.',
+  MemoryDegraded:
+    'Reading conversation history from the memory backend failed, so this query ran without prior context.',
+};
+
+/**
+ * Whether a query's status carries the controller's memory verdict at all.
+ *
+ * Both conditions are written by the same update that writes the terminal
+ * phase, so their presence — not the phase string — is the precise signal that
+ * there is an answer to read. A query that failed before dispatch is terminal
+ * and carries neither, and that says nothing about memory: reporting it as
+ * healthy would clear a notice that is still true.
+ */
+export function hasMemoryCondition(status: unknown): boolean {
+  if (!status || typeof status !== 'object') {
+    return false;
+  }
+  const conditions = (status as QueryStatusWithPhase).conditions;
+  if (!Array.isArray(conditions)) {
+    return false;
+  }
+  return conditions.some(
+    c =>
+      c?.type !== undefined &&
+      (MEMORY_CONDITION_TYPES as readonly string[]).includes(c.type),
+  );
+}
+
+/**
+ * Extract the memory problem a query's status reports, or null when it reports
+ * none. MemoryUnavailable wins over MemoryDegraded: losing the backend
+ * outright is the more useful thing to say. Only meaningful when
+ * hasMemoryCondition is true.
+ */
+export function extractMemoryNotice(status: unknown): MemoryNotice | null {
+  if (!status || typeof status !== 'object') {
+    return null;
+  }
+  const conditions = (status as QueryStatusWithPhase).conditions;
+  if (!Array.isArray(conditions)) {
+    return null;
+  }
+  for (const type of MEMORY_CONDITION_TYPES) {
+    const condition = conditions.find(c => c?.type === type);
+    if (condition?.status !== 'True') {
+      continue;
+    }
+    return {
+      type,
+      message:
+        condition.message?.trim() || MEMORY_NOTICE_FALLBACK_MESSAGE[type],
+    };
+  }
+  return null;
+}
 
 // Type guard for checking if a phase is terminal
 function isTerminalPhase(
@@ -86,6 +181,7 @@ export type ChatResponse = {
   status: QueryStatusPhase;
   terminal: boolean;
   response?: string;
+  memoryLookup?: MemoryNoticeLookup;
   messages?: Array<{
     role: string;
     content?: string;
@@ -310,6 +406,17 @@ export const chatService = {
           status: validatedPhase,
           response: response,
           messages: messages,
+          // Only when the controller's verdict is actually on the object. An
+          // absent key means "nothing to say", which the caller must not read
+          // as "nothing wrong".
+          ...(hasMemoryCondition(status)
+            ? {
+                memoryLookup: {
+                  settled: true,
+                  notice: extractMemoryNotice(status),
+                },
+              }
+            : {}),
         };
       }
 
@@ -317,6 +424,41 @@ export const chatService = {
     } catch {
       return { status: 'error', terminal: true };
     }
+  },
+
+  /**
+   * Poll a query until its memory verdict appears, then report it. The
+   * streaming path needs this rather than reading the query once: the executor
+   * closes the stream before the controller writes the terminal status, so the
+   * conditions are not on the resource yet when the last chunk arrives. The
+   * paths that already hold a terminal response read `memoryLookup` off it
+   * instead.
+   *
+   * Returns an unsettled lookup when the budget runs out, when every read
+   * failed, or when the query settled without a verdict. A transient error does
+   * not end the attempts — one bad response inside the window must not be
+   * reported as a clean bill of health.
+   */
+  async resolveMemoryNotice(
+    queryName: string,
+    attempts: number = MEMORY_NOTICE_POLL_ATTEMPTS,
+    delayMs: number = MEMORY_NOTICE_POLL_INTERVAL_MS,
+  ): Promise<MemoryNoticeLookup> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (attempt > 0) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+      let status: QueryDetailResponse['status'];
+      try {
+        status = (await this.getQuery(queryName))?.status;
+      } catch {
+        continue;
+      }
+      if (hasMemoryCondition(status)) {
+        return {settled: true, notice: extractMemoryNotice(status)};
+      }
+    }
+    return MEMORY_LOOKUP_UNSETTLED;
   },
 
   async streamQueryStatus(

--- a/tools/ark-cli/src/commands/status/index.tsx
+++ b/tools/ark-cli/src/commands/status/index.tsx
@@ -17,8 +17,11 @@ import {
 import {
   runReadinessChecks,
   describeStorageBackend,
+  describeNamespaceMemory,
   type ReadinessCheckResult,
   type BackendDetection,
+  type NamespaceMemoryCheck,
+  type NamespaceMemoryStatus,
 } from '../../lib/readinessChecks.js';
 import {arkServices} from '../../arkServices.js';
 import type {ArkService} from '../../types/arkService.js';
@@ -96,10 +99,34 @@ function backendStatusLine(detection: BackendDetection) {
   };
 }
 
+function namespaceMemoryStatusLine(check: NamespaceMemoryCheck) {
+  const display: Record<
+    NamespaceMemoryStatus,
+    {icon: string; color: StatusColor; details: string}
+  > = {
+    ready: {icon: '●', color: 'green', details: check.message},
+    unresolved: {icon: '✗', color: 'red', details: 'not resolving'},
+    missing: {icon: '✗', color: 'red', details: 'missing'},
+    'no-broker': {icon: '○', color: 'yellow', details: 'not configured'},
+    undetermined: {icon: '?', color: 'yellow', details: 'undetermined'},
+  };
+  const {icon, color, details} = display[check.status];
+  return {
+    icon,
+    iconColor: color,
+    status: 'default memory',
+    statusColor: color,
+    name: '',
+    details,
+    subtext: check.status === 'ready' ? undefined : check.message,
+  };
+}
+
 function buildStatusSections(
   data: StatusData & {clusterAccess?: boolean; clusterInfo?: any},
   versionInfo?: ArkVersionInfo,
-  backend?: BackendDetection
+  backend?: BackendDetection,
+  namespaceMemory?: NamespaceMemoryCheck
 ): StatusSection[] {
   const sections: StatusSection[] = [];
 
@@ -305,6 +332,9 @@ function buildStatusSections(
       }
     }
   }
+  if (namespaceMemory) {
+    arkStatusLines.push(namespaceMemoryStatusLine(namespaceMemory));
+  }
   if (backend) {
     arkStatusLines.push(backendStatusLine(backend));
   }
@@ -335,19 +365,34 @@ export async function checkStatus(
     ]);
 
     // Only probe for the storage backend if the cluster is reachable; probing an
-    // unreachable cluster would just retry to its timeout.
-    const detection: BackendDetection = statusData.clusterAccess
-      ? await describeStorageBackend()
-      : {
-          backend: 'unknown',
-          status: 'unreachable',
-          message:
-            'Cluster is not reachable — cannot determine the storage backend.',
-        };
+    // unreachable cluster would just retry to its timeout. The memory check is
+    // scoped to the kubeconfig's current namespace: the invariant it reports on
+    // is per-namespace, and that is the namespace the user's queries land in.
+    // Both probes are independent, so they run together rather than in series.
+    const [detection, namespaceMemory] = await Promise.all([
+      statusData.clusterAccess
+        ? describeStorageBackend()
+        : Promise.resolve<BackendDetection>({
+            backend: 'unknown',
+            status: 'unreachable',
+            message:
+              'Cluster is not reachable — cannot determine the storage backend.',
+          }),
+      statusData.clusterAccess && statusData.arkReady
+        ? describeNamespaceMemory(
+            statusData.clusterInfo?.namespace || 'default'
+          )
+        : Promise.resolve(undefined),
+    ]);
 
     spinner.stop();
 
-    const sections = buildStatusSections(statusData, versionInfo, detection);
+    const sections = buildStatusSections(
+      statusData,
+      versionInfo,
+      detection,
+      namespaceMemory
+    );
     StatusFormatter.printSections(sections);
 
     if (options?.waitForReady) {

--- a/tools/ark-cli/src/lib/readinessChecks.spec.ts
+++ b/tools/ark-cli/src/lib/readinessChecks.spec.ts
@@ -5,8 +5,12 @@ vi.mock('execa', () => ({
 }));
 
 const {execa} = await import('execa');
-const {detectStorageBackend, describeStorageBackend, runReadinessChecks} =
-  await import('./readinessChecks.js');
+const {
+  detectStorageBackend,
+  describeStorageBackend,
+  describeNamespaceMemory,
+  runReadinessChecks,
+} = await import('./readinessChecks.js');
 const mockedExeca = execa as vi.MockedFunction<typeof execa>;
 
 function kubectlOk(stdout = '') {
@@ -145,6 +149,466 @@ describe('describeStorageBackend', () => {
     const result = await describeStorageBackend();
     expect(result.backend).toBe('unknown');
     expect(result.status).toBe('undetermined');
+  });
+});
+
+describe('describeNamespaceMemory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function notFound(kind: string, name: string) {
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: `Error from server (NotFound): ${kind} "${name}" not found`,
+    } as any;
+  }
+
+  function memoryJson(status: Record<string, unknown>) {
+    return kubectlOk(JSON.stringify({status}));
+  }
+
+  function configMapList(enabledValues: string[]) {
+    return kubectlOk(enabledValues.map((v) => `${v}\n`).join(''));
+  }
+
+  // kubectl is called in this order: the ArkConfig override, the Memory (the
+  // overridden name first, when one applies), and only when no Memory is
+  // usable, the broker ConfigMap listing followed by the broker Service.
+  function respond(handlers: {
+    arkconfig?: any;
+    memories?: Record<string, any>;
+    configmaps?: any;
+    services?: any;
+  }) {
+    mockedExeca.mockImplementation(((_cmd: string, args: string[]) => {
+      if (args[1] === 'arkconfig') {
+        return Promise.resolve(handlers.arkconfig ?? kubectlOk(''));
+      }
+      if (args[1] === 'memory') {
+        const name = args[2];
+        return Promise.resolve(
+          handlers.memories?.[name] ??
+            notFound('memories.ark.mckinsey.com', name)
+        );
+      }
+      if (args[1] === 'configmap') {
+        return Promise.resolve(handlers.configmaps ?? configMapList([]));
+      }
+      if (args[1] === 'service') {
+        return Promise.resolve(handlers.services ?? kubectlOk(''));
+      }
+      return Promise.resolve(kubectlFail('unexpected call'));
+    }) as any);
+  }
+
+  function callsFor(resource: string) {
+    return mockedExeca.mock.calls
+      .map((call: any) => call[1] as string[])
+      .filter((args) => args[1] === resource);
+  }
+
+  it('is ready when the memory carries a resolved address', async () => {
+    respond({
+      memories: {
+        default: memoryJson({
+          phase: 'ready',
+          lastResolvedAddress: 'http://ark-broker.team-a.svc:8080',
+        }),
+      },
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('ready');
+    expect(result.memoryName).toBe('default');
+    expect(result.message).toBe('http://ark-broker.team-a.svc:8080');
+  });
+
+  it('scopes the memory read to the namespace it was asked about', async () => {
+    respond({
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('memory')[0]).toEqual([
+      'get',
+      'memory',
+      'default',
+      '--namespace',
+      'team-a',
+      '-o',
+      'json',
+    ]);
+  });
+
+  it('reads the ArkConfig singleton cluster-scoped, by jsonpath', async () => {
+    respond({
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('arkconfig')[0]).toEqual([
+      'get',
+      'arkconfig',
+      'default',
+      '-o',
+      'jsonpath={.spec.defaultMemory.name}',
+    ]);
+  });
+
+  it('does not list the broker ConfigMaps when a memory is usable', async () => {
+    respond({
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('configmap')).toHaveLength(0);
+  });
+
+  it('is unresolved when the memory exists but never resolved an address', async () => {
+    respond({
+      memories: {
+        default: memoryJson({
+          phase: 'error',
+          message: 'service ark-broker not found',
+        }),
+      },
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('unresolved');
+    expect(result.message).toContain('service ark-broker not found');
+  });
+
+  it('is unresolved when lastResolvedAddress is present but empty', async () => {
+    respond({
+      memories: {
+        default: memoryJson({phase: 'running', lastResolvedAddress: ''}),
+      },
+    });
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'unresolved',
+    });
+  });
+
+  it('is missing when an enabled broker ConfigMap exists but no memory does', async () => {
+    respond({configmaps: configMapList(['true'])});
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('missing');
+    expect(result.message).toContain('team-a');
+  });
+
+  it('scopes the broker ConfigMap listing to the namespace, over both names', async () => {
+    respond({configmaps: configMapList(['true'])});
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('configmap')[0]).toEqual([
+      'get',
+      'configmap',
+      'ark-config-broker',
+      'ark-config-streaming',
+      '--namespace',
+      'team-a',
+      '--ignore-not-found',
+      '-o',
+      'jsonpath={range .items[*]}{.data.enabled}{"\\n"}{end}',
+    ]);
+  });
+
+  it('does not count a broker ConfigMap that is present but disabled', async () => {
+    respond({configmaps: configMapList(['false'])});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'no-broker',
+    });
+  });
+
+  it('counts a broker when only one of the two ConfigMaps is enabled', async () => {
+    respond({configmaps: configMapList(['false', 'true'])});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'missing',
+    });
+  });
+
+  // The telemetry ConfigMaps are independently disablable, so their absence is
+  // not proof there is no broker. Claiming otherwise was a confident false
+  // statement about a namespace that has one.
+  it('finds a broker from its Service when both ConfigMaps are disabled', async () => {
+    respond({
+      configmaps: configMapList(['false']),
+      services: kubectlOk('service/ark-broker'),
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('missing');
+    expect(result.message).toContain('has a broker');
+  });
+
+  it('finds a broker from its Service when no ConfigMap exists at all', async () => {
+    respond({services: kubectlOk('service/ark-broker')});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'missing',
+    });
+  });
+
+  it('does not probe for the Service once a ConfigMap has answered', async () => {
+    respond({configmaps: configMapList(['true'])});
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('service')).toHaveLength(0);
+  });
+
+  it('scopes the broker Service probe to the namespace, by chart label', async () => {
+    respond({services: kubectlOk('service/ark-broker')});
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('service')[0]).toEqual([
+      'get',
+      'service',
+      '--namespace',
+      'team-a',
+      '--selector',
+      'app.kubernetes.io/name=ark-broker',
+      '-o',
+      'name',
+    ]);
+  });
+
+  it('is undetermined when the Service probe cannot answer either', async () => {
+    respond({services: kubectlFail('services is forbidden')});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'undetermined',
+    });
+  });
+
+  it('is no-broker when neither a memory nor an enabled ConfigMap exists', async () => {
+    respond({configmaps: configMapList([])});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'no-broker',
+    });
+  });
+
+  it('uses the ArkConfig name when the Memory it names resolves', async () => {
+    respond({
+      arkconfig: kubectlOk('shared-history'),
+      memories: {
+        'shared-history': memoryJson({
+          lastResolvedAddress: 'http://shared:8080',
+        }),
+      },
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('ready');
+    expect(result.memoryName).toBe('shared-history');
+    expect(result.message).toBe('http://shared:8080');
+  });
+
+  // The admission webhook only injects the ArkConfig name when that Memory
+  // exists and resolves, so an absent or unresolved one leaves the namespace
+  // running on Memory/default. Judging the override alone reported a healthy
+  // namespace as broken.
+  it('falls back to Memory/default when the ArkConfig name is absent', async () => {
+    respond({
+      arkconfig: kubectlOk('shared-history'),
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('ready');
+    expect(result.memoryName).toBe('default');
+  });
+
+  it('falls back to Memory/default when the ArkConfig name never resolved', async () => {
+    respond({
+      arkconfig: kubectlOk('shared-history'),
+      memories: {
+        'shared-history': memoryJson({phase: 'error'}),
+        default: memoryJson({lastResolvedAddress: 'http://b:80'}),
+      },
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('ready');
+    expect(result.memoryName).toBe('default');
+  });
+
+  it('probes only once when ArkConfig names the fallback memory itself', async () => {
+    respond({
+      arkconfig: kubectlOk('default'),
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('memory')).toHaveLength(1);
+  });
+
+  it('treats an absent ArkConfig as no override', async () => {
+    respond({
+      arkconfig: notFound('arkconfigs.ark.mckinsey.com', 'default'),
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.memoryName).toBe('default');
+    expect(result.status).toBe('ready');
+  });
+
+  // The aggregated API server serves no arkconfigs, and kubectl words that
+  // differently from a missing object. Reading it as "could not tell" made
+  // every broken namespace on the postgresql backend report undetermined.
+  it('treats an ArkConfig the cluster does not serve as no override', async () => {
+    respond({
+      arkconfig: kubectlFail(
+        'error: the server doesn\'t have a resource type "arkconfig"'
+      ),
+      configmaps: configMapList(['true']),
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('missing');
+    expect(result.message).not.toContain('ArkConfig');
+  });
+
+  it('does not retry an ArkConfig the cluster does not serve', async () => {
+    respond({
+      arkconfig: kubectlFail(
+        'error: the server doesn\'t have a resource type "arkconfig"'
+      ),
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await describeNamespaceMemory('team-a');
+
+    expect(callsFor('arkconfig')).toHaveLength(1);
+  });
+
+  // A namespace-scoped user cannot read the cluster-scoped ArkConfig, so the
+  // fallback verdict may be judging the wrong name. A healthy answer still
+  // stands; an accusation does not.
+  it('keeps a healthy verdict when ArkConfig cannot be read', async () => {
+    respond({
+      arkconfig: kubectlFail('arkconfigs.ark.mckinsey.com is forbidden'),
+      memories: {default: memoryJson({lastResolvedAddress: 'http://b:80'})},
+    });
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'ready',
+    });
+  });
+
+  it('downgrades a missing verdict to undetermined when ArkConfig cannot be read', async () => {
+    respond({
+      arkconfig: kubectlFail('arkconfigs.ark.mckinsey.com is forbidden'),
+      configmaps: configMapList(['true']),
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('undetermined');
+    expect(result.message).toContain('ArkConfig could not be read');
+  });
+
+  it('downgrades an unresolved verdict to undetermined when ArkConfig cannot be read', async () => {
+    respond({
+      arkconfig: kubectlFail('arkconfigs.ark.mckinsey.com is forbidden'),
+      memories: {default: memoryJson({phase: 'error'})},
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('undetermined');
+    expect(result.message).toContain('ArkConfig could not be read');
+  });
+
+  // The fall-through verdict must name the Memory the executor will actually
+  // look for, not the one ArkConfig asked for and did not get.
+  it('names the fallback memory when neither the override nor default exists', async () => {
+    respond({
+      arkconfig: kubectlOk('shared-history'),
+      configmaps: configMapList(['true']),
+    });
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('missing');
+    expect(result.memoryName).toBe('default');
+    expect(result.message).toContain('"default"');
+    expect(result.message).toContain('ArkConfig names "shared-history"');
+  });
+
+  it('is undetermined when reading the memory is forbidden', async () => {
+    respond({
+      memories: {
+        default: kubectlFail('memories.ark.mckinsey.com is forbidden'),
+      },
+    });
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'undetermined',
+    });
+  });
+
+  it('is undetermined when the namespace itself does not exist', async () => {
+    respond({memories: {default: notFound('namespaces', 'team-a')}});
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('undetermined');
+    expect(result.message).toContain('does not exist');
+  });
+
+  it('is undetermined when the memory payload is not JSON', async () => {
+    respond({memories: {default: kubectlOk('not json')}});
+
+    await expect(describeNamespaceMemory('team-a')).resolves.toMatchObject({
+      status: 'undetermined',
+    });
+  });
+
+  // Failing closed to "no broker" would have printed a reassuring line drawn
+  // from no evidence at all.
+  it('is undetermined when the broker ConfigMap listing fails', async () => {
+    respond({configmaps: kubectlFail('configmaps is forbidden')});
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('undetermined');
+    expect(result.message).toContain('has a broker');
+  });
+
+  // The message used to blame the ConfigMap listing even when it was the
+  // Service probe that could not answer.
+  it('does not blame the ConfigMap probe for a Service probe failure', async () => {
+    respond({services: kubectlFail('services is forbidden')});
+
+    const result = await describeNamespaceMemory('team-a');
+
+    expect(result.status).toBe('undetermined');
+    expect(result.message).not.toContain('ConfigMap');
   });
 });
 

--- a/tools/ark-cli/src/lib/readinessChecks.ts
+++ b/tools/ark-cli/src/lib/readinessChecks.ts
@@ -25,6 +25,20 @@ export interface ReadinessCheckResult {
   message?: string;
 }
 
+export type NamespaceMemoryStatus =
+  | 'ready'
+  | 'unresolved'
+  | 'missing'
+  | 'no-broker'
+  | 'undetermined';
+
+export interface NamespaceMemoryCheck {
+  status: NamespaceMemoryStatus;
+  namespace: string;
+  memoryName: string;
+  message: string;
+}
+
 export type ReadinessProgress = (result: ReadinessCheckResult) => void;
 
 const API_GROUP_POLL_INTERVAL_MS = 10000;
@@ -50,8 +64,15 @@ async function runKubectl(
 
 type FailureReason = 'not-found' | 'forbidden' | 'unreachable' | 'undetermined';
 
+// A resource type the cluster does not serve at all. kubectl reports this
+// differently from a missing object, and it is just as final an answer — the
+// aggregated API server serves no arkconfigs, so this is the normal reply
+// there rather than something to retry.
+const UNSERVED_RESOURCE_PATTERN =
+  /doesn't have a resource type|no matches for kind|the server could not find the requested resource/i;
+
 function classifyFailure(stderr: string): FailureReason {
-  if (/not\s*found/i.test(stderr)) {
+  if (/not\s*found/i.test(stderr) || UNSERVED_RESOURCE_PATTERN.test(stderr)) {
     return 'not-found';
   }
   if (/forbidden|unauthorized/i.test(stderr)) {
@@ -77,7 +98,10 @@ function isAuthoritativeResult(result: {
   if (result.exitCode === 0) {
     return true;
   }
-  return /not\s*found|forbidden/i.test(result.stderr);
+  return (
+    /not\s*found|forbidden/i.test(result.stderr) ||
+    UNSERVED_RESOURCE_PATTERN.test(result.stderr)
+  );
 }
 
 async function probeKubectl(
@@ -165,6 +189,291 @@ export async function describeStorageBackend(): Promise<BackendDetection> {
     };
   }
   return unknownFrom(apiReason);
+}
+
+// The Memory name the broker chart creates, and the one NewMemoryForQuery
+// hardcodes when a Query carries no spec.memory. ArkConfig can name a
+// different one, but only as a candidate — see describeNamespaceMemory.
+const FALLBACK_MEMORY_NAME = 'default';
+
+// Either ConfigMap is a broker presence signal, and only when its data carries
+// enabled: "true" — the same test BrokerServiceRefFor applies before the
+// controller's default-Memory backstop will act on it.
+const BROKER_CONFIGMAP_NAMES = ['ark-config-broker', 'ark-config-streaming'];
+
+// The ConfigMaps are not the whole story: they are rendered only when
+// otelEndpoint.enabled / streaming.enabled are set, both of which default true
+// but are independently disablable. A broker installed purely for message and
+// session storage has neither, and reporting "no broker in this namespace"
+// there is a confident claim that happens to be false. The label is the
+// chart's rather than the release's, so a renamed release still matches. This
+// mirrors DefaultMemoryReconciler's own two-signal lookup.
+const BROKER_SERVICE_SELECTOR = 'app.kubernetes.io/name=ark-broker';
+
+const BROKER_ENABLED_JSONPATH = '{range .items[*]}{.data.enabled}{"\\n"}{end}';
+
+type MemoryProbe =
+  | {outcome: 'resolved'; address: string}
+  | {outcome: 'unresolved'; detail: string}
+  | {outcome: 'absent'}
+  | {outcome: 'undetermined'; detail: string};
+
+type BrokerProbe = 'present' | 'absent' | 'undetermined';
+
+type MemoryOverride =
+  | {kind: 'name'; name: string}
+  | {kind: 'none'}
+  | {kind: 'undetermined'};
+
+// kubectl reports a missing namespace and a missing object with the same
+// NotFound status, so the two are told apart by the message. Reporting on a
+// namespace that does not exist as "no broker here" would be a confident
+// answer drawn from nothing.
+function isMissingNamespace(stderr: string): boolean {
+  return /namespaces?\s+"[^"]*"\s+not\s+found/i.test(stderr);
+}
+
+async function probeMemory(
+  namespace: string,
+  name: string
+): Promise<MemoryProbe> {
+  const result = await probeKubectl(
+    ['get', 'memory', name, '--namespace', namespace, '-o', 'json'],
+    10000
+  );
+
+  if (result.exitCode !== 0) {
+    if (isMissingNamespace(result.stderr)) {
+      return {
+        outcome: 'undetermined',
+        detail: `namespace ${namespace} does not exist`,
+      };
+    }
+    const reason = classifyFailure(result.stderr);
+    if (reason === 'not-found') {
+      return {outcome: 'absent'};
+    }
+    return {outcome: 'undetermined', detail: reason};
+  }
+
+  let address = '';
+  let phase = '';
+  let statusMessage = '';
+  try {
+    const parsed = JSON.parse(result.stdout);
+    address = parsed?.status?.lastResolvedAddress || '';
+    phase = parsed?.status?.phase || '';
+    statusMessage = parsed?.status?.message || '';
+  } catch {
+    return {outcome: 'undetermined', detail: 'unreadable kubectl output'};
+  }
+
+  if (address) {
+    return {outcome: 'resolved', address};
+  }
+  return {
+    outcome: 'unresolved',
+    detail: statusMessage || phase || 'no resolved address',
+  };
+}
+
+async function probeBrokerConfigMaps(namespace: string): Promise<BrokerProbe> {
+  const result = await probeKubectl(
+    [
+      'get',
+      'configmap',
+      ...BROKER_CONFIGMAP_NAMES,
+      '--namespace',
+      namespace,
+      '--ignore-not-found',
+      '-o',
+      `jsonpath=${BROKER_ENABLED_JSONPATH}`,
+    ],
+    10000
+  );
+  if (result.exitCode !== 0) {
+    return 'undetermined';
+  }
+  const enabled = result.stdout
+    .split('\n')
+    .some((line) => line.trim() === 'true');
+  return enabled ? 'present' : 'absent';
+}
+
+async function probeBrokerService(namespace: string): Promise<BrokerProbe> {
+  const result = await probeKubectl(
+    [
+      'get',
+      'service',
+      '--namespace',
+      namespace,
+      '--selector',
+      BROKER_SERVICE_SELECTOR,
+      '-o',
+      'name',
+    ],
+    10000
+  );
+  if (result.exitCode !== 0) {
+    return 'undetermined';
+  }
+  return result.stdout.trim() ? 'present' : 'absent';
+}
+
+async function probeBroker(namespace: string): Promise<BrokerProbe> {
+  const fromConfigMaps = await probeBrokerConfigMaps(namespace);
+  if (fromConfigMaps === 'present') {
+    return fromConfigMaps;
+  }
+  const fromService = await probeBrokerService(namespace);
+  if (fromService === 'present') {
+    return fromService;
+  }
+  // Neither signal found it. Say so only if both probes actually answered.
+  if (fromConfigMaps === 'undetermined' || fromService === 'undetermined') {
+    return 'undetermined';
+  }
+  return 'absent';
+}
+
+// ArkConfig is cluster-scoped and optional, and the aggregated API server does
+// not serve it at all — both of which classifyFailure reports as not-found, a
+// legitimate "there is no override". "Could not tell" is different: a
+// namespace-scoped user is forbidden from reading a cluster-scoped resource,
+// and would otherwise be judged against the wrong name.
+async function readDefaultMemoryOverride(): Promise<MemoryOverride> {
+  const result = await probeKubectl(
+    [
+      'get',
+      'arkconfig',
+      'default',
+      '-o',
+      'jsonpath={.spec.defaultMemory.name}',
+    ],
+    10000
+  );
+  if (result.exitCode === 0) {
+    const name = result.stdout.trim();
+    return name ? {kind: 'name', name} : {kind: 'none'};
+  }
+  if (classifyFailure(result.stderr) === 'not-found') {
+    return {kind: 'none'};
+  }
+  return {kind: 'undetermined'};
+}
+
+/**
+ * Report whether the namespace ends up with a Memory the executor can use.
+ *
+ * Existence is not the question: NewHTTPMemory errors when
+ * status.lastResolvedAddress is empty, so a Memory left unresolved by a
+ * missing broker Service fails every query in the namespace rather than
+ * degrading. A namespace with no broker is expected to have no Memory, so that
+ * is reported as unconfigured rather than broken.
+ *
+ * ArkConfig.defaultMemory only changes the answer when the Memory it names
+ * both exists and resolves: resolveInjectableMemory declines to inject
+ * otherwise, and NewMemoryForQuery then falls back to the hardcoded name
+ * `default`. So the override is a candidate, and `default` decides the verdict
+ * whenever that candidate is not usable.
+ */
+export async function describeNamespaceMemory(
+  namespace: string
+): Promise<NamespaceMemoryCheck> {
+  const override = await readDefaultMemoryOverride();
+
+  if (override.kind === 'name' && override.name !== FALLBACK_MEMORY_NAME) {
+    const probe = await probeMemory(namespace, override.name);
+    if (probe.outcome === 'resolved') {
+      return {
+        namespace,
+        memoryName: override.name,
+        status: 'ready',
+        message: probe.address,
+      };
+    }
+    if (probe.outcome === 'undetermined') {
+      return {
+        namespace,
+        memoryName: override.name,
+        status: 'undetermined',
+        message: `Could not read Memory "${override.name}" in namespace ${namespace} (${probe.detail}).`,
+      };
+    }
+  }
+
+  const unusedOverride =
+    override.kind === 'name' && override.name !== FALLBACK_MEMORY_NAME
+      ? override.name
+      : undefined;
+  const check = await describeFallbackMemory(namespace, unusedOverride);
+
+  // The override read failed, so this verdict may be judging the wrong name.
+  // Only downgrade one that accuses the namespace of being broken.
+  if (
+    override.kind === 'undetermined' &&
+    (check.status === 'missing' || check.status === 'unresolved')
+  ) {
+    return {
+      ...check,
+      status: 'undetermined',
+      message: `${check.message} ArkConfig could not be read, so a cluster-wide default memory name may apply instead.`,
+    };
+  }
+  return check;
+}
+
+async function describeFallbackMemory(
+  namespace: string,
+  unusedOverride?: string
+): Promise<NamespaceMemoryCheck> {
+  const base = {namespace, memoryName: FALLBACK_MEMORY_NAME};
+  // The operator asked for a different name and is not getting it. Without
+  // saying so, the remediation below reads as "create Memory/default", which
+  // is right for the executor and confusing next to their own ArkConfig.
+  const overrideNote = unusedOverride
+    ? ` ArkConfig names "${unusedOverride}", which is not usable here, so resolution falls back to "${FALLBACK_MEMORY_NAME}".`
+    : '';
+  const probe = await probeMemory(namespace, FALLBACK_MEMORY_NAME);
+
+  if (probe.outcome === 'resolved') {
+    return {...base, status: 'ready', message: probe.address};
+  }
+  if (probe.outcome === 'undetermined') {
+    return {
+      ...base,
+      status: 'undetermined',
+      message: `Could not read Memory "${FALLBACK_MEMORY_NAME}" in namespace ${namespace} (${probe.detail}).`,
+    };
+  }
+  if (probe.outcome === 'unresolved') {
+    return {
+      ...base,
+      status: 'unresolved',
+      message: `Memory "${FALLBACK_MEMORY_NAME}" in namespace ${namespace} has not resolved an address (${probe.detail}); queries using it will fail.${overrideNote}`,
+    };
+  }
+
+  const broker = await probeBroker(namespace);
+  if (broker === 'undetermined') {
+    return {
+      ...base,
+      status: 'undetermined',
+      message: `Could not determine whether namespace ${namespace} has a broker, so a missing Memory cannot be judged.`,
+    };
+  }
+  if (broker === 'present') {
+    return {
+      ...base,
+      status: 'missing',
+      message: `Namespace ${namespace} has a broker but no Memory "${FALLBACK_MEMORY_NAME}"; chats there will silently lose conversation history.${overrideNote}`,
+    };
+  }
+  return {
+    ...base,
+    status: 'no-broker',
+    message: `No broker in namespace ${namespace}, so no conversation history is kept there.`,
+  };
 }
 
 export async function detectStorageBackend(): Promise<DetectedBackend> {


### PR DESCRIPTION
## Context

#2642 described a `conversationId` that silently loses context, and listed four fixes. The first two shipped: the executor logs at default verbosity, and the `Query` carries `MemoryUnavailable` / `MemoryDegraded` conditions.

Nobody displayed them. `lib/services/chat.ts` **typed** a `conditions` array and `.conditions` had zero readers anywhere in the dashboard, so the signal existed end to end and died at the last hop — a user whose namespace has no reachable memory still saw a chat that looked like it was working. ark-api already passes `status` through as a dict, so no API change was needed.

This is layer 5 of #2731 and the half of #2642 that was never delivered.

## Two things that make these conditions harder to read than they look

**They are set on every query whose dispatch completes.** `setConditionMemoryUnavailable` / `setConditionMemoryDegraded` (`ark/internal/controller/query_controller.go:977-1012`, called at `:1647-1648`) run unconditionally, with `Status: "False"` and a *positive* message on the healthy path. Gating the notice on the condition being **present** would show it on every query. The gate is `status === 'True'`.

**A query that fails before dispatch carries neither.** Those setters run only after `sendQueryA2A` returns without error; the error branch returns at `:1621-1632`. An absent condition is therefore not a clean bill of health, it is an absence of evidence. So the code reads *presence of either condition type* to decide whether there is an answer at all, and leaves the notice untouched when there is none. Without that, a turn that failed for any unrelated reason cleared a warning that was still true.

## What this adds

| Surface | Change |
|---|---|
| Chat | A notice at the top of the conversation when the last turn reported either condition `True`, quoting the condition's own message |
| `ark status` | A `default memory` line for the current namespace, beside `default model` |
| ark-api | None needed |

### Chat

The streaming path — the default (`storedIsChatStreamingEnabledAtom` defaults to `true`) — cannot read the verdict off the stream: the executor calls `finalizeStream` and closes it *before* the controller writes the terminal status, so the conditions are not on the resource yet when the last chunk arrives. It polls for them afterwards, unawaited, because the answer is already on screen and blocking the turn on an informational lookup would only keep the composer disabled.

That poll outlives its turn, which is the interesting part: `isProcessing` goes false immediately, so the target switcher and **New chat** are both live while it runs. Its result is dropped unless the chat, the turn and the mount are all still the ones that asked for it, and the turn's identity is snapshotted when the turn *starts* rather than when the poll fires — most of the window in which the user can switch away is while the turn is still running.

The polling loop and the post-approval result already hold a terminal response, so they read the verdict straight off it with no second request.

The notice reuses the `ChatNotice` pill from #3300 and sits next to the engine-tool warning, rather than adding a second notice style to the same panel.

### `ark status`

It asks whether the Memory **resolves**, not whether it exists: `NewHTTPMemory` errors on an empty `status.lastResolvedAddress` (`ark/executors/completions/memory_http.go:44-47`), so a Memory left unresolved by a missing broker Service makes every query in the namespace *fail* rather than degrade.

`ArkConfig.defaultMemory` is a **candidate**, not the answer. `resolveInjectableMemory` injects that name only when the Memory already exists and resolves; otherwise `NewMemoryForQuery` falls back to the hardcoded `default`. Judging the ArkConfig name alone reported a healthy namespace as broken.

Broker presence requires the ConfigMap to carry `enabled: "true"`, the same test `BrokerServiceRefFor` applies (`ark/internal/telemetry/routing/broker_discovery.go:149`). Anything unreadable is `undetermined` rather than guessed.

## Known limits, deliberately

- **The notice needs a `conversationId`.** `memoryUnavailable := isNoop && conversationId != "" && !isSubTarget` (`ark/executors/completions/handler.go:374`), and the chat only ever *has* one because `createConversation` minted it inside `NewHTTPMemory`. So in a namespace that never had a working Memory the chat never obtains one and the notice never fires; that case is covered by the `ark status` line. The notice fires when a chat that *had* continuity loses the backend, which is #2642's scenario. Inferring "no conversationId came back ⇒ no memory" was rejected: a custom execution engine returning neither a conversationId nor an A2A contextId would produce a false warning, and a false warning is worse than a missing one.
- **The check is a status line, not a readiness gate.** `runReadinessChecks` returns `[]` on etcd, and its other callers (`tools/ark-cli/src/commands/install/index.ts:497` and `:709`) `process.exit(1)` on any failed check — a namespace legitimately without a broker would fail the install. Exit codes are unchanged.
- **Workflow Studio chat is not covered.** `components/workflow-studio/use-studio-chat.ts` has its own state and panel and does not go through `useChatSession`. Out of scope here; it does set a conversationId, so it can trip the condition without showing it.
- Item 3 of #2642's sketch — rejecting a `conversationId` query at admission when no Memory is reachable — stays out of scope, as the issue itself asks.

## Review guide

Start with the two rules, both in `services/ark-dashboard/ark-dashboard/lib/services/chat.ts`:

- `hasMemoryCondition` — is there a verdict to read?
- `extractMemoryNotice` — `status === 'True'`, `MemoryUnavailable` before `MemoryDegraded`
- `chatService.resolveMemoryNotice` — returns `{settled, notice}`; `settled: false` means "could not tell", never "nothing wrong"

Then the three places the notice is written, in `lib/hooks/use-chat-session.ts`: `applyMemoryLookup` and its four guards, `beginMemoryNoticeTurn` (called from `sendMessage`), and the call sites in `handlePollChatResponse`, `applyTerminalResult` and the streaming branch of `sendMessage`.

CLI side, `tools/ark-cli/src/lib/readinessChecks.ts`: `describeNamespaceMemory` is the candidate-then-fallback rule, `describeFallbackMemory` the verdict, `probeMemory` / `probeBroker` / `readDefaultMemoryOverride` the three tri-state probes. `UNSERVED_RESOURCE_PATTERN` is why the aggregated API server not serving `arkconfigs` reads as "no override" rather than "could not tell".

## Verification

- Dashboard: 2543 tests pass; `tsc --noEmit` reports nothing in tracked source
- ark-cli: 697 tests, `npm run build`, `prettier --check` on the touched files
- Every new test was checked to **fail** against the wrong implementation via a temporary revert — 21 mutations in total, including the presence gate, the missing terminal wait, existence-only memory checks, substring ConfigMap matching, judging the ArkConfig override alone, failing closed on an unlistable ConfigMap, and each of the four notice guards
- Live on a kind cluster, in scratch namespaces: `ready` with the resolved broker address, `missing` with an enabled broker ConfigMap and no Memory, `no-broker` with `enabled: "false"`, `unresolved` for a Memory pointing at a missing Service, `undetermined` for a namespace that does not exist, and a healthy namespace still reporting `ready` with `ArkConfig.defaultMemory.name` naming something absent
- Not verified live: the ArkConfig-override branch. The test cluster's `arkconfigs` CRD predates layer 4's `defaultMemory` field, so the override cannot be applied there. Unit tests only

Part of #2731. Closes #3284.
