### PR TITLE
fix: use info icon for engine tool chat notice

### DIFF
--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/chat-panel.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/chat/chat-panel.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatPanel } from '@/components/chat/chat-panel';
+import { useChatSession } from '@/lib/hooks';
+
+vi.mock('@/lib/hooks', () => ({
+  useChatSession: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics/singleton', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@/components/icons', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/components/icons')>();
+  return {
+    ...actual,
+    Info: () => <svg data-testid="info-icon" />,
+    Warning: () => <svg data-testid="warning-icon" />,
+  };
+});
+
+type ChatSession = ReturnType<typeof useChatSession>;
+
+function chatSession(overrides: Partial<ChatSession> = {}): ChatSession {
+  return {
+    messages: [],
+    sessionId: 'session-1',
+    isProcessing: false,
+    isWaitingForApprovalResponse: false,
+    error: null,
+    sendMessage: vi.fn(async () => {}),
+    clearChat: vi.fn(),
+    messagesEndRef: { current: null },
+    scrollContainerRef: { current: null },
+    handleScroll: vi.fn(),
+    cancelQuery: vi.fn(),
+    pollAfterApproval: vi.fn(async () => {}),
+    parameterVariant: 'agent',
+    hasParameters: false,
+    availableParameters: [],
+    teamAgents: [],
+    parameterRows: [],
+    addParameterRow: vi.fn(),
+    setParameterRowName: vi.fn(),
+    setParameterRowValue: vi.fn(),
+    setParameterRowAgent: vi.fn(),
+    removeParameterRow: vi.fn(),
+    canAddParameterRow: false,
+    missingParameters: [],
+    engineToolWarning: null,
+    ...overrides,
+  };
+}
+
+function renderChatPanel(overrides: Partial<ChatSession> = {}) {
+  vi.mocked(useChatSession).mockReturnValue(chatSession(overrides));
+  return render(<ChatPanel name="test-agent" type="agent" />);
+}
+
+const ENGINE_TOOL_WARNING =
+  'executor-claude-agent-sdk will not receive: get-coordinates (http)';
+
+describe('ChatPanel engine tool notice', () => {
+  it('renders the engine tool notice when the session reports one', () => {
+    renderChatPanel({ engineToolWarning: ENGINE_TOOL_WARNING });
+
+    expect(screen.getByText(ENGINE_TOOL_WARNING)).toBeInTheDocument();
+  });
+
+  it('presents the notice as information rather than a warning', () => {
+    renderChatPanel({ engineToolWarning: ENGINE_TOOL_WARNING });
+
+    expect(screen.queryByTestId('warning-icon')).not.toBeInTheDocument();
+
+    const iconShell = screen.getByTestId('info-icon').parentElement;
+    expect(iconShell).toHaveClass('text-status-information');
+    expect(iconShell).not.toHaveClass('text-status-warning');
+  });
+
+  it('renders no notice when the session reports no engine tool warning', () => {
+    renderChatPanel({ engineToolWarning: null });
+
+    expect(screen.queryByTestId('info-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('warning-icon')).not.toBeInTheDocument();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { ChatMessageList } from '@/components/chat/chat-message-list';
 import { ChatNotice } from '@/components/chat/chat-notice';
-import { Autorenew, Build, Info, Send, Stop, Warning } from '@/components/icons';
+import { Autorenew, Build, Info, Send, Stop } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { ChatParameterFields } from '@/components/ui/chat-parameter-fields';
 import { IconShell } from '@/components/ui/icon-shell';
@@ -114,7 +114,7 @@ export function ChatPanel({
         className="h-0 min-h-0 flex-1">
         <div className="space-y-4 p-4">
           {engineToolWarning && (
-            <ChatNotice icon={<Warning />} iconClassName="text-status-warning">
+            <ChatNotice icon={<Info />} iconClassName="text-status-information">
               {engineToolWarning}
             </ChatNotice>
           )}


### PR DESCRIPTION
fix: use info icon for engine tool chat notice

<img width="875" height="520" alt="image" src="https://github.com/user-attachments/assets/0fcfe054-99b9-47b8-ac9f-1032eec8a350" />

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [x] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [x] Update `./docs`
- [x] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 