### PR TITLE
fix(controller): ignore spec.cancel on terminal queries

### DIFF
--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -209,7 +209,7 @@ func (r *QueryReconciler) handleFinalizer(ctx context.Context, obj *arkv1alpha1.
 }
 
 func (r *QueryReconciler) handleQueryExecution(ctx context.Context, req ctrl.Request, obj arkv1alpha1.Query) (ctrl.Result, error) {
-	if obj.Spec.Cancel && obj.Status.Phase != statusCanceled {
+	if obj.Spec.Cancel && !isTerminalPhase(obj.Status.Phase) {
 		r.cleanupExistingOperation(req.NamespacedName)
 		if err := r.updateStatus(ctx, &obj, statusCanceled); err != nil {
 			return ctrl.Result{}, err

--- a/ark/internal/controller/query_controller.go
+++ b/ark/internal/controller/query_controller.go
@@ -1088,6 +1088,9 @@ func (r *QueryReconciler) updateStatusWithDuration(ctx context.Context, query *a
 	// The executor needs the taskID to detect this is a resumption after approval
 	// and clears it after processing (handler.go).
 	return r.mutateStatus(ctx, query, func(q *arkv1alpha1.Query) bool {
+		if status == statusCanceled && isTerminalPhase(q.Status.Phase) {
+			return false
+		}
 		saved.restoreOnto(q)
 		q.Status.Phase = status
 		r.setConditionForPhase(q, status)

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -580,14 +580,18 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			refetched := &arkv1alpha1.Query{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: q.Name, Namespace: q.Namespace}, refetched)).To(Succeed())
 			terminalRV := refetched.ResourceVersion
-			terminalReason := findCompletedCondition(refetched).Reason
+			refetchedCond := findCompletedCondition(refetched)
+			Expect(refetchedCond).NotTo(BeNil())
+			terminalReason := refetchedCond.Reason
 
 			time.Sleep(20 * time.Millisecond)
 
 			after := reconcile(refetched)
 			Expect(after.Status.Phase).To(Equal(statusDone), "terminal phase must be preserved")
 			Expect(after.ResourceVersion).To(Equal(terminalRV), "no status write should have been issued on a terminal query")
-			Expect(findCompletedCondition(after).Reason).To(Equal(terminalReason), "condition reason must not be clobbered")
+			afterCond := findCompletedCondition(after)
+			Expect(afterCond).NotTo(BeNil())
+			Expect(afterCond.Reason).To(Equal(terminalReason), "condition reason must not be clobbered")
 		})
 	})
 
@@ -603,7 +607,8 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 		reconcile := func(q *arkv1alpha1.Query) *arkv1alpha1.Query {
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: q.Name, Namespace: q.Namespace}}
-			_, _ = r.handleQueryExecution(ctx, req, *q)
+			_, err := r.handleQueryExecution(ctx, req, *q)
+			Expect(err).NotTo(HaveOccurred())
 			out := &arkv1alpha1.Query{}
 			Expect(k8sClient.Get(ctx, req.NamespacedName, out)).To(Succeed())
 			return out
@@ -624,7 +629,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 
 				Expect(after.Status.Phase).To(Equal(phase), "terminal phase must be preserved")
 				Expect(after.ResourceVersion).To(Equal(terminalRV), "no status write should be issued when cancelling a terminal query")
-				Expect(findCompletedCondition(after).Reason).To(Equal(wantReason), "condition reason must not be clobbered to QueryCanceled")
+				afterCond := findCompletedCondition(after)
+				Expect(afterCond).NotTo(BeNil())
+				Expect(afterCond.Reason).To(Equal(wantReason), "condition reason must not be clobbered to QueryCanceled")
 			},
 			Entry("done stays done", "cancel-done", statusDone, "QuerySucceeded"),
 			Entry("error stays error", "cancel-error", statusError, "QueryErrored"),
@@ -654,7 +661,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Expect(after.ResourceVersion).To(Equal(terminalRV), "cancel must issue no status write once the refetch sees a terminal phase")
 			Expect(after.Status.Response).NotTo(BeNil())
 			Expect(after.Status.Response.Phase).To(Equal(statusDone), "the completed response must not be stranded under a canceled phase")
-			Expect(findCompletedCondition(after).Reason).To(Equal("QuerySucceeded"), "condition reason must not be clobbered to QueryCanceled")
+			afterCond := findCompletedCondition(after)
+			Expect(afterCond).NotTo(BeNil())
+			Expect(afterCond.Reason).To(Equal("QuerySucceeded"), "condition reason must not be clobbered to QueryCanceled")
 		})
 	})
 
@@ -686,7 +695,9 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			after := &arkv1alpha1.Query{}
 			Expect(k8sClient.Get(ctx, req.NamespacedName, after)).To(Succeed())
 			Expect(after.Status.Phase).To(Equal(statusCanceled), "a running query must transition to canceled")
-			Expect(findCompletedCondition(after).Reason).To(Equal("QueryCanceled"), "condition reason must reflect the cancel")
+			afterCond := findCompletedCondition(after)
+			Expect(afterCond).NotTo(BeNil())
+			Expect(afterCond.Reason).To(Equal("QueryCanceled"), "condition reason must reflect the cancel")
 
 			Expect(opCanceled).To(BeTrue(), "the in-flight operation's context must be canceled")
 			_, exists := r.operations.Load(req.NamespacedName)

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -591,6 +591,47 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 		})
 	})
 
+	Context("spec.cancel on a terminal query", func() {
+		var (
+			ctx context.Context
+			r   *QueryReconciler
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			r = &QueryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		})
+
+		reconcile := func(q *arkv1alpha1.Query) *arkv1alpha1.Query {
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: q.Name, Namespace: q.Namespace}}
+			_, _ = r.handleQueryExecution(ctx, req, *q)
+			out := &arkv1alpha1.Query{}
+			Expect(k8sClient.Get(ctx, req.NamespacedName, out)).To(Succeed())
+			return out
+		}
+
+		DescribeTable(
+			"cancel does not overwrite a terminal phase",
+			func(name, phase, wantReason string) {
+				q := newTimeoutQuery(name).seed(ctx, k8sClient, "")
+				Expect(r.updateStatus(ctx, q, phase)).To(Succeed())
+
+				refetched := &arkv1alpha1.Query{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: q.Name, Namespace: q.Namespace}, refetched)).To(Succeed())
+				terminalRV := refetched.ResourceVersion
+
+				refetched.Spec.Cancel = true
+				after := reconcile(refetched)
+
+				Expect(after.Status.Phase).To(Equal(phase), "terminal phase must be preserved")
+				Expect(after.ResourceVersion).To(Equal(terminalRV), "no status write should be issued when cancelling a terminal query")
+				Expect(findCompletedCondition(after).Reason).To(Equal(wantReason), "condition reason must not be clobbered to QueryCanceled")
+			},
+			Entry("done stays done", "cancel-done", statusDone, "QuerySucceeded"),
+			Entry("error stays error", "cancel-error", statusError, "QueryErrored"),
+			Entry("canceled stays canceled", "cancel-canceled", statusCanceled, "QueryCanceled"),
+		)
+	})
+
 	Context("safety-net requeue", func() {
 		It("arms a bounded requeue for an in-flight op without spawning a duplicate", func() {
 			r := &QueryReconciler{

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -658,6 +658,42 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 		})
 	})
 
+	Context("spec.cancel on a running query", func() {
+		var (
+			ctx context.Context
+			r   *QueryReconciler
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			r = &QueryReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		})
+
+		It("cancels a running query and tears down its in-flight operation", func() {
+			q := newTimeoutQuery("cancel-running").seed(ctx, k8sClient, "")
+			Expect(r.updateStatus(ctx, q, statusRunning)).To(Succeed())
+
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: q.Name, Namespace: q.Namespace}}
+			opCanceled := false
+			r.operations.Store(req.NamespacedName, context.CancelFunc(func() { opCanceled = true }))
+
+			refetched := &arkv1alpha1.Query{}
+			Expect(k8sClient.Get(ctx, req.NamespacedName, refetched)).To(Succeed())
+			refetched.Spec.Cancel = true
+
+			_, err := r.handleQueryExecution(ctx, req, *refetched)
+			Expect(err).NotTo(HaveOccurred())
+
+			after := &arkv1alpha1.Query{}
+			Expect(k8sClient.Get(ctx, req.NamespacedName, after)).To(Succeed())
+			Expect(after.Status.Phase).To(Equal(statusCanceled), "a running query must transition to canceled")
+			Expect(findCompletedCondition(after).Reason).To(Equal("QueryCanceled"), "condition reason must reflect the cancel")
+
+			Expect(opCanceled).To(BeTrue(), "the in-flight operation's context must be canceled")
+			_, exists := r.operations.Load(req.NamespacedName)
+			Expect(exists).To(BeFalse(), "the tracked operation must be removed on cancel")
+		})
+	})
+
 	Context("safety-net requeue", func() {
 		It("arms a bounded requeue for an in-flight op without spawning a duplicate", func() {
 			r := &QueryReconciler{

--- a/ark/internal/controller/query_controller_test.go
+++ b/ark/internal/controller/query_controller_test.go
@@ -630,6 +630,32 @@ var _ = Describe("Query Controller handleRunningPhase", func() {
 			Entry("error stays error", "cancel-error", statusError, "QueryErrored"),
 			Entry("canceled stays canceled", "cancel-canceled", statusCanceled, "QueryCanceled"),
 		)
+
+		It("does not clobber a query that reached done after the reconcile snapshot was taken", func() {
+			q := newTimeoutQuery("cancel-refetch-race").seed(ctx, k8sClient, "")
+			q.Status.Response = &arkv1alpha1.Response{
+				Target:  arkv1alpha1.QueryTarget{Type: "agent", Name: "test-agent"},
+				Content: "the completed answer",
+				Phase:   statusDone,
+			}
+			Expect(r.updateStatus(ctx, q, statusDone)).To(Succeed())
+
+			persisted := &arkv1alpha1.Query{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: q.Name, Namespace: q.Namespace}, persisted)).To(Succeed())
+			terminalRV := persisted.ResourceVersion
+
+			staleSnapshot := persisted.DeepCopy()
+			staleSnapshot.Status.Phase = statusRunning
+			staleSnapshot.Spec.Cancel = true
+
+			after := reconcile(staleSnapshot)
+
+			Expect(after.Status.Phase).To(Equal(statusDone), "refetched terminal phase must win over the stale running snapshot")
+			Expect(after.ResourceVersion).To(Equal(terminalRV), "cancel must issue no status write once the refetch sees a terminal phase")
+			Expect(after.Status.Response).NotTo(BeNil())
+			Expect(after.Status.Response.Phase).To(Equal(statusDone), "the completed response must not be stranded under a canceled phase")
+			Expect(findCompletedCondition(after).Reason).To(Equal("QuerySucceeded"), "condition reason must not be clobbered to QueryCanceled")
+		})
 	})
 
 	Context("safety-net requeue", func() {


### PR DESCRIPTION
## Summary
- Setting `spec.cancel = true` on a Query that had already reached a terminal phase (`done`/`error`) overwrote `status.phase` to `canceled` while leaving the original response intact, producing an internally inconsistent status (`phase: canceled` + `response.phase: done`, condition reason flipped to `QueryCanceled`).
- Gate the cancel branch in `handleQueryExecution` on `!isTerminalPhase(...)` instead of `!= statusCanceled`, so `spec.cancel` is a no-op once a Query is `done`, `error`, or `canceled` in the reconcile snapshot.
- Close the TOCTOU race the snapshot guard alone leaves open: the guard checks the reconcile's (possibly stale) phase, but `updateStatusWithDuration` refetches inside `mutateStatus` and wrote `canceled` unconditionally. When `executeQueryAsync` persists a terminal phase *after* the snapshot was taken, cancel still clobbered it. The cancel write now declines on the refetched object (`return false` when already terminal), mirroring the existing `failQueryOnTimeout` pattern.
- Tests: a `DescribeTable` asserting cancel preserves the terminal phase (no status write, condition reason intact) for `done`/`error`/`canceled`, plus a test driving the refetch race with a stale `running` snapshot to prove the mutator-level guard.

Fixes #2673