### PR TITLE
feat(apiserver): expose metrics endpoint and add WAL/slot-lag monitoring

### DIFF
--- a/ark/dist/chart-apiserver/README.md
+++ b/ark/dist/chart-apiserver/README.md
@@ -72,6 +72,17 @@ Enabling it adds a second ClusterRole, `ark-apiserver-admission-webhooks`, grant
 Before wiring either mechanism the apiserver runs a `SelfSubjectAccessReview` for each of its watches. A missing or deleted `ark-apiserver-admission-policy` ClusterRoleBinding therefore lands on the same fallback as an unsupported host, naming the binding — rather than leaving the plugin's informers unable to sync, which upstream turns into a 10-second stall and an opaque `Forbidden` on **every write**. The review needs no extra RBAC (`system:basic-user` grants it to all authenticated identities). It confirms the grant exists at startup only; a binding removed while the process is running still fails at request time, which is what that mechanism's `required` is for.
 - `policy.extraParamRules` — extra RBAC rules for policies that use `paramKind`. The plugin builds a dynamic informer per `paramKind` and the policy silently never matches if it cannot read that resource. ConfigMaps and Secrets are already covered by the parameter-resolution role, so ConfigMap-based params work out of the box; **any other `paramKind` needs a rule here.**
 
+### Metrics
+
+`metrics.enabled=true` (default `false`) serves Prometheus metrics on port `8443` and adds a `metrics` port to the Service (and to the NetworkPolicy when enabled). The endpoint exposes the Ark apiserver collectors (`ark_apiserver_storage_*`, `ark_apiserver_requests_*`, `ark_apiserver_admission_enforcement_active`), the watch broadcaster collectors (`ark_apiserver_watch_*`) and the PostgreSQL backend gauges:
+
+- `ark_apiserver_wal_consumer_active` — `1` on the replica running the WAL consumer; across a healthy deployment the sum is exactly `1`.
+- `ark_apiserver_wal_last_message_timestamp_seconds` — staleness means the consumer is wedged.
+- `ark_apiserver_replication_slot_lag_bytes` — WAL pinned by the `ark_cdc` slot; a climbing value is the disk-filling condition described under "Replication slot lifecycle". Sampled every 30s on the leader; `NaN` elsewhere. The query reads `pg_replication_slots`, which works for the slot owner by default — a locked-down role needs `GRANT pg_monitor TO <role>`.
+- `ark_apiserver_db_pool_*` — connection pool stats (`sql.DBStats`); `wait_count_total` rising means pool exhaustion.
+
+`metrics.secure=true` (default) serves HTTPS and requires a bearer token authorized via TokenReview/SubjectAccessReview; the RBAC is already covered by the `system:auth-delegator` binding. `metrics.serviceMonitor.enabled=true` renders a ServiceMonitor (requires the Prometheus Operator CRDs) scraping every `metrics.serviceMonitor.interval` (default `30s`).
+
 ### Replication slot lifecycle
 
 The apiserver creates a **persistent** logical replication slot named `ark_cdc` on the configured PostgreSQL database to drive its watch stream. The slot survives apiserver pod restarts, which is what lets watchers resume from the last confirmed WAL position rather than missing events from the restart gap.

--- a/ark/dist/chart-apiserver/README.md
+++ b/ark/dist/chart-apiserver/README.md
@@ -74,10 +74,10 @@ Before wiring either mechanism the apiserver runs a `SelfSubjectAccessReview` fo
 
 ### Metrics
 
-`metrics.enabled=true` (default `false`) serves Prometheus metrics on port `8443` and adds a `metrics` port to the Service (and to the NetworkPolicy when enabled). The endpoint exposes the Ark apiserver collectors (`ark_apiserver_storage_*`, `ark_apiserver_requests_*`, `ark_apiserver_admission_enforcement_active`), the watch broadcaster collectors (`ark_apiserver_watch_*`) and the PostgreSQL backend gauges:
+`metrics.enabled=true` (default `false`) serves Prometheus metrics on `metrics.port` (default `8443`) and adds a `metrics` port to the Service (and to the NetworkPolicy when enabled). The endpoint exposes the Ark apiserver collectors (`ark_apiserver_storage_*`, `ark_apiserver_requests_*`, `ark_apiserver_admission_enforcement_active`), the watch broadcaster collectors (`ark_apiserver_watch_*`) and the PostgreSQL backend gauges:
 
 - `ark_apiserver_wal_consumer_active` — `1` on the replica running the WAL consumer; across a healthy deployment the sum is exactly `1`.
-- `ark_apiserver_wal_last_message_timestamp_seconds` — staleness means the consumer is wedged.
+- `ark_apiserver_wal_last_message_timestamp_seconds` — staleness means the consumer is wedged. `NaN` on replicas not running the consumer (including a leader that just lost the lease), so a `time() - ark_apiserver_wal_last_message_timestamp_seconds > 300` alert stays quiet on followers; if you scope it anyway, join on `ark_apiserver_wal_consumer_active == 1`.
 - `ark_apiserver_replication_slot_lag_bytes` — WAL pinned by the `ark_cdc` slot; a climbing value is the disk-filling condition described under "Replication slot lifecycle". Sampled every 30s on the leader; `NaN` elsewhere. The query reads `pg_replication_slots`, which works for the slot owner by default — a locked-down role needs `GRANT pg_monitor TO <role>`.
 - `ark_apiserver_db_pool_*` — connection pool stats (`sql.DBStats`); `wait_count_total` rising means pool exhaustion.
 

--- a/ark/dist/chart-apiserver/templates/deployment.yaml
+++ b/ark/dist/chart-apiserver/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           args:
             - --role=apiserver
             - --leader-elect
-            - --metrics-bind-address={{ ternary ":8443" "0" .Values.metrics.enabled }}
+            - --metrics-bind-address={{ ternary (printf ":%d" (int .Values.metrics.port)) "0" .Values.metrics.enabled }}
             {{- if .Values.metrics.enabled }}
             - --metrics-secure={{ .Values.metrics.secure }}
             {{- end }}
@@ -109,7 +109,7 @@ spec:
               protocol: TCP
             {{- if .Values.metrics.enabled }}
             - name: metrics
-              containerPort: 8443
+              containerPort: {{ .Values.metrics.port }}
               protocol: TCP
             {{- end }}
           livenessProbe:

--- a/ark/dist/chart-apiserver/templates/deployment.yaml
+++ b/ark/dist/chart-apiserver/templates/deployment.yaml
@@ -39,7 +39,10 @@ spec:
           args:
             - --role=apiserver
             - --leader-elect
-            - --metrics-bind-address=0
+            - --metrics-bind-address={{ ternary ":8443" "0" .Values.metrics.enabled }}
+            {{- if .Values.metrics.enabled }}
+            - --metrics-secure={{ .Values.metrics.secure }}
+            {{- end }}
             - --health-probe-bind-address=:8081
           env:
             - name: ENABLE_WEBHOOKS
@@ -104,6 +107,11 @@ spec:
             - name: health
               containerPort: 8081
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 8443
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/ark/dist/chart-apiserver/templates/networkpolicy.yaml
+++ b/ark/dist/chart-apiserver/templates/networkpolicy.yaml
@@ -25,7 +25,7 @@ spec:
           protocol: TCP
     {{- if .Values.metrics.enabled }}
     - ports:
-        - port: 8443
+        - port: {{ .Values.metrics.port }}
           protocol: TCP
     {{- end }}
 {{- end }}

--- a/ark/dist/chart-apiserver/templates/networkpolicy.yaml
+++ b/ark/dist/chart-apiserver/templates/networkpolicy.yaml
@@ -23,4 +23,9 @@ spec:
     - ports:
         - port: 8081
           protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - ports:
+        - port: 8443
+          protocol: TCP
+    {{- end }}
 {{- end }}

--- a/ark/dist/chart-apiserver/templates/prometheus/monitor.yaml
+++ b/ark/dist/chart-apiserver/templates/prometheus/monitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ark-apiserver-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ark-apiserver.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- if .Values.metrics.secure }}
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        # The metrics server uses an ephemeral self-signed cert with no CA to
+        # verify against, so skip verification (still TLS on the wire).
+        insecureSkipVerify: true
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ark-apiserver.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/ark/dist/chart-apiserver/templates/service.yaml
+++ b/ark/dist/chart-apiserver/templates/service.yaml
@@ -12,5 +12,11 @@ spec:
       port: {{ .Values.apiserver.port }}
       targetPort: {{ .Values.apiserver.port }}
       protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: 8443
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "ark-apiserver.selectorLabels" . | nindent 4 }}

--- a/ark/dist/chart-apiserver/templates/service.yaml
+++ b/ark/dist/chart-apiserver/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
       protocol: TCP
     {{- if .Values.metrics.enabled }}
     - name: metrics
-      port: 8443
+      port: {{ .Values.metrics.port }}
       targetPort: metrics
       protocol: TCP
     {{- end }}

--- a/ark/dist/chart-apiserver/values.yaml
+++ b/ark/dist/chart-apiserver/values.yaml
@@ -127,6 +127,18 @@ policy:
   #       verbs: ["get", "list", "watch"]
   extraParamRules: []
 
+# Prometheus metrics endpoint (controller-runtime metrics server on port 8443). Serves
+# the Ark apiserver collectors plus the WAL consumer, replication slot lag and DB pool
+# gauges from the PostgreSQL backend.
+metrics:
+  enabled: false
+  # Serve HTTPS with authn/authz filtering (TokenReview + SubjectAccessReview); the
+  # auth-delegator binding the chart already grants covers the required RBAC.
+  secure: true
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
 networkPolicy:
   enabled: false
   extraIngressFrom: []

--- a/ark/dist/chart-apiserver/values.yaml
+++ b/ark/dist/chart-apiserver/values.yaml
@@ -127,11 +127,12 @@ policy:
   #       verbs: ["get", "list", "watch"]
   extraParamRules: []
 
-# Prometheus metrics endpoint (controller-runtime metrics server on port 8443). Serves
+# Prometheus metrics endpoint (controller-runtime metrics server on metrics.port). Serves
 # the Ark apiserver collectors plus the WAL consumer, replication slot lag and DB pool
 # gauges from the PostgreSQL backend.
 metrics:
   enabled: false
+  port: 8443
   # Serve HTTPS with authn/authz filtering (TokenReview + SubjectAccessReview); the
   # auth-delegator binding the chart already grants covers the required RBAC.
   secure: true

--- a/ark/internal/apiserver/metrics/metrics.go
+++ b/ark/internal/apiserver/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
@@ -118,13 +119,18 @@ func (*enforcementCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
+// Registered on controller-runtime's registry: that is the one served by
+// --metrics-bind-address, so registering on the prometheus default registry
+// would leave these collectors unscrapeable.
 func init() {
-	prometheus.MustRegister(StorageOperations)
-	prometheus.MustRegister(StorageLatency)
-	prometheus.MustRegister(RequestsTotal)
-	prometheus.MustRegister(RequestDuration)
-	prometheus.MustRegister(ActiveResources)
-	prometheus.MustRegister(EnforcementActive)
+	ctrlmetrics.Registry.MustRegister(
+		StorageOperations,
+		StorageLatency,
+		RequestsTotal,
+		RequestDuration,
+		ActiveResources,
+		EnforcementActive,
+	)
 }
 
 func RecordStorageOperation(operation, kind, status string) {

--- a/ark/internal/apiserver/metrics/metrics_test.go
+++ b/ark/internal/apiserver/metrics/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // resetReadyFns clears the process-wide hooks so cases do not leak into each other. These tests
@@ -124,6 +125,39 @@ func TestSetEnforcementReadyFunc_ReplacesPreviousHook(t *testing.T) {
 	SetEnforcementReadyFunc(MechanismCEL, func() bool { return false })
 
 	assertEnforcement(t, 0, 0)
+}
+
+// Guards against a collector regressing to the prometheus default registry:
+// --metrics-bind-address serves controller-runtime's registry, so a metric
+// registered anywhere else is unscrapeable.
+func TestMetricsGatheredByControllerRuntimeRegistry(t *testing.T) {
+	StorageOperations.WithLabelValues("get", "RegistryTest", "success")
+	StorageLatency.WithLabelValues("get", "RegistryTest")
+	RequestsTotal.WithLabelValues("registrytests", "get")
+	RequestDuration.WithLabelValues("registrytests", "get")
+	ActiveResources.WithLabelValues("RegistryTest")
+
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	gathered := make(map[string]bool, len(families))
+	for _, f := range families {
+		gathered[f.GetName()] = true
+	}
+
+	for _, name := range []string{
+		"ark_apiserver_storage_operations_total",
+		"ark_apiserver_storage_latency_seconds",
+		"ark_apiserver_requests_total",
+		"ark_apiserver_request_duration_seconds",
+		"ark_apiserver_active_resources",
+		"ark_apiserver_admission_enforcement_active",
+	} {
+		if !gathered[name] {
+			t.Errorf("metric %s not gathered by controller-runtime registry", name)
+		}
+	}
 }
 
 func TestRecordStorageOperation(t *testing.T) {

--- a/ark/internal/storage/postgresql/metrics.go
+++ b/ark/internal/storage/postgresql/metrics.go
@@ -2,11 +2,21 @@
 
 package postgresql
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"context"
+	"database/sql"
+	"math"
+	"sync/atomic"
+	"time"
 
-// Broadcaster observability. Defined in the postgresql package (rather than
-// internal/apiserver/metrics) to keep the storage layer free of an upward
-// dependency on the apiserver package. Registered once via init().
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Broadcaster and WAL observability. Defined in the postgresql package (rather
+// than internal/apiserver/metrics) to keep the storage layer free of an upward
+// dependency on the apiserver package. Registered once via init() on
+// controller-runtime's registry, which is what --metrics-bind-address serves.
 var (
 	broadcasterRelistTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -58,13 +68,141 @@ var (
 		},
 		[]string{"kind"},
 	)
+
+	walConsumerActive = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ark_apiserver_wal_consumer_active",
+			Help: "1 while this replica runs the WAL consumer (leader-gated, so a healthy deployment sums to 1)",
+		},
+	)
+
+	walLastMessageTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ark_apiserver_wal_last_message_timestamp_seconds",
+			Help: "Unix time of the last WAL message (XLogData or keepalive) received by the consumer",
+		},
+	)
+
+	replicationSlotLagBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "ark_apiserver_replication_slot_lag_bytes",
+			Help: "WAL bytes between pg_current_wal_lsn() and the ark_cdc slot's confirmed_flush_lsn; NaN on replicas not running the WAL consumer",
+		},
+	)
 )
 
+const slotLagSampleInterval = 30 * time.Second
+
+// slotLagSampler runs only alongside the WAL consumer (leader only): non-leader
+// replicas hold no slot, so they keep exporting the NaN set at init.
+type slotLagSampler struct {
+	interval time.Duration
+	query    func(context.Context) (float64, error)
+}
+
+func (s *slotLagSampler) run(ctx context.Context) {
+	defer replicationSlotLagBytes.Set(math.NaN())
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sample(ctx)
+		}
+	}
+}
+
+func (s *slotLagSampler) sample(ctx context.Context) {
+	lag, err := s.query(ctx)
+	if err != nil {
+		replicationSlotLagBytes.Set(math.NaN())
+		return
+	}
+	replicationSlotLagBytes.Set(lag)
+}
+
+func (p *PostgreSQLBackend) querySlotLag(ctx context.Context) (float64, error) {
+	var lag sql.NullFloat64
+	err := p.db.QueryRowContext(ctx, `
+		SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)
+		FROM pg_replication_slots
+		WHERE slot_name = $1`, walSlotName).Scan(&lag)
+	if err != nil {
+		return 0, err
+	}
+	if !lag.Valid {
+		return math.NaN(), nil
+	}
+	return lag.Float64, nil
+}
+
+var (
+	dbPoolMaxOpenDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_max_open_connections",
+		"Maximum number of open connections to the database", nil, nil)
+	dbPoolOpenDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_open_connections",
+		"Established connections to the database, in use and idle", nil, nil)
+	dbPoolInUseDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_in_use_connections",
+		"Connections currently in use", nil, nil)
+	dbPoolIdleDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_idle_connections",
+		"Idle connections", nil, nil)
+	dbPoolWaitCountDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_wait_count_total",
+		"Total number of connection waits because the pool was exhausted", nil, nil)
+	dbPoolWaitDurationDesc = prometheus.NewDesc(
+		"ark_apiserver_db_pool_wait_duration_seconds_total",
+		"Total time blocked waiting for a connection", nil, nil)
+)
+
+// dbPoolStats is installed by New; until then the collector emits nothing.
+var dbPoolStats atomic.Pointer[func() sql.DBStats]
+
+func setDBPoolStats(fn func() sql.DBStats) {
+	dbPoolStats.Store(&fn)
+}
+
+type dbPoolCollector struct{}
+
+func (dbPoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- dbPoolMaxOpenDesc
+	ch <- dbPoolOpenDesc
+	ch <- dbPoolInUseDesc
+	ch <- dbPoolIdleDesc
+	ch <- dbPoolWaitCountDesc
+	ch <- dbPoolWaitDurationDesc
+}
+
+func (dbPoolCollector) Collect(ch chan<- prometheus.Metric) {
+	fn := dbPoolStats.Load()
+	if fn == nil {
+		return
+	}
+	s := (*fn)()
+	ch <- prometheus.MustNewConstMetric(dbPoolMaxOpenDesc, prometheus.GaugeValue, float64(s.MaxOpenConnections))
+	ch <- prometheus.MustNewConstMetric(dbPoolOpenDesc, prometheus.GaugeValue, float64(s.OpenConnections))
+	ch <- prometheus.MustNewConstMetric(dbPoolInUseDesc, prometheus.GaugeValue, float64(s.InUse))
+	ch <- prometheus.MustNewConstMetric(dbPoolIdleDesc, prometheus.GaugeValue, float64(s.Idle))
+	ch <- prometheus.MustNewConstMetric(dbPoolWaitCountDesc, prometheus.CounterValue, float64(s.WaitCount))
+	ch <- prometheus.MustNewConstMetric(dbPoolWaitDurationDesc, prometheus.CounterValue, s.WaitDuration.Seconds())
+}
+
 func init() {
-	prometheus.MustRegister(broadcasterRelistTotal)
-	prometheus.MustRegister(broadcasterRelistFailures)
-	prometheus.MustRegister(broadcasterEventsDispatched)
-	prometheus.MustRegister(broadcasterEventsDropped)
-	prometheus.MustRegister(watcherRelistFailures)
-	prometheus.MustRegister(broadcasterActiveWatchers)
+	replicationSlotLagBytes.Set(math.NaN())
+	ctrlmetrics.Registry.MustRegister(
+		broadcasterRelistTotal,
+		broadcasterRelistFailures,
+		broadcasterEventsDispatched,
+		broadcasterEventsDropped,
+		watcherRelistFailures,
+		broadcasterActiveWatchers,
+		walConsumerActive,
+		walLastMessageTimestamp,
+		replicationSlotLagBytes,
+		dbPoolCollector{},
+	)
 }

--- a/ark/internal/storage/postgresql/metrics.go
+++ b/ark/internal/storage/postgresql/metrics.go
@@ -79,7 +79,7 @@ var (
 	walLastMessageTimestamp = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "ark_apiserver_wal_last_message_timestamp_seconds",
-			Help: "Unix time of the last WAL message (XLogData or keepalive) received by the consumer",
+			Help: "Unix time of the last WAL message (XLogData or keepalive) received by the consumer; NaN on replicas not running the WAL consumer",
 		},
 	)
 
@@ -192,6 +192,7 @@ func (dbPoolCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func init() {
+	walLastMessageTimestamp.Set(math.NaN())
 	replicationSlotLagBytes.Set(math.NaN())
 	ctrlmetrics.Registry.MustRegister(
 		broadcasterRelistTotal,

--- a/ark/internal/storage/postgresql/metrics_test.go
+++ b/ark/internal/storage/postgresql/metrics_test.go
@@ -19,6 +19,16 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// A follower never runs the consumer, so its timestamp must read NaN rather
+// than 0: `time() - <timestamp> > 300` would otherwise fire on every replica
+// that is not the leader. First in the package's test order so it observes
+// the init() value before any test drives the consumer.
+func TestLastMessageTimestampIsNaNWithoutConsumer(t *testing.T) {
+	if got := testutil.ToFloat64(walLastMessageTimestamp); !math.IsNaN(got) {
+		t.Errorf("ark_apiserver_wal_last_message_timestamp_seconds before any consumer ran = %v, want NaN", got)
+	}
+}
+
 // swapDBPoolStats installs fn for the test and restores the previous value,
 // so tests over the package-level pointer do not leak into each other.
 func swapDBPoolStats(t *testing.T, fn func() sql.DBStats) {
@@ -214,6 +224,9 @@ func TestStartWALConsumerSetsActiveGauge(t *testing.T) {
 	<-done
 	if got := testutil.ToFloat64(walConsumerActive); got != 0 {
 		t.Errorf("ark_apiserver_wal_consumer_active after stop = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(walLastMessageTimestamp); !math.IsNaN(got) {
+		t.Errorf("ark_apiserver_wal_last_message_timestamp_seconds after stop = %v, want NaN", got)
 	}
 }
 

--- a/ark/internal/storage/postgresql/metrics_test.go
+++ b/ark/internal/storage/postgresql/metrics_test.go
@@ -1,0 +1,251 @@
+/* Copyright 2025. McKinsey & Company */
+
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// swapDBPoolStats installs fn for the test and restores the previous value,
+// so tests over the package-level pointer do not leak into each other.
+func swapDBPoolStats(t *testing.T, fn func() sql.DBStats) {
+	t.Helper()
+	previous := dbPoolStats.Load()
+	if fn == nil {
+		dbPoolStats.Store(nil)
+	} else {
+		setDBPoolStats(fn)
+	}
+	t.Cleanup(func() { dbPoolStats.Store(previous) })
+}
+
+// Guards against a collector regressing to the prometheus default registry:
+// --metrics-bind-address serves controller-runtime's registry, so a metric
+// registered anywhere else is unscrapeable.
+func TestMetricsGatheredByControllerRuntimeRegistry(t *testing.T) {
+	broadcasterRelistTotal.WithLabelValues("RegistryTest")
+	broadcasterRelistFailures.WithLabelValues("RegistryTest")
+	broadcasterEventsDispatched.WithLabelValues("RegistryTest")
+	broadcasterEventsDropped.WithLabelValues("RegistryTest")
+	watcherRelistFailures.WithLabelValues("RegistryTest")
+	broadcasterActiveWatchers.WithLabelValues("RegistryTest")
+	swapDBPoolStats(t, func() sql.DBStats { return sql.DBStats{} })
+
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	gathered := make(map[string]bool, len(families))
+	for _, f := range families {
+		gathered[f.GetName()] = true
+	}
+
+	for _, name := range []string{
+		"ark_apiserver_watch_broadcaster_relist_total",
+		"ark_apiserver_watch_broadcaster_relist_failures_total",
+		"ark_apiserver_watch_broadcaster_events_dispatched_total",
+		"ark_apiserver_watch_broadcaster_events_dropped_total",
+		"ark_apiserver_watch_watcher_relist_failures_total",
+		"ark_apiserver_watch_broadcaster_active_watchers",
+		"ark_apiserver_wal_consumer_active",
+		"ark_apiserver_wal_last_message_timestamp_seconds",
+		"ark_apiserver_replication_slot_lag_bytes",
+		"ark_apiserver_db_pool_max_open_connections",
+		"ark_apiserver_db_pool_open_connections",
+		"ark_apiserver_db_pool_in_use_connections",
+		"ark_apiserver_db_pool_idle_connections",
+		"ark_apiserver_db_pool_wait_count_total",
+		"ark_apiserver_db_pool_wait_duration_seconds_total",
+	} {
+		if !gathered[name] {
+			t.Errorf("metric %s not gathered by controller-runtime registry", name)
+		}
+	}
+}
+
+func TestDBPoolCollector(t *testing.T) {
+	swapDBPoolStats(t, func() sql.DBStats {
+		return sql.DBStats{
+			MaxOpenConnections: 40,
+			OpenConnections:    7,
+			InUse:              3,
+			Idle:               4,
+			WaitCount:          9,
+			WaitDuration:       1500 * time.Millisecond,
+		}
+	})
+
+	expected := `
+# HELP ark_apiserver_db_pool_idle_connections Idle connections
+# TYPE ark_apiserver_db_pool_idle_connections gauge
+ark_apiserver_db_pool_idle_connections 4
+# HELP ark_apiserver_db_pool_in_use_connections Connections currently in use
+# TYPE ark_apiserver_db_pool_in_use_connections gauge
+ark_apiserver_db_pool_in_use_connections 3
+# HELP ark_apiserver_db_pool_max_open_connections Maximum number of open connections to the database
+# TYPE ark_apiserver_db_pool_max_open_connections gauge
+ark_apiserver_db_pool_max_open_connections 40
+# HELP ark_apiserver_db_pool_open_connections Established connections to the database, in use and idle
+# TYPE ark_apiserver_db_pool_open_connections gauge
+ark_apiserver_db_pool_open_connections 7
+# HELP ark_apiserver_db_pool_wait_count_total Total number of connection waits because the pool was exhausted
+# TYPE ark_apiserver_db_pool_wait_count_total counter
+ark_apiserver_db_pool_wait_count_total 9
+# HELP ark_apiserver_db_pool_wait_duration_seconds_total Total time blocked waiting for a connection
+# TYPE ark_apiserver_db_pool_wait_duration_seconds_total counter
+ark_apiserver_db_pool_wait_duration_seconds_total 1.5
+`
+	if err := testutil.CollectAndCompare(dbPoolCollector{}, strings.NewReader(expected)); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDBPoolCollectorEmitsNothingBeforeBackendExists(t *testing.T) {
+	swapDBPoolStats(t, nil)
+
+	if got := testutil.CollectAndCount(dbPoolCollector{}); got != 0 {
+		t.Errorf("expected no samples before a backend installs the stats func, got %d", got)
+	}
+}
+
+func TestSlotLagSamplerSample(t *testing.T) {
+	s := &slotLagSampler{query: func(context.Context) (float64, error) { return 2048, nil }}
+	s.sample(context.Background())
+	if got := testutil.ToFloat64(replicationSlotLagBytes); got != 2048 {
+		t.Errorf("slot lag = %v, want 2048", got)
+	}
+
+	s.query = func(context.Context) (float64, error) { return 0, errors.New("boom") }
+	s.sample(context.Background())
+	if got := testutil.ToFloat64(replicationSlotLagBytes); !math.IsNaN(got) {
+		t.Errorf("slot lag after query error = %v, want NaN", got)
+	}
+}
+
+func TestSlotLagSamplerRunSamplesUntilStopped(t *testing.T) {
+	var calls atomic.Int64
+	s := &slotLagSampler{
+		interval: time.Millisecond,
+		query: func(context.Context) (float64, error) {
+			calls.Add(1)
+			return 64, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for calls.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("sampler made %d calls, want at least 3", calls.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-done
+	if got := testutil.ToFloat64(replicationSlotLagBytes); !math.IsNaN(got) {
+		t.Errorf("slot lag after sampler stop = %v, want NaN", got)
+	}
+}
+
+func TestHandleWALMessageUpdatesLastMessageTimestamp(t *testing.T) {
+	backend, _ := newTestBackendWithBroadcasters()
+	state := &walStreamState{relations: make(map[uint32]*pglogrepl.RelationMessage)}
+
+	walLastMessageTimestamp.Set(0)
+	msg := &pgproto3.CopyData{Data: append([]byte{pglogrepl.PrimaryKeepaliveMessageByteID}, make([]byte, 17)...)}
+	if err := backend.handleWALMessage(nil, msg, state); err != nil {
+		t.Fatalf("handleWALMessage keepalive: %v", err)
+	}
+	if got := testutil.ToFloat64(walLastMessageTimestamp); got == 0 {
+		t.Error("keepalive did not update ark_apiserver_wal_last_message_timestamp_seconds")
+	}
+
+	walLastMessageTimestamp.Set(0)
+	msg = &pgproto3.CopyData{Data: encodeXLogData(0x200, encodeInsertMessage(1, makeTuple("Agent", "default", "a")))}
+	if err := backend.handleWALMessage(nil, msg, state); err != nil {
+		t.Fatalf("handleWALMessage xlog: %v", err)
+	}
+	if got := testutil.ToFloat64(walLastMessageTimestamp); got == 0 {
+		t.Error("XLogData did not update ark_apiserver_wal_last_message_timestamp_seconds")
+	}
+}
+
+func TestStartWALConsumerSetsActiveGauge(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &PostgreSQLBackend{ctx: ctx, cancel: cancel, connStr: "host=127.0.0.1 port=1 user=ark connect_timeout=1"}
+
+	done := make(chan struct{})
+	go func() {
+		p.startWALConsumer()
+		close(done)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for testutil.ToFloat64(walConsumerActive) != 1 {
+		select {
+		case <-deadline:
+			t.Fatal("ark_apiserver_wal_consumer_active never reached 1 while the consumer was running")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-done
+	if got := testutil.ToFloat64(walConsumerActive); got != 0 {
+		t.Errorf("ark_apiserver_wal_consumer_active after stop = %v, want 0", got)
+	}
+}
+
+func TestQuerySlotLag(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	p := &PostgreSQLBackend{db: db}
+
+	mock.ExpectQuery("pg_wal_lsn_diff").WithArgs(walSlotName).
+		WillReturnRows(sqlmock.NewRows([]string{"lag"}).AddRow(4096))
+	lag, err := p.querySlotLag(context.Background())
+	if err != nil || lag != 4096 {
+		t.Errorf("querySlotLag = %v, %v; want 4096, nil", lag, err)
+	}
+
+	mock.ExpectQuery("pg_wal_lsn_diff").WithArgs(walSlotName).
+		WillReturnRows(sqlmock.NewRows([]string{"lag"}).AddRow(nil))
+	lag, err = p.querySlotLag(context.Background())
+	if err != nil || !math.IsNaN(lag) {
+		t.Errorf("querySlotLag on NULL confirmed_flush_lsn = %v, %v; want NaN, nil", lag, err)
+	}
+
+	mock.ExpectQuery("pg_wal_lsn_diff").WithArgs(walSlotName).
+		WillReturnRows(sqlmock.NewRows([]string{"lag"}))
+	if _, err = p.querySlotLag(context.Background()); err == nil {
+		t.Error("querySlotLag with no slot row should error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/ark/internal/storage/postgresql/postgresql.go
+++ b/ark/internal/storage/postgresql/postgresql.go
@@ -303,6 +303,8 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
+	setDBPoolStats(db.Stats)
+
 	backend.warmPool()
 	go backend.refreshBookmarkLoop()
 	go backend.cleanupLoop()
@@ -317,6 +319,8 @@ func New(cfg Config, converter storage.TypeConverter) (*PostgreSQLBackend, error
 func (p *PostgreSQLBackend) StartWALConsumer() {
 	p.walOnce.Do(func() {
 		go p.startWALConsumer()
+		sampler := &slotLagSampler{interval: slotLagSampleInterval, query: p.querySlotLag}
+		go sampler.run(p.ctx)
 	})
 }
 

--- a/ark/internal/storage/postgresql/wal_connection.go
+++ b/ark/internal/storage/postgresql/wal_connection.go
@@ -14,6 +14,9 @@ import (
 )
 
 func (p *PostgreSQLBackend) startWALConsumer() {
+	walConsumerActive.Set(1)
+	defer walConsumerActive.Set(0)
+
 	backoff := time.Second
 	maxBackoff := 30 * time.Second
 

--- a/ark/internal/storage/postgresql/wal_connection.go
+++ b/ark/internal/storage/postgresql/wal_connection.go
@@ -5,6 +5,7 @@ package postgresql
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -16,6 +17,7 @@ import (
 func (p *PostgreSQLBackend) startWALConsumer() {
 	walConsumerActive.Set(1)
 	defer walConsumerActive.Set(0)
+	defer walLastMessageTimestamp.Set(math.NaN())
 
 	backoff := time.Second
 	maxBackoff := 30 * time.Second

--- a/ark/internal/storage/postgresql/wal_consumer.go
+++ b/ark/internal/storage/postgresql/wal_consumer.go
@@ -55,6 +55,7 @@ func (p *PostgreSQLBackend) handleWALMessage(conn *pgconn.PgConn, rawMsg pgproto
 	if !ok {
 		return nil
 	}
+	walLastMessageTimestamp.SetToCurrentTime()
 
 	switch copyData.Data[0] {
 	case pglogrepl.PrimaryKeepaliveMessageByteID:

--- a/ark/scripts/validate-chart-values.sh
+++ b/ark/scripts/validate-chart-values.sh
@@ -166,6 +166,40 @@ check_absent   "servicemonitor drops cert refs without certmanager" 'metrics-ser
 all_nometrics="$(render_chart --set metrics.enable=false)"
 check_absent "no servicemonitor when metrics disabled" 'kind: ServiceMonitor' "$all_nometrics"
 
+# --- chart-apiserver: metrics endpoint gating ---
+
+APISERVER_CHART_DIR="$ARK_DIR/dist/chart-apiserver"
+
+render_apiserver() {
+    helm template test-release "$APISERVER_CHART_DIR" \
+        --api-versions "$PROM_CAP" \
+        --set postgresql.host=pg \
+        --set postgresql.user=ark \
+        --set postgresql.passwordSecretName=pg-secret \
+        "$@"
+}
+
+echo ""
+echo "Validating chart value rendering for chart-apiserver..."
+
+# Metrics are opt-in; the default render must not serve, expose or scrape anything.
+as_default="$(render_apiserver)"
+check_contains "apiserver metrics disabled by default" '--metrics-bind-address=0' "$as_default"
+check_absent   "no metrics-secure flag by default"     '--metrics-secure'         "$as_default"
+check_absent   "no metrics port by default"            'name: metrics'            "$as_default"
+check_absent   "no apiserver servicemonitor by default" 'kind: ServiceMonitor'    "$as_default"
+
+as_metrics="$(render_apiserver --set metrics.enabled=true)"
+check_contains "apiserver metrics enabled binds :8443" '--metrics-bind-address=:8443' "$as_metrics"
+check_contains "apiserver metrics secure by default"   '--metrics-secure=true'        "$as_metrics"
+check_contains "apiserver metrics port exposed"        'name: metrics'                "$as_metrics"
+check_absent   "apiserver servicemonitor still gated"  'kind: ServiceMonitor'         "$as_metrics"
+
+as_sm="$(render_apiserver --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true)"
+check_contains "apiserver servicemonitor renders when enabled" 'kind: ServiceMonitor'     "$as_sm"
+check_contains "apiserver servicemonitor scrapes https"        'scheme: https'            "$as_sm"
+check_contains "apiserver servicemonitor skips verify"         'insecureSkipVerify: true' "$as_sm"
+
 echo ""
 if [[ "$FAILED" -eq 0 ]]; then
     echo -e "${GREEN}All chart value checks passed${NC}"


### PR DESCRIPTION
## Summary

Fixes #3332.

- Register all Ark collectors on controller-runtime's registry instead of the prometheus default registry — `--metrics-bind-address` serves the former, so until now enabling the endpoint would have exposed none of the Ark metrics. A registry-gather test in each package guards against regressing.
- New WAL/DB metrics in the postgresql package: `ark_apiserver_wal_consumer_active` (with leader gating, `sum() != 1` is the alert), `ark_apiserver_wal_last_message_timestamp_seconds` (staleness = wedged consumer), `ark_apiserver_replication_slot_lag_bytes` (`pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)`, sampled every 30s on the leader only, NaN otherwise — the metric that would have made #3018 visible before it pinned 2 GB of WAL), and `ark_apiserver_db_pool_*` from `sql.DBStats`.
- chart-apiserver: opt-in `metrics.enabled` / `metrics.secure` / `metrics.serviceMonitor.*` values wiring the deployment args, container/Service ports, NetworkPolicy ingress (an enabled NetworkPolicy would otherwise block every scrape), and a ServiceMonitor mirroring the controller chart. Default render is byte-identical to main. No RBAC change needed: the SA's `system:auth-delegator` binding from #2801 already covers the secure endpoint's TokenReview/SAR.
- `validate-chart-values.sh` extended with a chart-apiserver section.

Coverage: new code in both metrics files fully unit-covered (registry gathers, pool collector exposition, sampler NaN semantics, `querySlotLag` via sqlmock, timestamp + active-gauge paths). Unit-unreachable and left for live verification: real slot-lag values against a live replication slot, two-replica leader hand-off of the active gauge, and a real Prometheus Operator scrape through the secure filter.

cc @Nab-0 @skazinka
