### PR TITLE
feat(dashboard): add MCP header overrides to agent and query authoring

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ChatMessageList } from '@/components/chat/chat-message-list';
 import { Autorenew, Build, Info, Send, Stop } from '@/components/icons';
 import { Button } from '@/components/ui/button';
+import { ChatMcpHeaderFields } from '@/components/ui/chat-mcp-header-fields';
 import { ChatParameterFields } from '@/components/ui/chat-parameter-fields';
 import { IconShell } from '@/components/ui/icon-shell';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -67,6 +68,7 @@ export function ChatPanel({
     removeParameterRow,
     canAddParameterRow,
     missingParameters,
+    mcpHeaders,
   } = useChatSession({ name, type });
 
   const [currentMessage, setCurrentMessage] = useState('');
@@ -173,6 +175,17 @@ export function ChatPanel({
             )}
           </div>
         )}
+        <div className="px-4 pt-4">
+          <ChatMcpHeaderFields
+            agentHeaders={mcpHeaders.agentHeaders}
+            rows={mcpHeaders.queryRows}
+            serverNames={mcpHeaders.serverNames}
+            onAddRow={mcpHeaders.addRow}
+            onUpdateRow={mcpHeaders.updateRow}
+            onRemoveRow={mcpHeaders.removeRow}
+            disabled={isProcessing}
+          />
+        </div>
         <div className="flex flex-col gap-2 px-4 py-3">
           <Textarea
             ref={inputRef}

--- a/services/ark-dashboard/ark-dashboard/components/forms/agent-form/create-agent-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/agent-form/create-agent-form.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/field';
 import { Form, FormField } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { McpHeaderOverridesEditor } from '@/components/ui/mcp-header-overrides-editor';
 import { ParameterEditor } from '@/components/ui/parameter-editor';
 import {
   Select,
@@ -52,9 +53,17 @@ export function CreateAgentForm({
     toolsLoading,
     unavailableTools,
     parameters,
+    mcpOverrideGroups,
+    mcpServerNames,
   } = state;
 
-  const { setParameters, handleToolToggle, isToolSelected, onSubmit } = actions;
+  const {
+    setParameters,
+    setMcpOverrideGroups,
+    handleToolToggle,
+    isToolSelected,
+    onSubmit,
+  } = actions;
 
   const promptValue = form.watch('prompt') || '';
   const isDisabled = form.formState.isSubmitting;
@@ -108,9 +117,9 @@ export function CreateAgentForm({
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="flex min-h-0 flex-1 items-start gap-20 overflow-hidden pb-2 pl-px">
+          className="flex min-h-0 flex-1 items-start gap-10 overflow-hidden pb-2 pl-px">
           {/* Left column — form fields (576px) */}
-          <div className="flex max-h-full min-h-0 w-[576px] flex-col gap-6 overflow-y-auto">
+          <div className="flex max-h-full min-h-0 w-[576px] min-w-0 flex-col gap-6 overflow-y-auto">
             <FormField
               control={form.control}
               name="name"
@@ -185,17 +194,6 @@ export function CreateAgentForm({
               }}
             />
 
-            <FieldSet className="gap-2">
-              <FieldTitle>Tools</FieldTitle>
-              <ToolsMultiSelect
-                availableTools={availableTools}
-                isToolSelected={isToolSelected}
-                onToggle={handleToolToggle}
-                toolsLoading={toolsLoading}
-                disabled={isDisabled}
-              />
-            </FieldSet>
-
             <FormField
               control={form.control}
               name="prompt"
@@ -211,10 +209,28 @@ export function CreateAgentForm({
                 />
               )}
             />
+
+            <FieldSet className="gap-2">
+              <FieldTitle>Tools</FieldTitle>
+              <ToolsMultiSelect
+                availableTools={availableTools}
+                isToolSelected={isToolSelected}
+                onToggle={handleToolToggle}
+                toolsLoading={toolsLoading}
+                disabled={isDisabled}
+              />
+            </FieldSet>
+
+            <McpHeaderOverridesEditor
+              groups={mcpOverrideGroups}
+              onChange={setMcpOverrideGroups}
+              serverNames={mcpServerNames}
+              disabled={isDisabled}
+            />
           </div>
 
-          {/* Right column — Variables panel (figma 4257:26496, 464px fixed) */}
-          <div className="bg-surface-primary flex max-h-full min-h-0 w-[464px] flex-none flex-col overflow-y-auto p-5">
+          {/* Right column — Variables panel (figma 4257:26496, 560px fixed) */}
+          <div className="bg-surface-primary flex max-h-full min-h-0 w-[560px] flex-none flex-col gap-8 overflow-y-auto p-5">
             <ParameterEditor
               parameters={parameters}
               onChange={setParameters}

--- a/services/ark-dashboard/ark-dashboard/components/forms/agent-form/types.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/agent-form/types.ts
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import type { Parameter } from '@/components/ui/parameter-editor';
 import type { Agent, AgentTool, Model, Skill, Tool } from '@/lib/services';
 import { kubernetesNameSchema } from '@/lib/utils/kubernetes-validation';
+import type { McpOverrideGroup } from '@/lib/utils/mcp-header-overrides';
 
 export const agentFormSchema = z.object({
   name: kubernetesNameSchema,
@@ -35,12 +36,15 @@ export interface AgentFormState {
   selectedTools: AgentTool[];
   unavailableTools: Tool[];
   parameters: Parameter[];
+  mcpOverrideGroups: McpOverrideGroup[];
+  mcpServerNames: string[];
   isExperimentalExecutionEngineEnabled: boolean;
   hasChanges: boolean;
 }
 
 export interface AgentFormActions {
   setParameters: (params: Parameter[]) => void;
+  setMcpOverrideGroups: (groups: McpOverrideGroup[]) => void;
   handleToolToggle: (tool: Tool, checked: boolean) => void;
   handleDeleteTool: (tool: Tool) => void;
   isToolSelected: (toolName: string) => boolean;

--- a/services/ark-dashboard/ark-dashboard/components/forms/agent-form/use-agent-form.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/agent-form/use-agent-form.ts
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from '@/components/ui/sonner';
 
@@ -25,6 +25,14 @@ import {
   toolsService,
 } from '@/lib/services';
 import { GET_ALL_AGENTS_QUERY_KEY } from '@/lib/services/agents-hooks';
+import {
+  type McpOverrideGroup,
+  groupsToOverrides,
+  mcpServerNamesFromTools,
+  overrideGroupsEqual,
+  overridesToGroups,
+  reconcileServerGroups,
+} from '@/lib/utils/mcp-header-overrides';
 import { useNamespace } from '@/providers/NamespaceProvider';
 
 import { AgentFormMode, type AgentFormValues, agentFormSchema } from './types';
@@ -66,6 +74,12 @@ export function useAgentForm({
   );
   const [parameters, setParameters] = useState<Parameter[]>([]);
   const [initialParameters, setInitialParameters] = useState<Parameter[]>([]);
+  const [mcpOverrideGroups, setMcpOverrideGroups] = useState<
+    McpOverrideGroup[]
+  >([]);
+  const [initialMcpOverrideGroups, setInitialMcpOverrideGroups] = useState<
+    McpOverrideGroup[]
+  >([]);
 
   const isExperimentalExecutionEngineEnabled = useAtomValue(
     isExperimentalExecutionEngineEnabledAtom,
@@ -122,6 +136,9 @@ export function useAgentForm({
           );
           setParameters(transformedParams);
           setInitialParameters(transformedParams);
+          const transformedOverrides = overridesToGroups(agentData.overrides);
+          setMcpOverrideGroups(transformedOverrides);
+          setInitialMcpOverrideGroups(transformedOverrides);
 
           form.reset({
             name: agentData.name,
@@ -169,6 +186,22 @@ export function useAgentForm({
     return transformFormParametersToApi(parameters);
   }, [parameters]);
 
+  const mapMcpOverridesToApi = useCallback(
+    () => groupsToOverrides(mcpOverrideGroups),
+    [mcpOverrideGroups],
+  );
+
+  const mcpServerNames = useMemo(() => {
+    const selectedNames = new Set(selectedTools.map(tool => tool.name));
+    return mcpServerNamesFromTools(
+      availableTools.filter(tool => selectedNames.has(tool.name)),
+    );
+  }, [selectedTools, availableTools]);
+
+  useEffect(() => {
+    setMcpOverrideGroups(prev => reconcileServerGroups(prev, mcpServerNames));
+  }, [mcpServerNames]);
+
   const onSubmit = useCallback(
     async (values: AgentFormValues) => {
       setSaving(true);
@@ -194,6 +227,9 @@ export function useAgentForm({
             prompt: values.prompt || undefined,
             tools: selectedTools,
             parameters: mapParametersToApi(),
+            overrides: mapMcpOverridesToApi().length
+              ? mapMcpOverridesToApi()
+              : undefined,
           };
 
           await agentsService.create(createData);
@@ -223,6 +259,7 @@ export function useAgentForm({
             prompt: agent.isA2A ? undefined : values.prompt || null,
             tools: agent.isA2A ? undefined : selectedTools,
             parameters: agent.isA2A ? undefined : mapParametersToApi(),
+            overrides: agent.isA2A ? undefined : mapMcpOverridesToApi(),
           };
 
           const updated = await agentsService.update(agent.name, updateData);
@@ -237,6 +274,7 @@ export function useAgentForm({
           form.reset(values);
           setInitialTools(selectedTools);
           setInitialParameters(parameters);
+          setInitialMcpOverrideGroups(mcpOverrideGroups);
         }
 
         onSuccessRef.current?.();
@@ -254,6 +292,8 @@ export function useAgentForm({
       selectedTools,
       parameters,
       mapParametersToApi,
+      mcpOverrideGroups,
+      mapMcpOverridesToApi,
       queryClient,
       namespace,
       form,
@@ -292,8 +332,16 @@ export function useAgentForm({
     [parameters, initialParameters],
   );
 
+  const hasMcpOverridesChanged = useCallback(
+    () => !overrideGroupsEqual(mcpOverrideGroups, initialMcpOverrideGroups),
+    [mcpOverrideGroups, initialMcpOverrideGroups],
+  );
+
   const hasChanges =
-    form.formState.isDirty || hasToolsChanged() || hasParametersChanged();
+    form.formState.isDirty ||
+    hasToolsChanged() ||
+    hasParametersChanged() ||
+    hasMcpOverridesChanged();
 
   return {
     form,
@@ -309,11 +357,14 @@ export function useAgentForm({
       selectedTools,
       unavailableTools,
       parameters,
+      mcpOverrideGroups,
+      mcpServerNames,
       isExperimentalExecutionEngineEnabled,
       hasChanges,
     },
     actions: {
       setParameters,
+      setMcpOverrideGroups,
       handleToolToggle,
       handleDeleteTool,
       isToolSelected,

--- a/services/ark-dashboard/ark-dashboard/components/forms/agent-form/view-agent-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/agent-form/view-agent-form.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/field';
 import { Form, FormField } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { McpHeaderOverridesEditor } from '@/components/ui/mcp-header-overrides-editor';
 import { ParameterEditor } from '@/components/ui/parameter-editor';
 import {
   Select,
@@ -73,12 +74,15 @@ export function ViewAgentForm({
     toolsLoading,
     unavailableTools,
     parameters,
+    mcpOverrideGroups,
+    mcpServerNames,
     isExperimentalExecutionEngineEnabled,
     hasChanges,
   } = state;
 
   const {
     setParameters,
+    setMcpOverrideGroups,
     handleToolToggle,
     handleDeleteTool,
     isToolSelected,
@@ -306,6 +310,15 @@ export function ViewAgentForm({
                             </FieldDescription>
                           )}
                         </FieldSet>
+                      )}
+
+                      {!isA2A && (
+                        <McpHeaderOverridesEditor
+                          groups={mcpOverrideGroups}
+                          onChange={setMcpOverrideGroups}
+                          serverNames={mcpServerNames}
+                          disabled={isDisabled}
+                        />
                       )}
 
                       {isA2A && (

--- a/services/ark-dashboard/ark-dashboard/components/ui/chat-mcp-header-fields.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/chat-mcp-header-fields.tsx
@@ -1,0 +1,418 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Add, ChevronDown, Info, Lock, Trash } from '@/components/icons';
+import { Button } from '@/components/ui/button';
+import { HeaderNameField } from '@/components/ui/header-name-field';
+import { HeaderOverrideSelect } from '@/components/ui/header-override-select';
+import { IconShell } from '@/components/ui/icon-shell';
+import {
+  COLUMN_LABEL_CLASS,
+  LabeledField,
+} from '@/components/ui/labeled-field';
+import { McpServerSelect } from '@/components/ui/mcp-server-select';
+import {
+  GHOST_TRIGGER,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useMcpSecretOptions } from '@/lib/hooks/use-mcp-secret-options';
+import { useMcpServerHeaders } from '@/lib/hooks/use-mcp-server-headers';
+import type { AgentHeaderSummary } from '@/lib/hooks/use-query-mcp-headers';
+import { cn } from '@/lib/utils';
+import {
+  type McpHeaderRow,
+  type McpHeaderSource,
+  isSensitiveHeaderName,
+} from '@/lib/utils/mcp-header-overrides';
+
+const PRECEDENCE_TOOLTIP =
+  'Header overrides set here apply to this query only and take precedence over the same header on the agent. The agent keeps its own value for every other query.';
+
+const SOURCE_ITEMS: { value: McpHeaderSource; label: string }[] = [
+  { value: 'secretKeyRef', label: 'Secret' },
+  { value: 'value', label: 'Plain value' },
+];
+
+const inputClass =
+  'text-fg-primary placeholder:text-fg-secondary min-w-0 flex-1 bg-transparent text-sm leading-4 tracking-[-0.112px] outline-none disabled:cursor-not-allowed disabled:opacity-50';
+
+const underlineClass =
+  'focus-within:border-b-stroke-status-focus flex h-10 min-w-0 items-center border-b border-white/[0.16]';
+
+export interface ChatMcpHeaderFieldsProps {
+  readonly agentHeaders: AgentHeaderSummary[];
+  readonly rows: McpHeaderRow[];
+  readonly serverNames?: string[];
+  readonly onAddRow: () => void;
+  readonly onUpdateRow: (id: string, updates: Partial<McpHeaderRow>) => void;
+  readonly onRemoveRow: (id: string) => void;
+  readonly disabled?: boolean;
+}
+
+export function ChatMcpHeaderFields({
+  agentHeaders,
+  rows,
+  serverNames = [],
+  onAddRow,
+  onUpdateRow,
+  onRemoveRow,
+  disabled,
+}: ChatMcpHeaderFieldsProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [advancedRows, setAdvancedRows] = useState<Record<string, boolean>>({});
+
+  const {
+    options,
+    secretNames,
+    loaded: secretsLoaded,
+  } = useMcpSecretOptions(expanded);
+
+  const { headerNamesByServer, allHeaderNames } = useMcpServerHeaders(
+    serverNames,
+    expanded,
+  );
+
+  const declaredNamesFor = (row: McpHeaderRow) => {
+    const fromServer = row.serverName
+      ? (headerNamesByServer[row.serverName] ?? [])
+      : allHeaderNames;
+    const fromAgent = agentHeaders
+      .map(header => header.name)
+      .filter(name => !!name);
+    return Array.from(new Set([...fromAgent, ...fromServer]));
+  };
+
+  const isAdvanced = (row: McpHeaderRow) =>
+    row.source !== 'secretKeyRef' || advancedRows[row.id] === true;
+
+  const revealAdvanced = (rowId: string) =>
+    setAdvancedRows(prev => ({ ...prev, [rowId]: true }));
+
+  const effectiveCount =
+    agentHeaders.filter(header => !header.shadowed).length + rows.length;
+
+  const secretItems = secretNames.map(name => ({ value: name, label: name }));
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          className="text-fg-secondary inline-flex items-center gap-2 text-sm">
+          <IconShell
+            size="sm"
+            className={cn('transition-transform', expanded && 'rotate-180')}>
+            <ChevronDown />
+          </IconShell>
+          Header overrides
+          <span className="text-fg-tertiary text-xs">
+            {effectiveCount} effective
+          </span>
+        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="How header override precedence works"
+              className="text-fg-secondary inline-flex cursor-help p-0">
+              <Info className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            {PRECEDENCE_TOOLTIP}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {expanded && (
+        <div className="flex flex-col gap-3">
+          {agentHeaders.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-fg-tertiary text-xs uppercase tracking-wide">
+                From this agent
+              </span>
+              {agentHeaders.map(header => (
+                <div
+                  key={header.id}
+                  className="flex h-9 items-center gap-2 border-b border-white/[0.16]">
+                  <span
+                    className={cn(
+                      'text-fg-primary min-w-0 flex-1 truncate text-sm',
+                      header.shadowed &&
+                        'text-fg-tertiary line-through decoration-1',
+                    )}>
+                    {header.name || 'Unnamed header'}
+                  </span>
+                  <span className="text-fg-tertiary shrink-0 text-xs">
+                    {header.sourceLabel}
+                  </span>
+                  <span className="text-fg-tertiary shrink-0 text-xs">
+                    {header.scope}
+                  </span>
+                  {header.shadowed ? (
+                    <span className="text-status-warning shrink-0 text-xs">
+                      overridden below
+                    </span>
+                  ) : (
+                    <span className="text-fg-tertiary inline-flex shrink-0 items-center gap-1 text-xs">
+                      <Lock className="size-3 shrink-0" />
+                      from agent
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {rows.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-fg-tertiary text-xs uppercase tracking-wide">
+                This query only
+              </span>
+              <div className="flex items-center gap-3">
+                <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+                  MCP server
+                </span>
+                <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+                  Header name
+                </span>
+                <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+                  Header override
+                </span>
+                <span className="w-8 shrink-0" />
+              </div>
+
+              {rows.map(row => {
+                const keyItems = options
+                  .filter(option => option.secretName === row.secretName)
+                  .map(option => ({
+                    value: option.secretKey,
+                    label: option.secretKey,
+                  }));
+
+                return (
+                  <div key={row.id} className="flex flex-col gap-2">
+                    <div className="flex items-center gap-3">
+                      <div className="flex min-w-0 flex-1 items-center">
+                        <McpServerSelect
+                          id={`mcp-${row.id}-server`}
+                          serverNames={serverNames}
+                          value={row.serverName}
+                          disabled={disabled}
+                          onChange={serverName =>
+                            onUpdateRow(row.id, { serverName })
+                          }
+                        />
+                      </div>
+
+                      <div className="flex min-w-0 flex-1 items-center">
+                        <HeaderNameField
+                          id={`mcp-${row.id}-name`}
+                          value={row.name}
+                          suggestions={declaredNamesFor(row)}
+                          disabled={disabled}
+                          onChange={name => onUpdateRow(row.id, { name })}
+                          className="w-full"
+                        />
+                      </div>
+
+                      <div className="flex min-w-0 flex-1 items-center">
+                        {isAdvanced(row) ? (
+                          <Select
+                            items={SOURCE_ITEMS}
+                            value={row.source}
+                            onValueChange={value =>
+                              onUpdateRow(row.id, {
+                                source: String(value) as McpHeaderSource,
+                              })
+                            }
+                            disabled={disabled}>
+                            <SelectTrigger
+                              id={`mcp-${row.id}-source`}
+                              aria-label="Header override"
+                              className={cn(
+                                GHOST_TRIGGER,
+                                'h-10 w-full min-w-0',
+                              )}>
+                              <SelectValue placeholder="Select source" />
+                            </SelectTrigger>
+                            <SelectContent className="bg-fill-onsurface-ui-2">
+                              {SOURCE_ITEMS.map(item => (
+                                <SelectItem key={item.value} value={item.value}>
+                                  <SelectItemText>{item.label}</SelectItemText>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <HeaderOverrideSelect
+                            hideLabel
+                            id={`mcp-${row.id}-override`}
+                            options={options}
+                            loaded={secretsLoaded}
+                            secretName={row.secretName}
+                            secretKey={row.secretKey}
+                            disabled={disabled}
+                            onSelectSecret={(secretName, secretKey) =>
+                              onUpdateRow(row.id, {
+                                source: 'secretKeyRef',
+                                secretName,
+                                secretKey,
+                              })
+                            }
+                            onSelectAdvanced={() => revealAdvanced(row.id)}
+                            className="w-full"
+                          />
+                        )}
+                      </div>
+
+                      <div className="flex h-10 w-8 shrink-0 items-center justify-center border-b border-white/[0.16]">
+                        <button
+                          type="button"
+                          onClick={() => onRemoveRow(row.id)}
+                          disabled={disabled}
+                          aria-label="Remove header override"
+                          className="text-fg-secondary hover:text-status-error transition-colors disabled:cursor-not-allowed disabled:opacity-50">
+                          <Trash className="size-4" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {isAdvanced(row) && (
+                      <div className="grid grid-cols-2 items-start gap-3">
+                        {row.source === 'secretKeyRef' ? (
+                          <>
+                            <LabeledField
+                              id={`mcp-${row.id}-secret-name`}
+                              label="Secret">
+                              <Select
+                                items={secretItems}
+                                value={row.secretName || undefined}
+                                onValueChange={value =>
+                                  onUpdateRow(row.id, {
+                                    secretName: String(value),
+                                    secretKey: '',
+                                  })
+                                }
+                                disabled={disabled}>
+                                <SelectTrigger
+                                  id={`mcp-${row.id}-secret-name`}
+                                  className={cn(
+                                    GHOST_TRIGGER,
+                                    'h-10 w-full min-w-0',
+                                  )}>
+                                  <SelectValue placeholder="Select secret" />
+                                </SelectTrigger>
+                                <SelectContent className="bg-fill-onsurface-ui-2">
+                                  {secretItems.map(item => (
+                                    <SelectItem
+                                      key={item.value}
+                                      value={item.value}>
+                                      <SelectItemText>
+                                        {item.label}
+                                      </SelectItemText>
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </LabeledField>
+                            <LabeledField
+                              id={`mcp-${row.id}-secret-key`}
+                              label="Key in secret">
+                              <Select
+                                items={keyItems}
+                                value={row.secretKey || undefined}
+                                onValueChange={value =>
+                                  onUpdateRow(row.id, {
+                                    secretKey: String(value),
+                                  })
+                                }
+                                disabled={disabled || !row.secretName}>
+                                <SelectTrigger
+                                  id={`mcp-${row.id}-secret-key`}
+                                  className={cn(
+                                    GHOST_TRIGGER,
+                                    'h-10 w-full min-w-0',
+                                  )}>
+                                  <SelectValue placeholder="Select key" />
+                                </SelectTrigger>
+                                <SelectContent className="bg-fill-onsurface-ui-2">
+                                  {keyItems.map(item => (
+                                    <SelectItem
+                                      key={item.value}
+                                      value={item.value}>
+                                      <SelectItemText>
+                                        {item.label}
+                                      </SelectItemText>
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </LabeledField>
+                          </>
+                        ) : (
+                          <LabeledField
+                            id={`mcp-${row.id}-value`}
+                            label="Value"
+                            className="col-span-2">
+                            <div className={underlineClass}>
+                              <input
+                                id={`mcp-${row.id}-value`}
+                                type="text"
+                                value={row.value}
+                                onChange={event =>
+                                  onUpdateRow(row.id, {
+                                    value: event.target.value,
+                                  })
+                                }
+                                placeholder="Header value"
+                                disabled={disabled}
+                                className={inputClass}
+                              />
+                            </div>
+                          </LabeledField>
+                        )}
+
+                        {row.source === 'value' &&
+                          isSensitiveHeaderName(row.name) && (
+                            <span className="text-status-warning col-span-2 text-xs">
+                              Sent in plain text with this query. A secret is
+                              safer.
+                            </span>
+                          )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="self-start"
+            onClick={onAddRow}
+            disabled={disabled}>
+            <Add className="size-4" />
+            Override a header
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/header-name-field.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/header-name-field.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useId } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const inputClass =
+  'text-fg-primary placeholder:text-fg-secondary min-w-0 flex-1 bg-transparent text-sm leading-4 tracking-[-0.112px] outline-none disabled:cursor-not-allowed disabled:opacity-50';
+
+const underlineClass =
+  'focus-within:border-b-stroke-status-focus flex h-10 min-w-0 items-center border-b border-white/[0.16]';
+
+export interface HeaderNameFieldProps {
+  readonly id: string;
+  readonly value: string;
+  readonly suggestions?: string[];
+  readonly disabled?: boolean;
+  readonly onChange: (name: string) => void;
+  readonly className?: string;
+}
+
+export function HeaderNameField({
+  id,
+  value,
+  suggestions = [],
+  disabled,
+  onChange,
+  className,
+}: HeaderNameFieldProps) {
+  const listId = `${useId()}-header-names`;
+  const hasSuggestions = suggestions.length > 0;
+
+  return (
+    <div className={cn(underlineClass, className)}>
+      <input
+        id={id}
+        type="text"
+        aria-label="Header name"
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        placeholder="Header-Name"
+        disabled={disabled}
+        autoComplete="off"
+        list={hasSuggestions ? listId : undefined}
+        className={inputClass}
+      />
+      {hasSuggestions && (
+        <datalist id={listId}>
+          {suggestions.map(name => (
+            <option key={name} value={name} />
+          ))}
+        </datalist>
+      )}
+    </div>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/header-override-select.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/header-override-select.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { Warning } from '@/components/icons';
+import { IconShell } from '@/components/ui/icon-shell';
+import { LabeledField } from '@/components/ui/labeled-field';
+import {
+  GHOST_TRIGGER,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  type McpSecretOption,
+  secretOptionValue,
+} from '@/lib/hooks/use-mcp-secret-options';
+import { cn } from '@/lib/utils';
+
+export const ADVANCED_OPTION_VALUE = '__advanced__';
+
+const ADVANCED_OPTION_LABEL = 'Advanced…';
+
+export interface HeaderOverrideSelectProps {
+  readonly id: string;
+  readonly options: McpSecretOption[];
+  readonly loaded: boolean;
+  readonly secretName: string;
+  readonly secretKey: string;
+  readonly disabled?: boolean;
+  readonly onSelectSecret: (secretName: string, secretKey: string) => void;
+  readonly onSelectAdvanced: () => void;
+  readonly className?: string;
+  readonly hideLabel?: boolean;
+}
+
+export function HeaderOverrideSelect({
+  id,
+  options,
+  loaded,
+  secretName,
+  secretKey,
+  disabled,
+  onSelectSecret,
+  onSelectAdvanced,
+  className,
+  hideLabel,
+}: HeaderOverrideSelectProps) {
+  const items = useMemo(
+    () => [
+      ...options.map(option => ({
+        value: option.value,
+        label: option.label,
+      })),
+      { value: ADVANCED_OPTION_VALUE, label: ADVANCED_OPTION_LABEL },
+    ],
+    [options],
+  );
+
+  const currentValue = secretOptionValue(secretName, secretKey);
+  const isKnown = options.some(option => option.value === currentValue);
+  const hasSelection = !!secretName && !!secretKey;
+  const isMissing = loaded && hasSelection && !isKnown;
+
+  const handleChange = (next: string) => {
+    if (next === ADVANCED_OPTION_VALUE) {
+      onSelectAdvanced();
+      return;
+    }
+    const option = options.find(item => item.value === next);
+    if (option) onSelectSecret(option.secretName, option.secretKey);
+  };
+
+  const body = (
+    <>
+      <Select
+        items={items}
+        value={isKnown ? currentValue : undefined}
+        onValueChange={value => handleChange(String(value))}
+        disabled={disabled}>
+        <SelectTrigger
+          id={id}
+          aria-label={hideLabel ? 'Header override' : undefined}
+          className={cn(GHOST_TRIGGER, 'h-10 w-full min-w-0')}>
+          <SelectValue placeholder="Select a secret" />
+        </SelectTrigger>
+        <SelectContent className="bg-fill-onsurface-ui-2">
+          {items.map(item => (
+            <SelectItem key={item.value} value={item.value}>
+              <SelectItemText>{item.label}</SelectItemText>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {isMissing && (
+        <span className="text-status-error inline-flex items-center gap-1 text-xs">
+          <IconShell size="sm" className="text-status-error">
+            <Warning />
+          </IconShell>
+          {secretName}/{secretKey} is not available in this namespace
+        </span>
+      )}
+
+      {loaded && options.length === 0 && (
+        <span className="text-fg-tertiary text-xs">
+          No secrets in this namespace yet.
+        </span>
+      )}
+    </>
+  );
+
+  if (hideLabel) {
+    return (
+      <div className={cn('flex min-w-0 flex-col gap-1', className)}>{body}</div>
+    );
+  }
+
+  return (
+    <LabeledField id={id} label="Header override" className={className}>
+      {body}
+    </LabeledField>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/labeled-field.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/labeled-field.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export const COLUMN_LABEL_CLASS = 'text-fg-secondary label-small-primary';
+
+export interface LabeledFieldProps {
+  readonly id: string;
+  readonly label: string;
+  readonly className?: string;
+  readonly children: React.ReactNode;
+}
+
+export function LabeledField({
+  id,
+  label,
+  className,
+  children,
+}: LabeledFieldProps) {
+  return (
+    <div className={cn('flex min-w-0 flex-col gap-1.5', className)}>
+      <label htmlFor={id} className={COLUMN_LABEL_CLASS}>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/mcp-header-overrides-editor.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/mcp-header-overrides-editor.tsx
@@ -1,0 +1,532 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { Add, Info, OpenInNew, Trash, VpnKey, Warning } from '@/components/icons';
+import { NamespacedLink } from '@/components/namespaced-link';
+import { Button } from '@/components/ui/button';
+import { IconShell } from '@/components/ui/icon-shell';
+import {
+  COLUMN_LABEL_CLASS,
+  LabeledField,
+} from '@/components/ui/labeled-field';
+import {
+  GHOST_TRIGGER,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useMcpSecretOptions } from '@/lib/hooks/use-mcp-secret-options';
+import { useMcpServerHeaders } from '@/lib/hooks/use-mcp-server-headers';
+import { cn } from '@/lib/utils';
+import {
+  type McpHeaderRow,
+  type McpHeaderSource,
+  type McpOverrideGroup,
+  addHeaderRow,
+  countHeaders,
+  describeScope,
+  isSensitiveHeaderName,
+} from '@/lib/utils/mcp-header-overrides';
+
+import { HeaderNameField } from './header-name-field';
+import { HeaderOverrideSelect } from './header-override-select';
+import { McpServerSelect } from './mcp-server-select';
+
+const HEADERS_TOOLTIP_TEXT =
+  'Header overrides are added to every call this agent makes to a matching MCP server. Use a secret for tokens so the value is never stored on the agent itself. A query can override any header set here.';
+
+const SOURCE_ITEMS: { value: McpHeaderSource; label: string }[] = [
+  { value: 'secretKeyRef', label: 'Secret' },
+  { value: 'value', label: 'Plain value' },
+  { value: 'queryParameterRef', label: 'Query parameter' },
+  { value: 'configMapKeyRef', label: 'ConfigMap' },
+];
+
+const inputClass =
+  'text-fg-primary placeholder:text-fg-secondary min-w-0 flex-1 bg-transparent text-sm leading-4 tracking-[-0.112px] outline-none disabled:cursor-not-allowed disabled:opacity-50';
+
+const underlineClass =
+  'focus-within:border-b-stroke-status-focus flex h-10 min-w-0 items-center border-b border-white/[0.16]';
+
+export interface McpHeaderOverridesEditorProps {
+  readonly groups: McpOverrideGroup[];
+  readonly onChange: (groups: McpOverrideGroup[]) => void;
+  readonly serverNames?: string[];
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+export function McpHeaderOverridesEditor({
+  groups,
+  onChange,
+  serverNames = [],
+  disabled,
+  className,
+}: McpHeaderOverridesEditorProps) {
+  const { options, secretNames, loaded: secretsLoaded } = useMcpSecretOptions();
+  const { headerNamesByServer, allHeaderNames } =
+    useMcpServerHeaders(serverNames);
+  const [advancedRows, setAdvancedRows] = useState<Record<string, boolean>>({});
+
+  const declaredNamesFor = useCallback(
+    (header: McpHeaderRow) =>
+      header.serverName
+        ? (headerNamesByServer[header.serverName] ?? [])
+        : allHeaderNames,
+    [headerNamesByServer, allHeaderNames],
+  );
+
+  const revealAdvanced = useCallback((headerId: string) => {
+    setAdvancedRows(prev => ({ ...prev, [headerId]: true }));
+  }, []);
+
+  const isAdvanced = useCallback(
+    (header: McpHeaderRow) =>
+      header.source !== 'secretKeyRef' || advancedRows[header.id] === true,
+    [advancedRows],
+  );
+
+  const updateHeader = useCallback(
+    (groupId: string, headerId: string, updates: Partial<McpHeaderRow>) => {
+      onChange(
+        groups.map(group =>
+          group.id === groupId
+            ? {
+                ...group,
+                headers: group.headers.map(header =>
+                  header.id === headerId ? { ...header, ...updates } : header,
+                ),
+              }
+            : group,
+        ),
+      );
+    },
+    [groups, onChange],
+  );
+
+  const removeHeader = useCallback(
+    (groupId: string, headerId: string) => {
+      onChange(
+        groups.reduce<McpOverrideGroup[]>((acc, group) => {
+          if (group.id !== groupId) {
+            acc.push(group);
+            return acc;
+          }
+
+          const headers = group.headers.filter(
+            header => header.id !== headerId,
+          );
+          if (headers.length > 0) acc.push({ ...group, headers });
+          return acc;
+        }, []),
+      );
+    },
+    [groups, onChange],
+  );
+
+  const addRule = useCallback(() => {
+    onChange(addHeaderRow(groups));
+  }, [groups, onChange]);
+
+  const rows = useMemo(
+    () =>
+      groups.flatMap(group =>
+        group.headers.map(header => ({ group, header })),
+      ),
+    [groups],
+  );
+
+  const secretItems = useMemo(
+    () => secretNames.map(name => ({ value: name, label: name })),
+    [secretNames],
+  );
+
+  const renderValueFields = (group: McpOverrideGroup, header: McpHeaderRow) => {
+    if (header.source === 'secretKeyRef') {
+      const keyItems = options
+        .filter(option => option.secretName === header.secretName)
+        .map(option => ({ value: option.secretKey, label: option.secretKey }));
+      const secretMissing =
+        secretsLoaded &&
+        !!header.secretName &&
+        !secretNames.includes(header.secretName);
+
+      return (
+        <>
+          <LabeledField id={`mcp-${header.id}-secret-name`} label="Secret">
+            <Select
+              items={secretItems}
+              value={header.secretName || undefined}
+              onValueChange={value =>
+                updateHeader(group.id, header.id, {
+                  secretName: String(value),
+                  secretKey: '',
+                })
+              }
+              disabled={disabled}>
+              <SelectTrigger
+                id={`mcp-${header.id}-secret-name`}
+                className={cn(GHOST_TRIGGER, 'h-10 w-full min-w-0')}>
+                <SelectValue placeholder="Select secret" />
+              </SelectTrigger>
+              <SelectContent className="bg-fill-onsurface-ui-2">
+                {secretItems.map(item => (
+                  <SelectItem key={item.value} value={item.value}>
+                    <SelectItemText>{item.label}</SelectItemText>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </LabeledField>
+
+          <LabeledField id={`mcp-${header.id}-secret-key`} label="Key in secret">
+            <Select
+              items={keyItems}
+              value={header.secretKey || undefined}
+              onValueChange={value =>
+                updateHeader(group.id, header.id, { secretKey: String(value) })
+              }
+              disabled={disabled || !header.secretName}>
+              <SelectTrigger
+                id={`mcp-${header.id}-secret-key`}
+                className={cn(GHOST_TRIGGER, 'h-10 w-full min-w-0')}>
+                <SelectValue placeholder="Select key" />
+              </SelectTrigger>
+              <SelectContent className="bg-fill-onsurface-ui-2">
+                {keyItems.map(item => (
+                  <SelectItem key={item.value} value={item.value}>
+                    <SelectItemText>{item.label}</SelectItemText>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </LabeledField>
+
+          {secretMissing && (
+            <span className="text-status-error col-span-2 inline-flex items-center gap-1 text-xs">
+              <IconShell size="sm" className="text-status-error">
+                <Warning />
+              </IconShell>
+              Secret &ldquo;{header.secretName}&rdquo; not found in this
+              namespace
+            </span>
+          )}
+        </>
+      );
+    }
+
+    if (header.source === 'value') {
+      const sensitive = isSensitiveHeaderName(header.name);
+      return (
+        <>
+          <LabeledField
+            id={`mcp-${header.id}-value`}
+            label="Value"
+            className="col-span-2">
+            <div className={underlineClass}>
+              <input
+                id={`mcp-${header.id}-value`}
+                type="text"
+                value={header.value}
+                onChange={event =>
+                  updateHeader(group.id, header.id, {
+                    value: event.target.value,
+                  })
+                }
+                placeholder="Header value"
+                disabled={disabled}
+                className={inputClass}
+              />
+            </div>
+          </LabeledField>
+          {sensitive && (
+            <span className="text-status-warning col-span-2 inline-flex items-center gap-1 text-xs">
+              <IconShell size="sm" className="text-status-warning">
+                <Warning />
+              </IconShell>
+              Stored in plain text on the agent. Use a secret for credentials.
+            </span>
+          )}
+        </>
+      );
+    }
+
+    if (header.source === 'queryParameterRef') {
+      return (
+        <>
+          <LabeledField
+            id={`mcp-${header.id}-query-parameter`}
+            label="Query parameter name"
+            className="col-span-2">
+            <div className={underlineClass}>
+              <input
+                id={`mcp-${header.id}-query-parameter`}
+                type="text"
+                value={header.queryParameterName}
+                onChange={event =>
+                  updateHeader(group.id, header.id, {
+                    queryParameterName: event.target.value,
+                  })
+                }
+                placeholder="parameter_name"
+                disabled={disabled}
+                className={inputClass}
+              />
+            </div>
+          </LabeledField>
+          <span className="text-fg-tertiary col-span-2 text-xs">
+            Value comes from a query parameter at run time.
+          </span>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <LabeledField id={`mcp-${header.id}-configmap-name`} label="ConfigMap">
+          <div className={underlineClass}>
+            <input
+              id={`mcp-${header.id}-configmap-name`}
+              type="text"
+              value={header.configMapName}
+              onChange={event =>
+                updateHeader(group.id, header.id, {
+                  configMapName: event.target.value,
+                })
+              }
+              placeholder="ConfigMap name"
+              disabled={disabled}
+              className={inputClass}
+            />
+          </div>
+        </LabeledField>
+        <LabeledField
+          id={`mcp-${header.id}-configmap-key`}
+          label="Key in ConfigMap">
+          <div className={underlineClass}>
+            <input
+              id={`mcp-${header.id}-configmap-key`}
+              type="text"
+              value={header.configMapKey}
+              onChange={event =>
+                updateHeader(group.id, header.id, {
+                  configMapKey: event.target.value,
+                })
+              }
+              placeholder="Key"
+              disabled={disabled}
+              className={inputClass}
+            />
+          </div>
+        </LabeledField>
+      </>
+    );
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-5', className)}>
+      <div className="flex w-full items-start justify-between">
+        <div className="flex min-w-0 flex-1 flex-col items-start justify-center gap-2">
+          <div className="flex items-center gap-2">
+            <h3 className="text-fg-secondary label-regular-primary">
+              Header overrides
+            </h3>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="How header overrides work"
+                  className="text-fg-secondary inline-flex cursor-help p-0">
+                  <Info className="size-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                {HEADERS_TOOLTIP_TEXT}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <p className="text-fg-secondary text-xs leading-4 tracking-[0.024px]">
+            {countHeaders(groups)} header
+            {countHeaders(groups) === 1 ? '' : 's'}
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={addRule}
+          disabled={disabled}>
+          <Add className="size-4" />
+          Add rule
+        </Button>
+      </div>
+
+      {rows.length === 0 && (
+        <div className="border-stroke-tertiary flex flex-col gap-2 border border-dashed p-4">
+          <p className="text-fg-secondary text-sm">
+            No header overrides are sent to MCP servers. Select an MCP tool and
+            a header appears here for its server.
+          </p>
+          <div className="flex items-center gap-1">
+            <NamespacedLink
+              href="/secrets"
+              className="text-fg-secondary inline-flex items-center gap-1 text-xs font-medium underline underline-offset-2 hover:opacity-80">
+              <IconShell size="sm">
+                <VpnKey />
+              </IconShell>
+              Manage secrets
+              <IconShell size="sm">
+                <OpenInNew />
+              </IconShell>
+            </NamespacedLink>
+          </div>
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+              MCP server
+            </span>
+            <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+              Header name
+            </span>
+            <span className={cn(COLUMN_LABEL_CLASS, 'min-w-0 flex-1')}>
+              Header override
+            </span>
+            <span className="w-8 shrink-0" />
+          </div>
+
+          {rows.map(({ group, header }) => (
+            <div key={header.id} className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-1 items-center">
+                  {group.matchLabels.length > 0 ? (
+                    <div className={cn(underlineClass, 'w-full')}>
+                      <span className="text-fg-secondary min-w-0 truncate text-sm">
+                        {describeScope(group)}
+                      </span>
+                    </div>
+                  ) : (
+                    <McpServerSelect
+                      id={`mcp-${header.id}-server`}
+                      serverNames={serverNames}
+                      value={header.serverName}
+                      disabled={disabled}
+                      onChange={serverName =>
+                        updateHeader(group.id, header.id, { serverName })
+                      }
+                    />
+                  )}
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-center">
+                  <HeaderNameField
+                    id={`mcp-${header.id}-name`}
+                    value={header.name}
+                    suggestions={declaredNamesFor(header)}
+                    disabled={disabled}
+                    onChange={name =>
+                      updateHeader(group.id, header.id, { name })
+                    }
+                    className="w-full"
+                  />
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-center">
+                  {isAdvanced(header) ? (
+                    <Select
+                      items={SOURCE_ITEMS}
+                      value={header.source}
+                      onValueChange={value =>
+                        updateHeader(group.id, header.id, {
+                          source: String(value) as McpHeaderSource,
+                        })
+                      }
+                      disabled={disabled}>
+                      <SelectTrigger
+                        id={`mcp-${header.id}-source`}
+                        aria-label="Header override"
+                        className={cn(GHOST_TRIGGER, 'h-10 w-full min-w-0')}>
+                        <SelectValue placeholder="Select source" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-fill-onsurface-ui-2">
+                        {SOURCE_ITEMS.map(item => (
+                          <SelectItem key={item.value} value={item.value}>
+                            <SelectItemText>{item.label}</SelectItemText>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <HeaderOverrideSelect
+                      hideLabel
+                      id={`mcp-${header.id}-override`}
+                      options={options}
+                      loaded={secretsLoaded}
+                      secretName={header.secretName}
+                      secretKey={header.secretKey}
+                      disabled={disabled}
+                      onSelectSecret={(secretName, secretKey) =>
+                        updateHeader(group.id, header.id, {
+                          source: 'secretKeyRef',
+                          secretName,
+                          secretKey,
+                        })
+                      }
+                      onSelectAdvanced={() => revealAdvanced(header.id)}
+                      className="w-full"
+                    />
+                  )}
+                </div>
+
+                <div className="flex h-10 w-8 shrink-0 items-center justify-center border-b border-white/[0.16]">
+                  <button
+                    type="button"
+                    onClick={() => removeHeader(group.id, header.id)}
+                    disabled={disabled}
+                    aria-label="Remove header override"
+                    className="text-fg-secondary hover:text-status-error transition-colors disabled:cursor-not-allowed disabled:opacity-50">
+                    <Trash className="size-4" />
+                  </button>
+                </div>
+              </div>
+
+              {isAdvanced(header) && (
+                <div className="grid grid-cols-2 items-start gap-3">
+                  {renderValueFields(group, header)}
+                </div>
+              )}
+            </div>
+          ))}
+
+          <div className="flex items-center justify-between gap-3 pt-1">
+            <span className="text-fg-tertiary text-xs">
+              Ark applies header overrides to every MCP server unless the rule
+              is narrowed by labels.
+            </span>
+            <NamespacedLink
+              href="/secrets"
+              className="text-fg-secondary inline-flex items-center gap-1 text-xs underline underline-offset-2 hover:opacity-80">
+              <IconShell size="sm">
+                <VpnKey />
+              </IconShell>
+              Create a secret
+            </NamespacedLink>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/components/ui/mcp-server-select.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/ui/mcp-server-select.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import {
+  GHOST_TRIGGER,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import {
+  ALL_MCP_SERVERS_LABEL,
+  ALL_MCP_SERVERS_VALUE,
+} from '@/lib/utils/mcp-header-overrides';
+
+export interface McpServerSelectProps {
+  readonly id: string;
+  readonly serverNames: string[];
+  readonly value?: string;
+  readonly disabled?: boolean;
+  readonly onChange: (serverName: string | undefined) => void;
+  readonly className?: string;
+}
+
+export function McpServerSelect({
+  id,
+  serverNames,
+  value,
+  disabled,
+  onChange,
+  className,
+}: McpServerSelectProps) {
+  const items = useMemo(() => {
+    const names = new Set(serverNames);
+    if (value) names.add(value);
+
+    return [
+      { value: ALL_MCP_SERVERS_VALUE, label: ALL_MCP_SERVERS_LABEL },
+      ...Array.from(names)
+        .sort((a, b) => a.localeCompare(b))
+        .map(name => ({ value: name, label: name })),
+    ];
+  }, [serverNames, value]);
+
+  return (
+    <Select
+      items={items}
+      value={value ?? ALL_MCP_SERVERS_VALUE}
+      onValueChange={next => {
+        const selected = String(next);
+        onChange(selected === ALL_MCP_SERVERS_VALUE ? undefined : selected);
+      }}
+      disabled={disabled}>
+      <SelectTrigger
+        id={id}
+        aria-label="MCP server"
+        className={cn(GHOST_TRIGGER, 'h-10 w-full min-w-0', className)}>
+        <SelectValue placeholder={ALL_MCP_SERVERS_LABEL} />
+      </SelectTrigger>
+      <SelectContent className="bg-fill-onsurface-ui-2">
+        {items.map(item => (
+          <SelectItem key={item.value} value={item.value}>
+            <SelectItemText>{item.label}</SelectItemText>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-chat-session.ts
@@ -23,9 +23,10 @@ import {
   type TeamAgentParameters,
   useAgentQueryParameters,
 } from '@/lib/hooks/use-agent-query-parameters';
+import { useQueryMcpHeaders } from '@/lib/hooks/use-query-mcp-headers';
 import { useStickyScroll } from '@/lib/hooks/use-sticky-scroll';
 import { chatService } from '@/lib/services';
-import type { ChatResponse } from '@/lib/services/chat';
+import type { ChatResponse, QueryOverride } from '@/lib/services/chat';
 import type {
   ArkExtendedChunk,
   ExtendedChatMessage,
@@ -316,6 +317,8 @@ export function useChatSession({
     toApiParameters,
   } = useAgentQueryParameters(name, type);
 
+  const mcpHeaders = useQueryMcpHeaders(name, type);
+
   useEffect(() => {
     return () => {
       if (stopPollingRef.current) {
@@ -348,7 +351,11 @@ export function useChatSession({
   } | null>(null);
 
   const handleStreamChatResponse = useCallback(
-    async (userMessage: string, apiParameters?: ApiQueryParameter[]) => {
+    async (
+      userMessage: string,
+      apiParameters?: ApiQueryParameter[],
+      apiOverrides?: QueryOverride[],
+    ) => {
       chatStreamAbortControllerRef.current = new AbortController();
 
       const messageArray = buildChatMessages(chatMessages, userMessage);
@@ -429,6 +436,7 @@ export function useChatSession({
           queryTimeout,
           chatStreamAbortControllerRef.current.signal,
           apiParameters,
+          apiOverrides,
         );
 
       queryName = streamQueryName;
@@ -809,7 +817,11 @@ export function useChatSession({
   );
 
   const handlePollChatResponse = useCallback(
-    async (userMessage: string, apiParameters?: ApiQueryParameter[]) => {
+    async (
+      userMessage: string,
+      apiParameters?: ApiQueryParameter[],
+      apiOverrides?: QueryOverride[],
+    ) => {
       const messageArray = buildChatMessages(chatMessages, userMessage);
 
       const query = await chatService.submitChatQuery(
@@ -821,6 +833,7 @@ export function useChatSession({
         undefined,
         queryTimeout,
         apiParameters,
+        apiOverrides,
       );
 
       lastQueryName.current = query.name;
@@ -981,6 +994,7 @@ export function useChatSession({
       }
 
       const apiParameters = toApiParameters();
+      const apiOverrides = mcpHeaders.toApiOverrides();
 
       trackEvent({
         name: 'chat_message_sent',
@@ -1001,10 +1015,18 @@ export function useChatSession({
 
       try {
         if (isChatStreamingEnabled) {
-          await handleStreamChatResponse(userMessage, apiParameters);
+          await handleStreamChatResponse(
+            userMessage,
+            apiParameters,
+            apiOverrides,
+          );
           await ensureConversationId();
         } else {
-          await handlePollChatResponse(userMessage, apiParameters);
+          await handlePollChatResponse(
+            userMessage,
+            apiParameters,
+            apiOverrides,
+          );
         }
       } catch (err) {
         console.error('Error sending message:', err);
@@ -1048,6 +1070,7 @@ export function useChatSession({
       name,
       resumeAutoScroll,
       toApiParameters,
+      mcpHeaders,
       type,
       updateChatMessages,
     ],
@@ -1241,5 +1264,6 @@ export function useChatSession({
     removeParameterRow,
     canAddParameterRow,
     missingParameters,
+    mcpHeaders,
   };
 }

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-mcp-secret-options.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-mcp-secret-options.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { secretsService } from '@/lib/services';
+
+export interface McpSecretOption {
+  value: string;
+  label: string;
+  secretName: string;
+  secretKey: string;
+}
+
+export interface UseMcpSecretOptionsResult {
+  options: McpSecretOption[];
+  secretNames: string[];
+  loaded: boolean;
+}
+
+interface SecretEntry {
+  name: string;
+  keys: string[];
+}
+
+const USABLE_SECRET_TYPE = 'Opaque';
+
+export function secretOptionValue(
+  secretName: string,
+  secretKey: string,
+): string {
+  return `${secretName}/${secretKey}`;
+}
+
+export function useMcpSecretOptions(
+  enabled: boolean = true,
+): UseMcpSecretOptionsResult {
+  const [entries, setEntries] = useState<SecretEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || loaded) return;
+
+    let cancelled = false;
+
+    secretsService
+      .getAll()
+      .then(secrets =>
+        Promise.all(
+          secrets.map(async secret => {
+            try {
+              const detail = await secretsService.get(secret.name);
+              return {
+                name: secret.name,
+                keys: detail.type === USABLE_SECRET_TYPE ? (detail.keys ?? []) : [],
+              };
+            } catch {
+              return { name: secret.name, keys: [] };
+            }
+          }),
+        ),
+      )
+      .then(result => {
+        if (!cancelled) setEntries(result.filter(entry => entry.keys.length > 0));
+      })
+      .catch(() => {
+        if (!cancelled) setEntries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, loaded]);
+
+  const options = useMemo(
+    () =>
+      entries.flatMap(entry =>
+        entry.keys.map(key => ({
+          value: secretOptionValue(entry.name, key),
+          label: `${entry.name} · ${key}`,
+          secretName: entry.name,
+          secretKey: key,
+        })),
+      ),
+    [entries],
+  );
+
+  const secretNames = useMemo(
+    () => entries.map(entry => entry.name),
+    [entries],
+  );
+
+  return { options, secretNames, loaded };
+}

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-mcp-server-headers.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-mcp-server-headers.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { mcpServersService } from '@/lib/services';
+
+export interface UseMcpServerHeadersResult {
+  headerNamesByServer: Record<string, string[]>;
+  allHeaderNames: string[];
+  loaded: boolean;
+}
+
+export function useMcpServerHeaders(
+  serverNames: string[],
+  enabled: boolean = true,
+): UseMcpServerHeadersResult {
+  const serverKey = useMemo(
+    () => Array.from(new Set(serverNames)).sort().join(','),
+    [serverNames],
+  );
+
+  const [headerNamesByServer, setHeaderNamesByServer] = useState<
+    Record<string, string[]>
+  >({});
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const names = serverKey ? serverKey.split(',') : [];
+    if (names.length === 0) {
+      setHeaderNamesByServer({});
+      setLoaded(true);
+      return;
+    }
+
+    let cancelled = false;
+    setLoaded(false);
+
+    Promise.all(
+      names.map(async (name): Promise<[string, string[]]> => {
+        try {
+          const detail = await mcpServersService.get(name);
+          const headers = detail?.headers ?? [];
+          return [name, headers.map(header => header.name)];
+        } catch {
+          return [name, []];
+        }
+      }),
+    )
+      .then(entries => {
+        if (!cancelled) setHeaderNamesByServer(Object.fromEntries(entries));
+      })
+      .catch(() => {
+        if (!cancelled) setHeaderNamesByServer({});
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [serverKey, enabled]);
+
+  const allHeaderNames = useMemo(() => {
+    const merged = new Set<string>();
+    for (const names of Object.values(headerNamesByServer)) {
+      for (const name of names) merged.add(name);
+    }
+    return Array.from(merged).sort((a, b) => a.localeCompare(b));
+  }, [headerNamesByServer]);
+
+  return { headerNamesByServer, allHeaderNames, loaded };
+}

--- a/services/ark-dashboard/ark-dashboard/lib/hooks/use-query-mcp-headers.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/hooks/use-query-mcp-headers.ts
@@ -1,0 +1,160 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { components } from '@/lib/api/generated/types';
+import { agentsService, toolsService } from '@/lib/services';
+import {
+  type McpHeaderRow,
+  type McpOverrideGroup,
+  createHeaderRow,
+  describeScope,
+  groupsToOverrides,
+  mcpServerNamesFromTools,
+  overridesToGroups,
+} from '@/lib/utils/mcp-header-overrides';
+
+type AgentOverride = components['schemas']['AgentOverride'];
+
+export interface AgentHeaderSummary {
+  id: string;
+  name: string;
+  scope: string;
+  sourceLabel: string;
+  shadowed: boolean;
+}
+
+export interface UseQueryMcpHeadersResult {
+  agentHeaders: AgentHeaderSummary[];
+  queryRows: McpHeaderRow[];
+  serverNames: string[];
+  hasAnything: boolean;
+  addRow: () => void;
+  updateRow: (id: string, updates: Partial<McpHeaderRow>) => void;
+  removeRow: (id: string) => void;
+  reset: () => void;
+  toApiOverrides: () => AgentOverride[] | undefined;
+}
+
+function describeSource(row: McpHeaderRow): string {
+  switch (row.source) {
+    case 'secretKeyRef':
+      return row.secretName && row.secretKey
+        ? `${row.secretName}/${row.secretKey}`
+        : 'secret';
+    case 'configMapKeyRef':
+      return row.configMapName && row.configMapKey
+        ? `${row.configMapName}/${row.configMapKey}`
+        : 'configMap';
+    case 'queryParameterRef':
+      return row.queryParameterName
+        ? `parameter ${row.queryParameterName}`
+        : 'query parameter';
+    default:
+      return row.value ? 'value set' : 'no value';
+  }
+}
+
+export function useQueryMcpHeaders(
+  name: string,
+  type: string,
+): UseQueryMcpHeadersResult {
+  const [agentGroups, setAgentGroups] = useState<McpOverrideGroup[]>([]);
+  const [queryRows, setQueryRows] = useState<McpHeaderRow[]>([]);
+  const [serverNames, setServerNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (type !== 'agent' || !name) {
+      setAgentGroups([]);
+      setServerNames([]);
+      return;
+    }
+
+    let cancelled = false;
+    Promise.all([
+      agentsService.getByName(name),
+      toolsService.getAll().catch(() => []),
+    ])
+      .then(([agent, tools]) => {
+        if (cancelled) return;
+        setAgentGroups(overridesToGroups(agent?.overrides));
+
+        const agentToolNames = new Set(
+          (agent?.tools ?? []).map(tool => tool.name),
+        );
+        setServerNames(
+          mcpServerNamesFromTools(
+            tools.filter(tool => agentToolNames.has(tool.name)),
+          ),
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setAgentGroups([]);
+        setServerNames([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [name, type]);
+
+  const queryNames = useMemo(
+    () =>
+      new Set(
+        queryRows
+          .map(row => row.name.trim().toLowerCase())
+          .filter(rowName => rowName.length > 0),
+      ),
+    [queryRows],
+  );
+
+  const agentHeaders = useMemo<AgentHeaderSummary[]>(
+    () =>
+      agentGroups.flatMap(group =>
+        group.headers.map(header => ({
+          id: header.id,
+          name: header.name,
+          scope: describeScope(group),
+          sourceLabel: describeSource(header),
+          shadowed: queryNames.has(header.name.trim().toLowerCase()),
+        })),
+      ),
+    [agentGroups, queryNames],
+  );
+
+  const addRow = useCallback(() => {
+    setQueryRows(prev => [...prev, createHeaderRow('secretKeyRef')]);
+  }, []);
+
+  const updateRow = useCallback((id: string, updates: Partial<McpHeaderRow>) => {
+    setQueryRows(prev =>
+      prev.map(row => (row.id === id ? { ...row, ...updates } : row)),
+    );
+  }, []);
+
+  const removeRow = useCallback((id: string) => {
+    setQueryRows(prev => prev.filter(row => row.id !== id));
+  }, []);
+
+  const reset = useCallback(() => setQueryRows([]), []);
+
+  const toApiOverrides = useCallback(() => {
+    const overrides = groupsToOverrides([
+      { id: 'query', matchLabels: [], headers: queryRows },
+    ]);
+    return overrides.length > 0 ? overrides : undefined;
+  }, [queryRows]);
+
+  return {
+    agentHeaders,
+    queryRows,
+    serverNames,
+    hasAnything: agentHeaders.length > 0 || queryRows.length > 0,
+    addRow,
+    updateRow,
+    removeRow,
+    reset,
+    toApiOverrides,
+  };
+}

--- a/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/services/chat.ts
@@ -14,6 +14,7 @@ interface AxiosError extends Error {
 }
 
 export type QueryParameter = components['schemas']['QueryParameter'];
+export type QueryOverride = components['schemas']['AgentOverride'];
 export type QueryResponse = components['schemas']['QueryResponse'];
 export type QueryDetailResponse = components['schemas']['QueryDetailResponse'];
 export type QueryListResponse = components['schemas']['QueryListResponse'];
@@ -213,6 +214,7 @@ export const chatService = {
     enableStreaming?: boolean,
     timeout?: string,
     parameters?: QueryParameter[],
+    overrides?: QueryOverride[],
   ): Promise<QueryDetailResponse> {
     const queryRequest: QueryCreateRequest = {
       name: `chat-query-${generateUUID()}`,
@@ -226,6 +228,7 @@ export const chatService = {
       conversationId,
       timeout,
       ...(parameters && parameters.length > 0 ? { parameters } : {}),
+      ...(overrides && overrides.length > 0 ? { overrides } : {}),
     };
 
     if (enableStreaming) {
@@ -405,6 +408,7 @@ export const chatService = {
     timeout?: string,
     abortSignal?: AbortSignal,
     parameters?: QueryParameter[],
+    overrides?: QueryOverride[],
   ): Promise<{
     queryName: string;
     chunks: AsyncGenerator<Record<string, unknown>, void, unknown>;
@@ -418,6 +422,7 @@ export const chatService = {
       true,
       timeout,
       parameters,
+      overrides,
     );
 
     const queryName = query.name;

--- a/services/ark-dashboard/ark-dashboard/lib/utils/groupToolsByLabels.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/utils/groupToolsByLabels.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '../services/tools';
+import { getMcpServerName } from './mcp-header-overrides';
 
 export const groupToolsByLabel = (tools: Tool[]) => {
   const groups: Record<string, { tools: Tool[]; isMcp: boolean }> = {};
@@ -19,16 +20,7 @@ export const groupToolsByLabel = (tools: Tool[]) => {
       isMcp = false;
     } else if (tool.type === 'mcp') {
       // For MCP tools, use the server name from labels
-      if (tool.labels && typeof tool.labels === 'object') {
-        const labels = tool.labels as Record<string, string>;
-        if (labels['mcp/server']) {
-          groupName = labels['mcp/server'];
-        } else {
-          groupName = 'MCP Tools';
-        }
-      } else {
-        groupName = 'MCP Tools';
-      }
+      groupName = getMcpServerName(tool) ?? 'MCP Tools';
       isMcp = true;
     }
 

--- a/services/ark-dashboard/ark-dashboard/lib/utils/mcp-header-overrides.ts
+++ b/services/ark-dashboard/ark-dashboard/lib/utils/mcp-header-overrides.ts
@@ -1,0 +1,318 @@
+'use client';
+
+import type { components } from '@/lib/api/generated/types';
+import type { Tool } from '@/lib/services/tools';
+import { generateUUID } from '@/lib/utils/uuid';
+
+type AgentOverride = components['schemas']['AgentOverride'];
+type AgentHeader = components['schemas']['AgentHeader'];
+
+export const MCP_RESOURCE_TYPE = 'mcpserver';
+
+export const MCP_SERVER_LABEL = 'mcp/server';
+
+export const ALL_MCP_SERVERS_LABEL = 'All MCP servers';
+
+export const ALL_MCP_SERVERS_VALUE = '__all_mcp_servers__';
+
+export type McpHeaderSource =
+  | 'secretKeyRef'
+  | 'value'
+  | 'queryParameterRef'
+  | 'configMapKeyRef';
+
+export interface McpHeaderRow {
+  id: string;
+  name: string;
+  source: McpHeaderSource;
+  value: string;
+  secretName: string;
+  secretKey: string;
+  configMapName: string;
+  configMapKey: string;
+  queryParameterName: string;
+  serverName?: string;
+}
+
+export interface McpLabelRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface McpOverrideGroup {
+  id: string;
+  matchLabels: McpLabelRow[];
+  headers: McpHeaderRow[];
+  serverName?: string;
+}
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'x-access-token',
+  'api-key',
+]);
+
+export function isSensitiveHeaderName(name: string): boolean {
+  return SENSITIVE_HEADER_NAMES.has(name.trim().toLowerCase());
+}
+
+export function createHeaderRow(
+  source: McpHeaderSource = 'secretKeyRef',
+  serverName?: string,
+): McpHeaderRow {
+  return {
+    id: generateUUID(),
+    name: '',
+    source,
+    value: '',
+    secretName: '',
+    secretKey: '',
+    configMapName: '',
+    configMapKey: '',
+    queryParameterName: '',
+    serverName,
+  };
+}
+
+export function createOverrideGroup(): McpOverrideGroup {
+  return {
+    id: generateUUID(),
+    matchLabels: [],
+    headers: [createHeaderRow()],
+  };
+}
+
+export function createServerGroup(serverName: string): McpOverrideGroup {
+  return {
+    id: generateUUID(),
+    matchLabels: [],
+    headers: [createHeaderRow('secretKeyRef', serverName)],
+    serverName,
+  };
+}
+
+export function isUnconfiguredHeaderRow(row: McpHeaderRow): boolean {
+  return (
+    !row.name.trim() &&
+    !row.value.trim() &&
+    !row.secretName.trim() &&
+    !row.secretKey.trim() &&
+    !row.configMapName.trim() &&
+    !row.configMapKey.trim() &&
+    !row.queryParameterName.trim()
+  );
+}
+
+function isLabelRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getMcpServerName(tool: Tool): string | null {
+  if (tool.type !== 'mcp' || !isLabelRecord(tool.labels)) return null;
+  const serverName = tool.labels[MCP_SERVER_LABEL];
+  return typeof serverName === 'string' && serverName.length > 0
+    ? serverName
+    : null;
+}
+
+export function mcpServerNamesFromTools(tools: Tool[]): string[] {
+  const names = new Set<string>();
+  for (const tool of tools) {
+    const serverName = getMcpServerName(tool);
+    if (serverName) names.add(serverName);
+  }
+  return Array.from(names).sort((a, b) => a.localeCompare(b));
+}
+
+export function reconcileServerGroups(
+  groups: McpOverrideGroup[],
+  serverNames: string[],
+): McpOverrideGroup[] {
+  const wanted = new Set(serverNames);
+
+  const kept = groups.filter(group => {
+    if (!group.serverName || wanted.has(group.serverName)) return true;
+    return !group.headers.every(isUnconfiguredHeaderRow);
+  });
+
+  const present = new Set(
+    kept
+      .map(group => group.serverName)
+      .filter((name): name is string => name !== undefined),
+  );
+
+  const added = serverNames
+    .filter(name => !present.has(name))
+    .map(createServerGroup);
+
+  if (added.length === 0 && kept.length === groups.length) return groups;
+  return [...kept, ...added];
+}
+
+export function describeScope(group: McpOverrideGroup): string {
+  const labels = group.matchLabels.filter(label => label.key.trim());
+  if (labels.length === 0) return ALL_MCP_SERVERS_LABEL;
+  return labels.map(label => `${label.key}=${label.value}`).join(', ');
+}
+
+export function addHeaderRow(groups: McpOverrideGroup[]): McpOverrideGroup[] {
+  const unscoped = groups.filter(
+    group => !group.serverName && group.matchLabels.length === 0,
+  );
+  const target = unscoped[unscoped.length - 1];
+
+  if (!target) return [...groups, createOverrideGroup()];
+
+  return groups.map(group =>
+    group.id === target.id
+      ? { ...group, headers: [...group.headers, createHeaderRow()] }
+      : group,
+  );
+}
+
+function headerToRow(header: AgentHeader): McpHeaderRow {
+  const row = createHeaderRow('value');
+  row.name = header.name;
+
+  const valueFrom = header.value?.valueFrom;
+  if (valueFrom?.secretKeyRef) {
+    row.source = 'secretKeyRef';
+    row.secretName = valueFrom.secretKeyRef.name;
+    row.secretKey = valueFrom.secretKeyRef.key;
+    return row;
+  }
+  if (valueFrom?.configMapKeyRef) {
+    row.source = 'configMapKeyRef';
+    row.configMapName = valueFrom.configMapKeyRef.name;
+    row.configMapKey = valueFrom.configMapKeyRef.key;
+    return row;
+  }
+  if (valueFrom?.queryParameterRef) {
+    row.source = 'queryParameterRef';
+    row.queryParameterName = valueFrom.queryParameterRef.name;
+    return row;
+  }
+
+  row.source = 'value';
+  row.value = header.value?.value ?? '';
+  return row;
+}
+
+function rowToHeader(row: McpHeaderRow): AgentHeader | null {
+  const name = row.name.trim();
+  if (!name) return null;
+
+  switch (row.source) {
+    case 'secretKeyRef': {
+      if (!row.secretName.trim() || !row.secretKey.trim()) return null;
+      return {
+        name,
+        value: {
+          valueFrom: {
+            secretKeyRef: {
+              name: row.secretName.trim(),
+              key: row.secretKey.trim(),
+            },
+          },
+        },
+      };
+    }
+    case 'configMapKeyRef': {
+      if (!row.configMapName.trim() || !row.configMapKey.trim()) return null;
+      return {
+        name,
+        value: {
+          valueFrom: {
+            configMapKeyRef: {
+              name: row.configMapName.trim(),
+              key: row.configMapKey.trim(),
+            },
+          },
+        },
+      };
+    }
+    case 'queryParameterRef': {
+      if (!row.queryParameterName.trim()) return null;
+      return {
+        name,
+        value: {
+          valueFrom: {
+            queryParameterRef: { name: row.queryParameterName.trim() },
+          },
+        },
+      };
+    }
+    default: {
+      if (!row.value) return null;
+      return { name, value: { value: row.value } };
+    }
+  }
+}
+
+export function overridesToGroups(
+  overrides: AgentOverride[] | null | undefined,
+): McpOverrideGroup[] {
+  if (!overrides) return [];
+
+  return overrides
+    .filter(override => override.resourceType === MCP_RESOURCE_TYPE)
+    .map(override => ({
+      id: generateUUID(),
+      matchLabels: Object.entries(
+        override.labelSelector?.matchLabels ?? {},
+      ).map(([key, value]) => ({ id: generateUUID(), key, value })),
+      headers: (override.headers ?? []).map(headerToRow),
+    }));
+}
+
+export function groupsToOverrides(
+  groups: McpOverrideGroup[],
+): AgentOverride[] {
+  return groups.reduce<AgentOverride[]>((acc, group) => {
+    const headers = group.headers
+      .map(rowToHeader)
+      .filter((header): header is AgentHeader => header !== null);
+
+    if (headers.length === 0) return acc;
+
+    const labels = group.matchLabels.filter(label => label.key.trim());
+    const override: AgentOverride = {
+      resourceType: MCP_RESOURCE_TYPE,
+      headers,
+    };
+
+    if (labels.length > 0) {
+      override.labelSelector = {
+        matchLabels: Object.fromEntries(
+          labels.map(label => [label.key.trim(), label.value.trim()]),
+        ),
+      };
+    }
+
+    acc.push(override);
+    return acc;
+  }, []);
+}
+
+export function countHeaders(groups: McpOverrideGroup[]): number {
+  return groups.reduce((total, group) => total + group.headers.length, 0);
+}
+
+export function overrideGroupsEqual(
+  a: McpOverrideGroup[],
+  b: McpOverrideGroup[],
+): boolean {
+  return (
+    JSON.stringify(groupsToOverrides(a)) === JSON.stringify(groupsToOverrides(b))
+  );
+}
+
+export function headerIdentity(group: McpOverrideGroup, name: string): string {
+  return `${describeScope(group)}::${name.trim().toLowerCase()}`;
+}


### PR DESCRIPTION
> # ⚠️ DESIGN ONLY — DO NOT MERGE
>
> Design only. The implementation is not optimised — when this is picked up, the
> dev team to rebuild the UI if needed.

## Summary

Design exploration for #2589. Dashboard only — no backend changes needed.

**Agent form — a "Header overrides" panel under Tools**

- Selecting an MCP-backed tool creates a card for that tool's server, read from the
  `mcp/server` label the MCPServer controller already stamps on every Tool.
  Deselecting removes the card only if nothing was typed into it.
- One dropdown lists every usable `secret · key` pair in the namespace. Picking one
  fills source, secret and key in a single click, replacing the old five-step path.
- A referenced secret missing from the namespace reports itself on the row.
- Plain values on sensitive header names (`Authorization`, `X-Api-Key`, `Cookie`, …)
  draw an inline warning pointing at secrets instead.
- Header-name field autocompletes from the headers each MCP server declares.
- Tools moved below the prompt so the two MCP blocks read as one column.

**Chat composer — the query wins, and you can see it**

An override set here applies to that one query only; the agent keeps its own value for
every other query.

- Collapsed, the disclosure reads `Header overrides · N effective`.
- Expanded, **From this agent** lists the agent's headers read-only with a lock.
  **This query only** holds the editable rows.
- A query row whose header name matches an agent row strikes that agent row through
  and marks it *overridden below*.
- `N effective` = unshadowed agent headers + query rows, i.e. exactly what reaches
  the server.
- Secrets and server headers are fetched only when the disclosure is open.

## No backend follow-up

Unlike the sessions work, this needs nothing from ark-api. `overrides` is already on
`AgentCreateRequest`, `AgentUpdateRequest` and `QueryCreateRequest` in the generated
types, and ark-api already persists it — `agents.py:172` and `queries.py:224`/`294`.
The YAML this emits is byte-identical to what you would hand-write today.

## Known limitation

`overridesToGroups` cannot recover which server a stored rule was authored against —
the CRD scopes by `labelSelector` only, and our MCPServer CRs carry no labels. So
`serverName` is UI scaffolding: reopening a saved agent shows stored rows as
*All MCP servers* until the tool-derived cards recompute alongside them. Genuine
per-server targeting needs labels on MCPServer CRs — a separate ticket.

## Notes for reviewers

- Lint, build and tests were deliberately not run on this branch. It is a design draft
  that must not merge; CI is the first signal.
- `package-lock.json`, `pyproject.toml` and the `uv.lock` files are untouched — local
  devspace churn, kept out of the commit.
- The sessions read-only changes from #3024 are also in my working tree and are
  deliberately **not** in this PR.
- No tests added for the new components, in keeping with design-only scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
