### PR TITLE
fix(dashboard): clickable checkbox labels and wrapped tool description

### DIFF
--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 
 import {
@@ -20,6 +20,7 @@ import {
 import {
   FieldDescription,
   FieldError,
+  FieldLabel,
   FieldSet,
   FieldTitle,
 } from '@/components/ui/field';
@@ -62,6 +63,7 @@ export function SelectorSection({
   unavailableAgents,
   disabled,
 }: Readonly<SelectorSectionProps>) {
+  const terminateToolId = useId();
   const [isPromptExpanded, setIsPromptExpanded] = useState(false);
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const selectedStrategy = form.watch('strategy');
@@ -206,12 +208,17 @@ export function SelectorSection({
             render={({ field }) => (
               <div className="flex flex-row items-start gap-3">
                 <Checkbox
+                  id={terminateToolId}
                   checked={field.value ?? true}
                   onCheckedChange={field.onChange}
                   disabled={disabled}
                 />
                 <div className="space-y-1 leading-none">
-                  <FieldTitle>Enable Terminate Tool</FieldTitle>
+                  <FieldLabel
+                    htmlFor={terminateToolId}
+                    className="cursor-pointer">
+                    Enable Terminate Tool
+                  </FieldLabel>
                   <p className="text-fg-tertiary text-xs">
                     Allow the selector agent to use the terminate tool to end
                     the conversation early when appropriate.

--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/selector-section.tsx
@@ -216,7 +216,8 @@ export function SelectorSection({
                 <div className="space-y-1 leading-none">
                   <FieldLabel
                     htmlFor={terminateToolId}
-                    className="cursor-pointer">
+                    disabled={disabled}
+                    className={disabled ? undefined : 'cursor-pointer'}>
                     Enable Terminate Tool
                   </FieldLabel>
                   <p className="text-fg-tertiary text-xs">

--- a/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/strategy-section.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/team-form/sections/strategy-section.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { Checkbox } from '@/components/ui/checkbox';
@@ -48,6 +49,7 @@ export function StrategySection({
   selectedMembers,
   disabled,
 }: Readonly<StrategySectionProps>) {
+  const loopsId = useId();
   const selectedStrategy = useWatch({ control: form.control, name: 'strategy' });
   const loopsChecked = useWatch({ control: form.control, name: 'loops' });
   const enableTerminateTool = useWatch({
@@ -105,6 +107,7 @@ export function StrategySection({
           render={({ field }) => (
             <div className="flex flex-row items-center gap-2">
               <Checkbox
+                id={loopsId}
                 checked={field.value}
                 onCheckedChange={checked => {
                   field.onChange(checked);
@@ -114,7 +117,9 @@ export function StrategySection({
                 }}
                 disabled={disabled}
               />
-              <Label className="text-sm font-normal">
+              <Label
+                htmlFor={loopsId}
+                className="cursor-pointer text-sm font-normal">
                 Enable loops (cycle through members repeatedly)
               </Label>
             </div>

--- a/services/ark-dashboard/ark-dashboard/components/forms/tool-form/tool-form.tsx
+++ b/services/ark-dashboard/ark-dashboard/components/forms/tool-form/tool-form.tsx
@@ -40,6 +40,9 @@ const RequiredMarker = () => (
 const inlineSelectTriggerClassName =
   'focus-visible:border-b-stroke-status-focus w-full rounded-none border-0 border-b border-white/[0.24] bg-transparent px-0 hover:border-b-white/40';
 
+const inlineTextareaClassName =
+  'min-h-9 resize-none border-0 border-b-[1px] border-b-stroke-tertiary bg-transparent px-0 py-1 shadow-none hover:border-b-stroke-tertiary-hover hover:bg-transparent focus-visible:border-b-stroke-status-focus focus-visible:bg-transparent focus-visible:shadow-elevation-0 focus-visible:ring-0 aria-invalid:border-b-status-error aria-invalid:ring-0 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-fg-disabled disabled:placeholder:text-fg-disabled';
+
 const jsonTextareaClassName = (expanded: boolean) =>
   cn(
     'resize-none font-mono transition-all duration-200',
@@ -207,11 +210,13 @@ export function ToolForm({
                   <FieldTitle>
                     Description {!isViewing && <RequiredMarker />}
                   </FieldTitle>
-                  <Input
-                    variant="inline"
+                  <Textarea
+                    autoResize
+                    rows={1}
                     placeholder="Tool description"
                     disabled={isDisabled}
                     aria-invalid={!!fieldState.error}
+                    className={inlineTextareaClassName}
                     {...field}
                   />
                   <FieldError>{fieldState.error?.message}</FieldError>

--- a/tests/pytest/ui-tests/pages/tools_page.py
+++ b/tests/pytest/ui-tests/pages/tools_page.py
@@ -123,7 +123,7 @@ class ToolsPage(BasePage):
             logger.info("Name was cleared by type selection re-render, re-filling")
             name_input.fill(tool_name)
 
-        description_input = self.page.locator("input#description, input[name='description']").first
+        description_input = self.page.locator("textarea#description, textarea[name='description'], input#description, input[name='description']").first
         description_input.wait_for(state="visible", timeout=15000)
         description_input.fill(description)
 


### PR DESCRIPTION
## Summary

- `team-form/sections/strategy-section.tsx` — "Enable loops" had no `id`/`htmlFor` pair, so clicking the label did nothing. Added the association and `cursor-pointer`, matching `editors/team-editor.tsx`.
- `team-form/sections/selector-section.tsx` — same defect on "Enable Terminate Tool". `FieldTitle` renders a `<div>`, so it was swapped for `FieldLabel`, which has the same styling but renders a `<label>`.
- `tool-form/tool-form.tsx` — the description was a single-line `Input`, and view mode disables it, so the clipped text was unreachable. Now a `Textarea` with `autoResize`, styled to match the inline inputs around it.

### Why no Expand button

#3219 asks for wrapping plus an Expand button. Wrapping alone is enough: a clamped field would reproduce the bug, since a disabled textarea cannot be scrolled. Descriptions are two to four lines of prose, so there is nothing worth hiding behind a click — unlike Input Schema and Annotations, which hold JSON.

## Checklist

- [x] Follow the [contributor guide](./CONTRIBUTING.md)
- [x] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [x] Linked issues #3219 , #2987 