### PR TITLE
fix: refactor get agents and teams to use list 

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/dialogs/agents-api-dialog.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/dialogs/agents-api-dialog.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentsAPIDialog } from '@/components/dialogs/agents-api-dialog';
-import type { Agent } from '@/lib/services';
+import type { AgentListItem } from '@/lib/services';
 
 vi.mock('@/providers/NamespaceProvider', () => ({
   useNamespace: () => ({
@@ -15,7 +15,7 @@ vi.mock('@/providers/NamespaceProvider', () => ({
 }));
 
 const mockCopy = vi.fn();
-const mockGetAll = vi.fn();
+const mockList = vi.fn();
 
 vi.mock('copy-to-clipboard', () => ({
   default: (text: string) => {
@@ -26,13 +26,17 @@ vi.mock('copy-to-clipboard', () => ({
 
 vi.mock('@/lib/services', () => ({
   agentsService: {
-    getAll: (...args: unknown[]) => mockGetAll(...args),
+    list: (...args: unknown[]) => mockList(...args),
   },
 }));
 
-const mockAgents: Agent[] = [
-  { id: '1', name: 'test-agent', description: 'Test agent' } as Agent,
-  { id: '2', name: 'another-agent', description: 'Another agent' } as Agent,
+const mockAgents: AgentListItem[] = [
+  { id: '1', name: 'test-agent', description: 'Test agent' } as AgentListItem,
+  {
+    id: '2',
+    name: 'another-agent',
+    description: 'Another agent',
+  } as AgentListItem,
 ];
 
 const mockOnOpenChange = vi.fn();
@@ -49,7 +53,7 @@ const renderLoaded = async () => {
 describe('AgentsAPIDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetAll.mockResolvedValue(mockAgents);
+    mockList.mockResolvedValue(mockAgents);
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { origin: 'http://localhost:3000' },
@@ -72,13 +76,13 @@ describe('AgentsAPIDialog', () => {
     renderDialog(false);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(mockGetAll).not.toHaveBeenCalled();
+    expect(mockList).not.toHaveBeenCalled();
   });
 
   it('fetches agents and selects the first one by default', async () => {
     await renderLoaded();
 
-    expect(mockGetAll).toHaveBeenCalled();
+    expect(mockList).toHaveBeenCalled();
     expect(screen.getByRole('combobox')).toHaveTextContent('test-agent');
   });
 
@@ -209,7 +213,7 @@ describe('AgentsAPIDialog', () => {
   });
 
   it('handles an empty agents list', async () => {
-    mockGetAll.mockResolvedValue([]);
+    mockList.mockResolvedValue([]);
     renderDialog(true);
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/tool-form/use-tool-form.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/tool-form/use-tool-form.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/lib/services', () => ({
     getDetail: vi.fn(),
   },
   agentsService: {
-    getAll: vi.fn(),
+    list: vi.fn(),
   },
   teamsService: {
     getAll: vi.fn(),
@@ -61,7 +61,7 @@ function values(overrides: Partial<ToolFormValues> = {}): ToolFormValues {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockAgentsService.getAll.mockResolvedValue([]);
+  mockAgentsService.list.mockResolvedValue([]);
   mockTeamsService.getAll.mockResolvedValue([]);
   mockToolsService.create.mockResolvedValue(undefined);
 });
@@ -181,7 +181,7 @@ describe('useToolForm', () => {
   });
 
   it('loads agents when type becomes agent', async () => {
-    mockAgentsService.getAll.mockResolvedValue([{ name: 'agent-1' }] as never);
+    mockAgentsService.list.mockResolvedValue([{ name: 'agent-1' }] as never);
     const { result } = renderHook(() => useToolForm({ mode: ToolFormMode.CREATE }));
 
     act(() => {
@@ -189,7 +189,7 @@ describe('useToolForm', () => {
     });
 
     await waitFor(() => {
-      expect(mockAgentsService.getAll).toHaveBeenCalled();
+      expect(mockAgentsService.list).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(result.current.state.agents).toEqual([{ name: 'agent-1' }]);

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sessions-conversations/new-session-dialog.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sessions-conversations/new-session-dialog.test.tsx
@@ -60,7 +60,7 @@ describe('NewSessionDialog', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(agentsService.getAll).mockResolvedValue(mockAgents as any);
+    vi.mocked(agentsService.list).mockResolvedValue(mockAgents as any);
     vi.mocked(teamsService.getAll).mockResolvedValue(mockTeams as any);
     vi.mocked(toolsService.getAll).mockResolvedValue(mockTools as any);
   });
@@ -89,7 +89,7 @@ describe('NewSessionDialog', () => {
       },
     });
 
-    vi.mocked(agentsService.getAll).mockReturnValue(new Promise(() => {})); // Never resolves
+    vi.mocked(agentsService.list).mockReturnValue(new Promise(() => {})); // Never resolves
     vi.mocked(teamsService.getAll).mockReturnValue(new Promise(() => {}));
     vi.mocked(toolsService.getAll).mockReturnValue(new Promise(() => {}));
 

--- a/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
+++ b/services/ark-dashboard/ark-dashboard/app/(dashboard)/query/[id]/page.tsx
@@ -576,8 +576,8 @@ function QueryDetailContent() {
         setMemoriesLoading(true);
         try {
           const [agents, models, teams, tools, memories] = await Promise.all([
-            agentsService.getAll(namespace),
-            modelsService.getAll(namespace),
+            agentsService.list(namespace),
+            modelsService.list(namespace),
             teamsService.getAll(namespace),
             toolsService.getAll(namespace),
             memoriesService.getAll(namespace),

--- a/services/ark-dashboard/ark-dashboard/components/dialogs/agents-api-dialog.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/dialogs/agents-api-dialog.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { type Agent, agentsService } from '@/lib/services';
+import { type AgentListItem, agentsService } from '@/lib/services';
 import { useNamespace } from '@/providers/NamespaceProvider';
 
 import { getBashSnippet } from './code-snippets/bash-snippet';
@@ -43,7 +43,7 @@ export function AgentsAPIDialog({
   onOpenChange,
 }: Readonly<AgentsAPIDialogProps>) {
   const { namespace } = useNamespace();
-  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agents, setAgents] = useState<AgentListItem[]>([]);
   const [copiedEndpoint, setCopiedEndpoint] = useState(false);
   const [copiedCode, setCopiedCode] = useState(false);
   const [userSelectedAgent, setUserSelectedAgent] = useState<string | null>(
@@ -54,7 +54,7 @@ export function AgentsAPIDialog({
 
   useEffect(() => {
     if (!open) return;
-    agentsService.getAll(namespace).then(setAgents).catch(console.error);
+    agentsService.list(namespace).then(setAgents).catch(console.error);
   }, [namespace, open]);
 
   const selectedAgent = (() => {

--- a/services/ark-dashboard/ark-dashboard/components/forms/agent-form/use-agent-form.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/agent-form/use-agent-form.ts
@@ -15,7 +15,7 @@ import type {
   AgentTool,
   AgentUpdateRequest,
   ExecutionEngine,
-  Model,
+  ModelListItem,
   Tool,
 } from '@/lib/services';
 import {
@@ -60,7 +60,7 @@ export function useAgentForm({
   );
   const [saving, setSaving] = useState(false);
   const [agent, setAgent] = useState<Agent | null>(null);
-  const [models, setModels] = useState<Model[]>([]);
+  const [models, setModels] = useState<ModelListItem[]>([]);
   const [availableTools, setAvailableTools] = useState<Tool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(true);
   const [selectedTools, setSelectedTools] = useState<AgentTool[]>([]);
@@ -101,7 +101,7 @@ export function useAgentForm({
           const [agentData, modelsData, toolsData, enginesData] =
             await Promise.all([
               agentsService.getByName(namespace, agentName),
-              modelsService.getAll(namespace),
+              modelsService.list(namespace),
               toolsService.getAll(namespace),
               enginesPromise,
             ]);
@@ -139,7 +139,7 @@ export function useAgentForm({
           });
         } else {
           const [modelsData, toolsData, enginesData] = await Promise.all([
-            modelsService.getAll(namespace),
+            modelsService.list(namespace),
             toolsService.getAll(namespace),
             enginesPromise,
           ]);

--- a/services/ark-dashboard/ark-dashboard/components/forms/tool-form/types.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/tool-form/types.ts
@@ -1,7 +1,7 @@
 import type { UseFormReturn } from 'react-hook-form';
 import * as z from 'zod';
 
-import type { Agent, Team } from '@/lib/services';
+import type { AgentListItem, Team } from '@/lib/services';
 import type { ToolDetail } from '@/lib/services/tools';
 
 export const toolFormSchema = z
@@ -71,7 +71,7 @@ export interface ToolFormState {
   loading: boolean;
   saving: boolean;
   tool: ToolDetail | null;
-  agents: Agent[];
+  agents: AgentListItem[];
   teams: Team[];
   agentsLoading: boolean;
   teamsLoading: boolean;

--- a/services/ark-dashboard/ark-dashboard/components/forms/tool-form/use-tool-form.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/tool-form/use-tool-form.ts
@@ -6,7 +6,7 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import { toast } from '@/components/ui/sonner';
 import {
-  type Agent,
+  type AgentListItem,
   type Team,
   agentsService,
   teamsService,
@@ -56,7 +56,7 @@ export function useToolForm({
   const [loading, setLoading] = useState(isViewing);
   const [saving, setSaving] = useState(false);
   const [tool, setTool] = useState<ToolDetail | null>(null);
-  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agents, setAgents] = useState<AgentListItem[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [teamsLoading, setTeamsLoading] = useState(false);
@@ -109,7 +109,7 @@ export function useToolForm({
     const loadAgents = async () => {
       setAgentsLoading(true);
       try {
-        const data = await agentsService.getAll(namespace);
+        const data = await agentsService.list(namespace);
         if (!cancelled) setAgents(data);
       } catch (error) {
         console.error('Failed to load agents:', error);

--- a/services/ark-dashboard/ark-dashboard/components/sessions-conversations/new-session-dialog.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/sessions-conversations/new-session-dialog.tsx
@@ -62,7 +62,7 @@ export function NewSessionDialog({ open, onOpenChange }: Props) {
 
   const { data: agents = [], isLoading: loadingAgents } = useQuery({
     queryKey: ['agents', namespace],
-    queryFn: () => agentsService.getAll(namespace),
+    queryFn: () => agentsService.list(namespace),
     enabled: Boolean(namespace),
   });
 

--- a/services/ark-dashboard/ark-dashboard/lib/services/participants.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/participants.ts
@@ -11,7 +11,7 @@ export interface Participant {
 export const participantsService = {
   async getAll(namespace: string): Promise<Participant[]> {
     const results = await Promise.allSettled([
-      agentsService.getAll(namespace),
+      agentsService.list(namespace),
       teamsService.getAll(namespace),
       toolsService.getAll(namespace),
     ]);


### PR DESCRIPTION
## Summary
- Migrate `agentsService.getAll()` → `agentsService.list()` in `participants.ts`, `new-session-dialog.tsx`, `use-tool-form.ts`, `agents-api-dialog.tsx`, and `query/[id]/page.tsx`
- Migrate `modelsService.getAll()` → `modelsService.list()` in `use-agent-form.ts` and `query/[id]/page.tsx`
- Drop the N+1 detail-fetch fan-out at these call sites, keeping the lean list response since none of them read detail-only fields (`tools`, `parameters`, `config`, etc.)
- Leave `tools-section.tsx`, `secrets-section.tsx`, and `use-team-form.ts` (+ its section components) on `getAll()`, since they read detail-only fields (`agent.tools`, `model.config`)
- Update test mocks in `agents-api-dialog.test.tsx`, `new-session-dialog.test.tsx`, and `use-tool-form.test.ts` to match

Closes #3344