### PR TITLE
docs: surface authentication and tenancy guides under Operate ARK

### DIFF
--- a/docs/content/how-to-guides/_meta.js
+++ b/docs/content/how-to-guides/_meta.js
@@ -80,6 +80,10 @@ export default {
     title: 'Deploy ARK',
     href: '/operations-guide/deploying-ark'
   },
+  authentication: {
+    title: 'Configure authentication and SSO',
+    href: '/developer-guide/authentication'
+  },
   'multi-tenant-dashboard': {
     title: 'Host the dashboard for multiple namespaces',
     href: '/operations-guide/multi-tenant-dashboard-hosting'

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -39,5 +39,7 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 ### Platform operations (day-2 and runtime)
 - [Deploy ARK](/operations-guide/deploying-ark).
 - [Configure authentication and SSO](/developer-guide/authentication).
+- [Host the dashboard for multiple namespaces](/operations-guide/multi-tenant-dashboard-hosting).
+- [Manage tenants and namespaces](/operations-guide/tenant-namespace-management).
 - [Marketplace](/operations-guide/marketplace).
 - [Cloud deployments](/operations-guide/provisioning).

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -38,5 +38,6 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 
 ### Platform operations (day-2 and runtime)
 - [Deploy ARK](/operations-guide/deploying-ark).
+- [Configure authentication and SSO](/developer-guide/authentication).
 - [Marketplace](/operations-guide/marketplace).
 - [Cloud deployments](/operations-guide/provisioning).


### PR DESCRIPTION
## Summary
- Add the authentication guide to the How-to Guides tree under the **Operate ARK (operators / SRE)** separator, pointing at `/developer-guide/authentication`
- Link the two operate pages that were in `_meta.js` but missing from the How-to Guides overview: multi-tenant dashboard hosting and tenant/namespace management

The authentication page already existed but `developer-guide/` is a hidden legacy folder, so the page was unreachable from the visible nav. This follows the existing convention of surfacing hidden-folder pages via `href` entries.