### PR TITLE
fix(dashboard): return 502/504 instead of 500 when ark-api proxy fetch fails

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/app/api/v1/proxy-route.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/app/api/v1/proxy-route.test.ts
@@ -313,6 +313,80 @@ describe('app/api/v1/[...proxy]/route', () => {
     });
   });
 
+  describe('backend failure handling', () => {
+    it('returns a structured 502 when the backend fetch throws (e.g. ECONNREFUSED)', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const cause = new TypeError('fetch failed');
+      mockFetch.mockRejectedValueOnce(cause);
+
+      const response = await GET(
+        makeRequest('/api/v1/agents'),
+        makeContext(['agents']),
+      );
+
+      expect(response.status).toBe(502);
+      const body = await response.json();
+      expect(body).toEqual({
+        error: 'backend unavailable',
+        detail: 'fetch failed',
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        '[proxy] ark-api request failed',
+        expect.objectContaining({
+          target: 'http://ark-api:80/v1/agents',
+          method: 'GET',
+          timedOut: false,
+          cause,
+        }),
+      );
+      consoleError.mockRestore();
+    });
+
+    it('returns 504 when the request exceeds ARK_API_PROXY_TIMEOUT_MS', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      process.env.ARK_API_PROXY_TIMEOUT_MS = '1';
+      // Never resolve on its own; reject only once the combined abort fires.
+      mockFetch.mockImplementationOnce(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject((init.signal as AbortSignal).reason),
+            );
+          }),
+      );
+
+      const response = await GET(
+        makeRequest('/api/v1/agents'),
+        makeContext(['agents']),
+      );
+
+      expect(response.status).toBe(504);
+      const body = await response.json();
+      expect(body.error).toBe('backend timeout');
+      expect(consoleError).toHaveBeenCalledWith(
+        '[proxy] ark-api request failed',
+        expect.objectContaining({ timedOut: true }),
+      );
+      delete process.env.ARK_API_PROXY_TIMEOUT_MS;
+      consoleError.mockRestore();
+    });
+
+    it('rethrows (does not return 502) when the client aborted the request', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const request = makeRequest('/api/v1/agents');
+      Object.defineProperty(request, 'signal', { value: controller.signal });
+      const cause = new DOMException('aborted', 'AbortError');
+      mockFetch.mockRejectedValueOnce(cause);
+
+      await expect(GET(request, makeContext(['agents']))).rejects.toBe(cause);
+    });
+  });
+
   describe('response passthrough', () => {
     it('forwards the backend status code', async () => {
       mockFetch.mockResolvedValueOnce(makeBackendResponse({ status: 422 }));

--- a/services/ark-dashboard/ark-dashboard/app/api/v1/[...proxy]/route.ts
+++ b/services/ark-dashboard/ark-dashboard/app/api/v1/[...proxy]/route.ts
@@ -109,6 +109,11 @@ function backendBaseUrl(): string {
   return `${protocol}://${host}:${port}`;
 }
 
+function proxyTimeoutMs(): number {
+  const parsed = Number(process.env.ARK_API_PROXY_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30_000;
+}
+
 async function proxyToArkApi(
   request: NextRequest,
   proxyPath: string[],
@@ -146,10 +151,14 @@ async function proxyToArkApi(
     headers.set('Authorization', `Bearer ${token.access_token}`);
   }
 
+  // Bound the backend call so a hung ark-api can't pile requests up in Node's
+  // queue and exhaust the dashboard process. Abort on either a client
+  // disconnect (request.signal) or the timeout, whichever fires first.
+  const timeoutSignal = AbortSignal.timeout(proxyTimeoutMs());
   const fetchOptions: BackendFetchOptions = {
     method: request.method,
     headers,
-    signal: request.signal,
+    signal: AbortSignal.any([request.signal, timeoutSignal]),
   };
 
   if (request.body && request.method !== 'GET' && request.method !== 'HEAD') {
@@ -157,7 +166,31 @@ async function proxyToArkApi(
     fetchOptions.duplex = 'half';
   }
 
-  const backendResponse = await fetch(targetUrl, fetchOptions);
+  let backendResponse: Response;
+  try {
+    backendResponse = await fetch(targetUrl, fetchOptions);
+  } catch (error) {
+    // The client went away; nothing to return to.
+    if (request.signal.aborted) {
+      throw error;
+    }
+    // Surface the real cause here so it isn't buried under auth.js's blanket
+    // JWTSessionError wrapper, which has nothing to do with the failure.
+    const timedOut = timeoutSignal.aborted;
+    console.error('[proxy] ark-api request failed', {
+      target: targetUrl,
+      method: request.method,
+      timedOut,
+      cause: error,
+    });
+    return NextResponse.json(
+      {
+        error: timedOut ? 'backend timeout' : 'backend unavailable',
+        detail: error instanceof Error ? error.message : String(error),
+      },
+      { status: timedOut ? 504 : 502 },
+    );
+  }
 
   const responseHeaders = new Headers(backendResponse.headers);
   // Hop-by-hop and content-length headers can confuse Next.js's response


### PR DESCRIPTION
## Summary
- Wrap the `[...proxy]` route's backend `fetch()` in try/catch so ark-api being down or slow no longer surfaces as a generic HTTP 500 mislabeled `JWTSessionError` (fixes #2582)
- Return structured JSON on failure: `502 backend unavailable` for connection errors, `504 backend timeout` when the deadline is exceeded
- Add an explicit timeout via `AbortSignal.timeout(...)`, combined with the client's `request.signal` through `AbortSignal.any([...])`, so a hung ark-api can't pile requests up and exhaust the dashboard's Node process
- Timeout is configurable via `ARK_API_PROXY_TIMEOUT_MS` (default 30s)
- Log the real cause (`[proxy] ark-api request failed` with target URL, method, timed-out flag, error) so it isn't buried under auth.js's blanket error wrapper
- Rethrow on client disconnect instead of returning a misleading 502
- Add unit tests for the 502, 504, and client-abort paths

Fixes #2582