### PR TITLE
fix(dashboard): stop assuming the default namespace for workflow pod steps

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/sections/sessions-section.test.tsx
@@ -12,7 +12,7 @@ import { useWorkflow, useWorkflows } from '@/lib/services/workflows-hooks';
 
 vi.mock('@/providers/NamespaceProvider', () => ({
   useNamespace: () => ({
-    namespace: 'default',
+    namespace: 'tenant-alpha',
     isNamespaceResolved: true,
     isPending: false,
     readOnlyMode: false,
@@ -950,6 +950,30 @@ describe('SessionsSection', () => {
 
       const loadingText = screen.queryByText(/updating/i);
       expect(loadingText).toBeInTheDocument();
+    });
+  });
+
+  describe('Namespace scoping', () => {
+    it('lists workflows from the active namespace, not a hardcoded default', () => {
+      render(<SessionsSection />);
+
+      expect(useWorkflows).toHaveBeenCalledWith(
+        'tenant-alpha',
+        expect.any(Object),
+      );
+      expect(useWorkflows).not.toHaveBeenCalledWith(
+        'default',
+        expect.anything(),
+      );
+    });
+
+    it('fetches workflow detail from the active namespace', () => {
+      render(<SessionsSection />);
+
+      expect(useWorkflow).toHaveBeenCalledWith(
+        'tenant-alpha',
+        expect.any(String),
+      );
     });
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/workflow-mapper.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/lib/services/workflow-mapper.test.ts
@@ -121,3 +121,54 @@ describe('mapArgoWorkflowsToSessions', () => {
     expect(sessions[1].startedAt).toBe('2024-01-02T00:00:00Z');
   });
 });
+
+describe('pod step namespace', () => {
+  function makePodWorkflow(namespace: string | undefined): ArgoWorkflow {
+    return makeWorkflow({
+      metadata: {
+        name: 'wf-1',
+        namespace,
+        creationTimestamp: '2024-01-01T00:00:00Z',
+        uid: 'uid-1',
+      },
+      status: {
+        phase: 'Succeeded',
+        startedAt: '2024-01-01T00:00:00Z',
+        finishedAt: '2024-01-01T00:01:00Z',
+        nodes: {
+          'wf-1': {
+            id: 'wf-1',
+            name: 'wf-1',
+            displayName: 'wf-1',
+            type: 'DAG',
+            phase: 'Succeeded',
+            children: ['wf-1-task-a'],
+          },
+          'wf-1-task-a': {
+            id: 'wf-1-task-a',
+            name: 'wf-1.task-a',
+            displayName: 'task-a',
+            type: 'Pod',
+            phase: 'Succeeded',
+            boundaryID: 'wf-1',
+            startedAt: '2024-01-01T00:00:05Z',
+            finishedAt: '2024-01-01T00:00:20Z',
+          },
+        },
+      },
+    } as Partial<ArgoWorkflow>);
+  }
+
+  it("carries the workflow's own namespace onto pod step details", () => {
+    const session = mapArgoWorkflowToSession(makePodWorkflow('tenant-alpha'));
+
+    expect(session.namespace).toBe('tenant-alpha');
+    expect(session.steps[0].detail?.namespace).toBe('tenant-alpha');
+  });
+
+  it('leaves the pod step namespace unset rather than assuming default', () => {
+    const session = mapArgoWorkflowToSession(makePodWorkflow(undefined));
+
+    expect(session.steps[0].detail?.namespace).toBeUndefined();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/lib/services/workflow-mapper.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/workflow-mapper.ts
@@ -135,7 +135,7 @@ function buildNodeDetail(
   if (node.type === 'Pod' && node.id) {
     detail.workflowName = workflowName;
     detail.nodeId = node.id;
-    detail.namespace = workflowNamespace || 'default';
+    detail.namespace = workflowNamespace;
 
     if (node.podName) {
       detail.podName = node.podName;


### PR DESCRIPTION
## Summary
- The line #3302 reports (`useWorkflows('default', filters)` in `sessions-section.tsx`) was already fixed by #3149, which landed after the issue was filed. This closes the one remaining instance of the same bug class.
- `workflow-mapper.ts` fell back to `'default'` when building Pod-node details, so log fetches and Argo deep links from the Sessions tab resolved against `default` and were rejected in any tenant namespace. It now uses the workflow's own namespace; both consumers already guard on `detail.namespace`, so an absent namespace hides the logs and the link rather than issuing a forbidden request.
- Pin the reported regression: the `sessions-section` suite now runs under a tenant namespace instead of `default` and asserts `useWorkflows` and `useWorkflow` receive it. Both new assertions were verified to fail against the pre-fix code.

Closes #3302