### PR TITLE
feat(chart): make the ark-deployer ClusterRole optional via rbac.deployer.enable

### DIFF
--- a/ark/dist/chart/templates/rbac/ark-deployer-role.yaml
+++ b/ark/dist/chart/templates/rbac/ark-deployer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enable }}
+{{- if and .Values.rbac.enable .Values.rbac.deployer.enable }}
 # ARK Deployer ClusterRole
 #
 # This ClusterRole defines the minimum permissions required to deploy ARK

--- a/ark/dist/chart/values.yaml
+++ b/ark/dist/chart/values.yaml
@@ -77,6 +77,12 @@ completions:
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:
   enable: true
+  # The ark-deployer ClusterRole grants the permissions needed to deploy Ark
+  # from a CI/CD system (e.g. GitHub Actions with OIDC federation). The role is
+  # not bound by the chart and is not used by the controller itself. Disable it
+  # if you do not deploy Ark through a CI/CD identity.
+  deployer:
+    enable: true
   # Service account impersonation for multi-tenancy
   impersonation:
     # Enable impersonation to allow the controller to execute queries using the


### PR DESCRIPTION
## Summary
- Gate the ark-deployer ClusterRole behind `rbac.deployer.enable` (default true)
- The role is only needed for CI/CD deployment identities (e.g. GitHub Actions OIDC federation); it is unbound by the chart and unused by the controller