### PR TITLE
fix(charts): add pg_isready startup, liveness and readiness probes to ark-storage-dev

### DIFF
--- a/charts/ark-storage-dev/templates/deployment.yaml
+++ b/charts/ark-storage-dev/templates/deployment.yaml
@@ -67,6 +67,24 @@ spec:
                   key: password
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
+          startupProbe:
+            exec:
+              command: [pg_isready, -h, 127.0.0.1, -U, {{ .Values.user | quote }}, -d, {{ .Values.database | quote }}]
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 60
+          livenessProbe:
+            exec:
+              command: [pg_isready, -h, 127.0.0.1, -U, {{ .Values.user | quote }}, -d, {{ .Values.database | quote }}]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command: [pg_isready, -h, 127.0.0.1, -U, {{ .Values.user | quote }}, -d, {{ .Values.database | quote }}]
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Problem

`charts/ark-storage-dev` declares no probes on the `postgresql` container, so the pod is Ready the moment the process starts. The official `postgres` image runs an init cycle on an empty data directory (initdb → temporary server → shutdown → real server) and only binds port 5432 at the very end. Everything that gates on pod readiness — `setup-e2e/setup-local.sh`'s `kubectl wait --for=condition=ready`, the postgresql integration lane's `helm --wait` — proceeds into that window, and ark-apiserver dies with `connection refused`, taking ark-controller and ark-completions through a restart each while the `v1alpha1.ark.mckinsey.com` APIService is unavailable. Details and the observed restart sequence are in #3392.

## Fix

Startup, liveness and readiness probes, all `pg_isready -h 127.0.0.1 -U <user> -d <database>`.

Two deliberate choices:

- **`-h 127.0.0.1`, not the socket default.** The entrypoint starts the init-time temporary server with `-c listen_addresses=''` (`docker-entrypoint.sh:297` in `postgres:16-alpine`), so it is reachable only over the Unix socket. A socket-default `pg_isready` would return 0 during that ~100 ms window; probing loopback TCP only succeeds once the final server is up. It also keeps the probe from producing `FATAL: the database system is shutting down` noise in the container log during init.
- **`startupProbe` gates liveness** instead of an `initialDelaySeconds`, matching the other charts. The thresholds are sized for a stateful container rather than copied from the HTTP services: `pg_isready` answers *rejecting connections* (rc 1) for the whole crash-recovery phase after an unclean stop, so the startup budget is 60 × 2 s — a shorter one would kill a recovery about to finish and restart it from the same redo point, which never converges. Liveness is 6 × 10 s with a 5 s timeout so a CPU-starved exec probe cannot turn a slow-but-healthy server into a recovery cycle. Readiness is 5 s / 3 s / 3 like `ark-api` and `ark-broker`.

`pg_isready` performs the startup handshake only, so it works unchanged with `ssl.enabled=true` and does not depend on `pg_hba` or database existence. It ships in both `15-alpine` and `16-alpine`.

## Verification

- `helm lint` clean; rendered with `ssl.enabled` on/off and with a user/database containing spaces, commas and brackets (`| quote` keeps the flow-sequence valid).
- Against `postgres:16-alpine` and `15-alpine` locally: TCP `pg_isready` first returns 0 at the same instant the final server logs `listening on IPv4`, ~7–14 s after container start on this machine. Without probes, that is the window in which the pod already counted as Ready.
- The 120 s startup budget equals `setup-local.sh`'s 120 s `kubectl wait`; on a healthy first boot the probe passes in the first few seconds.
- devspace is deliberately *not* listed among the fixed consumers: its `ark-storage-dev` deployment passes no `--wait`, so it still installs the apiserver during initdb and relies on the restart the root `devspace.yaml` already tolerates. Making it wait is a one-line `upgradeArgs` change I left out of this PR.

Fixes #3392
