### PR TITLE
docs: add six unreferenced operations pages to the Operate ARK nav

### DIFF
--- a/docs/content/how-to-guides/_meta.js
+++ b/docs/content/how-to-guides/_meta.js
@@ -92,6 +92,18 @@ export default {
     title: 'Manage tenants and namespaces',
     href: '/operations-guide/tenant-namespace-management'
   },
+  'postgres-storage': {
+    title: 'Use the PostgreSQL storage backend',
+    href: '/operations-guide/postgres-storage-backend'
+  },
+  monitoring: {
+    title: 'Monitor with Prometheus and Grafana',
+    href: '/operations-guide/monitoring'
+  },
+  'disaster-recovery': {
+    title: 'Back up and recover Ark',
+    href: '/operations-guide/disaster-recovery'
+  },
   'operate-marketplace': {
     title: 'Marketplace',
     href: '/operations-guide/marketplace'
@@ -99,6 +111,22 @@ export default {
   provisioning: {
     title: 'Cloud deployments',
     href: '/operations-guide/provisioning'
+  },
+
+  '---operate-integrations': { type: 'separator', title: 'Integrations' },
+  'mcp-oauth-callback': {
+    title: 'Configure the MCP OAuth callback',
+    href: '/operations-guide/mcp-oauth-callback'
+  },
+
+  '---operate-security': { type: 'separator', title: 'Security and assurance' },
+  'audit-trail': {
+    title: 'Audit who changed a resource',
+    href: '/operations-guide/audit-trail'
+  },
+  'model-url-security': {
+    title: 'Secure model base URLs',
+    href: '/operations-guide/model-url-security'
   }
 }
 

--- a/docs/content/how-to-guides/_meta.js
+++ b/docs/content/how-to-guides/_meta.js
@@ -80,6 +80,10 @@ export default {
     title: 'Deploy ARK',
     href: '/operations-guide/deploying-ark'
   },
+  authentication: {
+    title: 'Configure authentication and SSO',
+    href: '/developer-guide/authentication'
+  },
   'multi-tenant-dashboard': {
     title: 'Host the dashboard for multiple namespaces',
     href: '/operations-guide/multi-tenant-dashboard-hosting'

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -41,5 +41,15 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 - [Configure authentication and SSO](/developer-guide/authentication).
 - [Host the dashboard for multiple namespaces](/operations-guide/multi-tenant-dashboard-hosting).
 - [Manage tenants and namespaces](/operations-guide/tenant-namespace-management).
+- [Use the PostgreSQL storage backend](/operations-guide/postgres-storage-backend).
+- [Monitor with Prometheus and Grafana](/operations-guide/monitoring).
+- [Back up and recover Ark](/operations-guide/disaster-recovery).
 - [Marketplace](/operations-guide/marketplace).
 - [Cloud deployments](/operations-guide/provisioning).
+
+### Integrations
+- [Configure the MCP OAuth callback](/operations-guide/mcp-oauth-callback).
+
+### Security and assurance
+- [Audit who changed a resource](/operations-guide/audit-trail).
+- [Secure model base URLs](/operations-guide/model-url-security).

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -39,5 +39,7 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 ### Platform operations (day-2 and runtime)
 - [Deploy ARK](/operations-guide/deploying-ark).
 - [Configure authentication and SSO](/developer-guide/authentication).
+- [Host the dashboard for multiple namespaces](/operations-guide/multi-tenant-dashboard-hosting).
+- [Manage tenants and namespaces](/operations-guide/tenant-namespace-management).
 - [Marketplace](/operations-guide/marketplace).
 - [Cloud deployments](/operations-guide/provisioning).

--- a/docs/content/how-to-guides/index.mdx
+++ b/docs/content/how-to-guides/index.mdx
@@ -38,5 +38,6 @@ How-to guides help you complete **specific tasks**. Pick the task that matches w
 
 ### Platform operations (day-2 and runtime)
 - [Deploy ARK](/operations-guide/deploying-ark).
+- [Configure authentication and SSO](/developer-guide/authentication).
 - [Marketplace](/operations-guide/marketplace).
 - [Cloud deployments](/operations-guide/provisioning).


### PR DESCRIPTION
## Summary
- Add six `operations-guide/` pages that had no entry in any visible nav section to the How-to Guides tree under Operate ARK
- Group them following the existing `operations-guide/_meta.js` structure, adding `Integrations` and `Security and assurance` separators alongside the existing platform-operations list
- Mirror the same entries in the How-to Guides overview page

Pages added:

| Page | Nav title | Group |
| --- | --- | --- |
| `postgres-storage-backend` | Use the PostgreSQL storage backend | Platform operations |
| `monitoring` | Monitor with Prometheus and Grafana | Platform operations |
| `disaster-recovery` | Back up and recover Ark | Platform operations |
| `mcp-oauth-callback` | Configure the MCP OAuth callback | Integrations |
| `audit-trail` | Audit who changed a resource | Security and assurance |
| `model-url-security` | Secure model base URLs | Security and assurance |

`technical-debt-and-upcoming-refactoring` is deliberately left out — it is not a how-to and does not belong in this tree.

Note this is stacked on #3403; the base will retarget to `main` once that merges.