### PR TITLE
fix(dashboard): use MCP-appropriate placeholders in the MCP server form

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-server-fields.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-server-fields.tsx
@@ -132,6 +132,8 @@ export function McpServerFields({
               deleteRow={deleteRow}
               nameError={headerErrors[row.key]?.nameError}
               valueError={headerErrors[row.key]?.valueError}
+              namePlaceholder="e.g., Authorization"
+              valuePlaceholder="e.g., Bearer token"
             />
           ))}
           <Button

--- a/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-server-fields.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-server-fields.tsx
@@ -67,7 +67,7 @@ export function McpServerFields({
               <Input
                 variant="inline"
                 {...field}
-                placeholder="e.g., gpt-4-turbo"
+                placeholder="e.g., github-remote-mcp"
                 disabled={nameDisabled}
                 aria-invalid={!!fieldState.error}
               />

--- a/services/ark-dashboard/ark-dashboard/components/ui/conditionalInputRow.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/conditionalInputRow.tsx
@@ -32,6 +32,8 @@ interface ConditionalInputRowProps {
   deleteRow: (key: string) => void;
   nameError?: string;
   valueError?: string;
+  namePlaceholder?: string;
+  valuePlaceholder?: string;
 }
 
 export function ConditionalInputRow({
@@ -41,6 +43,8 @@ export function ConditionalInputRow({
   deleteRow,
   nameError,
   valueError,
+  namePlaceholder,
+  valuePlaceholder,
 }: ConditionalInputRowProps) {
   return (
     <div className="flex items-start gap-3">
@@ -50,7 +54,7 @@ export function ConditionalInputRow({
           variant="inline"
           value={data.name}
           onChange={e => onChange({ name: e.target.value })}
-          placeholder="e.g., Authorization"
+          placeholder={namePlaceholder}
           aria-invalid={!!nameError}
         />
         {nameError && (
@@ -86,7 +90,7 @@ export function ConditionalInputRow({
               variant="inline"
               value={data.value}
               onChange={e => onChange({ value: e.target.value })}
-              placeholder="e.g., Bearer token"
+              placeholder={valuePlaceholder}
               aria-invalid={!!valueError}
             />
             {valueError && (

--- a/services/ark-dashboard/ark-dashboard/components/ui/conditionalInputRow.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/conditionalInputRow.tsx
@@ -50,7 +50,7 @@ export function ConditionalInputRow({
           variant="inline"
           value={data.name}
           onChange={e => onChange({ name: e.target.value })}
-          placeholder="e.g., gpt-4-turbo"
+          placeholder="e.g., Authorization"
           aria-invalid={!!nameError}
         />
         {nameError && (
@@ -86,7 +86,7 @@ export function ConditionalInputRow({
               variant="inline"
               value={data.value}
               onChange={e => onChange({ value: e.target.value })}
-              placeholder="e.g., gpt-4-turbo"
+              placeholder="e.g., Bearer token"
               aria-invalid={!!valueError}
             />
             {valueError && (


### PR DESCRIPTION
## Summary
- Name field on the create/update MCP server form showed `e.g., gpt-4-turbo`, a model name copied from the model form. It now shows `e.g., github-remote-mcp`.
- The header rows showed the same model-name string for both header name and value. `ConditionalInputRow` is a shared `components/ui/` component, so the header examples are passed in as `namePlaceholder` / `valuePlaceholder` props from the MCP form rather than hardcoded in the shared component.

Fixes #3339