### PR TITLE
fix(dashboard): make MCP server description optional

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildHeader,
   buildSpec,
   buildUpdateAddressMode,
+  createFormSchema,
   type HeaderData,
   mapDetailAddress,
   mapDetailHeaders,
@@ -92,6 +93,29 @@ describe('mapDetailAddress', () => {
   });
 });
 
+describe('createFormSchema', () => {
+  const schema = createFormSchema({ kind: 'configuration' });
+
+  it('accepts a missing description', () => {
+    const result = schema.safeParse({
+      name: 'github-mcp',
+      configurationName: 'github-mcp-url',
+      transport: 'http',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty description', () => {
+    const result = schema.safeParse({ ...values, description: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('still requires the url', () => {
+    const result = schema.safeParse({ ...values, configurationName: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('buildSpec', () => {
   it('writes a configMapKeyRef for the configuration mode', () => {
     const spec = buildSpec(values, [], { kind: 'configuration' });
@@ -122,6 +146,25 @@ describe('buildSpec', () => {
     expect(spec.address).toEqual({
       valueFrom: { configMapKeyRef: { name: 'other-cm', key: 'value' } },
     });
+  });
+
+  it('keeps a provided description', () => {
+    const spec = buildSpec(values, [], { kind: 'configuration' });
+    expect(spec.description).toBe('GitHub remote MCP');
+  });
+
+  it('omits the description when it is empty', () => {
+    const spec = buildSpec({ ...values, description: '   ' }, [], {
+      kind: 'configuration',
+    });
+    expect(spec.description).toBeUndefined();
+  });
+
+  it('omits the description when it is not set', () => {
+    const spec = buildSpec({ ...values, description: undefined }, [], {
+      kind: 'configuration',
+    });
+    expect(spec.description).toBeUndefined();
   });
 
   it('round-trips a serviceRef untouched', () => {

--- a/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/utils.ts
@@ -36,7 +36,7 @@ export type UrlFieldState =
 export function createFormSchema(addressMode: AddressMode) {
   return z.object({
     name: kubernetesNameSchema,
-    description: z.string().min(1, 'Description is required'),
+    description: z.string().optional(),
     configurationName:
       addressMode.kind === 'service'
         ? z.string()
@@ -166,7 +166,7 @@ export function buildSpec(
   addressMode: AddressMode,
 ): MCPServerSpec {
   return {
-    description: values.description,
+    description: values.description?.trim() || undefined,
     transport: values.transport,
     address: buildAddress(values, addressMode),
     headers: headers.map(buildHeader),


### PR DESCRIPTION
## Summary
- Make the description field optional when creating or updating an MCP Server in the dashboard, matching the CRD and the Ark API where the field is already optional
- Omit the description from the spec entirely when it is blank, rather than writing an empty string

Closes #3341