### PR TITLE
fix: Bump xmldom to fix CVE

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2808,9 +2808,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
-      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,7 @@
     "minimatch": "^10.2.3",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
-    "@xmldom/xmldom": "0.9.11",
+    "@xmldom/xmldom": "0.9.12",
     "speech-rule-engine": "4.1.4",
     "uuid": "^14.0.0",
     "lodash-es": "4.18.1",


### PR DESCRIPTION
The docs site pins @xmldom/xmldom via an npm override (it is a transitive dependency of speech-rule-engine). The pinned 0.9.11 is affected by a set of high-severity DoS and XML-injection advisories; bump the override to 0.9.12, the fixed version.

Resolves CVE-2026-83608, CVE-2026-83609, CVE-2026-83612, CVE-2026-83613, CVE-2026-83614, CVE-2026-83615, CVE-2026-83616, CVE-2026-83617, CVE-2026-83618

Fixes #3408 

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 