### PR TITLE
feat(marketplace): follow manifest redirects and default to release asset

### DIFF
--- a/docs/content/developer-guide/marketplace.mdx
+++ b/docs/content/developer-guide/marketplace.mdx
@@ -124,6 +124,7 @@ Pick the scheme your host expects — **Bearer / token** for GitHub-style hosts,
 The URL must return the raw manifest bytes, not an HTML file-viewer page.
 
 - **GitHub** — open the file and click **Raw**, then copy the address: `https://raw.githubusercontent.com/<org>/<repo>/<branch>/marketplace.json` (private repos need a **Bearer / token** credential).
+- **GitHub release asset** — `https://github.com/<org>/<repo>/releases/download/<tag>/marketplace.json`, or `.../releases/latest/download/marketplace.json` to always track the latest release. These URLs redirect to a CDN host; ark-api follows the redirect.
 - **Azure DevOps Repos** — there is no "Raw" button. Don't build the URL by hand — use the [Azure DevOps](#azure-devops) mode: enter the organization, project, repository, branch, and path, and the dashboard builds and URL-encodes the fetch URL for you, with a preview before you save. Use a PAT scoped to **Code: Read**; the **Azure DevOps** mode auto-selects **HTTP Basic** auth for you.
 
 ## `marketplace.json` schema

--- a/docs/content/operations-guide/marketplace.mdx
+++ b/docs/content/operations-guide/marketplace.mdx
@@ -16,7 +16,7 @@ The dashboard chart accepts a `marketplaceSources` values key. A `post-install,p
 ```yaml
 marketplaceSources:
   - name: agents-at-scale-marketplace
-    url: https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json
+    url: https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json
     displayName: "Ark Marketplace"
 ```
 
@@ -56,11 +56,11 @@ Give entries different `namespace` values. A single `helm install`/`helm upgrade
 ```yaml
 marketplaceSources:
   - name: agents-at-scale-marketplace
-    url: https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json
+    url: https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json
     displayName: "Ark Marketplace"
     namespace: team-a
   - name: agents-at-scale-marketplace
-    url: https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json
+    url: https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json
     displayName: "Ark Marketplace"
     namespace: team-b
   - name: internal-catalog
@@ -161,7 +161,7 @@ So user changes survive upgrades; only untouched seeded defaults track the chart
 ## Operational notes
 
 - **Source availability.** ark-api fetches each source concurrently with a 10s per-source timeout and a 30s aggregator deadline, and caches successful fetches for one hour. A failing source surfaces an inline error and does not block the others.
-- **Outbound restrictions.** Source URLs must be `https`. ark-api rejects non-routable hosts (loopback, link-local, multicast, reserved) and does not follow redirects — including for credentialed fetches, so a credential cannot be used to reach internal/metadata services or leaked to a redirect target. Private RFC-1918 hosts are allowed for internal mirrors.
+- **Outbound restrictions.** Source URLs must be `https`. ark-api rejects non-routable hosts (loopback, link-local, multicast, reserved). Redirects are followed up to 5 hops, and each hop is re-validated: the target must be `https` and must pass the same host check, so a redirect cannot be used to reach internal/metadata services. The `Authorization` header of a credentialed fetch is dropped as soon as the redirect leaves the configured origin, so a credential is never leaked to a redirect target. Private RFC-1918 hosts are allowed for internal mirrors.
 - **Items not appearing.** Check the source URL returns valid JSON with an `items` array, is reachable from the ark-api pod, and uses `https`. For an authenticated source, an `auth_error` means the credential Secret is missing, the user lacks `get` on it, or the upstream rejected it (401/403).
 
 ## Uninstall and cleanup

--- a/docs/content/reference/marketplace-sources.mdx
+++ b/docs/content/reference/marketplace-sources.mdx
@@ -25,7 +25,7 @@ metadata:
   namespace: team-a
 data:
   agents-at-scale-marketplace: |
-    {"url":"https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json","displayName":"Ark Marketplace"}
+    {"url":"https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json","displayName":"Ark Marketplace"}
   internal-mirror: |
     {"url":"https://internal.example.com/marketplace.json","auth":{"scheme":"bearer","secretRef":"marketplace-source-internal-mirror-auth"}}
 ```
@@ -59,8 +59,9 @@ server-side:
 The credential is never returned by the API and never logged. The aggregator
 reads the Secret **under the requesting user's identity** (impersonation), so a
 user who cannot read the Secret cannot fetch with it — the source reports an
-`auth_error` for them. Credentialed fetches keep the SSRF guard and never follow
-redirects or send the header to another host.
+`auth_error` for them. Credentialed fetches keep the SSRF guard on every redirect
+hop and never send the header to another host: the `Authorization` header is
+dropped as soon as a redirect leaves the configured origin.
 
 ## RBAC
 
@@ -123,7 +124,7 @@ entries with `name`, `url`, optional `displayName`, and optional `namespace`
 ```yaml
 marketplaceSources:
   - name: agents-at-scale-marketplace
-    url: https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json
+    url: https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json
     displayName: "Ark Marketplace"
   - name: internal-mirror
     url: https://internal.example.com/marketplace.json

--- a/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_fetch.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_fetch.py
@@ -11,13 +11,15 @@ import httpx
 
 from ...models.marketplace_sources import AuthScheme
 
+MAX_REDIRECTS = 5
+
 
 class SourceBlockedError(Exception):
     """The source host resolved to a non-routable/blocked address (SSRF guard)."""
 
 
 class SourceRedirectError(Exception):
-    """The source responded with a redirect; credentialed fetches never follow."""
+    """The source redirect chain could not be followed safely."""
 
 
 async def resolve_safe_ip(host: str, port: int) -> Optional[str]:
@@ -57,18 +59,17 @@ def build_auth_header(scheme: AuthScheme, value: str) -> dict[str, str]:
     return {"Authorization": f"Basic {token}"}
 
 
-async def fetch_manifest(
+def _origin(url: str) -> tuple[str, str, int]:
+    parsed = urlparse(url)
+    return parsed.scheme, (parsed.hostname or ""), (parsed.port or 443)
+
+
+async def _get_pinned(
     http_client: httpx.AsyncClient,
     url: str,
-    *,
-    auth_header: Optional[dict[str, str]] = None,
-) -> object:
-    """Fetch a manifest with the SSRF guard applied and the IP pinned.
-
-    The Authorization header reaches only the configured host: the request targets the
-    validated IP with the original Host/SNI, and a redirect is an error (never followed).
-    Raises SourceBlockedError, SourceRedirectError, or httpx/JSON errors for callers to map.
-    """
+    auth_header: Optional[dict[str, str]],
+) -> httpx.Response:
+    """GET one URL against a validated IP, keeping the original Host/SNI."""
     parsed = urlparse(url)
     host = parsed.hostname
     port = parsed.port or 443
@@ -81,12 +82,46 @@ async def fetch_manifest(
         headers.update(auth_header)
 
     ip_url = httpx.URL(url).copy_with(host=safe_ip)
-    response = await http_client.get(
+    return await http_client.get(
         ip_url,
         headers=headers,
         extensions={"sni_hostname": host},
     )
-    if response.is_redirect:
-        raise SourceRedirectError("redirects are not followed")
-    response.raise_for_status()
-    return response.json()
+
+
+async def fetch_manifest(
+    http_client: httpx.AsyncClient,
+    url: str,
+    *,
+    auth_header: Optional[dict[str, str]] = None,
+) -> object:
+    """Fetch a manifest with the SSRF guard applied and the IP pinned.
+
+    Redirects are followed one hop at a time so every hop is re-validated: the target
+    must be https, its host must pass the SSRF guard, and the Authorization header is
+    dropped as soon as the origin changes, so a credential only ever reaches the
+    configured host. Raises SourceBlockedError, SourceRedirectError, or httpx/JSON
+    errors for callers to map.
+    """
+    current = url
+    origin = _origin(url)
+    header = auth_header
+
+    for _ in range(MAX_REDIRECTS + 1):
+        response = await _get_pinned(http_client, current, header)
+        if not response.is_redirect:
+            response.raise_for_status()
+            return response.json()
+
+        location = response.headers.get("location")
+        if not location:
+            raise SourceRedirectError("redirect is missing a location")
+        current = str(httpx.URL(current).join(location))
+        next_origin = _origin(current)
+        if next_origin[0] != "https":
+            raise SourceRedirectError("redirect target must be an https URL")
+        if next_origin != origin:
+            header = None
+            origin = next_origin
+
+    raise SourceRedirectError("too many redirects")

--- a/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_items.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_items.py
@@ -135,8 +135,8 @@ async def _fetch_source(
         manifest = await fetch_manifest(http_client, url, auth_header=auth_header)
     except SourceBlockedError:
         return _error_result(name, display_name, "source host is not allowed", "network_error")
-    except SourceRedirectError:
-        return _error_result(name, display_name, "redirects are not followed", "network_error")
+    except SourceRedirectError as e:
+        return _error_result(name, display_name, str(e), "network_error")
     except httpx.TimeoutException:
         return _error_result(name, display_name, "fetch timed out after 10s", "fetch_timeout")
     except httpx.HTTPStatusError as e:

--- a/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_sources.py
+++ b/services/ark-api/ark-api/src/ark_api/api/v1/marketplace_sources.py
@@ -125,10 +125,8 @@ async def _validate_source(url: str, auth_header: Optional[dict[str, str]]) -> N
             await fetch_manifest(http_client, url, auth_header=auth_header)
         except SourceBlockedError:
             raise HTTPException(status_code=400, detail="source host is not allowed")
-        except SourceRedirectError:
-            raise HTTPException(
-                status_code=400, detail="source returned a redirect, which is not followed"
-            )
+        except SourceRedirectError as e:
+            raise HTTPException(status_code=400, detail=f"source redirect failed: {e}")
         except httpx.HTTPStatusError as e:
             raise HTTPException(
                 status_code=400,

--- a/services/ark-api/ark-api/tests/test_marketplace_items.py
+++ b/services/ark-api/ark-api/tests/test_marketplace_items.py
@@ -46,9 +46,10 @@ def _secret(value):
 
 
 class _FakeResponse:
-    def __init__(self, payload, is_redirect=False):
+    def __init__(self, payload, is_redirect=False, location=None):
         self._payload = payload
         self.is_redirect = is_redirect
+        self.headers = {"location": location} if location else {}
 
     def raise_for_status(self):
         return None
@@ -363,18 +364,139 @@ class TestMarketplaceItemsAuth(unittest.TestCase):
             response = client.get("/v1/namespaces/team-a/marketplace-items")
         self.assertEqual(response.json()[0]["error"]["code"], "auth_error")
 
-    def test_credentialed_redirect_not_followed(self):
+    def test_credentialed_cross_host_redirect_drops_the_credential(self):
         mock_core = _make_core(
             [("a", "https://a.test/m.json", None, {"scheme": "bearer", "secretRef": "sec-a"})],
             secrets={"sec-a": "tok"},
         )
+        recorded: list = []
+
+        async def _fake_resolve(host, port):
+            return host
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url, headers=None, extensions=None):
+                recorded.append({"url": str(url), "headers": headers})
+                if "a.test" in str(url):
+                    return _FakeResponse(
+                        None, is_redirect=True, location="https://cdn.test/m.json"
+                    )
+                return _FakeResponse({"items": [{"name": "x"}]})
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(f"{MODULE}.get_impersonating_api_client", _fake_api_client)
+            )
+            stack.enter_context(patch(f"{MODULE}.client.CoreV1Api", return_value=mock_core))
+            stack.enter_context(
+                patch(f"{MODULE}.httpx.AsyncClient", lambda *a, **k: _Client())
+            )
+            stack.enter_context(patch(f"{FETCH}.resolve_safe_ip", _fake_resolve))
+            response = client.get("/v1/namespaces/team-a/marketplace-items")
+
+        self.assertEqual(response.json()[0]["items"], [{"name": "x"}])
+        self.assertIn("Authorization", recorded[0]["headers"])
+        self.assertNotIn(
+            "Authorization",
+            recorded[1]["headers"],
+            "credential must not follow a cross-host redirect",
+        )
+
+    def test_same_origin_redirect_keeps_the_credential(self):
+        mock_core = _make_core(
+            [("a", "https://a.test/m.json", None, {"scheme": "bearer", "secretRef": "sec-a"})],
+            secrets={"sec-a": "tok"},
+        )
+        recorded: list = []
+
+        async def _fake_resolve(host, port):
+            return host
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url, headers=None, extensions=None):
+                recorded.append({"url": str(url), "headers": headers})
+                if str(url).endswith("/m.json"):
+                    return _FakeResponse(None, is_redirect=True, location="/latest.json")
+                return _FakeResponse({"items": []})
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(f"{MODULE}.get_impersonating_api_client", _fake_api_client)
+            )
+            stack.enter_context(patch(f"{MODULE}.client.CoreV1Api", return_value=mock_core))
+            stack.enter_context(
+                patch(f"{MODULE}.httpx.AsyncClient", lambda *a, **k: _Client())
+            )
+            stack.enter_context(patch(f"{FETCH}.resolve_safe_ip", _fake_resolve))
+            response = client.get("/v1/namespaces/team-a/marketplace-items")
+
+        self.assertEqual(response.json()[0]["items"], [])
+        self.assertEqual(recorded[1]["url"], "https://a.test/latest.json")
+        self.assertIn("Authorization", recorded[1]["headers"])
+
+    def test_redirect_to_blocked_host_is_rejected(self):
+        mock_core = _make_core([("a", "https://a.test/m.json", None)])
+
+        async def _fake_resolve(host, port):
+            return None if host == "metadata.internal" else host
 
         async def get_impl(url):
-            return _FakeResponse({"items": []}, is_redirect=True)
+            if "a.test" in url:
+                return _FakeResponse(
+                    None, is_redirect=True, location="https://metadata.internal/m.json"
+                )
+            return _FakeResponse({"items": []})
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(f"{MODULE}.get_impersonating_api_client", _fake_api_client)
+            )
+            stack.enter_context(patch(f"{MODULE}.client.CoreV1Api", return_value=mock_core))
+            stack.enter_context(
+                patch(f"{MODULE}.httpx.AsyncClient", lambda *a, **k: _FakeAsyncClient(get_impl))
+            )
+            stack.enter_context(patch(f"{FETCH}.resolve_safe_ip", _fake_resolve))
+            response = client.get("/v1/namespaces/team-a/marketplace-items")
+
+        self.assertEqual(response.json()[0]["error"]["code"], "network_error")
+        self.assertEqual(
+            response.json()[0]["error"]["message"], "source host is not allowed"
+        )
+
+    def test_redirect_to_plain_http_is_rejected(self):
+        mock_core = _make_core([("a", "https://a.test/m.json", None)])
+
+        async def get_impl(url):
+            return _FakeResponse(None, is_redirect=True, location="http://a.test/m.json")
 
         with _patch(mock_core, get_impl):
             response = client.get("/v1/namespaces/team-a/marketplace-items")
         self.assertEqual(response.json()[0]["error"]["code"], "network_error")
+
+    def test_redirect_loop_is_capped(self):
+        mock_core = _make_core([("a", "https://a.test/m.json", None)])
+        calls = {"n": 0}
+
+        async def get_impl(url):
+            calls["n"] += 1
+            return _FakeResponse(None, is_redirect=True, location="https://a.test/m.json")
+
+        with _patch(mock_core, get_impl):
+            response = client.get("/v1/namespaces/team-a/marketplace-items")
+        self.assertEqual(response.json()[0]["error"]["message"], "too many redirects")
+        self.assertEqual(calls["n"], 6)
 
     def test_credentialed_blocked_host_not_fetched(self):
         mock_core = _make_core(

--- a/services/ark-dashboard/ark-dashboard/components/settings/manage-marketplace-settings.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/settings/manage-marketplace-settings.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/lib/services/marketplace-hooks';
 
 const PUBLIC_MARKETPLACE_URL =
-  'https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json';
+  'https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json';
 
 type SchemeChoice = 'none' | MarketplaceAuthScheme;
 

--- a/services/ark-dashboard/chart/values.yaml
+++ b/services/ark-dashboard/chart/values.yaml
@@ -177,7 +177,7 @@ httpRoute:
 # (see samples/marketplace/authenticated-source-rbac.yaml).
 marketplaceSources:
   - name: agents-at-scale-marketplace
-    url: https://raw.githubusercontent.com/mckinsey/agents-at-scale-marketplace/main/marketplace.json
+    url: https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json
     displayName: "Ark Marketplace"
   # - name: internal-mirror
   #   url: https://internal.example.com/marketplace.json


### PR DESCRIPTION
## Summary
- ark-api now follows marketplace manifest redirects one hop at a time (max 5), re-running the SSRF host guard and the `https` requirement on every hop
- The `Authorization` header of a credentialed fetch is dropped as soon as the redirect leaves the configured origin, so a credential can never reach a redirect target
- `SourceRedirectError` messages are propagated to callers instead of the fixed "redirects are not followed" string
- Default marketplace source URL switched to the release asset `https://github.com/mckinsey/agents-at-scale-marketplace/releases/download/v0.1.43/marketplace.json` (dashboard chart default, dashboard settings placeholder, docs)
- Docs updated: redirect policy in the operations guide and sources reference, plus a GitHub release asset entry in the "finding the manifest URL" list