### PR TITLE
feat(controller): per-namespace fair scheduling for bounded Query pool

### DIFF
--- a/ark/internal/controller/fair_scheduler.go
+++ b/ark/internal/controller/fair_scheduler.go
@@ -58,7 +58,7 @@ func (s *fairScheduler) tryAcquire(ns string) bool {
 
 	if s.inFlight >= s.max {
 		s.markWaitingLocked(ns, now)
-		s.publishLocked()
+		s.publishLocked(ns)
 		return false
 	}
 
@@ -66,14 +66,14 @@ func (s *fairScheduler) tryAcquire(ns string) bool {
 	if s.perNS[ns] >= share {
 		s.markWaitingLocked(ns, now)
 		queryFairnessDeniedTotal.WithLabelValues(ns).Inc()
-		s.publishLocked()
+		s.publishLocked(ns)
 		return false
 	}
 
 	s.inFlight++
 	s.perNS[ns]++
 	delete(s.waitingSeen, ns)
-	s.publishLocked()
+	s.publishLocked(ns)
 	return true
 }
 
@@ -91,9 +91,8 @@ func (s *fairScheduler) release(ns string) {
 	}
 	if s.perNS[ns] == 0 {
 		delete(s.perNS, ns)
-		queryInflightGauge.DeleteLabelValues(ns)
 	}
-	s.publishLocked()
+	s.publishLocked(ns)
 }
 
 // shareLocked is the per-namespace cap for the current active-tenant count,
@@ -110,37 +109,49 @@ func (s *fairScheduler) shareLocked(ns string, now time.Time) int {
 // countActiveLocked returns the number of namespaces currently competing for
 // the pool: those with in-flight work, plus those that attempted and were
 // denied within the window, plus ns itself. Stale waiting entries are pruned.
+// Computed arithmetically (no set allocation) since it runs on every acquire.
 func (s *fairScheduler) countActiveLocked(ns string, now time.Time) int {
+	s.pruneWaitingLocked(now)
+	active := s.activeTenantsLocked()
+	if _, inFlight := s.perNS[ns]; !inFlight {
+		if _, waiting := s.waitingSeen[ns]; !waiting {
+			active++
+		}
+	}
+	return active
+}
+
+// activeTenantsLocked counts namespaces holding a slot plus those with a
+// (non-pruned) waiting mark not already counted. Allocation-free.
+func (s *fairScheduler) activeTenantsLocked() int {
+	active := len(s.perNS)
+	for k := range s.waitingSeen {
+		if _, inFlight := s.perNS[k]; !inFlight {
+			active++
+		}
+	}
+	return active
+}
+
+func (s *fairScheduler) pruneWaitingLocked(now time.Time) {
 	for k, seen := range s.waitingSeen {
 		if now.Sub(seen) > s.window {
 			delete(s.waitingSeen, k)
 		}
 	}
-
-	active := make(map[string]struct{}, len(s.perNS)+len(s.waitingSeen)+1)
-	for k := range s.perNS {
-		active[k] = struct{}{}
-	}
-	for k := range s.waitingSeen {
-		active[k] = struct{}{}
-	}
-	active[ns] = struct{}{}
-	return len(active)
 }
 
 func (s *fairScheduler) markWaitingLocked(ns string, now time.Time) {
 	s.waitingSeen[ns] = now
 }
 
-func (s *fairScheduler) publishLocked() {
-	for ns, n := range s.perNS {
+// publishLocked updates only the changed namespace's in-flight gauge and the
+// active-tenant gauge, so cost is independent of how many namespaces hold slots.
+func (s *fairScheduler) publishLocked(ns string) {
+	if n := s.perNS[ns]; n > 0 {
 		queryInflightGauge.WithLabelValues(ns).Set(float64(n))
+	} else {
+		queryInflightGauge.DeleteLabelValues(ns)
 	}
-	active := len(s.perNS)
-	for ns := range s.waitingSeen {
-		if _, ok := s.perNS[ns]; !ok {
-			active++
-		}
-	}
-	queryActiveTenantsGauge.Set(float64(active))
+	queryActiveTenantsGauge.Set(float64(s.activeTenantsLocked()))
 }

--- a/ark/internal/controller/fair_scheduler.go
+++ b/ark/internal/controller/fair_scheduler.go
@@ -1,0 +1,146 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"sync"
+	"time"
+)
+
+// fairScheduler bounds concurrent Query executions globally while giving each
+// namespace an adaptive, max-min-fair share of the pool. It replaces the plain
+// global semaphore so a single tenant flooding queries can't monopolize
+// capacity and starve other tenants (issue #2698).
+//
+// The controller reconcile loop is pull-based: each queued Query key requeues
+// on a fixed backoff and independently attempts to acquire a slot. This type is
+// the gate those attempts consult — it does not own an ordering queue. Fairness
+// comes from capping each namespace at its current share; when a slot frees and
+// the entitled tenant isn't the one attempting acquisition, tenants already at
+// their share are denied and the slot waits at most one requeue delay for the
+// entitled tenant to cycle. A quiet tenant's wait is therefore bounded by the
+// requeue delay, not by another tenant's backlog size.
+type fairScheduler struct {
+	mu sync.Mutex
+
+	// max is the global concurrency bound (MaxConcurrentQueries).
+	max int
+	// window is how long a denied acquisition keeps a namespace counted as
+	// "active" (waiting) after its last attempt, so a tenant that stops
+	// requeuing ages out of the fair-share divisor.
+	window time.Duration
+
+	inFlight    int
+	perNS       map[string]int
+	waitingSeen map[string]time.Time
+
+	now func() time.Time
+}
+
+func newFairScheduler(maxConcurrent int, window time.Duration) *fairScheduler {
+	return &fairScheduler{
+		max:         maxConcurrent,
+		window:      window,
+		perNS:       make(map[string]int),
+		waitingSeen: make(map[string]time.Time),
+		now:         time.Now,
+	}
+}
+
+// tryAcquire grants a slot to ns if the global bound has room and ns is below
+// its current fair share. On denial it records ns as waiting (so it counts
+// toward the share divisor) and returns false; the caller requeues.
+func (s *fairScheduler) tryAcquire(ns string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+
+	if s.inFlight >= s.max {
+		s.markWaitingLocked(ns, now)
+		s.publishLocked()
+		return false
+	}
+
+	share := s.shareLocked(ns, now)
+	if s.perNS[ns] >= share {
+		s.markWaitingLocked(ns, now)
+		queryFairnessDeniedTotal.WithLabelValues(ns).Inc()
+		s.publishLocked()
+		return false
+	}
+
+	s.inFlight++
+	s.perNS[ns]++
+	delete(s.waitingSeen, ns)
+	s.publishLocked()
+	return true
+}
+
+// release returns a slot held by ns. It must be called exactly once per
+// successful tryAcquire.
+func (s *fairScheduler) release(ns string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.inFlight > 0 {
+		s.inFlight--
+	}
+	if s.perNS[ns] > 0 {
+		s.perNS[ns]--
+	}
+	if s.perNS[ns] == 0 {
+		delete(s.perNS, ns)
+		queryInflightGauge.DeleteLabelValues(ns)
+	}
+	s.publishLocked()
+}
+
+// shareLocked is the per-namespace cap for the current active-tenant count,
+// clamped to at least 1 so a namespace can always make progress.
+func (s *fairScheduler) shareLocked(ns string, now time.Time) int {
+	active := s.countActiveLocked(ns, now)
+	share := s.max / active
+	if share < 1 {
+		share = 1
+	}
+	return share
+}
+
+// countActiveLocked returns the number of namespaces currently competing for
+// the pool: those with in-flight work, plus those that attempted and were
+// denied within the window, plus ns itself. Stale waiting entries are pruned.
+func (s *fairScheduler) countActiveLocked(ns string, now time.Time) int {
+	for k, seen := range s.waitingSeen {
+		if now.Sub(seen) > s.window {
+			delete(s.waitingSeen, k)
+		}
+	}
+
+	active := make(map[string]struct{}, len(s.perNS)+len(s.waitingSeen)+1)
+	for k := range s.perNS {
+		active[k] = struct{}{}
+	}
+	for k := range s.waitingSeen {
+		active[k] = struct{}{}
+	}
+	active[ns] = struct{}{}
+	return len(active)
+}
+
+func (s *fairScheduler) markWaitingLocked(ns string, now time.Time) {
+	s.waitingSeen[ns] = now
+}
+
+func (s *fairScheduler) publishLocked() {
+	for ns, n := range s.perNS {
+		queryInflightGauge.WithLabelValues(ns).Set(float64(n))
+	}
+	active := len(s.perNS)
+	for ns := range s.waitingSeen {
+		if _, ok := s.perNS[ns]; !ok {
+			active++
+		}
+	}
+	queryActiveTenantsGauge.Set(float64(active))
+}

--- a/ark/internal/controller/fair_scheduler.go
+++ b/ark/internal/controller/fair_scheduler.go
@@ -160,9 +160,12 @@ func (s *fairScheduler) markWaitingLocked(ns string, now time.Time) {
 	s.waitingSeen[ns] = now
 }
 
-// publishLocked updates only the changed namespace's in-flight gauge and the
-// active-tenant gauge, so cost is independent of how many namespaces hold slots.
+// publishLocked prunes stale waiting marks, then updates the changed namespace's
+// in-flight gauge and the active-tenant gauge. Pruning here (rather than only on
+// the non-saturated acquire path) keeps the active-tenant gauge accurate on the
+// release and denial paths and bounds waitingSeen under sustained saturation.
 func (s *fairScheduler) publishLocked(ns string) {
+	s.pruneWaitingLocked(s.now())
 	if n := s.perNS[ns]; n > 0 {
 		queryInflightGauge.WithLabelValues(ns).Set(float64(n))
 	} else {

--- a/ark/internal/controller/fair_scheduler.go
+++ b/ark/internal/controller/fair_scheduler.go
@@ -63,7 +63,7 @@ func (s *fairScheduler) tryAcquire(ns string) bool {
 	}
 
 	share := s.shareLocked(ns, now)
-	if s.perNS[ns] >= share {
+	if s.perNS[ns] >= share && s.anyOtherWaitingBelowShareLocked(ns, share) {
 		s.markWaitingLocked(ns, now)
 		queryFairnessDeniedTotal.WithLabelValues(ns).Inc()
 		s.publishLocked(ns)
@@ -104,6 +104,21 @@ func (s *fairScheduler) shareLocked(ns string, now time.Time) int {
 		share = 1
 	}
 	return share
+}
+
+// anyOtherWaitingBelowShareLocked reports whether some namespace other than ns
+// is actively waiting (denied within the window) and still below its share, and
+// is therefore entitled to the next freed slot. A tenant already at its share
+// may exceed it only when this returns false, so the floor-division remainder
+// (max mod active) is handed out on demand instead of being stranded, while a
+// slot is still reserved for a tenant that actually has work waiting.
+func (s *fairScheduler) anyOtherWaitingBelowShareLocked(ns string, share int) bool {
+	for k := range s.waitingSeen {
+		if k != ns && s.perNS[k] < share {
+			return true
+		}
+	}
+	return false
 }
 
 // countActiveLocked returns the number of namespaces currently competing for

--- a/ark/internal/controller/fair_scheduler_test.go
+++ b/ark/internal/controller/fair_scheduler_test.go
@@ -1,0 +1,105 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestScheduler builds a scheduler with a controllable clock so the waiting
+// window can be exercised deterministically.
+func newTestScheduler(maxConcurrent int) (*fairScheduler, *time.Time) {
+	clock := time.Unix(0, 0)
+	s := newFairScheduler(maxConcurrent, 500*time.Millisecond)
+	s.now = func() time.Time { return clock }
+	return s, &clock
+}
+
+func TestFairScheduler_GlobalBound(t *testing.T) {
+	s, _ := newTestScheduler(2)
+
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("a"))
+	assert.False(t, s.tryAcquire("a"), "third acquire must be denied once the global bound is reached")
+
+	s.release("a")
+	assert.True(t, s.tryAcquire("a"), "a slot must be grantable again after release")
+}
+
+// The marquee invariant: once a second tenant appears, the busy tenant is held
+// at its fair share and the quiet tenant gets a slot — its wait is not coupled
+// to the busy tenant's backlog.
+func TestFairScheduler_QuietTenantNotStarved(t *testing.T) {
+	s, _ := newTestScheduler(2)
+
+	// Busy tenant fills the pool while it's the only active tenant.
+	require.True(t, s.tryAcquire("busy"))
+	require.True(t, s.tryAcquire("busy"))
+
+	// Quiet tenant arrives, is denied (pool full) but now counts as active.
+	assert.False(t, s.tryAcquire("quiet"))
+
+	// A busy slot frees. With two active tenants the share is 1, so the freed
+	// slot goes to the quiet tenant, and the busy tenant cannot reclaim it.
+	s.release("busy")
+	assert.True(t, s.tryAcquire("quiet"), "quiet tenant must get the freed slot")
+	assert.False(t, s.tryAcquire("busy"), "busy tenant must be held at its fair share of 1")
+}
+
+func TestFairScheduler_EqualSplitAcrossTenants(t *testing.T) {
+	s, _ := newTestScheduler(4)
+
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("b"))
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("b"))
+
+	assert.False(t, s.tryAcquire("a"), "a is at its share of 2")
+	assert.False(t, s.tryAcquire("b"), "b is at its share of 2")
+	assert.Equal(t, 2, s.perNS["a"])
+	assert.Equal(t, 2, s.perNS["b"])
+}
+
+func TestFairScheduler_ShareExpandsAsTenantsDrain(t *testing.T) {
+	s, clock := newTestScheduler(4)
+
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("b"))
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("b"))
+
+	// b drains completely and stops competing.
+	s.release("b")
+	s.release("b")
+
+	// b's waiting mark ages out; a is then the only active tenant and may use
+	// the whole pool.
+	*clock = clock.Add(time.Second)
+	assert.True(t, s.tryAcquire("a"))
+	assert.True(t, s.tryAcquire("a"))
+	assert.Equal(t, 4, s.perNS["a"])
+}
+
+func TestFairScheduler_WaitingEntryAgesOut(t *testing.T) {
+	s, clock := newTestScheduler(4)
+
+	// a takes the whole pool as the sole active tenant.
+	for i := 0; i < 4; i++ {
+		require.True(t, s.tryAcquire("a"))
+	}
+	// b is denied (pool full) and recorded as waiting.
+	assert.False(t, s.tryAcquire("b"))
+
+	s.release("a") // a=3, one slot free
+
+	// While b is still fresh, two tenants are active (share 2) and a is over it.
+	assert.False(t, s.tryAcquire("a"), "a must yield the free slot while b is actively waiting")
+
+	// b goes quiet past the window; a reclaims the free slot.
+	*clock = clock.Add(time.Second)
+	assert.True(t, s.tryAcquire("a"), "a must reclaim capacity once b ages out of the active set")
+}

--- a/ark/internal/controller/fair_scheduler_test.go
+++ b/ark/internal/controller/fair_scheduler_test.go
@@ -121,6 +121,32 @@ func TestFairScheduler_ShareExpandsAsTenantsDrain(t *testing.T) {
 	assert.Equal(t, 4, s.perNS["a"])
 }
 
+// The active-tenant count must return to zero once everything drains and the
+// waiting marks age out, on the release/denial paths too — not only when a
+// later non-saturated acquire happens to prune.
+func TestFairScheduler_ActiveTenantsClearAfterDrain(t *testing.T) {
+	s, clock := newTestScheduler(2)
+
+	// a fills the pool; b is denied at the global cap and left waiting.
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("a"))
+	assert.False(t, s.tryAcquire("b"))
+
+	// a drains completely. b never acquired, so only its waiting mark remains.
+	s.release("a")
+	s.release("a")
+
+	// Before the window elapses b still counts as active.
+	assert.Equal(t, 1, s.activeTenantsLocked())
+
+	// Past the window a release must prune b, dropping the active count to zero
+	// with nothing running.
+	*clock = clock.Add(time.Second)
+	s.publishLocked("a")
+	assert.Equal(t, 0, s.activeTenantsLocked())
+	assert.Empty(t, s.waitingSeen)
+}
+
 func TestFairScheduler_WaitingEntryAgesOut(t *testing.T) {
 	s, clock := newTestScheduler(4)
 

--- a/ark/internal/controller/fair_scheduler_test.go
+++ b/ark/internal/controller/fair_scheduler_test.go
@@ -64,6 +64,43 @@ func TestFairScheduler_EqualSplitAcrossTenants(t *testing.T) {
 	assert.Equal(t, 2, s.perNS["b"])
 }
 
+// The floor-division remainder (max mod active) must be handed out on demand,
+// not stranded once every backlogged tenant sits at its share.
+func TestFairScheduler_RemainderNotStranded(t *testing.T) {
+	s, _ := newTestScheduler(4)
+
+	// Three backlogged tenants each reach the share of 1 (4/3 floored).
+	require.True(t, s.tryAcquire("a"))
+	require.True(t, s.tryAcquire("b"))
+	require.True(t, s.tryAcquire("c"))
+
+	// One slot remains. No tenant is waiting below its share, so the leftover
+	// slot is grantable rather than stranded behind the fairness check.
+	assert.True(t, s.tryAcquire("a"), "the remainder slot must be grantable, not stranded")
+	assert.Equal(t, 4, s.inFlight)
+
+	// The pool is now full: the next attempt is refused by the global bound.
+	assert.False(t, s.tryAcquire("b"), "further acquires are refused only by the global cap")
+}
+
+// A busy tenant must be able to use spare capacity that quiet, low-demand
+// tenants are entitled to but are not asking for. A tenant holding fewer slots
+// than its share does not reserve capacity unless it is actively waiting.
+func TestFairScheduler_BusyTenantUsesSpareLeftByQuietTenant(t *testing.T) {
+	s, _ := newTestScheduler(4)
+
+	// Quiet tenant takes a single slot and stops asking (no waiting mark).
+	require.True(t, s.tryAcquire("quiet"))
+
+	// Busy tenant is not throttled to its notional share of 2: it fills every
+	// remaining slot because "quiet" has no pending demand.
+	require.True(t, s.tryAcquire("busy"))
+	require.True(t, s.tryAcquire("busy"))
+	assert.True(t, s.tryAcquire("busy"), "busy must claim the slot quiet is not asking for")
+	assert.Equal(t, 3, s.perNS["busy"])
+	assert.Equal(t, 4, s.inFlight)
+}
+
 func TestFairScheduler_ShareExpandsAsTenantsDrain(t *testing.T) {
 	s, clock := newTestScheduler(4)
 

--- a/ark/internal/controller/fairness_metrics.go
+++ b/ark/internal/controller/fairness_metrics.go
@@ -1,0 +1,44 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Fair-scheduler metrics. The namespace label is bounded by the number of
+// tenant namespaces with in-flight Query work; series are deleted when a
+// namespace drains to zero so idle tenants don't leak stale series.
+var (
+	queryInflightGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ark_query_inflight",
+			Help: "Query executions currently running in goroutines, by namespace.",
+		},
+		[]string{"namespace"},
+	)
+
+	queryActiveTenantsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ark_query_active_tenants",
+			Help: "Namespaces with in-flight or waiting Query work, used as the fair-share divisor.",
+		},
+	)
+
+	queryFairnessDeniedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ark_query_fairness_denied_total",
+			Help: "Query slot acquisitions denied because the namespace was at its fair share, by namespace.",
+		},
+		[]string{"namespace"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		queryInflightGauge,
+		queryActiveTenantsGauge,
+		queryFairnessDeniedTotal,
+	)
+}

--- a/ark/internal/controller/fairness_metrics.go
+++ b/ark/internal/controller/fairness_metrics.go
@@ -7,9 +7,12 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// Fair-scheduler metrics. The namespace label is bounded by the number of
-// tenant namespaces with in-flight Query work; series are deleted when a
-// namespace drains to zero so idle tenants don't leak stale series.
+// Fair-scheduler metrics. ark_query_inflight series are deleted when a
+// namespace drains to zero, so that gauge's cardinality tracks namespaces with
+// in-flight Query work. ark_query_fairness_denied_total is a counter and is
+// never deleted, so it retains one series per namespace ever denied for the
+// controller's lifetime — unbounded on clusters that create ephemeral or
+// per-PR namespaces.
 var (
 	queryInflightGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -29,7 +32,7 @@ var (
 	queryFairnessDeniedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ark_query_fairness_denied_total",
-			Help: "Query slot acquisitions denied because the namespace was at its fair share, by namespace.",
+			Help: "Query slot acquire attempts denied because the namespace was at its fair share, by namespace. Increments once per denied attempt; queries re-attempt on requeue, so the rate reflects retry frequency, not the number of distinct starved queries.",
 		},
 		[]string{"namespace"},
 	)

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +78,11 @@ const (
 	// when MaxConcurrentQueries is reached. Short enough to be responsive,
 	// long enough to avoid a busy-loop while in-flight queries drain.
 	queryCapacityRequeueDelay = 250 * time.Millisecond
+	// queryFairnessWaitWindow is how long a namespace denied a slot stays in
+	// the fair-share divisor after its last attempt. A few requeue cycles, so
+	// a still-competing tenant keeps its share while one that stops requeuing
+	// ages out and lets the remaining tenants expand.
+	queryFairnessWaitWindow = 4 * queryCapacityRequeueDelay
 	// queryRunningSafetyRequeue re-reconciles a running Query whose execution
 	// goroutine died so it converges to a terminal phase instead of stranding.
 	// Delayed, not immediate, to avoid the requeue storm of #2198/#2362.
@@ -116,7 +120,7 @@ type QueryReconciler struct {
 	// default (1).
 	MaxConcurrentReconciles int
 
-	sem        *semaphore.Weighted
+	sched      *fairScheduler
 	operations sync.Map
 
 	// brokerEndpoint resolves the broker endpoint for a namespace, used by the
@@ -310,7 +314,7 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{RequeueAfter: queryRunningSafetyRequeue}, nil
 	}
 
-	if r.sem != nil && !r.sem.TryAcquire(1) {
+	if r.sched != nil && !r.sched.tryAcquire(req.Namespace) {
 		log.V(1).Info("query execution capacity reached, requeuing", "query", req.String(), "cap", r.MaxConcurrentQueries)
 		if obj.Status.Phase != statusQueued {
 			if err := r.updateStatus(ctx, &obj, statusQueued); err != nil {
@@ -329,8 +333,8 @@ func (r *QueryReconciler) handleRunningPhase(ctx context.Context, req ctrl.Reque
 
 	if obj.Status.Phase != statusRunning {
 		if err := r.updateStatus(ctx, &obj, statusRunning); err != nil {
-			if r.sem != nil {
-				r.sem.Release(1)
+			if r.sched != nil {
+				r.sched.release(req.Namespace)
 			}
 			return ctrl.Result{}, err
 		}
@@ -518,8 +522,8 @@ func (r *QueryReconciler) finishExecuteQueryAsync(ctx context.Context, namespace
 		r.markQueryErroredAfterPanic(ctx, namespacedName, rec)
 	}
 	r.operations.Delete(namespacedName)
-	if r.sem != nil {
-		r.sem.Release(1)
+	if r.sched != nil {
+		r.sched.release(namespacedName.Namespace)
 	}
 }
 
@@ -1671,7 +1675,7 @@ func (r *QueryReconciler) handleQueryDispatch(
 
 func (r *QueryReconciler) initSemaphore() {
 	if r.MaxConcurrentQueries > 0 {
-		r.sem = semaphore.NewWeighted(int64(r.MaxConcurrentQueries))
+		r.sched = newFairScheduler(r.MaxConcurrentQueries, queryFairnessWaitWindow)
 	}
 }
 

--- a/ark/internal/controller/query_controller_fairness_test.go
+++ b/ark/internal/controller/query_controller_fairness_test.go
@@ -1,0 +1,89 @@
+/* Copyright 2025. McKinsey & Company */
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	arkv1alpha1 "mckinsey.com/ark/api/v1alpha1"
+	eventingconfig "mckinsey.com/ark/internal/eventing/config"
+	telemetryconfig "mckinsey.com/ark/internal/telemetry/config"
+)
+
+// End-to-end check that Reconcile threads the Query's namespace into the fair
+// scheduler: a tenant saturating the pool cannot reclaim a freed slot that the
+// scheduler is reserving for a starved tenant, and that starved tenant then
+// transitions queued -> running. The share algorithm itself is unit-tested in
+// fair_scheduler_test.go; this verifies the controller wiring across two real
+// namespaces.
+var _ = Describe("Query Controller per-namespace fairness", func() {
+	It("reserves a freed slot for a starved tenant over the saturating one", func() {
+		ctx := context.Background()
+
+		const busyNS, quietNS = "fairness-busy", "fairness-quiet"
+		for _, ns := range []string{busyNS, quietNS} {
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: ns},
+			}))).To(Succeed())
+		}
+
+		r := &QueryReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			Telemetry:            telemetryconfig.NewProvider(ctx, nil),
+			Eventing:             eventingconfig.NewProviderWithClient(ctx, nil),
+			MaxConcurrentQueries: 2,
+		}
+		r.initSemaphore()
+
+		// Busy tenant already holds the whole pool.
+		Expect(r.sched.tryAcquire(busyNS)).To(BeTrue())
+		Expect(r.sched.tryAcquire(busyNS)).To(BeTrue())
+
+		quiet := &arkv1alpha1.Query{
+			ObjectMeta: metav1.ObjectMeta{Name: "quiet-query", Namespace: quietNS},
+			Spec: arkv1alpha1.QuerySpec{
+				Target: &arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				TTL:    &metav1.Duration{Duration: time.Hour},
+			},
+		}
+		Expect(quiet.Spec.SetInputString("fairness test")).To(Succeed())
+		Expect(k8sClient.Create(ctx, quiet)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, quiet) })
+		quietReq := ctrl.Request{NamespacedName: types.NamespacedName{Name: quiet.Name, Namespace: quiet.Namespace}}
+
+		// Pool is full: the quiet tenant is parked in queued and now counts as a
+		// waiting tenant.
+		_, err := r.handleRunningPhase(ctx, quietReq, *quiet)
+		Expect(err).NotTo(HaveOccurred())
+		queued := &arkv1alpha1.Query{}
+		Expect(k8sClient.Get(ctx, quietReq.NamespacedName, queued)).To(Succeed())
+		Expect(queued.Status.Phase).To(Equal(statusQueued))
+
+		// One busy slot frees. Two tenants are now active so the fair share is 1;
+		// the busy tenant is already at it and must NOT reclaim the free slot even
+		// though the global pool has room.
+		r.sched.release(busyNS)
+		Expect(r.sched.tryAcquire(busyNS)).To(BeFalse(),
+			"saturating tenant must not reclaim a slot reserved for the starved tenant while capacity remains")
+
+		// The starved tenant takes the reserved slot and transitions to running.
+		_, err = r.handleRunningPhase(ctx, quietReq, *queued)
+		Expect(err).NotTo(HaveOccurred())
+		running := &arkv1alpha1.Query{}
+		Expect(k8sClient.Get(ctx, quietReq.NamespacedName, running)).To(Succeed())
+		Expect(running.Status.Phase).To(Equal(statusRunning))
+		_, exists := r.operations.Load(quietReq.NamespacedName)
+		Expect(exists).To(BeTrue(), "quiet tenant should have been granted a slot and spawned execution")
+		r.cleanupExistingOperation(quietReq.NamespacedName)
+	})
+})

--- a/ark/internal/controller/query_controller_queued_error_test.go
+++ b/ark/internal/controller/query_controller_queued_error_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/semaphore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,15 +50,15 @@ func TestHandleRunningPhase_QueuedUpdateError_ReturnsError(t *testing.T) {
 		Client:               c,
 		Scheme:               c.Scheme(),
 		MaxConcurrentQueries: 1,
-		sem:                  semaphore.NewWeighted(1),
+		sched:                newFairScheduler(1, queryFairnessWaitWindow),
 	}
-	require.True(t, r.sem.TryAcquire(1), "pre-condition: saturate the semaphore so handleRunningPhase hits the queued-write branch")
+	require.True(t, r.sched.tryAcquire(q.Namespace), "pre-condition: saturate the pool so handleRunningPhase hits the queued-write branch")
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: q.Name, Namespace: q.Namespace}}
 	_, err := r.handleRunningPhase(context.Background(), req, *q)
 
 	require.Error(t, err, "handleRunningPhase must surface a queued-write failure so the reconciler retries")
-	assert.False(t, r.sem.TryAcquire(1), "sem-full branch must not attempt a new acquisition; the pre-acquired slot is still held")
+	assert.False(t, r.sched.tryAcquire(q.Namespace), "capacity-full branch must not acquire a new slot; the pre-acquired slot is still held")
 }
 
 func TestHandleRunningPhase_RunningUpdateError_ReleasesSemaphore(t *testing.T) {
@@ -78,14 +77,14 @@ func TestHandleRunningPhase_RunningUpdateError_ReleasesSemaphore(t *testing.T) {
 		Client:               c,
 		Scheme:               c.Scheme(),
 		MaxConcurrentQueries: 1,
-		sem:                  semaphore.NewWeighted(1),
+		sched:                newFairScheduler(1, queryFairnessWaitWindow),
 	}
 
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: q.Name, Namespace: q.Namespace}}
 	_, err := r.handleRunningPhase(context.Background(), req, *q)
 
 	require.Error(t, err, "handleRunningPhase must surface a running-write failure so the reconciler retries")
-	assert.True(t, r.sem.TryAcquire(1), "semaphore slot must be released on running-write error to prevent a permanent leak")
+	assert.True(t, r.sched.tryAcquire(q.Namespace), "slot must be released on running-write error to prevent a permanent leak")
 }
 
 func TestFailQueryOnTimeout_StatusUpdateError_Propagates(t *testing.T) {

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -327,9 +326,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Client:               k8sClient,
 				Scheme:               k8sClient.Scheme(),
 				MaxConcurrentQueries: 1,
-				sem:                  semaphore.NewWeighted(1),
+				sched:                newFairScheduler(1, queryFairnessWaitWindow),
 			}
-			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "pre-condition: semaphore should start drainable")
+			Expect(r.sched.tryAcquire("default")).To(BeTrue(), "pre-condition: semaphore should start drainable")
 
 			query := arkv1alpha1.Query{
 				ObjectMeta: metav1.ObjectMeta{
@@ -360,7 +359,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 0,
 			}
-			Expect(r.sem).To(BeNil(), "nil semaphore means enforcement is disabled")
+			Expect(r.sched).To(BeNil(), "nil semaphore means enforcement is disabled")
 
 			query := arkv1alpha1.Query{
 				ObjectMeta: metav1.ObjectMeta{
@@ -404,9 +403,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
 				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 1,
-				sem:                  semaphore.NewWeighted(1),
+				sched:                newFairScheduler(1, queryFairnessWaitWindow),
 			}
-			Expect(r.sem.TryAcquire(1)).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
 
 			query := newTestQuery("phase-queued-then-running")
 			Expect(k8sClient.Create(ctx, query)).To(Succeed())
@@ -420,7 +419,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Expect(k8sClient.Get(ctx, req.NamespacedName, queued)).To(Succeed())
 			Expect(queued.Status.Phase).To(Equal(statusQueued))
 
-			r.sem.Release(1)
+			r.sched.release("default")
 
 			_, err = r.handleRunningPhase(ctx, req, *queued)
 			Expect(err).NotTo(HaveOccurred())
@@ -443,7 +442,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 0,
 			}
-			Expect(r.sem).To(BeNil())
+			Expect(r.sched).To(BeNil())
 
 			query := newTestQuery("phase-no-semaphore")
 			Expect(k8sClient.Create(ctx, query)).To(Succeed())
@@ -465,9 +464,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Client:               k8sClient,
 				Scheme:               k8sClient.Scheme(),
 				MaxConcurrentQueries: 1,
-				sem:                  semaphore.NewWeighted(1),
+				sched:                newFairScheduler(1, queryFairnessWaitWindow),
 			}
-			Expect(r.sem.TryAcquire(1)).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
 
 			query := newTestQuery("phase-queued-idempotent")
 			Expect(k8sClient.Create(ctx, query)).To(Succeed())
@@ -623,18 +622,21 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 	})
 
 	Context("initSemaphore", func() {
-		It("creates a semaphore sized to MaxConcurrentQueries", func() {
+		It("creates a fair scheduler sized to MaxConcurrentQueries", func() {
 			r := &QueryReconciler{MaxConcurrentQueries: 3}
 			r.initSemaphore()
-			Expect(r.sem).NotTo(BeNil())
-			Expect(r.sem.TryAcquire(3)).To(BeTrue(), "should permit MaxConcurrentQueries acquisitions")
-			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "should deny the next acquisition once the cap is reached")
+			Expect(r.sched).NotTo(BeNil())
+			// Cap is 3: three acquisitions succeed, the fourth is refused.
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeFalse(), "should deny acquisitions past MaxConcurrentQueries")
 		})
 
-		It("leaves the semaphore nil when MaxConcurrentQueries is 0", func() {
+		It("leaves the scheduler nil when MaxConcurrentQueries is 0", func() {
 			r := &QueryReconciler{MaxConcurrentQueries: 0}
 			r.initSemaphore()
-			Expect(r.sem).To(BeNil())
+			Expect(r.sched).To(BeNil())
 		})
 	})
 
@@ -647,7 +649,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 	})
 
 	Context("SetupWithManager", func() {
-		It("registers the controller and sizes the semaphore from MaxConcurrentQueries", func() {
+		It("registers the controller and sizes the scheduler from MaxConcurrentQueries", func() {
 			mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -660,9 +662,11 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 			Expect(r.SetupWithManager(mgr)).To(Succeed())
 
-			Expect(r.sem).NotTo(BeNil(), "initSemaphore should have run via SetupWithManager")
-			Expect(r.sem.TryAcquire(2)).To(BeTrue(), "semaphore should permit MaxConcurrentQueries acquisitions")
-			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "semaphore should refuse the next acquisition once the cap is reached")
+			Expect(r.sched).NotTo(BeNil(), "initSemaphore should have run via SetupWithManager")
+			// Cap is 2: two acquisitions succeed, the third is refused.
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeFalse(), "scheduler should refuse acquisitions past MaxConcurrentQueries")
 		})
 	})
 
@@ -670,12 +674,12 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 		It("deletes the operation entry and releases the semaphore", func() {
 			r := &QueryReconciler{
 				MaxConcurrentQueries: 1,
-				sem:                  semaphore.NewWeighted(1),
+				sched:                newFairScheduler(1, queryFairnessWaitWindow),
 			}
 			// Saturate the semaphore to model "a query is already in flight"; the
 			// next TryAcquire fails until something releases the slot.
-			Expect(r.sem.TryAcquire(1)).To(BeTrue())
-			Expect(r.sem.TryAcquire(1)).To(BeFalse(), "semaphore should now be full")
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeFalse(), "semaphore should now be full")
 
 			namespacedName := types.NamespacedName{Name: "finish-query", Namespace: "default"}
 			_, cancel := context.WithCancel(context.Background())
@@ -686,7 +690,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 			_, exists := r.operations.Load(namespacedName)
 			Expect(exists).To(BeFalse(), "operations entry should be cleared")
-			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "semaphore slot should have been released")
+			Expect(r.sched.tryAcquire("default")).To(BeTrue(), "semaphore slot should have been released")
 		})
 
 		It("does not panic when the semaphore is nil", func() {
@@ -707,9 +711,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 				Telemetry:            telemetryconfig.NewProvider(context.Background(), nil),
 				Eventing:             eventingconfig.NewProviderWithClient(context.Background(), nil),
 				MaxConcurrentQueries: 1,
-				sem:                  semaphore.NewWeighted(1),
+				sched:                newFairScheduler(1, queryFairnessWaitWindow),
 			}
-			Expect(r.sem.TryAcquire(1)).To(BeTrue())
+			Expect(r.sched.tryAcquire("default")).To(BeTrue())
 
 			namespacedName := types.NamespacedName{Name: "panic-query", Namespace: "default"}
 			r.operations.Store(namespacedName, context.CancelFunc(func() {}))
@@ -721,7 +725,7 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 			_, exists := r.operations.Load(namespacedName)
 			Expect(exists).To(BeFalse(), "cleanup must run even on panic")
-			Expect(r.sem.TryAcquire(1)).To(BeTrue(), "semaphore must be released even on panic")
+			Expect(r.sched.tryAcquire("default")).To(BeTrue(), "semaphore must be released even on panic")
 		})
 	})
 })

--- a/docs/content/reference/scalability.mdx
+++ b/docs/content/reference/scalability.mdx
@@ -21,7 +21,7 @@ The controller's default resource allocation is intentionally conservative. Prod
 
 The Query controller exposes two knobs via Helm values under `controllerManager`:
 
-- **`maxConcurrentQueries`** (default `32`) — caps the number of Query executions running concurrently as in-process goroutines. When the cap is reached, the reconciler requeues so the backlog stays in the workqueue instead of the controller heap. This bounds memory under burst load. Set to `0` to disable the cap (not recommended — susceptible to OOM under burst load).
+- **`maxConcurrentQueries`** (default `32`) — caps the number of Query executions running concurrently as in-process goroutines. When the cap is reached, the reconciler requeues so the backlog stays in the workqueue instead of the controller heap. This bounds memory under burst load. Set to `0` to disable the cap (not recommended — susceptible to OOM under burst load). The cap is shared max-min-fair across active namespaces: each namespace with in-flight or recently-waiting queries gets an adaptive share (`maxConcurrentQueries` divided by the number of active namespaces, floor 1), so one tenant flooding queries cannot monopolize the pool and starve others (#2698). A namespace with demand below its share leaves the remainder for others; idle namespaces do not reduce anyone's share.
 - **`maxConcurrentReconciles`** (default `4`) — caps the number of Query reconciles running in parallel. The workqueue dedupes per-key, so this only enables concurrency *across different* Query objects, not faster repeats of the same one. Set to `0` to use the controller-runtime default (1).
 
 The two knobs are independent and both effective at the defaults. `maxConcurrentReconciles` controls how fast queued queries are picked up; `maxConcurrentQueries` bounds how many of them can be in-flight at once. Raise both together if the controller has spare CPU/memory headroom and queue depth is growing. Lower `maxConcurrentQueries` if the controller pod is near its memory limit during bursts.
@@ -61,6 +61,12 @@ All executors — including the default completions executor — run as separate
 ### Metrics
 
 The controller exposes Prometheus metrics over a TLS-protected endpoint. A ServiceMonitor template is included in the Helm chart (disabled by default) for integration with the Prometheus Operator. Standard controller-runtime metrics cover reconciliation rates, queue depths, and error counts.
+
+The fair scheduler adds three metrics for cross-tenant starvation visibility:
+
+- **`ark_query_inflight{namespace}`** — Query executions currently running, per namespace. Compare across namespaces to see how the pool is shared.
+- **`ark_query_active_tenants`** — number of namespaces competing for the pool (the fair-share divisor). A rising value means each tenant's share is shrinking.
+- **`ark_query_fairness_denied_total{namespace}`** — slot acquire attempts denied because a namespace was at its fair share. A sustained non-zero rate for a namespace indicates it is being held at its share by contention from other tenants; the rate reflects requeue frequency, not the count of distinct starved queries.
 
 Ark also integrates with OpenTelemetry for distributed tracing across the query lifecycle — from the controller through A2A dispatch to executors. See the [Monitoring](/operations-guide/monitoring) guide for setup instructions.
 


### PR DESCRIPTION
## Summary
- Replace the global Query execution semaphore with a per-namespace fair scheduler so one tenant flooding queries can't monopolize the bounded worker pool and starve others (#2698, the last open controller sub-task of #2597).
- Each active namespace gets an adaptive max-min share (`MaxConcurrentQueries / active tenants`, floor 1); a short waiting window ages out tenants that stop requeuing so idle capacity is reclaimed.
- A starved tenant's wait is now bounded by the requeue delay rather than by another tenant's backlog size — the multi-tenant failure mode from the 51-namespace repro in #2597.
- Add metrics `ark_query_inflight{namespace}`, `ark_query_active_tenants`, `ark_query_fairness_denied_total{namespace}` for cross-tenant starvation visibility.
- No new configuration surface — fairness reuses the existing `MaxConcurrentQueries`.

## How the fair share is computed

The share is divided across **currently/recently-active** namespaces, **not** across every namespace that exists. The scheduler has no notion of how many namespaces are provisioned in the cluster — idle ones are invisible to it. If 10 namespaces exist but only 1 is submitting, that namespace gets the **entire** pool (not 1/10).

`shareLocked` computes `share = MaxConcurrentQueries / countActiveLocked(...)`, floored at 1, on **every acquire attempt**. The active set (`countActiveLocked`) is the union of:
1. namespaces with in-flight work (`perNS[ns] > 0`),
2. namespaces that attempted and were denied within the waiting window (`waitingSeen`, stale entries pruned each call), and
3. the calling namespace itself.

A namespace that holds no slot and hasn't attempted recently contributes 0 to the divisor.

**Waiting window (the "recently" part):** on denial, the namespace is stamped into `waitingSeen` and stays counted as active for `queryFairnessWaitWindow = 4 * queryCapacityRequeueDelay` (~1s). Queued queries requeue every 250ms, so a namespace that's still competing keeps refreshing its stamp and stays in the divisor; one that stops submitting ages out within ~1s. This is what makes the cap track *very recently active* rather than *ever seen*.

**Timeline (max = 32):**
- Only `ns-A` active → `active = 1`, share = 32 → A fills the whole pool.
- `ns-B` starts, pool full → B's attempt is denied → B enters `waitingSeen` → `active = 2`, share = 16. A holds 32 (> 16), so as A's queries finish it can't win the freed slots (over share); they go to B until both settle at 16/16. No preemption — A's running queries are never killed; fairness applies only to the *next* free slot.
- `ns-C…J` never submit → never enter `perNS`/`waitingSeen` → never affect the divisor. Split is 16/16, not 3.2 each across ten.
- `ns-B` goes quiet → its `waitingSeen` entry expires (~1s) and its in-flight drains → `active = 1` → A reclaims the full 32.

**Design notes for review:**
- Fairness is enforced **only at acquisition**, never by preemption. Worst-case extra wait for a newly-active tenant is ~one requeue delay (250ms), not the busy tenant's whole backlog.
- The ~1s window is **derived from** the requeue delay (`4 * queryCapacityRequeueDelay`), not independently tunable — intentional coupling (a few requeue cycles), but the one magic-number relationship to be aware of.

Closes #2698

🤖 Generated with [Claude Code](https://claude.com/claude-code)