### PR TITLE
fix: harden HTTP caching and TLS ciphers as per pentest findings

### DIFF
--- a/.github/actions/deploy-additional-services/action.yml
+++ b/.github/actions/deploy-additional-services/action.yml
@@ -84,6 +84,9 @@ runs:
             --set controller.config.proxy-buffer-size="16k" \
             --set controller.config.proxy-buffers-number="4" \
             --set controller.config.large-client-header-buffers="4 16k" \
+            --set controller.config.ssl-protocols="TLSv1.2 TLSv1.3" \
+            --set-string controller.config.ssl-prefer-server-ciphers="true" \
+            --set controller.config.ssl-ciphers="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384" \
             $( [ -n "${{ inputs.load_balancer_annotations }}" ] && echo "--set controller.service.annotations={${{ inputs.load_balancer_annotations }}}" ) \
             --wait
         

--- a/services/ark-api/ark-api/src/ark_api/main.py
+++ b/services/ark-api/ark-api/src/ark_api/main.py
@@ -24,7 +24,7 @@ from .core.config import setup_logging
 from .auth.middleware import AuthMiddleware
 from .auth.constants import AuthMode
 from .auth.config import get_public_routes
-from .middleware import ReadOnlyMiddleware
+from .middleware import CacheControlMiddleware, ReadOnlyMiddleware
 from .openapi.security import add_security_to_openapi
 from .api.v1.a2a_gateway import get_a2a_manager
 from ark_sdk.k8s import init_k8s
@@ -235,8 +235,11 @@ async def session_aware_middleware(request: Request, call_next):
     logger.info(
         f"Response: {request.method} {request.url.path} - {session_info} - Status: {response.status_code} - Time: {process_time:.3f}s"
     )
-    
+
     return response
+
+
+app.add_middleware(CacheControlMiddleware)
 
 
 # Custom exception handler for validation errors

--- a/services/ark-api/ark-api/src/ark_api/middleware.py
+++ b/services/ark-api/ark-api/src/ark_api/middleware.py
@@ -2,7 +2,33 @@ import os
 from typing import Callable
 
 from fastapi import Request, Response
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+CACHE_CONTROL_VALUE = "no-cache, no-store, must-revalidate"
+
+
+class CacheControlMiddleware:
+    """Stamp no-cache directives on every response so sensitive data is not cached."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_cache_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers["Cache-Control"] = CACHE_CONTROL_VALUE
+                headers["Pragma"] = "no-cache"
+                headers["Expires"] = "0"
+            await send(message)
+
+        await self.app(scope, receive, send_with_cache_headers)
 
 
 class ReadOnlyMiddleware(BaseHTTPMiddleware):

--- a/services/ark-api/ark-api/tests/test_cache_control_middleware.py
+++ b/services/ark-api/ark-api/tests/test_cache_control_middleware.py
@@ -1,0 +1,71 @@
+import unittest
+
+from ark_api.middleware import CACHE_CONTROL_VALUE, CacheControlMiddleware
+
+
+class TestCacheControlMiddleware(unittest.IsolatedAsyncioTestCase):
+    async def _run(self, scope, start_headers=None):
+        sent = []
+
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": list(start_headers or []),
+            })
+            await send({"type": "http.response.body", "body": b""})
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            sent.append(message)
+
+        await CacheControlMiddleware(app)(scope, receive, send)
+        return sent
+
+    def _headers(self, sent):
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        return {k.decode().lower(): v.decode() for k, v in start["headers"]}
+
+    async def test_stamps_cache_headers_on_http_response(self):
+        sent = await self._run({"type": "http"})
+        headers = self._headers(sent)
+
+        self.assertEqual(headers["cache-control"], CACHE_CONTROL_VALUE)
+        self.assertEqual(headers["pragma"], "no-cache")
+        self.assertEqual(headers["expires"], "0")
+
+    async def test_overrides_existing_cache_control(self):
+        sent = await self._run(
+            {"type": "http"},
+            start_headers=[(b"cache-control", b"public, max-age=3600")],
+        )
+        headers = self._headers(sent)
+
+        self.assertEqual(headers["cache-control"], CACHE_CONTROL_VALUE)
+
+    async def test_body_is_passed_through_untouched(self):
+        sent = await self._run({"type": "http"})
+
+        self.assertEqual(sent[-1]["type"], "http.response.body")
+
+    async def test_non_http_scope_is_untouched(self):
+        sent = []
+
+        async def app(scope, receive, send):
+            await send({"type": "websocket.accept"})
+
+        async def receive():
+            return {"type": "websocket.connect"}
+
+        async def send(message):
+            sent.append(message)
+
+        await CacheControlMiddleware(app)({"type": "websocket"}, receive, send)
+
+        self.assertEqual(sent, [{"type": "websocket.accept"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Checklist
[Pentest Report](https://mckinsey.sharepoint.com/sites/spt-int-8qr3g7vmyt7h/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fspt%2Dint%2D8qr3g7vmyt7h%2FShared%20Documents%2F%5FBox%2FOne%20Firm%20Pentesting%2F5%2E%20Scoping%20%5F%20Customer%20Reports%2F%2D%20Client%20Practice%20%2D%20Pentesting%2FARK%2FTASK3279068%2FDataArt%5FMcKinsey%2EARK%28ScopeA%29%5FPenetrationTesting%5FReport%5Fv1%2E0%5F08132026%2Epdf&parent=%2Fsites%2Fspt%2Dint%2D8qr3g7vmyt7h%2FShared%20Documents%2F%5FBox%2FOne%20Firm%20Pentesting%2F5%2E%20Scoping%20%5F%20Customer%20Reports%2F%2D%20Client%20Practice%20%2D%20Pentesting%2FARK%2FTASK3279068&p=true&ga=1&share=cQpe%5FMRonpBkTqtqgewAI6jeEgUCPVtulsuGAbI1RcQ8pNeSpA&lpmkr=QX%5FByvwTo0M)

Resolves three low-priority pentest findings:

1. **Missing cache-control directives** — responses containing sensitive data (resources, API keys, secrets) could be cached by browsers or intermediate proxies.
   **Fix:** added `CacheControlMiddleware` to ark-api that stamps every response with `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, and `Expires: 0`. Implemented as pure ASGI so streaming/SSE responses are untouched, and registered last so it is outermost and overrides any route-set headers. Unit tests added.

2. **L2 — TLS cipher suites without forward secrecy** — the server allowed `TLS_RSA_*` suites, so intercepted traffic could be decrypted if the private key were stolen.
   **Fix:** pinned the ingress-nginx controller to TLS 1.2/1.3 with a forward-secrecy-only cipher list (ECDHE/DHE key exchange), removing all `TLS_RSA_*` suites.

3. **L3 — weak CBC-mode ciphers** — CBC suites are exposed to padding-oracle attacks (POODLE, Zombie POODLE, GOLDENDOODLE).
   **Fix:** the same ingress cipher list is AEAD-only (GCM / CHACHA20-POLY1305), so all `*_CBC_*` suites are dropped. L2 and L3 are resolved by this single cipher/protocol change.


- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 