### PR TITLE
fix: preserve ark-api uv.lock instead of deleting it on every build

### DIFF
--- a/services/ark-api/ark-api/uv.lock
+++ b/services/ark-api/ark-api/uv.lock
@@ -9,10 +9,10 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
@@ -309,7 +309,7 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 wheels = [
-    { filename = "ark_sdk-0.1.68-py3-none-any.whl", hash = "sha256:d307ef4e5858087f29b5ec77038e7c45ef8e99a9118a07dd069966891153b03e" },
+    { filename = "ark_sdk-0.1.68-py3-none-any.whl", hash = "sha256:ff6a4831836602a1437bd28ba7b80be80bd5a31ab08a005d7b25e62f352a13c3" },
 ]
 
 [package.metadata]

--- a/services/ark-api/build.mk
+++ b/services/ark-api/build.mk
@@ -59,7 +59,7 @@ $(ARK_API_STAMP_DEPS): $(ARK_API_SERVICE_SOURCE_DIR)/pyproject.toml $(ARK_SDK_WH
 	sed -i.bak 's|path = "../../../out/ark-sdk/py-sdk/dist/ark_sdk-.*\.whl"|path = "./out/$(notdir $(ARK_SDK_WHL))"|' pyproject.toml && \
 	uv remove ark_sdk || true && \
 	uv add ./out/$(notdir $(ARK_SDK_WHL)) && \
-	rm -f uv.lock && uv sync
+	uv lock && uv sync
 	@touch $@
 
 # OpenAPI generation (side effect of test)
@@ -96,7 +96,7 @@ $(ARK_API_STAMP_INSTALL): $(ARK_API_STAMP_BUILD) $$(LOCALHOST_GATEWAY_STAMP_INST
 	sed -i.bak 's|path = "../../out/ark-sdk/py-sdk/dist/ark_sdk-.*\.whl"|path = "./out/$(notdir $(ARK_SDK_WHL))"|' pyproject.toml && \
 	uv remove ark_sdk || true && \
 	uv add ./out/$(notdir $(ARK_SDK_WHL)) && \
-	rm -f uv.lock && uv sync
+	uv lock && uv sync
 	cd ${ARK_API_SERVICE_DIR}
 	./scripts/build-and-push.sh -i $(ARK_API_IMAGE) -t $(ARK_API_TAG) -f $(ARK_API_SERVICE_DIR)/Dockerfile -c $(ARK_API_SERVICE_DIR)
 	helm upgrade --install $(ARK_API_SERVICE_NAME) $(ARK_API_SERVICE_DIR)/chart \

--- a/services/ark-api/sync-ark-sdk.sh
+++ b/services/ark-api/sync-ark-sdk.sh
@@ -19,5 +19,5 @@ cd ark-api
 sed -i.bak "s|path = \"../../out/ark-sdk/py-sdk/dist/ark_sdk-.*\.whl\"|path = \"./out/${WHEEL_NAME}\"|" pyproject.toml && \
 uv remove ark_sdk || true && \
 uv add "./out/${WHEEL_NAME}" && \
-rm -f uv.lock && uv sync
+uv lock && uv sync
 cd ../


### PR DESCRIPTION
## Summary
- `services/ark-api/build.mk` and `sync-ark-sdk.sh` ran `rm -f uv.lock && uv sync` to pick up the freshly-built local `ark_sdk` wheel, which threw away every pinned dependency, not just `ark_sdk`
- `openai` has no upper bound in `pyproject.toml`, so each build re-resolved to whatever was newest on PyPI at that moment; `openai`'s bundled schema docstrings change between releases and flow into `openapi.json` → `types.ts`
- This let the "check generated types are unchanged" CI job fail on `main` with no code change involved, just because time passed and a new `openai` patch was published between a PR's CI run and the post-merge push run
- Fix: replace `rm -f uv.lock && uv sync` with `uv lock && uv sync`, which updates only the affected entry and keeps everything else pinned as committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)