### PR TITLE
fix: CVEs 84292 84394 fast uri

### DIFF
--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -7719,6 +7719,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",

--- a/services/ark-broker/ark-broker/package-lock.json
+++ b/services/ark-broker/ark-broker/package-lock.json
@@ -5511,9 +5511,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -7718,13 +7718,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/services/ark-broker/ark-broker/package.json
+++ b/services/ark-broker/ark-broker/package.json
@@ -95,7 +95,7 @@
     "ws": "^8.21.0",
     "form-data": "^4.0.6",
     "undici": "^7.28.0",
-    "fast-uri": "^3.1.6",
+    "fast-uri": "^4.1.4",
     "dockerode": {
       "protobufjs": "^7.6.5"
     }

--- a/tools/ark-cli/package-lock.json
+++ b/tools/ark-cli/package-lock.json
@@ -1864,7 +1864,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3123,7 +3123,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3807,9 +3807,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",

--- a/tools/ark-cli/package.json
+++ b/tools/ark-cli/package.json
@@ -95,7 +95,7 @@
     "flatted": "^3.4.2",
     "tar": "^7.5.11",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": "^3.1.6",
+    "fast-uri": "^4.1.4",
     "ws": "^8.21.0",
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",


### PR DESCRIPTION
Closes #3345

## CVE Fixes

| CVE | Package | File | Current → Target | Kind |
|-----|---------|------|------------------|------|
| CVE-2026-84292 | fast-uri | tools/ark-cli/package.json | ^3.1.6 → ^4.1.4 | override-update |
| CVE-2026-84292 | fast-uri | services/ark-broker/ark-broker/package.json | ^3.1.6 → ^4.1.4 | override-update |
| CVE-2026-84394 | fast-uri | tools/ark-cli/package.json | ^3.1.6 → ^4.1.4 | override-update |
| CVE-2026-84394 | fast-uri | services/ark-broker/ark-broker/package.json | ^3.1.6 → ^4.1.4 | override-update |

## Changes

- Bumped `fast-uri` from `^3.1.6` to `^4.1.4` in the `overrides` field for `tools/ark-cli` and `services/ark-broker/ark-broker`, and regenerated both lockfiles.
- Restored `openapi-types@12.1.3` in `services/ark-broker/ark-broker/package-lock.json`, dropped by the initial lockfile regeneration and causing `npm ci` to fail with `EUSAGE`.

## Breaking change assessment

`fast-uri` is only pinned via `overrides` in both packages — neither codebase imports it directly. It is a transitive dependency of `ajv`/schema-validation packages. No source changes were needed for the v3→v4 bump.

## Test evidence

- `services/ark-broker/ark-broker`: `npm ci` clean, `npm run lint` clean, `npm test` — 34 suites / 552 tests passing
- `tools/ark-cli`: `npm ci` clean, no code changes

## CVE Details

**CVE-2026-84292:** fast-uri vulnerable to authority injection via an unvalidated port in serialize
**CVE-2026-84394:** fast-uri vulnerable to host confusion via an unclosed bracket in the URI authority

Both are HIGH severity vulnerabilities in fast-uri 3.1.6, fixed in version 4.1.4.