### PR TITLE
feat(dashboard): move model base URL to a configuration

### DIFF
--- a/docs/content/user-guide/models.mdx
+++ b/docs/content/user-guide/models.mdx
@@ -33,6 +33,8 @@ The example below creates an OpenAI `gpt-4o-mini` model called `default`. You ca
 
 ![Add Model form filled in for the default OpenAI model](/models/add-form.png)
 
+**Base URL** can be typed in directly, or picked from an existing [Configuration](/user-guide/configurations). Editing a model whose base URL is a literal value shows a **Move to configuration** button next to the picker, which opens the same "create configuration" dialog pre-filled with that URL — useful for turning a one-off endpoint into something shared and swappable per environment.
+
 The form changes per provider:
 
 - **Azure OpenAI** adds an **Authentication** dropdown (API Key / Managed Identity / Workload Identity) and an **API Version** field.

--- a/docs/content/user-guide/models.mdx
+++ b/docs/content/user-guide/models.mdx
@@ -33,7 +33,7 @@ The example below creates an OpenAI `gpt-4o-mini` model called `default`. You ca
 
 ![Add Model form filled in for the default OpenAI model](/models/add-form.png)
 
-**Base URL** can be typed in directly, or picked from an existing [Configuration](/user-guide/configurations). Editing a model whose base URL is a literal value shows a **Move to configuration** button next to the picker, which opens the same "create configuration" dialog pre-filled with that URL — useful for turning a one-off endpoint into something shared and swappable per environment.
+**Base URL** is picked from an existing [Configuration](/user-guide/configurations), or created inline with **Add New**. Editing a model whose base URL is still a literal value (created via YAML, or before this picker existed) shows a **Move to configuration** button instead, which opens the same "create configuration" dialog pre-filled with that URL — useful for turning a one-off endpoint into something shared and swappable per environment. You can also leave that literal value as-is and edit unrelated fields; it's only rewritten if you actually pick or create a configuration.
 
 The form changes per provider:
 

--- a/services/ark-api/devspace.yaml
+++ b/services/ark-api/devspace.yaml
@@ -15,7 +15,7 @@ images:
     image: ark-api-dev
     dockerfile: Dockerfile.dev
     context: .
-    buildKit: {}
+    # buildKit: {}
 
 dependencies:
   ark-sdk:

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/mcp-url-field.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/mcp-url-field.test.tsx
@@ -31,13 +31,20 @@ vi.mock('@/lib/services/secrets-hooks', () => ({
   }),
 }));
 
-function Harness({ state }: { readonly state: UrlFieldState }) {
+function Harness({
+  state,
+  configurationName,
+}: {
+  readonly state: UrlFieldState;
+  readonly configurationName?: string;
+}) {
   const form = useForm<FormValues>({
     defaultValues: {
       name: 'github-mcp',
       description: 'x',
       configurationName:
-        state.kind === 'configuration' ? state.configurationName : '',
+        configurationName ??
+        (state.kind === 'configuration' ? state.configurationName : ''),
       transport: 'http',
     },
   });
@@ -71,6 +78,20 @@ describe('McpUrlField', () => {
     expect(
       screen.getByRole('button', { name: 'Move to configuration' }),
     ).toBeInTheDocument();
+  });
+
+  it('clears the literal hint once a configuration has been selected in-session', () => {
+    render(
+      <Harness
+        state={{ kind: 'literal', url: 'https://api.githubcopilot.com/mcp/' }}
+        configurationName="github-mcp-url"
+      />,
+    );
+    expect(screen.queryByText(/stored in/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add New' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Move to configuration' }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders a service reference read-only', () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/mcp-forms/utils.test.ts
@@ -223,10 +223,46 @@ describe('buildUpdateAddressMode', () => {
     });
   });
 
-  it('has no original to preserve for a literal address', () => {
+  it('carries the literal url forward as a fallback, not an original', () => {
     expect(
       buildUpdateAddressMode({ kind: 'literal', url: 'https://legacy/mcp' }),
-    ).toEqual({ kind: 'configuration' });
+    ).toEqual({ kind: 'configuration', literalUrl: 'https://legacy/mcp' });
+  });
+});
+
+describe('editing an MCP server with a legacy literal address', () => {
+  it('does not require a configuration when the field is untouched', () => {
+    const mode = buildUpdateAddressMode({
+      kind: 'literal',
+      url: 'https://legacy.example/mcp',
+    });
+    const schema = createFormSchema(mode);
+    const result = schema.safeParse({ ...values, configurationName: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('preserves the literal url in the built address when untouched', () => {
+    const mode = buildUpdateAddressMode({
+      kind: 'literal',
+      url: 'https://legacy.example/mcp',
+    });
+    const spec = buildSpec({ ...values, configurationName: '' }, [], mode);
+    expect(spec.address).toEqual({ value: 'https://legacy.example/mcp' });
+  });
+
+  it('moves to a configuration once one is selected', () => {
+    const mode = buildUpdateAddressMode({
+      kind: 'literal',
+      url: 'https://legacy.example/mcp',
+    });
+    const spec = buildSpec(
+      { ...values, configurationName: 'github-mcp-url' },
+      [],
+      mode,
+    );
+    expect(spec.address).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'github-mcp-url', key: 'value' } },
+    });
   });
 });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/create-model-form.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/create-model-form.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CreateModelForm } from '@/components/forms/model-forms/create-model-form';
+import { useGetAllConfigurations } from '@/lib/services/configurations-hooks';
 import {
   useCreateSecret,
   useGetAllSecrets,
@@ -14,6 +15,11 @@ vi.mock('@/lib/services/secrets-hooks', () => ({
   useGetAllSecrets: vi.fn(),
   useGetSecret: vi.fn(),
   useCreateSecret: vi.fn(),
+}));
+
+vi.mock('@/lib/services/configurations-hooks', () => ({
+  useGetAllConfigurations: vi.fn(),
+  useCreateConfiguration: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock('@/lib/services/models-hooks', () => ({
@@ -73,6 +79,11 @@ describe('CreateModelForm - AWS Bedrock (issue #2810)', () => {
     vi.mocked(useGetSecret).mockReturnValue({
       data: { keys: ['token'] },
       isPending: false,
+    } as never);
+    vi.mocked(useGetAllConfigurations).mockReturnValue({
+      data: [{ id: 'ai-gateway-url', name: 'ai-gateway-url' }],
+      isPending: false,
+      error: null,
     } as never);
   });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/model-configuration-form.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/model-configuration-form.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,14 +43,32 @@ const bedrockDefaults = (overrides: Partial<FormValues> = {}): FormValues =>
     ...overrides,
   }) as FormValues;
 
-function Harness({ defaultValues }: { defaultValues: FormValues }) {
+const openaiDefaults = (overrides: Partial<FormValues> = {}): FormValues =>
+  ({
+    name: 'my-openai-model',
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    secret: 'openai-token',
+    baseUrl: '',
+    ...overrides,
+  }) as FormValues;
+
+function Harness({
+  defaultValues,
+  baseUrlState,
+}: {
+  defaultValues: FormValues;
+  baseUrlState?: Parameters<
+    typeof ModelConfigurationFormContext.Provider
+  >[0]['value']['baseUrlState'];
+}) {
   const form = useForm<FormValues>({ defaultValues });
   return (
     <ModelConfigurationFormContext.Provider
       value={{
         formId: 'test-form',
         form,
-        provider: 'bedrock',
+        provider: defaultValues.provider,
         onSubmit: vi.fn(),
         isSubmitPending: false,
         disabledFields: {},
@@ -57,13 +76,17 @@ function Harness({ defaultValues }: { defaultValues: FormValues }) {
           defaultValues.provider === 'bedrock'
             ? defaultValues.bedrockAuthMethod
             : undefined,
+        baseUrlState,
       }}>
       <ModelConfiguratorForm />
     </ModelConfigurationFormContext.Provider>
   );
 }
 
-const renderForm = (defaultValues: FormValues) => {
+const renderForm = (
+  defaultValues: FormValues,
+  baseUrlState?: Parameters<typeof Harness>[0]['baseUrlState'],
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -72,7 +95,7 @@ const renderForm = (defaultValues: FormValues) => {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <Harness defaultValues={defaultValues} />
+      <Harness defaultValues={defaultValues} baseUrlState={baseUrlState} />
     </QueryClientProvider>,
   );
 };
@@ -116,5 +139,87 @@ describe('ModelConfiguratorForm - AWS Bedrock', () => {
 
     expect(screen.getByText('API Key Secret')).toBeInTheDocument();
     expect(screen.queryByText('API Key Secret Key')).not.toBeInTheDocument();
+  });
+});
+
+describe('ModelConfiguratorForm - Base URL field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGetAllSecrets).mockReturnValue({
+      data: [{ id: 'openai-token', name: 'openai-token' }],
+      isPending: false,
+      error: null,
+    } as never);
+    vi.mocked(useCreateSecret).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+    vi.mocked(useGetAllConfigurations).mockReturnValue({
+      data: [{ id: 'ai-gateway', name: 'ai-gateway' }],
+      isPending: false,
+      error: null,
+    } as never);
+  });
+
+  const baseUrlFieldset = () =>
+    screen.getByText('Base URL').closest('fieldset') as HTMLElement;
+
+  it('shows the stored value even when it is not in the loaded configurations list', async () => {
+    const user = userEvent.setup();
+    renderForm(openaiDefaults({ baseUrl: 'deleted-gateway' }));
+
+    await user.click(
+      within(baseUrlFieldset()).getByRole('combobox'),
+    );
+
+    expect(
+      await screen.findByRole('option', {
+        name: /deleted-gateway \(not found in this namespace\)/,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not flag a value that is present in the loaded configurations list', async () => {
+    const user = userEvent.setup();
+    renderForm(openaiDefaults({ baseUrl: 'ai-gateway' }));
+
+    await user.click(
+      within(baseUrlFieldset()).getByRole('combobox'),
+    );
+
+    expect(
+      screen.queryByRole('option', { name: /not found in this namespace/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the literal hint and "Move to configuration" while the field is untouched', () => {
+    renderForm(openaiDefaults({ baseUrl: '' }), {
+      kind: 'literal',
+      url: 'https://legacy.example/v1',
+    });
+
+    expect(
+      screen.getByText(/This URL is currently stored in the model itself/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Move to configuration' }),
+    ).toBeInTheDocument();
+  });
+
+  it('clears the literal hint once a configuration has been selected in-session', () => {
+    renderForm(openaiDefaults({ baseUrl: 'ai-gateway' }), {
+      kind: 'literal',
+      url: 'https://legacy.example/v1',
+    });
+
+    expect(
+      screen.queryByText(/This URL is currently stored in the model itself/),
+    ).not.toBeInTheDocument();
+    expect(
+      within(baseUrlFieldset()).getByRole('button', { name: 'Add New' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Move to configuration' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/model-configuration-form.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/model-configuration-form.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelConfiguratorForm } from '@/components/forms/model-forms/model-configuration-form';
 import { ModelConfigurationFormContext } from '@/components/forms/model-forms/model-configuration-form-context';
 import type { FormValues } from '@/components/forms/model-forms/schema';
+import { useGetAllConfigurations } from '@/lib/services/configurations-hooks';
 import {
   useCreateSecret,
   useGetAllSecrets,
@@ -14,6 +15,11 @@ import {
 vi.mock('@/lib/services/secrets-hooks', () => ({
   useGetAllSecrets: vi.fn(),
   useCreateSecret: vi.fn(),
+}));
+
+vi.mock('@/lib/services/configurations-hooks', () => ({
+  useGetAllConfigurations: vi.fn(),
+  useCreateConfiguration: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock('@/providers/NamespaceProvider', () => ({
@@ -85,6 +91,11 @@ describe('ModelConfiguratorForm - AWS Bedrock', () => {
     vi.mocked(useCreateSecret).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
+    } as never);
+    vi.mocked(useGetAllConfigurations).mockReturnValue({
+      data: [{ id: 'ai-gateway-url', name: 'ai-gateway-url' }],
+      isPending: false,
+      error: null,
     } as never);
   });
 

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/update-model-form.test.tsx
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/update-model-form.test.tsx
@@ -1,0 +1,119 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UpdateModelForm } from '@/components/forms/model-forms/update-model-form';
+import type { Model } from '@/lib/services';
+import { useGetAllConfigurations } from '@/lib/services/configurations-hooks';
+import { useUpdateModelById } from '@/lib/services/models-hooks';
+import { useGetAllSecrets } from '@/lib/services/secrets-hooks';
+
+vi.mock('@/lib/services/secrets-hooks', () => ({
+  useGetAllSecrets: vi.fn(),
+  useCreateSecret: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('@/lib/services/configurations-hooks', () => ({
+  useGetAllConfigurations: vi.fn(),
+  useCreateConfiguration: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('@/lib/services/models-hooks', () => ({
+  useUpdateModelById: vi.fn(),
+}));
+
+vi.mock('@/lib/hooks/use-namespaced-navigation', () => ({
+  useNamespacedNavigation: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/providers/NamespaceProvider', () => ({
+  useNamespace: () => ({ namespace: 'default', readOnlyMode: false }),
+}));
+
+vi.mock('@/lib/analytics/hooks', () => ({
+  useTrackClick: () => vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const legacyLiteralModel: Model = {
+  id: 'legacy-openai',
+  name: 'legacy-openai',
+  provider: 'openai',
+  model: 'gpt-4o-mini',
+  config: {
+    openai: {
+      apiKey: {
+        valueFrom: { secretKeyRef: { name: 'openai-token', key: 'token' } },
+      },
+      baseUrl: { value: 'https://legacy.example/v1' },
+    },
+  },
+} as unknown as Model;
+
+const renderForm = (model: Model) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UpdateModelForm model={model} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('UpdateModelForm - editing a model with a legacy literal base URL', () => {
+  const mutateAsync = vi.fn().mockResolvedValue({ id: 'legacy-openai' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ id: 'legacy-openai' });
+    vi.mocked(useGetAllSecrets).mockReturnValue({
+      data: [{ id: 'openai-token', name: 'openai-token' }],
+      isPending: false,
+      error: null,
+    } as never);
+    vi.mocked(useGetAllConfigurations).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    } as never);
+    vi.mocked(useUpdateModelById).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as never);
+  });
+
+  it('submits successfully without forcing migration to a configuration', async () => {
+    const user = userEvent.setup();
+    renderForm(legacyLiteralModel);
+
+    expect(
+      screen.getByText(/This URL is currently stored in the model itself/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /update model/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        id: 'legacy-openai',
+        model: 'gpt-4o-mini',
+        config: {
+          openai: {
+            apiKey: {
+              valueFrom: {
+                secretKeyRef: { name: 'openai-token', key: 'token' },
+              },
+            },
+            baseUrl: { value: 'https://legacy.example/v1' },
+          },
+        },
+      });
+    });
+    expect(screen.queryByText(/base url is required/i)).not.toBeInTheDocument();
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildBaseUrlMode,
   buildBaseUrlValueSource,
+  CLEAR_BASE_URL_VALUE,
   createConfig,
   mapBaseUrlState,
 } from '@/components/forms/model-forms/utils';
@@ -108,6 +109,14 @@ describe('buildBaseUrlValueSource', () => {
     expect(buildBaseUrlValueSource(undefined)).toBeUndefined();
     expect(buildBaseUrlValueSource('')).toBeUndefined();
   });
+
+  it('clears the value even when a literal fallback exists, given the explicit clear sentinel', () => {
+    expect(
+      buildBaseUrlValueSource(CLEAR_BASE_URL_VALUE, {
+        literalUrl: 'https://legacy.example/v1',
+      }),
+    ).toBeUndefined();
+  });
 });
 
 describe('createSchema - editing a model with a legacy literal base URL', () => {
@@ -183,5 +192,26 @@ describe('createConfig - preserving a legacy literal base URL on submit', () => 
     expect(config.openai?.baseUrl).toEqual({
       valueFrom: { configMapKeyRef: { name: 'ai-gateway', key: 'value' } },
     });
+  });
+
+  it('bedrock: clears a legacy literal base URL when "None" is explicitly selected', () => {
+    const formValues = {
+      name: 'my-bedrock-model',
+      provider: 'bedrock',
+      model: 'anthropic.claude-v2',
+      bedrockAuthMethod: 'iam',
+      bedrockApiKeySecretName: '',
+      bedrockAccessKeyIdSecretName: 'access-key',
+      bedrockSecretAccessKeySecretName: 'secret-key',
+      baseUrl: CLEAR_BASE_URL_VALUE,
+      region: '',
+      modelARN: '',
+    } as FormValues;
+
+    const config = createConfig(formValues, {
+      literalUrl: 'https://legacy-bedrock.example/v1',
+    });
+
+    expect(config.bedrock?.baseUrl).toBeUndefined();
   });
 });

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
@@ -32,6 +32,17 @@ describe('mapBaseUrlState', () => {
   it('reports unset when there is no source', () => {
     expect(mapBaseUrlState(undefined)).toEqual({ kind: 'unset' });
   });
+
+  it('reads a legacy literal value written as a bare string (kubectl shorthand)', () => {
+    expect(mapBaseUrlState('https://legacy.example/v1')).toEqual({
+      kind: 'literal',
+      url: 'https://legacy.example/v1',
+    });
+  });
+
+  it('reports unset for an empty bare string', () => {
+    expect(mapBaseUrlState('')).toEqual({ kind: 'unset' });
+  });
 });
 
 describe('buildBaseUrlMode', () => {

--- a/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/__tests__/unit/components/forms/model-forms/utils.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBaseUrlMode,
+  buildBaseUrlValueSource,
+  createConfig,
+  mapBaseUrlState,
+} from '@/components/forms/model-forms/utils';
+import { createSchema } from '@/components/forms/model-forms/schema';
+import type { FormValues } from '@/components/forms/model-forms/schema';
+
+describe('mapBaseUrlState', () => {
+  it('reads a configuration reference', () => {
+    expect(
+      mapBaseUrlState({
+        valueFrom: { configMapKeyRef: { name: 'ai-gateway', key: 'value' } },
+      }),
+    ).toEqual({
+      kind: 'configuration',
+      configurationName: 'ai-gateway',
+      configurationKey: 'value',
+    });
+  });
+
+  it('reads a legacy literal value', () => {
+    expect(mapBaseUrlState({ value: 'https://api.openai.com/v1' })).toEqual({
+      kind: 'literal',
+      url: 'https://api.openai.com/v1',
+    });
+  });
+
+  it('reports unset when there is no source', () => {
+    expect(mapBaseUrlState(undefined)).toEqual({ kind: 'unset' });
+  });
+});
+
+describe('buildBaseUrlMode', () => {
+  it('carries the original configuration name and key', () => {
+    expect(
+      buildBaseUrlMode({
+        kind: 'configuration',
+        configurationName: 'ai-gateway',
+        configurationKey: 'url',
+      }),
+    ).toEqual({ originalName: 'ai-gateway', originalKey: 'url' });
+  });
+
+  it('carries the literal url forward as a fallback, not an original', () => {
+    expect(
+      buildBaseUrlMode({ kind: 'literal', url: 'https://legacy.example/v1' }),
+    ).toEqual({ literalUrl: 'https://legacy.example/v1' });
+  });
+
+  it('has no fallback for an unset base url', () => {
+    expect(buildBaseUrlMode({ kind: 'unset' })).toEqual({});
+  });
+});
+
+describe('buildBaseUrlValueSource', () => {
+  it('writes a configMapKeyRef when a configuration is selected', () => {
+    expect(buildBaseUrlValueSource('ai-gateway')).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'ai-gateway', key: 'value' } },
+    });
+  });
+
+  it('preserves the original key when the configuration is unchanged', () => {
+    expect(
+      buildBaseUrlValueSource('ai-gateway', {
+        originalName: 'ai-gateway',
+        originalKey: 'url',
+      }),
+    ).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'ai-gateway', key: 'url' } },
+    });
+  });
+
+  it('falls back to the value key when the configuration changes', () => {
+    expect(
+      buildBaseUrlValueSource('other-gateway', {
+        originalName: 'ai-gateway',
+        originalKey: 'url',
+      }),
+    ).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'other-gateway', key: 'value' } },
+    });
+  });
+
+  it('preserves a legacy literal url when no configuration is selected', () => {
+    expect(
+      buildBaseUrlValueSource(undefined, {
+        literalUrl: 'https://legacy.example/v1',
+      }),
+    ).toEqual({ value: 'https://legacy.example/v1' });
+  });
+
+  it('returns undefined when there is neither a configuration nor a literal fallback', () => {
+    expect(buildBaseUrlValueSource(undefined)).toBeUndefined();
+    expect(buildBaseUrlValueSource('')).toBeUndefined();
+  });
+});
+
+describe('createSchema - editing a model with a legacy literal base URL', () => {
+  const openaiValues = {
+    name: 'my-model',
+    provider: 'openai' as const,
+    model: 'gpt-4o-mini',
+    secret: 'openai-token',
+  };
+
+  it('requires a configuration when there is no literal fallback', () => {
+    const schema = createSchema(false);
+    const result = schema.safeParse({ ...openaiValues, baseUrl: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('does not require a configuration when a literal fallback exists', () => {
+    const schema = createSchema(true);
+    const result = schema.safeParse({ ...openaiValues, baseUrl: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('leaves bedrock base URL optional either way', () => {
+    const bedrockValues = {
+      name: 'my-model',
+      provider: 'bedrock' as const,
+      model: 'anthropic.claude-v2',
+      bedrockAuthMethod: 'iam' as const,
+      bedrockApiKeySecretName: '',
+      bedrockAccessKeyIdSecretName: 'access-key',
+      bedrockSecretAccessKeySecretName: 'secret-key',
+      baseUrl: '',
+      region: '',
+      modelARN: '',
+    };
+    expect(createSchema(false).safeParse(bedrockValues).success).toBe(true);
+    expect(createSchema(true).safeParse(bedrockValues).success).toBe(true);
+  });
+});
+
+describe('createConfig - preserving a legacy literal base URL on submit', () => {
+  it('keeps the original literal value when the field is left untouched', () => {
+    const formValues = {
+      name: 'my-model',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      secret: 'openai-token',
+      baseUrl: '',
+    } as FormValues;
+
+    const config = createConfig(formValues, {
+      literalUrl: 'https://legacy.example/v1',
+    });
+
+    expect(config.openai?.baseUrl).toEqual({
+      value: 'https://legacy.example/v1',
+    });
+  });
+
+  it('migrates to a configuration once one is selected', () => {
+    const formValues = {
+      name: 'my-model',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      secret: 'openai-token',
+      baseUrl: 'ai-gateway',
+    } as FormValues;
+
+    const config = createConfig(formValues, {
+      literalUrl: 'https://legacy.example/v1',
+    });
+
+    expect(config.openai?.baseUrl).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'ai-gateway', key: 'value' } },
+    });
+  });
+});

--- a/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-url-field.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/mcp-url-field.tsx
@@ -54,57 +54,57 @@ export function McpUrlField({ form, state }: McpUrlFieldProps) {
     <FormField
       control={form.control}
       name="configurationName"
-      render={({ field, fieldState }) => (
-        <FieldSet className="gap-2">
-          <FieldTitle>URL</FieldTitle>
-          {state.kind === 'literal' && (
-            <p className="text-sm">
-              This URL is currently stored in the MCP server itself:{' '}
-              {state.url}
-            </p>
-          )}
-          <div className="flex items-center gap-3">
-            <Select onValueChange={field.onChange} value={field.value}>
-              <SelectTrigger
-                className={cn(GHOST_TRIGGER, 'flex-1')}
-                aria-invalid={!!fieldState.error}>
-                <SelectValue placeholder="Select a configuration" />
-              </SelectTrigger>
-              <SelectContent className="bg-fill-onsurface-ui-2">
-                {configurations?.map(configuration => (
-                  <SelectItem
-                    key={configuration.name}
-                    value={configuration.name}>
-                    <SelectItemText>{configuration.name}</SelectItemText>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <CreateResourceButton
-              kind="configuration"
-              label={
-                state.kind === 'literal' ? 'Move to configuration' : 'Add New'
-              }
-              dialogTitle={
-                state.kind === 'literal'
-                  ? 'Move URL to a configuration'
-                  : undefined
-              }
-              defaultValue={currentUrl}
-              onCreated={name =>
-                form.setValue('configurationName', name, {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                })
-              }
-            />
-          </div>
-          {configurations?.length === 0 && (
-            <p className="text-sm">No configurations in this namespace.</p>
-          )}
-          <FieldError>{fieldState.error?.message}</FieldError>
-        </FieldSet>
-      )}
+      render={({ field, fieldState }) => {
+        const stillLiteral = state.kind === 'literal' && !field.value;
+
+        return (
+          <FieldSet className="gap-2">
+            <FieldTitle>URL</FieldTitle>
+            {stillLiteral && (
+              <p className="text-sm">
+                This URL is currently stored in the MCP server itself:{' '}
+                {state.url}
+              </p>
+            )}
+            <div className="flex items-center gap-3">
+              <Select onValueChange={field.onChange} value={field.value}>
+                <SelectTrigger
+                  className={cn(GHOST_TRIGGER, 'flex-1')}
+                  aria-invalid={!!fieldState.error}>
+                  <SelectValue placeholder="Select a configuration" />
+                </SelectTrigger>
+                <SelectContent className="bg-fill-onsurface-ui-2">
+                  {configurations?.map(configuration => (
+                    <SelectItem
+                      key={configuration.name}
+                      value={configuration.name}>
+                      <SelectItemText>{configuration.name}</SelectItemText>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <CreateResourceButton
+                kind="configuration"
+                label={stillLiteral ? 'Move to configuration' : 'Add New'}
+                dialogTitle={
+                  stillLiteral ? 'Move URL to a configuration' : undefined
+                }
+                defaultValue={currentUrl}
+                onCreated={name =>
+                  form.setValue('configurationName', name, {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  })
+                }
+              />
+            </div>
+            {configurations?.length === 0 && (
+              <p className="text-sm">No configurations in this namespace.</p>
+            )}
+            <FieldError>{fieldState.error?.message}</FieldError>
+          </FieldSet>
+        );
+      }}
     />
   );
 }

--- a/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/mcp-forms/utils.ts
@@ -16,7 +16,12 @@ import { kubernetesNameSchema } from '@/lib/utils/kubernetes-validation';
 export const CONFIGURATION_VALUE_KEY = 'value';
 
 export type AddressMode =
-  | { kind: 'configuration'; originalName?: string; originalKey?: string }
+  | {
+      kind: 'configuration';
+      originalName?: string;
+      originalKey?: string;
+      literalUrl?: string;
+    }
   | { kind: 'service'; serviceRef: MCPServerServiceRef };
 
 export type UrlFieldState =
@@ -34,11 +39,13 @@ export type UrlFieldState =
     };
 
 export function createFormSchema(addressMode: AddressMode) {
+  const hasLiteralFallback =
+    addressMode.kind === 'configuration' && !!addressMode.literalUrl;
   return z.object({
     name: kubernetesNameSchema,
     description: z.string().optional(),
     configurationName:
-      addressMode.kind === 'service'
+      addressMode.kind === 'service' || hasLiteralFallback
         ? z.string()
         : z.string().min(1, 'URL is required'),
     transport: z.enum(['http', 'sse'], {
@@ -135,6 +142,9 @@ export function buildUpdateAddressMode(urlState: UrlFieldState): AddressMode {
       originalKey: urlState.configurationKey,
     };
   }
+  if (urlState.kind === 'literal') {
+    return { kind: 'configuration', literalUrl: urlState.url };
+  }
   return { kind: 'configuration' };
 }
 
@@ -145,7 +155,10 @@ export function buildAddress(
   if (addressMode.kind === 'service') {
     return { valueFrom: { serviceRef: addressMode.serviceRef } };
   }
-  const { originalName, originalKey } = addressMode;
+  const { originalName, originalKey, literalUrl } = addressMode;
+  if (!values.configurationName && literalUrl) {
+    return { value: literalUrl };
+  }
   const key =
     originalKey && values.configurationName === originalName
       ? originalKey

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form-context.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form-context.tsx
@@ -5,6 +5,7 @@ import type { UseFormReturn } from 'react-hook-form';
 
 import type { KeysOfUnion } from '@/lib/types/utils';
 
+import type { BaseUrlFieldState } from './utils';
 import type { FormValues } from './schema';
 
 export type DisabledFields = Partial<Record<KeysOfUnion<FormValues>, boolean>>;
@@ -18,6 +19,7 @@ interface ModelConfigurationFormContext {
   disabledFields?: DisabledFields;
   initialAzureAuthMethod?: 'apiKey' | 'managedIdentity' | 'workloadIdentity';
   initialBedrockAuthMethod?: 'apiKey' | 'iam';
+  baseUrlState?: BaseUrlFieldState;
 }
 
 const ModelConfigurationFormContext = createContext<

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from 'react';
 import type { Control } from 'react-hook-form';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { toast } from '@/components/ui/sonner';
 
 import { CreateResourceButton } from '@/components/forms/shared/create-resource-dialog';
 import {
@@ -31,23 +30,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { toast } from '@/components/ui/sonner';
 import { Spinner } from '@/components/ui/spinner';
 import {
   AZURE_AUTH_METHOD_DISPLAY_NAMES,
-  getModelTypeDisplayName,
   MODEL_PROVIDER_DISPLAY_NAMES,
   SUPPORTED_MODEL_PROVIDERS,
+  getModelTypeDisplayName,
 } from '@/lib/constants/model-types';
-import type { Secret } from '@/lib/services';
+import type { Configuration, Secret } from '@/lib/services';
+import { useGetAllConfigurations } from '@/lib/services/configurations-hooks';
 import { useGetAllSecrets } from '@/lib/services/secrets-hooks';
 import type { KeysOfUnion } from '@/lib/types/utils';
 import { cn } from '@/lib/utils';
 
 import { useModelConfigurationForm } from './model-configuration-form-context';
 import type { FormValues } from './schema';
+import type { BaseUrlFieldState } from './utils';
 
 export function ModelConfiguratorForm() {
-  const { form, formId, onSubmit, provider, disabledFields } =
+  const { form, formId, onSubmit, provider, disabledFields, baseUrlState } =
     useModelConfigurationForm();
 
   const {
@@ -55,6 +57,12 @@ export function ModelConfiguratorForm() {
     isPending: isSecretsPending,
     error: secretsError,
   } = useGetAllSecrets();
+
+  const {
+    data: configurations,
+    isPending: isConfigurationsPending,
+    error: configurationsError,
+  } = useGetAllConfigurations();
 
   useEffect(() => {
     if (secretsError) {
@@ -66,6 +74,17 @@ export function ModelConfiguratorForm() {
       });
     }
   }, [secretsError]);
+
+  useEffect(() => {
+    if (configurationsError) {
+      toast.error('Failed to get configurations', {
+        description:
+          configurationsError instanceof Error
+            ? configurationsError.message
+            : 'An unexpected error occurred',
+      });
+    }
+  }, [configurationsError]);
 
   return (
     <Form {...form}>
@@ -156,6 +175,9 @@ export function ModelConfiguratorForm() {
           <OpenAISpecificFields
             isSecretsPending={isSecretsPending}
             secrets={secrets}
+            isConfigurationsPending={isConfigurationsPending}
+            configurations={configurations}
+            baseUrlState={baseUrlState}
             control={form.control}
           />
         )}
@@ -163,6 +185,9 @@ export function ModelConfiguratorForm() {
           <AzureSpecificFields
             isSecretsPending={isSecretsPending}
             secrets={secrets}
+            isConfigurationsPending={isConfigurationsPending}
+            configurations={configurations}
+            baseUrlState={baseUrlState}
             control={form.control}
           />
         )}
@@ -170,6 +195,9 @@ export function ModelConfiguratorForm() {
           <AWSBedrockSpecificFields
             isSecretsPending={isSecretsPending}
             secrets={secrets}
+            isConfigurationsPending={isConfigurationsPending}
+            configurations={configurations}
+            baseUrlState={baseUrlState}
             control={form.control}
           />
         )}
@@ -177,6 +205,9 @@ export function ModelConfiguratorForm() {
           <AnthropicSpecificFields
             isSecretsPending={isSecretsPending}
             secrets={secrets}
+            isConfigurationsPending={isConfigurationsPending}
+            configurations={configurations}
+            baseUrlState={baseUrlState}
             control={form.control}
           />
         )}
@@ -188,6 +219,9 @@ export function ModelConfiguratorForm() {
 type ProviderFieldsProps = {
   isSecretsPending: boolean;
   secrets?: Secret[];
+  isConfigurationsPending: boolean;
+  configurations?: Configuration[];
+  baseUrlState?: BaseUrlFieldState;
   control: Control<FormValues, unknown, FormValues>;
 };
 
@@ -253,27 +287,98 @@ function SecretSelectorField({
   );
 }
 
+const CLEAR_BASE_URL_VALUE = '__none__';
+
 function BaseUrlField({
   control,
   placeholder,
+  configurations,
+  isConfigurationsPending,
+  baseUrlState,
+  optional = false,
 }: {
   control: Control<FormValues, unknown, FormValues>;
   placeholder: string;
+  configurations?: Configuration[];
+  isConfigurationsPending: boolean;
+  baseUrlState?: BaseUrlFieldState;
+  optional?: boolean;
 }) {
+  const { setValue } = useFormContext<FormValues>();
+
   return (
     <FormField
       control={control}
       name="baseUrl"
       render={({ field, fieldState }) => (
         <FieldSet className="gap-2">
-          <FieldTitle>Base URL</FieldTitle>
-          <Input
-            variant="inline"
-            {...field}
-            value={field.value ?? ''}
-            placeholder={placeholder}
-            aria-invalid={!!fieldState.error}
-          />
+          <FieldTitle>Base URL{optional ? ' (Optional)' : ''}</FieldTitle>
+          {baseUrlState?.kind === 'literal' && (
+            <p className="text-sm">
+              This URL is currently stored in the model itself:{' '}
+              {baseUrlState.url}
+            </p>
+          )}
+          <div className="flex items-center gap-3">
+            <Select
+              onValueChange={value =>
+                field.onChange(value === CLEAR_BASE_URL_VALUE ? '' : value)
+              }
+              value={(field.value as string) ?? ''}>
+              <SelectTrigger
+                className={cn(GHOST_TRIGGER, 'flex-1')}
+                aria-invalid={!!fieldState.error}>
+                <SelectValue placeholder={placeholder} />
+              </SelectTrigger>
+              <SelectContent className="bg-fill-onsurface-ui-2">
+                {isConfigurationsPending ? (
+                  <Spinner size="sm" className="mx-auto my-2" />
+                ) : (
+                  <>
+                    {optional && (
+                      <SelectItem value={CLEAR_BASE_URL_VALUE}>
+                        <SelectItemText>
+                          None (use the default endpoint)
+                        </SelectItemText>
+                      </SelectItem>
+                    )}
+                    {configurations?.map(configuration => (
+                      <SelectItem
+                        key={configuration.name}
+                        value={configuration.name}>
+                        <SelectItemText>{configuration.name}</SelectItemText>
+                      </SelectItem>
+                    ))}
+                  </>
+                )}
+              </SelectContent>
+            </Select>
+            <CreateResourceButton
+              kind="configuration"
+              label={
+                baseUrlState?.kind === 'literal'
+                  ? 'Move to configuration'
+                  : 'Add New'
+              }
+              dialogTitle={
+                baseUrlState?.kind === 'literal'
+                  ? 'Move URL to a configuration'
+                  : undefined
+              }
+              defaultValue={
+                baseUrlState?.kind === 'literal' ? baseUrlState.url : undefined
+              }
+              onCreated={name =>
+                setValue('baseUrl', name, {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                })
+              }
+            />
+          </div>
+          {configurations?.length === 0 && (
+            <p className="text-sm">No configurations in this namespace.</p>
+          )}
           <FieldError>{fieldState.error?.message}</FieldError>
         </FieldSet>
       )}
@@ -284,6 +389,9 @@ function BaseUrlField({
 function OpenAISpecificFields({
   isSecretsPending,
   secrets,
+  isConfigurationsPending,
+  configurations,
+  baseUrlState,
   control,
 }: ProviderFieldsProps) {
   return (
@@ -296,7 +404,13 @@ function OpenAISpecificFields({
         label="API Key"
         placeholder="Select a secret"
       />
-      <BaseUrlField control={control} placeholder="https://api.openai.com/v1" />
+      <BaseUrlField
+        control={control}
+        placeholder="Select a configuration"
+        configurations={configurations}
+        isConfigurationsPending={isConfigurationsPending}
+        baseUrlState={baseUrlState}
+      />
     </>
   );
 }
@@ -307,6 +421,9 @@ function AzureSpecificFields({
   control,
   isSecretsPending,
   secrets,
+  isConfigurationsPending,
+  configurations,
+  baseUrlState,
 }: AzureSpecificFieldsProps) {
   const { initialAzureAuthMethod } = useModelConfigurationForm();
   const watchedAuthMethod = useWatch({
@@ -401,7 +518,13 @@ function AzureSpecificFields({
           )}
         </>
       )}
-      <BaseUrlField control={control} placeholder="https://your-resource.openai.azure.com/" />
+      <BaseUrlField
+        control={control}
+        placeholder="Select a configuration"
+        configurations={configurations}
+        isConfigurationsPending={isConfigurationsPending}
+        baseUrlState={baseUrlState}
+      />
       <FormField
         control={control}
         name="azureApiVersion"
@@ -439,6 +562,9 @@ function AWSBedrockSpecificFields({
   control,
   isSecretsPending,
   secrets,
+  isConfigurationsPending,
+  configurations,
+  baseUrlState,
 }: ProviderFieldsProps) {
   const { initialBedrockAuthMethod } = useModelConfigurationForm();
   const watchedAuthMethod = useWatch({
@@ -503,26 +629,13 @@ function AWSBedrockSpecificFields({
           />
         </>
       )}
-      <FormField
+      <BaseUrlField
         control={control}
-        name="baseUrl"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Base URL (Optional)</FormLabel>
-            <FormControl>
-              <Input
-                {...field}
-                value={field.value ?? ''}
-                placeholder="https://bedrock-runtime.us-east-1.amazonaws.com"
-              />
-            </FormControl>
-            <FormDescription>
-              Leave blank to use the default AWS Bedrock endpoint. Set this to
-              route through a gateway (e.g. an AI gateway fronting Bedrock).
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
+        placeholder="Select a configuration"
+        configurations={configurations}
+        isConfigurationsPending={isConfigurationsPending}
+        baseUrlState={baseUrlState}
+        optional
       />
       <FormField
         control={control}
@@ -565,6 +678,9 @@ function AWSBedrockSpecificFields({
 function AnthropicSpecificFields({
   isSecretsPending,
   secrets,
+  isConfigurationsPending,
+  configurations,
+  baseUrlState,
   control,
 }: ProviderFieldsProps) {
   return (
@@ -577,7 +693,13 @@ function AnthropicSpecificFields({
         label="API Key"
         placeholder="Select a secret"
       />
-      <BaseUrlField control={control} placeholder="https://api.anthropic.com" />
+      <BaseUrlField
+        control={control}
+        placeholder="Select a configuration"
+        configurations={configurations}
+        isConfigurationsPending={isConfigurationsPending}
+        baseUrlState={baseUrlState}
+      />
       <FormField
         control={control}
         name="anthropicVersion"

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
@@ -46,6 +46,7 @@ import { cn } from '@/lib/utils';
 
 import { useModelConfigurationForm } from './model-configuration-form-context';
 import type { FormValues } from './schema';
+import { CLEAR_BASE_URL_VALUE } from './utils';
 import type { BaseUrlFieldState } from './utils';
 
 export function ModelConfiguratorForm() {
@@ -287,8 +288,6 @@ function SecretSelectorField({
   );
 }
 
-const CLEAR_BASE_URL_VALUE = '__none__';
-
 function BaseUrlField({
   control,
   placeholder,
@@ -331,11 +330,7 @@ function BaseUrlField({
               </p>
             )}
             <div className="flex items-center gap-3">
-              <Select
-                onValueChange={value =>
-                  field.onChange(value === CLEAR_BASE_URL_VALUE ? '' : value)
-                }
-                value={currentValue}>
+              <Select onValueChange={field.onChange} value={currentValue}>
                 <SelectTrigger
                   className={cn(GHOST_TRIGGER, 'flex-1')}
                   aria-invalid={!!fieldState.error}>

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/model-configuration-form.tsx
@@ -310,78 +310,91 @@ function BaseUrlField({
     <FormField
       control={control}
       name="baseUrl"
-      render={({ field, fieldState }) => (
-        <FieldSet className="gap-2">
-          <FieldTitle>Base URL{optional ? ' (Optional)' : ''}</FieldTitle>
-          {baseUrlState?.kind === 'literal' && (
-            <p className="text-sm">
-              This URL is currently stored in the model itself:{' '}
-              {baseUrlState.url}
-            </p>
-          )}
-          <div className="flex items-center gap-3">
-            <Select
-              onValueChange={value =>
-                field.onChange(value === CLEAR_BASE_URL_VALUE ? '' : value)
-              }
-              value={(field.value as string) ?? ''}>
-              <SelectTrigger
-                className={cn(GHOST_TRIGGER, 'flex-1')}
-                aria-invalid={!!fieldState.error}>
-                <SelectValue placeholder={placeholder} />
-              </SelectTrigger>
-              <SelectContent className="bg-fill-onsurface-ui-2">
-                {isConfigurationsPending ? (
-                  <Spinner size="sm" className="mx-auto my-2" />
-                ) : (
-                  <>
-                    {optional && (
-                      <SelectItem value={CLEAR_BASE_URL_VALUE}>
-                        <SelectItemText>
-                          None (use the default endpoint)
-                        </SelectItemText>
-                      </SelectItem>
-                    )}
-                    {configurations?.map(configuration => (
-                      <SelectItem
-                        key={configuration.name}
-                        value={configuration.name}>
-                        <SelectItemText>{configuration.name}</SelectItemText>
-                      </SelectItem>
-                    ))}
-                  </>
-                )}
-              </SelectContent>
-            </Select>
-            <CreateResourceButton
-              kind="configuration"
-              label={
-                baseUrlState?.kind === 'literal'
-                  ? 'Move to configuration'
-                  : 'Add New'
-              }
-              dialogTitle={
-                baseUrlState?.kind === 'literal'
-                  ? 'Move URL to a configuration'
-                  : undefined
-              }
-              defaultValue={
-                baseUrlState?.kind === 'literal' ? baseUrlState.url : undefined
-              }
-              onCreated={name =>
-                setValue('baseUrl', name, {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                })
-              }
-            />
-          </div>
-          {configurations?.length === 0 && (
-            <p className="text-sm">No configurations in this namespace.</p>
-          )}
-          <FieldError>{fieldState.error?.message}</FieldError>
-        </FieldSet>
-      )}
+      render={({ field, fieldState }) => {
+        const currentValue = (field.value as string) ?? '';
+        const stillLiteral = baseUrlState?.kind === 'literal' && !currentValue;
+        const isStoredValueMissing =
+          !!currentValue &&
+          currentValue !== CLEAR_BASE_URL_VALUE &&
+          !isConfigurationsPending &&
+          !configurations?.some(
+            configuration => configuration.name === currentValue,
+          );
+
+        return (
+          <FieldSet className="gap-2">
+            <FieldTitle>Base URL{optional ? ' (Optional)' : ''}</FieldTitle>
+            {stillLiteral && (
+              <p className="text-sm">
+                This URL is currently stored in the model itself:{' '}
+                {baseUrlState.url}
+              </p>
+            )}
+            <div className="flex items-center gap-3">
+              <Select
+                onValueChange={value =>
+                  field.onChange(value === CLEAR_BASE_URL_VALUE ? '' : value)
+                }
+                value={currentValue}>
+                <SelectTrigger
+                  className={cn(GHOST_TRIGGER, 'flex-1')}
+                  aria-invalid={!!fieldState.error}>
+                  <SelectValue placeholder={placeholder} />
+                </SelectTrigger>
+                <SelectContent className="bg-fill-onsurface-ui-2">
+                  {isConfigurationsPending ? (
+                    <Spinner size="sm" className="mx-auto my-2" />
+                  ) : (
+                    <>
+                      {optional && (
+                        <SelectItem value={CLEAR_BASE_URL_VALUE}>
+                          <SelectItemText>
+                            None (use the default endpoint)
+                          </SelectItemText>
+                        </SelectItem>
+                      )}
+                      {isStoredValueMissing && (
+                        <SelectItem value={currentValue}>
+                          <SelectItemText>
+                            {currentValue} (not found in this namespace)
+                          </SelectItemText>
+                        </SelectItem>
+                      )}
+                      {configurations?.map(configuration => (
+                        <SelectItem
+                          key={configuration.name}
+                          value={configuration.name}>
+                          <SelectItemText>
+                            {configuration.name}
+                          </SelectItemText>
+                        </SelectItem>
+                      ))}
+                    </>
+                  )}
+                </SelectContent>
+              </Select>
+              <CreateResourceButton
+                kind="configuration"
+                label={stillLiteral ? 'Move to configuration' : 'Add New'}
+                dialogTitle={
+                  stillLiteral ? 'Move URL to a configuration' : undefined
+                }
+                defaultValue={stillLiteral ? baseUrlState.url : undefined}
+                onCreated={name =>
+                  setValue('baseUrl', name, {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  })
+                }
+              />
+            </div>
+            {configurations?.length === 0 && (
+              <p className="text-sm">No configurations in this namespace.</p>
+            )}
+            <FieldError>{fieldState.error?.message}</FieldError>
+          </FieldSet>
+        );
+      }}
     />
   );
 }

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/schema.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/schema.ts
@@ -2,51 +2,65 @@ import { z } from 'zod';
 
 import { kubernetesNameSchema } from '@/lib/utils/kubernetes-validation';
 
-const openaiSchema = z.object({
-  name: kubernetesNameSchema,
-  provider: z.literal('openai'),
-  model: z.string().min(1, { message: 'Model is required' }),
-  secret: z.string().min(1, { message: 'API Key is required' }),
-  baseUrl: z.string().min(1, { message: 'Base URL is required' }),
-});
+function requiredBaseUrl(hasLiteralBaseUrl: boolean) {
+  return hasLiteralBaseUrl
+    ? z.string()
+    : z.string().min(1, { message: 'Base URL is required' });
+}
 
-const azureSchema = z
-  .object({
+function createOpenaiSchema(hasLiteralBaseUrl: boolean) {
+  return z.object({
     name: kubernetesNameSchema,
-    provider: z.literal('azure'),
+    provider: z.literal('openai'),
     model: z.string().min(1, { message: 'Model is required' }),
-    azureAuthMethod: z.enum(['apiKey', 'managedIdentity', 'workloadIdentity']),
-    secret: z.string(),
-    baseUrl: z.string().min(1, { message: 'Base URL is required' }),
-    azureApiVersion: z.string().nullish(),
-    azureClientId: z.string(),
-    azureTenantId: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.azureAuthMethod === 'apiKey' && !data.secret) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['secret'],
-        message: 'API Key is required when using API Key auth',
-      });
-    }
-    if (data.azureAuthMethod === 'workloadIdentity') {
-      if (!data.azureClientId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['azureClientId'],
-          message: 'Client ID is required for Workload Identity',
-        });
-      }
-      if (!data.azureTenantId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['azureTenantId'],
-          message: 'Tenant ID is required for Workload Identity',
-        });
-      }
-    }
+    secret: z.string().min(1, { message: 'API Key is required' }),
+    baseUrl: requiredBaseUrl(hasLiteralBaseUrl),
   });
+}
+
+function createAzureSchema(hasLiteralBaseUrl: boolean) {
+  return z
+    .object({
+      name: kubernetesNameSchema,
+      provider: z.literal('azure'),
+      model: z.string().min(1, { message: 'Model is required' }),
+      azureAuthMethod: z.enum([
+        'apiKey',
+        'managedIdentity',
+        'workloadIdentity',
+      ]),
+      secret: z.string(),
+      baseUrl: requiredBaseUrl(hasLiteralBaseUrl),
+      azureApiVersion: z.string().nullish(),
+      azureClientId: z.string(),
+      azureTenantId: z.string(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.azureAuthMethod === 'apiKey' && !data.secret) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['secret'],
+          message: 'API Key is required when using API Key auth',
+        });
+      }
+      if (data.azureAuthMethod === 'workloadIdentity') {
+        if (!data.azureClientId) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['azureClientId'],
+            message: 'Client ID is required for Workload Identity',
+          });
+        }
+        if (!data.azureTenantId) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['azureTenantId'],
+            message: 'Tenant ID is required for Workload Identity',
+          });
+        }
+      }
+    });
+}
 
 const bedrockSchema = z
   .object({
@@ -88,20 +102,26 @@ const bedrockSchema = z
     }
   });
 
-const anthropicSchema = z.object({
-  name: kubernetesNameSchema,
-  provider: z.literal('anthropic'),
-  model: z.string().min(1, { message: 'Model is required' }),
-  secret: z.string().min(1, { message: 'API Key is required' }),
-  baseUrl: z.string().min(1, { message: 'Base URL is required' }),
-  anthropicVersion: z.string().nullish(),
-});
+function createAnthropicSchema(hasLiteralBaseUrl: boolean) {
+  return z.object({
+    name: kubernetesNameSchema,
+    provider: z.literal('anthropic'),
+    model: z.string().min(1, { message: 'Model is required' }),
+    secret: z.string().min(1, { message: 'API Key is required' }),
+    baseUrl: requiredBaseUrl(hasLiteralBaseUrl),
+    anthropicVersion: z.string().nullish(),
+  });
+}
 
-export const schema = z.discriminatedUnion('provider', [
-  openaiSchema,
-  azureSchema,
-  bedrockSchema,
-  anthropicSchema,
-]);
+export function createSchema(hasLiteralBaseUrl = false) {
+  return z.discriminatedUnion('provider', [
+    createOpenaiSchema(hasLiteralBaseUrl),
+    createAzureSchema(hasLiteralBaseUrl),
+    bedrockSchema,
+    createAnthropicSchema(hasLiteralBaseUrl),
+  ]);
+}
+
+export const schema = createSchema(false);
 
 export type FormValues = z.infer<typeof schema>;

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
@@ -18,7 +18,7 @@ import { ModelConfiguratorForm } from './model-configuration-form';
 import type { DisabledFields } from './model-configuration-form-context';
 import { ModelConfigurationFormContext } from './model-configuration-form-context';
 import type { FormValues } from './schema';
-import { schema } from './schema';
+import { createSchema } from './schema';
 import {
   buildBaseUrlMode,
   createModelUpdateConfig,
@@ -46,7 +46,7 @@ export function UpdateModelForm({ model }: UpdateModelFormProps) {
   const baseUrlMode = buildBaseUrlMode(baseUrlState);
   const form = useForm<FormValues>({
     mode: 'onTouched',
-    resolver: zodResolver(schema),
+    resolver: zodResolver(createSchema(baseUrlState.kind === 'literal')),
     defaultValues,
   });
 

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/update-model-form.tsx
@@ -19,7 +19,12 @@ import type { DisabledFields } from './model-configuration-form-context';
 import { ModelConfigurationFormContext } from './model-configuration-form-context';
 import type { FormValues } from './schema';
 import { schema } from './schema';
-import { createModelUpdateConfig, getDefaultValuesForUpdate } from './utils';
+import {
+  buildBaseUrlMode,
+  createModelUpdateConfig,
+  getBaseUrlState,
+  getDefaultValuesForUpdate,
+} from './utils';
 
 const formId = 'model-update-form';
 
@@ -37,6 +42,8 @@ export function UpdateModelForm({ model }: UpdateModelFormProps) {
   const { readOnlyMode, namespace } = useNamespace();
 
   const defaultValues = getDefaultValuesForUpdate(model);
+  const baseUrlState = getBaseUrlState(model, model.provider);
+  const baseUrlMode = buildBaseUrlMode(baseUrlState);
   const form = useForm<FormValues>({
     mode: 'onTouched',
     resolver: zodResolver(schema),
@@ -50,7 +57,7 @@ export function UpdateModelForm({ model }: UpdateModelFormProps) {
   const { mutateAsync, isPending } = useUpdateModelById();
 
   const onSubmit = (formValues: FormValues) => {
-    const config = createModelUpdateConfig(formValues);
+    const config = createModelUpdateConfig(formValues, baseUrlMode);
     mutateAsync({
       id: model.id,
       model: formValues.model,
@@ -75,6 +82,7 @@ export function UpdateModelForm({ model }: UpdateModelFormProps) {
           defaultValues.provider === 'bedrock'
             ? defaultValues.bedrockAuthMethod
             : undefined,
+        baseUrlState,
       }}>
       <div className="content-shell flex min-h-0 w-full flex-1 flex-col gap-5 overflow-hidden">
         <header className="flex flex-none flex-col gap-4">

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.test.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import type { Model } from '@/lib/services';
 
-import { createConfig, getDefaultValuesForUpdate, getResetValues } from './utils';
+import {
+  buildBaseUrlMode,
+  createConfig,
+  getBaseUrlState,
+  getDefaultValuesForUpdate,
+  getResetValues,
+  mapBaseUrlState,
+} from './utils';
 import type { FormValues } from './schema';
 
 const baseBedrockForm: FormValues = {
@@ -50,17 +57,19 @@ describe('createConfig (bedrock)', () => {
     expect(config.bedrock?.secretAccessKey).toBeUndefined();
   });
 
-  it('includes baseUrl when set (e.g. a gateway endpoint)', () => {
+  it('includes baseUrl as a configMapKeyRef when a configuration is selected (e.g. a gateway endpoint)', () => {
     const config = createConfig({
       ...baseBedrockForm,
       bedrockAuthMethod: 'apiKey',
       bedrockApiKeySecretName: 'ai-gateway',
-      baseUrl: 'https://aws-bedrock.example.com/project-id',
+      baseUrl: 'bedrock-gateway-url',
     });
 
-    expect(config.bedrock?.baseUrl).toBe(
-      'https://aws-bedrock.example.com/project-id',
-    );
+    expect(config.bedrock?.baseUrl).toEqual({
+      valueFrom: {
+        configMapKeyRef: { name: 'bedrock-gateway-url', key: 'value' },
+      },
+    });
   });
 
   it('omits baseUrl when blank', () => {
@@ -139,5 +148,131 @@ describe('getDefaultValuesForUpdate (bedrock)', () => {
       bedrockAuthMethod: 'apiKey',
       bedrockApiKeySecretName: 'bedrock-credentials',
     });
+  });
+});
+
+describe('mapBaseUrlState', () => {
+  it('recognizes a configuration reference', () => {
+    expect(
+      mapBaseUrlState({
+        valueFrom: { configMapKeyRef: { name: 'openai-url', key: 'value' } },
+      }),
+    ).toEqual({
+      kind: 'configuration',
+      configurationName: 'openai-url',
+      configurationKey: 'value',
+    });
+  });
+
+  it('recognizes a legacy literal value', () => {
+    expect(mapBaseUrlState({ value: 'https://api.openai.com/v1' })).toEqual({
+      kind: 'literal',
+      url: 'https://api.openai.com/v1',
+    });
+  });
+
+  it('recognizes an unset optional field', () => {
+    expect(mapBaseUrlState(undefined)).toEqual({ kind: 'unset' });
+  });
+});
+
+describe('createConfig / getDefaultValuesForUpdate (baseUrl as configuration)', () => {
+  const openaiForm: FormValues = {
+    name: 'test-openai',
+    provider: 'openai',
+    model: 'gpt-4-turbo',
+    secret: 'openai-key',
+    baseUrl: 'openai-url',
+  };
+
+  it('sends a configMapKeyRef with key "value" for a brand-new selection', () => {
+    const config = createConfig(openaiForm);
+
+    expect(config.openai?.baseUrl).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'openai-url', key: 'value' } },
+    });
+  });
+
+  it('preserves the existing configMap key when the same configuration is kept', () => {
+    const mode = buildBaseUrlMode({
+      kind: 'configuration',
+      configurationName: 'openai-url',
+      configurationKey: 'custom-key',
+    });
+
+    const config = createConfig(openaiForm, mode);
+
+    expect(config.openai?.baseUrl).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'openai-url', key: 'custom-key' } },
+    });
+  });
+
+  it('falls back to key "value" when the user switches to a different configuration', () => {
+    const mode = buildBaseUrlMode({
+      kind: 'configuration',
+      configurationName: 'old-openai-url',
+      configurationKey: 'custom-key',
+    });
+
+    const config = createConfig(
+      { ...openaiForm, baseUrl: 'new-openai-url' },
+      mode,
+    );
+
+    expect(config.openai?.baseUrl).toEqual({
+      valueFrom: { configMapKeyRef: { name: 'new-openai-url', key: 'value' } },
+    });
+  });
+
+  it('reads back a legacy literal model into a literal state, not a configuration name', () => {
+    const model = {
+      name: 'test-openai',
+      provider: 'openai',
+      model: 'gpt-4-turbo',
+      config: {
+        openai: {
+          apiKey: {
+            valueFrom: { secretKeyRef: { name: 'openai-key', key: 'token' } },
+          },
+          baseUrl: { value: 'https://api.openai.com/v1' },
+        },
+      },
+    } as unknown as Model;
+
+    expect(getBaseUrlState(model, 'openai')).toEqual({
+      kind: 'literal',
+      url: 'https://api.openai.com/v1',
+    });
+    expect(getDefaultValuesForUpdate(model)).toMatchObject({ baseUrl: '' });
+  });
+
+  it('reads back a configured model into the configuration name', () => {
+    const model = {
+      name: 'test-openai',
+      provider: 'openai',
+      model: 'gpt-4-turbo',
+      config: {
+        openai: {
+          apiKey: {
+            valueFrom: { secretKeyRef: { name: 'openai-key', key: 'token' } },
+          },
+          baseUrl: {
+            valueFrom: { configMapKeyRef: { name: 'openai-url', key: 'value' } },
+          },
+        },
+      },
+    } as unknown as Model;
+
+    expect(getDefaultValuesForUpdate(model)).toMatchObject({
+      baseUrl: 'openai-url',
+    });
+  });
+});
+
+describe('createConfig (bedrock optional baseUrl)', () => {
+  it('omits baseUrl entirely when no configuration is selected', () => {
+    const config = createConfig(baseBedrockForm);
+
+    expect(config.bedrock?.baseUrl).toBeUndefined();
   });
 });

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
@@ -29,6 +29,9 @@ type BaseUrlValueSource = {
 };
 
 export function mapBaseUrlState(rawBaseUrl: unknown): BaseUrlFieldState {
+  if (typeof rawBaseUrl === 'string') {
+    return rawBaseUrl ? { kind: 'literal', url: rawBaseUrl } : { kind: 'unset' };
+  }
   const source =
     rawBaseUrl && typeof rawBaseUrl === 'object'
       ? (rawBaseUrl as BaseUrlValueSource)

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
@@ -8,6 +8,10 @@ import type { FormValues } from './schema';
 
 export const BASE_URL_CONFIGURATION_KEY = 'value';
 
+// Sentinel written by the Base URL field's "None" option (bedrock only) to
+// mean "explicitly clear", distinct from an untouched field left as ''.
+export const CLEAR_BASE_URL_VALUE = '__none__';
+
 export type BaseUrlFieldState =
   | {
       kind: 'configuration';
@@ -67,6 +71,9 @@ export function buildBaseUrlValueSource(
   configurationName: string | undefined | null,
   mode: BaseUrlMode = {},
 ): BaseUrlValueSource | undefined {
+  if (configurationName === CLEAR_BASE_URL_VALUE) {
+    return undefined;
+  }
   if (!configurationName) {
     return mode.literalUrl ? { value: mode.literalUrl } : undefined;
   }

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
@@ -6,8 +6,73 @@ import type {
 
 import type { FormValues } from './schema';
 
+export const BASE_URL_CONFIGURATION_KEY = 'value';
+
+export type BaseUrlFieldState =
+  | {
+      kind: 'configuration';
+      configurationName: string;
+      configurationKey: string;
+    }
+  | { kind: 'literal'; url: string }
+  | { kind: 'unset' };
+
+export type BaseUrlMode = {
+  originalName?: string;
+  originalKey?: string;
+};
+
+type BaseUrlValueSource = {
+  value?: string;
+  valueFrom?: { configMapKeyRef?: { name: string; key: string } };
+};
+
+export function mapBaseUrlState(rawBaseUrl: unknown): BaseUrlFieldState {
+  const source =
+    rawBaseUrl && typeof rawBaseUrl === 'object'
+      ? (rawBaseUrl as BaseUrlValueSource)
+      : undefined;
+  const configMapKeyRef = source?.valueFrom?.configMapKeyRef;
+  if (configMapKeyRef?.name) {
+    return {
+      kind: 'configuration',
+      configurationName: configMapKeyRef.name,
+      configurationKey: configMapKeyRef.key || BASE_URL_CONFIGURATION_KEY,
+    };
+  }
+  if (source?.value) {
+    return { kind: 'literal', url: source.value };
+  }
+  return { kind: 'unset' };
+}
+
+export function buildBaseUrlMode(state: BaseUrlFieldState): BaseUrlMode {
+  if (state.kind === 'configuration') {
+    return {
+      originalName: state.configurationName,
+      originalKey: state.configurationKey,
+    };
+  }
+  return {};
+}
+
+export function buildBaseUrlValueSource(
+  configurationName: string | undefined | null,
+  mode: BaseUrlMode = {},
+): { valueFrom: { configMapKeyRef: { name: string; key: string } } } | undefined {
+  if (!configurationName) {
+    return undefined;
+  }
+  const key =
+    mode.originalKey && configurationName === mode.originalName
+      ? mode.originalKey
+      : BASE_URL_CONFIGURATION_KEY;
+  return { valueFrom: { configMapKeyRef: { name: configurationName, key } } };
+}
+
 export function createConfig(
   formValues: FormValues,
+  baseUrlMode: BaseUrlMode = {},
 ): ModelCreateRequest['config'] {
   const config: ModelCreateRequest['config'] = {};
   switch (formValues.provider) {
@@ -21,12 +86,12 @@ export function createConfig(
             },
           },
         },
-        baseUrl: formValues.baseUrl,
+        baseUrl: buildBaseUrlValueSource(formValues.baseUrl, baseUrlMode)!,
       };
       return config;
     case 'azure': {
       const azureConfig: Record<string, unknown> = {
-        baseUrl: formValues.baseUrl,
+        baseUrl: buildBaseUrlValueSource(formValues.baseUrl, baseUrlMode)!,
         ...(formValues.azureApiVersion && {
           apiVersion: { value: formValues.azureApiVersion },
         }),
@@ -60,8 +125,12 @@ export function createConfig(
       return config;
     }
     case 'bedrock': {
+      const bedrockBaseUrl = buildBaseUrlValueSource(
+        formValues.baseUrl,
+        baseUrlMode,
+      );
       const bedrockConfig: Record<string, unknown> = {
-        ...(formValues.baseUrl && { baseUrl: formValues.baseUrl }),
+        ...(bedrockBaseUrl && { baseUrl: bedrockBaseUrl }),
         ...(formValues.region && { region: formValues.region }),
         ...(formValues.modelARN && { modelArn: formValues.modelARN }),
       };
@@ -105,7 +174,7 @@ export function createConfig(
             },
           },
         },
-        baseUrl: formValues.baseUrl,
+        baseUrl: buildBaseUrlValueSource(formValues.baseUrl, baseUrlMode)!,
         ...(formValues.anthropicVersion && {
           version: { value: formValues.anthropicVersion },
         }),
@@ -116,8 +185,9 @@ export function createConfig(
 
 export function createModelUpdateConfig(
   formValues: FormValues,
+  baseUrlMode: BaseUrlMode = {},
 ): ModelUpdateRequest['config'] {
-  return createConfig(formValues);
+  return createConfig(formValues, baseUrlMode);
 }
 
 export function getResetValues(currentFormValues: FormValues): FormValues {
@@ -203,6 +273,20 @@ function getAuthSubKey(
   return auth[camelKey] ?? auth[camelToSnake(camelKey)];
 }
 
+export function getBaseUrlState(
+  model: Model,
+  provider: string,
+): BaseUrlFieldState {
+  return mapBaseUrlState(
+    getConfigValue<unknown>(model.config, [provider, 'baseUrl']),
+  );
+}
+
+function getBaseUrlConfigurationName(model: Model, provider: string): string {
+  const state = getBaseUrlState(model, provider);
+  return state.kind === 'configuration' ? state.configurationName : '';
+}
+
 export function getDefaultValuesForUpdate(model: Model): FormValues {
   switch (model.provider) {
     case 'openai':
@@ -218,12 +302,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
             'secretKeyRef',
             'name',
           ]) || '',
-        baseUrl:
-          getConfigValue<string>(model.config, [
-            'openai',
-            'baseUrl',
-            'value',
-          ]) || '',
+        baseUrl: getBaseUrlConfigurationName(model, 'openai'),
       };
     case 'azure': {
       const auth = getConfigValue<Record<string, unknown>>(model.config, [
@@ -308,9 +387,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
         model: model.model,
         azureAuthMethod,
         secret,
-        baseUrl:
-          getConfigValue<string>(model.config, ['azure', 'baseUrl', 'value']) ||
-          '',
+        baseUrl: getBaseUrlConfigurationName(model, 'azure'),
         azureApiVersion:
           getConfigValue<string>(model.config, [
             'azure',
@@ -354,12 +431,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
             'secretKeyRef',
             'name',
           ]) || '',
-        baseUrl:
-          getConfigValue<string>(model.config, [
-            'bedrock',
-            'baseUrl',
-            'value',
-          ]) || '',
+        baseUrl: getBaseUrlConfigurationName(model, 'bedrock'),
         region:
           getConfigValue<string>(model.config, [
             'bedrock',
@@ -387,12 +459,7 @@ export function getDefaultValuesForUpdate(model: Model): FormValues {
             'secretKeyRef',
             'name',
           ]) || '',
-        baseUrl:
-          getConfigValue<string>(model.config, [
-            'anthropic',
-            'baseUrl',
-            'value',
-          ]) || '',
+        baseUrl: getBaseUrlConfigurationName(model, 'anthropic'),
         anthropicVersion:
           getConfigValue<string>(model.config, [
             'anthropic',

--- a/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
+++ b/services/ark-dashboard/ark-dashboard/components/forms/model-forms/utils.ts
@@ -20,6 +20,7 @@ export type BaseUrlFieldState =
 export type BaseUrlMode = {
   originalName?: string;
   originalKey?: string;
+  literalUrl?: string;
 };
 
 type BaseUrlValueSource = {
@@ -53,15 +54,18 @@ export function buildBaseUrlMode(state: BaseUrlFieldState): BaseUrlMode {
       originalKey: state.configurationKey,
     };
   }
+  if (state.kind === 'literal') {
+    return { literalUrl: state.url };
+  }
   return {};
 }
 
 export function buildBaseUrlValueSource(
   configurationName: string | undefined | null,
   mode: BaseUrlMode = {},
-): { valueFrom: { configMapKeyRef: { name: string; key: string } } } | undefined {
+): BaseUrlValueSource | undefined {
   if (!configurationName) {
-    return undefined;
+    return mode.literalUrl ? { value: mode.literalUrl } : undefined;
   }
   const key =
     mode.originalKey && configurationName === mode.originalName
@@ -86,6 +90,9 @@ export function createConfig(
             },
           },
         },
+        // Non-null: the schema requires either a selected configuration or a
+        // preserved baseUrlMode.literalUrl for this provider, so one of the
+        // two branches in buildBaseUrlValueSource always returns a value.
         baseUrl: buildBaseUrlValueSource(formValues.baseUrl, baseUrlMode)!,
       };
       return config;

--- a/tests/pytest/ui-tests/pages/models_page.py
+++ b/tests/pytest/ui-tests/pages/models_page.py
@@ -18,7 +18,7 @@ class ModelsPage(BasePage):
     MODEL_TYPE_SELECT = "select, [role='combobox']"
     MODEL_INPUT = "input[name='model'], input[placeholder*='model' i]"
     API_KEY_SELECT = "button:has-text('Select a secret'), [role='combobox']:has-text('Select')"
-    BASE_URL_INPUT = "input[name='baseUrl'], input[placeholder*='url' i], input[type='url']"
+    BASE_URL_FIELDSET = "xpath=//*[contains(text(),'Base URL')]/parent::*"
     SAVE_BUTTON = "button:has-text('Add Model'), button:has-text('Create'), button:has-text('Save')"
     CONFIRM_DELETE_DIALOG = "[role='dialog'], [role='alertdialog'], .modal, div:has-text('confirm'), div:has-text('delete')"
     CONFIRM_DELETE_BUTTON = "button:has-text('Delete'), button:has-text('Confirm'), button:has-text('Yes')"
@@ -70,6 +70,21 @@ class ModelsPage(BasePage):
         self.page.locator(f"[role='option']:has-text('{option_text}')").first.click()
         self.wait_for_element_hidden("[role='listbox'], [data-slot='select-content']", timeout=3000)
 
+    def _set_base_url_via_configuration(self, model_name: str, base_url: str) -> None:
+        base_url_fieldset = self.page.locator(self.BASE_URL_FIELDSET).first
+        add_button = base_url_fieldset.locator(
+            "button:has-text('Add New'), button:has-text('Move to configuration')"
+        ).first
+        add_button.wait_for(state="visible", timeout=3000)
+        add_button.click()
+
+        dialog = self.page.locator("[role='dialog']")
+        dialog.wait_for(state="visible", timeout=5000)
+        dialog.get_by_label("Name").fill(f"{model_name}-base-url")
+        dialog.get_by_label("Value").fill(base_url)
+        dialog.get_by_role("button", name="Create").click()
+        self.wait_for_element_hidden("[role='dialog']", timeout=5000)
+
     def create_model_with_verification(self, model_name: str, model_type: str, model: str, secret_name: str, base_url: str = None) -> dict:
         logger.info(f"Creating {model_type} model: {model_name}")
         
@@ -91,9 +106,7 @@ class ModelsPage(BasePage):
         
         if base_url:
             try:
-                base_url_input = self.page.locator(self.BASE_URL_INPUT).first
-                base_url_input.wait_for(state="visible", timeout=3000)
-                base_url_input.fill(base_url)
+                self._set_base_url_via_configuration(model_name, base_url)
             except TimeoutError as e:
                 logger.info(f"No base URL field visible for {model_type}, skipping: {e}")
             except Exception as e:


### PR DESCRIPTION
## Summary
- Adds a "Move to configuration" option for a model's Base URL, mirroring the MCP wizard pattern: a literal URL already on the model can be moved into a shared Configuration, or left as-is
- Selecting a different configuration falls back to key `value`, unless it's the same ConfigMap the model was already reading from (preserves a custom key)
- Update/create model forms and `createConfig`/`getBaseUrlState` utils updated to read/write `baseUrl` as either a literal value or a `configMapKeyRef`
- Documents the Base URL / configuration picker in the Models user guide

Closes https://github.com/mckinsey/agents-at-scale-ark/issues/3455

## Demo

https://github.com/user-attachments/assets/0362488b-4122-4bb0-afe0-d74e7a9e95e1

